### PR TITLE
ci: fail when requirements.lock does not match requirements.in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,53 @@ jobs:
           python registry/build.py --check
           python -m pytest -q registry/
 
+  lock-drift:
+    # Nothing installs from requirements.in. This workflow, the Dockerfiles and
+    # the Trivy workflow all read requirements.lock, so an edit to the .in alone
+    # ships nothing and still goes green. That is how uvicorn sat eighteen minor
+    # releases behind through several Dependabot PRs that each passed CI and
+    # were closed as no-ops.
+    #
+    # Recompiles and fails if the committed lock is not what the .in currently
+    # produces. Calls `make lock-check` rather than repeating the pip-compile
+    # command, so there is one definition of what the lock should be, the same
+    # reason registry.yaml is the single source for the compiled views.
+    #
+    # pip-tools is pinned in the component Makefiles. Without that this job
+    # fails whenever pip-tools ships a release, for a reason unrelated to the
+    # change under review, and a check that fails at random gets ignored.
+    runs-on: ubuntu-latest
+    strategy:
+      # Report every stale component in one run. Otherwise you fix one, push,
+      # and find the next.
+      fail-fast: false
+      matrix:
+        component: [receiver, scanner, discovery]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: the committed lock matches requirements.in
+        working-directory: ${{ matrix.component }}
+        run: |
+          # pip-compile writes the entire lock to stdout, thousands of lines
+          # that bury the result. Keep it for the failure path only.
+          if ! make lock >/tmp/compile.log 2>&1; then
+            echo "::error::pip-compile failed for ${{ matrix.component }}"
+            tail -40 /tmp/compile.log
+            exit 1
+          fi
+          if ! git diff --quiet requirements.lock; then
+            echo "::error::${{ matrix.component }}/requirements.lock is stale. Run 'make lock' in ${{ matrix.component }}/ and commit the result."
+            echo ""
+            git diff --stat requirements.lock
+            echo ""
+            echo "Versions added or removed:"
+            # Package names contain digits, dots and hyphens: h11, rpds-py,
+            # markdown-it-py. A narrower pattern drops them silently.
+            git diff requirements.lock | grep -E "^[+-][a-zA-Z0-9_.-]+==" || true
+            exit 1
+          fi
+          echo "${{ matrix.component }}/requirements.lock is current."
+
   receiver-test:
     runs-on: ubuntu-latest
     steps:

--- a/discovery/Makefile
+++ b/discovery/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lock upgrade
+.PHONY: lock upgrade lock-check
 
 # Lockfiles are compiled inside the same base image this component ships on.
 # pip-compile bakes environment markers from the interpreter running it, so a
@@ -6,15 +6,31 @@
 # the Docker build. Bump this alongside the Dockerfile, never on its own.
 PY_IMAGE ?= python:3.12-slim
 
+# pip-tools is pinned because CI recompiles the lock and fails if it moves.
+# An unpinned pip-tools means the version that generated the committed lock
+# and the version CI checks it with can differ, and the job then fails for a
+# reason that has nothing to do with the change under review. A check that
+# fails at random gets ignored, then disabled. Bump this deliberately and
+# regenerate all three components in the same commit.
+PIP_TOOLS_VERSION ?= 7.6.0
+
 # Recompile, preserving versions already pinned in requirements.lock.
 # Use after editing requirements.in.
 lock:
 	docker run --rm -v "$$PWD:/w" -w /w $(PY_IMAGE) sh -c \
-	  "pip install -q pip-tools && pip-compile --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
+	  "pip install -q pip-tools==$(PIP_TOOLS_VERSION) && pip-compile --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
 
 # Recompile, allowing every package to move to its newest compatible version.
 # Use when a scan reports a CVE in a transitive dependency: `lock` keeps
 # existing pins and will not clear it on its own.
 upgrade:
 	docker run --rm -v "$$PWD:/w" -w /w $(PY_IMAGE) sh -c \
-	  "pip install -q pip-tools && pip-compile --upgrade --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
+	  "pip install -q pip-tools==$(PIP_TOOLS_VERSION) && pip-compile --upgrade --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
+
+# Fail if requirements.lock is not what requirements.in currently compiles to.
+# Nothing installs from requirements.in: CI, the Dockerfile and Trivy all read
+# the lock. So an edit to the .in alone changes nothing and still goes green.
+# This is what CI runs. Run it locally before pushing to save a round trip.
+lock-check: lock
+	@git diff --exit-code requirements.lock \
+	  || { echo ""; echo "requirements.lock is stale. Run 'make lock' in this directory and commit the result."; exit 1; }

--- a/receiver/Makefile
+++ b/receiver/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lock upgrade
+.PHONY: lock upgrade lock-check
 
 # Lockfiles are compiled inside the same base image this component ships on.
 # pip-compile bakes environment markers from the interpreter running it, so a
@@ -6,15 +6,31 @@
 # the Docker build. Bump this alongside the Dockerfile, never on its own.
 PY_IMAGE ?= python:3.12-slim
 
+# pip-tools is pinned because CI recompiles the lock and fails if it moves.
+# An unpinned pip-tools means the version that generated the committed lock
+# and the version CI checks it with can differ, and the job then fails for a
+# reason that has nothing to do with the change under review. A check that
+# fails at random gets ignored, then disabled. Bump this deliberately and
+# regenerate all three components in the same commit.
+PIP_TOOLS_VERSION ?= 7.6.0
+
 # Recompile, preserving versions already pinned in requirements.lock.
 # Use after editing requirements.in.
 lock:
 	docker run --rm -v "$$PWD:/w" -w /w $(PY_IMAGE) sh -c \
-	  "pip install -q pip-tools && pip-compile --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
+	  "pip install -q pip-tools==$(PIP_TOOLS_VERSION) && pip-compile --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
 
 # Recompile, allowing every package to move to its newest compatible version.
 # Use when a scan reports a CVE in a transitive dependency: `lock` keeps
 # existing pins and will not clear it on its own.
 upgrade:
 	docker run --rm -v "$$PWD:/w" -w /w $(PY_IMAGE) sh -c \
-	  "pip install -q pip-tools && pip-compile --upgrade --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
+	  "pip install -q pip-tools==$(PIP_TOOLS_VERSION) && pip-compile --upgrade --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
+
+# Fail if requirements.lock is not what requirements.in currently compiles to.
+# Nothing installs from requirements.in: CI, the Dockerfile and Trivy all read
+# the lock. So an edit to the .in alone changes nothing and still goes green.
+# This is what CI runs. Run it locally before pushing to save a round trip.
+lock-check: lock
+	@git diff --exit-code requirements.lock \
+	  || { echo ""; echo "requirements.lock is stale. Run 'make lock' in this directory and commit the result."; exit 1; }

--- a/receiver/requirements.in
+++ b/receiver/requirements.in
@@ -1,6 +1,6 @@
 fastapi==0.141.*
 uvicorn[standard]==0.52.*
 httpx==0.28.*
-prometheus-client==0.21.*
+prometheus-client==0.26.*
 pydantic==2.*
 tzdata

--- a/receiver/requirements.lock
+++ b/receiver/requirements.lock
@@ -105,9 +105,9 @@ idna==3.18 \
     # via
     #   anyio
     #   httpx
-prometheus-client==0.21.1 \
-    --hash=sha256:252505a722ac04b0456be05c05f75f45d760c2911ffc45f2a06bcaed9f3ae3fb \
-    --hash=sha256:594b45c410d6f4f8888940fe80b5cc2521b305a1fafe1c58609ef715a001f301
+prometheus-client==0.26.0 \
+    --hash=sha256:04a91bcf94e2cf74a44a1a874d651a2e853ed354b6e822f3b7487751465d5c2b \
+    --hash=sha256:fa93d06737aa02bacd05794768508bb97d2fbee28cb3bca04eaae92f0ca953d6
     # via -r requirements.in
 pydantic==2.13.4 \
     --hash=sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba \

--- a/scanner/Makefile
+++ b/scanner/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lock upgrade install install-dev verify audit clean
+.PHONY: lock upgrade lock-check install install-dev verify audit clean
 
 # Lockfiles are compiled inside the same base image this component ships on.
 # pip-compile bakes environment markers from the interpreter running it, so a
@@ -6,12 +6,20 @@
 # the Docker build. Bump this alongside the Dockerfile, never on its own.
 PY_IMAGE ?= python:3.12-slim
 
+# pip-tools is pinned because CI recompiles the lock and fails if it moves.
+# An unpinned pip-tools means the version that generated the committed lock
+# and the version CI checks it with can differ, and the job then fails for a
+# reason that has nothing to do with the change under review. A check that
+# fails at random gets ignored, then disabled. Bump this deliberately and
+# regenerate all three components in the same commit.
+PIP_TOOLS_VERSION ?= 7.6.0
+
 # Generate pinned lockfile with hash verification.
 # Preserves versions already pinned in requirements.lock; use after editing
 # requirements.in.
 lock:
 	docker run --rm -v "$$PWD:/w" -w /w $(PY_IMAGE) sh -c \
-	  "pip install -q pip-tools && pip-compile --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
+	  "pip install -q pip-tools==$(PIP_TOOLS_VERSION) && pip-compile --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
 	@echo ""
 	@echo "requirements.lock generated with pinned versions and hashes."
 	@echo "Commit this file to the repo."
@@ -21,10 +29,18 @@ lock:
 # existing pins and will not clear it on its own.
 upgrade:
 	docker run --rm -v "$$PWD:/w" -w /w $(PY_IMAGE) sh -c \
-	  "pip install -q pip-tools && pip-compile --upgrade --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
+	  "pip install -q pip-tools==$(PIP_TOOLS_VERSION) && pip-compile --upgrade --generate-hashes --strip-extras --output-file=requirements.lock requirements.in"
 	@echo ""
 	@echo "requirements.lock regenerated with newest compatible versions."
 	@echo "Run the tests before committing: major bumps land here."
+
+# Fail if requirements.lock is not what requirements.in currently compiles to.
+# Nothing installs from requirements.in: CI, the Dockerfile and Trivy all read
+# the lock. So an edit to the .in alone changes nothing and still goes green.
+# This is what CI runs. Run it locally before pushing to save a round trip.
+lock-check: lock
+	@git diff --exit-code requirements.lock \
+	  || { echo ""; echo "requirements.lock is stale. Run 'make lock' in this directory and commit the result."; exit 1; }
 
 # Install from lockfile with hash verification
 # This is the secure install path: refuses to install if hashes don't match
@@ -36,7 +52,7 @@ install:
 
 # Install for development (includes dev deps, less strict)
 install-dev:
-	pip install pip-tools
+	pip install pip-tools==$(PIP_TOOLS_VERSION)
 	pip install -e ".[dev]"
 
 # Verify installed packages match lockfile hashes


### PR DESCRIPTION
Closes #45.

Nothing in the repo installs from `requirements.in`. This workflow, the three Dockerfiles and the Trivy workflow all read `requirements.lock`. So a change to the `.in` alone ships nothing and still passes CI.

That is not hypothetical. Pruning stale remote refs turned up closed Dependabot branches for `uvicorn-eq-0.51`, `prometheus-client-eq-0.26` and others. Each of those PRs was offered, looked like a no-op because it was one, and was closed. The lock never moved. By the time #44 landed, uvicorn was eighteen minor releases behind on a 0.x project where minor is where breaking changes are allowed.

## What this adds

A `lock-drift` job, matrixed across receiver, scanner and discovery, that recompiles the lock and fails if the committed file is not what the `.in` currently produces.

It calls `make lock-check` rather than repeating the pip-compile command. Same reasoning as `registry.yaml` being the single source for the compiled views: a second copy of the command is a second thing that drifts. The two jobs now sit next to each other in the file because they check the same class of invariant.

`fail-fast: false` so every stale component is reported in one run.

## pip-tools is now pinned

`pip install -q pip-tools` took whatever was latest at the moment it ran. With CI recompiling and comparing, that means the version that generated a committed lock and the version checking it can differ, and the job then fails for a reason unrelated to the change under review. A check that fails at random gets ignored, then disabled.

Pinned at 7.6.0 in all three Makefiles, with a comment saying why and to bump it deliberately across all three at once.

## Verified before adding the gate

All three components recompile byte-identical with the pin, so this passes on main from the first run rather than needing a fix alongside it.

Discovery did not, before this branch. Its lock was generated when the input was called `requirements.txt` and before `--strip-extras` was added, so the header and one `via` line still referenced the old filename. Regenerated separately on main first, in ee27cef, with every package, version and hash unchanged.

## The gate proved on this branch

`6c93a0d` bumps prometheus-client in `receiver/requirements.in` alone, without regenerating the lock. `lock-drift (receiver)` failed in 20s. `scanner` and `discovery` stayed green, and every other check on that commit passed,
including `demo-smoke`, because they all install from the lock and the lock still said 0.21.

The failure named the component, the file, the command to fix it and the
package:

    Error: receiver/requirements.lock is stale. Run 'make lock' in receiver/ and commit the result.
     receiver/requirements.lock | 6 +++---
    Versions added or removed:
    -prometheus-client==0.21.1 \
    +prometheus-client==0.26.0 \

The next commit regenerates the lock. prometheus-client moves 0.21.1 to 0.26.0 with no new transitive dependencies across the five minors, and `demo-smoke` still asserts on `aiguard_findings_total`, which is what this library produces.