### PR TITLE
temporary: revert containment to prove CI catches it

### DIFF
--- a/endpoint/windows/ai-guard-collector.ps1
+++ b/endpoint/windows/ai-guard-collector.ps1
@@ -379,7 +379,7 @@ function Resolve-PhysicalPath {
 # real findings to prevent an unlikely one.
 function Resolve-UnderHome {
     param([string]$Path)
-    $real = Resolve-PhysicalPath $Path
+    $real = [IO.Path]::GetFullPath($Path)
     if (-not $real) { return $null }
 
     # Resolved once and kept: the profile is physically resolved too, or a


### PR DESCRIPTION
Deliberately reverts the containment fix to confirm the windows-path-containment job catches it. Will be closed without merging. Acceptance criterion for #38.