### PR TITLE
receiver: bump fastapi to 0.141 and uvicorn to 0.52

### DIFF
--- a/receiver/requirements.in
+++ b/receiver/requirements.in
@@ -1,5 +1,5 @@
-fastapi==0.140.*
-uvicorn[standard]==0.34.*
+fastapi==0.141.*
+uvicorn[standard]==0.52.*
 httpx==0.28.*
 prometheus-client==0.21.*
 pydantic==2.*

--- a/receiver/requirements.lock
+++ b/receiver/requirements.lock
@@ -29,9 +29,9 @@ click==8.4.2 \
     --hash=sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6 \
     --hash=sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76
     # via uvicorn
-fastapi==0.140.0 \
-    --hash=sha256:e951c0a0d9540bf5d9a2a9e078fd415da2ab7e312d435139e7d9e2e7fe9f0b23 \
-    --hash=sha256:f338951b82fd74ca8f843163aec43ea1a1ce84d515415a50fa98fa25572a5544
+fastapi==0.141.1 \
+    --hash=sha256:bfb91aa2d334c61cb35ba9a116fc123b3d3df31640b801cf57a7a78ec3f603b3 \
+    --hash=sha256:e8822fc40db1e1858054d7a949a888695bc9bdce70139178e33bd2871a453ca1
     # via -r requirements.in
 h11==0.16.0 \
     --hash=sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1 \
@@ -340,9 +340,9 @@ tzdata==2026.3 \
     --hash=sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415 \
     --hash=sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931
     # via -r requirements.in
-uvicorn==0.34.3 \
-    --hash=sha256:16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885 \
-    --hash=sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a
+uvicorn==0.52.1 \
+    --hash=sha256:112ec661814189acbccd3f7b86460147cc065fc92c0821afa78918780e4354dd \
+    --hash=sha256:e4403f9d93188cf9d1088e9f40e3acd12630e2df8675316704379a7fc20fff6a
     # via -r requirements.in
 uvloop==0.22.1 \
     --hash=sha256:017bd46f9e7b78e81606329d07141d3da446f8798c6baeec124260e22c262772 \


### PR DESCRIPTION
Supersedes #40 and #41.

Both Dependabot PRs edit `receiver/requirements.in` only. Nothing in the repo installs from that file: CI, the Dockerfile and the Trivy workflow all read `receiver/requirements.lock`. Both PRs were passing CI while the image kept shipping fastapi 0.140 and uvicorn 0.34, so the green tick on each was confirming the old versions still work.

Done as one branch because both land in the same lock and one `make lock` resolves them together.

uvicorn crossed eighteen minor releases. The lock diff shows httptools, uvloop, watchfiles, websockets, python-dotenv and pyyaml all unchanged and still `# via uvicorn`, so the `[standard]` extra resolves to the same package set as before.

Verified locally with the demo compose against the rebuilt image: receiver healthy on 0.52, findings ingested across all six surfaces.