### PR TITLE
collectors: throttle warn findings to hourly instead of every run

### DIFF
--- a/endpoint/linux/README.md
+++ b/endpoint/linux/README.md
@@ -76,9 +76,9 @@ username in `user`.
 
 ## Reporting behaviour
 
-Identical to the other collectors: warn findings (personal accounts) post
-every run; info findings post at most once per 24 hours (state in
-`/var/lib/ai-guard/`); a new tool or an account change posts immediately.
+Identical to the other collectors: warn findings post at most once per hour, info findings 
+at most once per 24 hours (state in /var/lib/ai-guard/). A new tool or an account change 
+is a new key and reports immediately at either severity.
 If the registry cannot be fetched or parsed the script exits non-zero and
 reports nothing, on the principle that an empty scan is indistinguishable
 from a clean machine.

--- a/endpoint/linux/ai-guard-collector.sh
+++ b/endpoint/linux/ai-guard-collector.sh
@@ -52,6 +52,11 @@ STATE_FILE="$STATE_DIR/reported.state"
 SUMMARY_DIR="$STATE_DIR"
 SUMMARY_FILE="$SUMMARY_DIR/last_scan.txt"
 INFO_INTERVAL=$((24 * 3600))
+# warn findings (personal accounts) are a persistent state, not an event, so
+# repeating them at every run adds volume without adding information. The
+# first report already said it. New keys bypass the throttle entirely, so an
+# account switch still surfaces on the next run.
+WARN_INTERVAL=$((3600))
 
 PY=$(command -v python3 || true)
 
@@ -225,7 +230,7 @@ json_escape() {
 # report <surface> <tool> <account> <evidence>
 report() {
   local surface="$1" tool="$2" acct="$3" evidence="$4"
-  local severity="info" key prev
+  local severity="info" key prev interval
 
   if [ -n "$acct" ] && ! is_corp "$acct"; then
     severity="warn"; WARN_COUNT=$((WARN_COUNT + 1))
@@ -233,14 +238,17 @@ report() {
 
   if [ -n "$acct" ]; then SUMMARY="$SUMMARY $tool($acct);"; else SUMMARY="$SUMMARY $tool;"; fi
 
+  # Throttle by severity: info daily, warn hourly. A key with no previous
+  # timestamp falls through regardless, so new findings are never delayed.
   key="$surface|$tool|$acct"
-  if [ "$severity" = "info" ]; then
-    prev=$(state_get "$key")
-    if [ -n "$prev" ] && [ $((NOW_EPOCH - prev)) -lt "$INFO_INTERVAL" ]; then
-      printf '%s %s\n' "$key" "$prev" >> "$STATE_NEW"
-      SUPPRESSED=$((SUPPRESSED + 1))
-      return
-    fi
+  interval="$INFO_INTERVAL"
+  [ "$severity" = "warn" ] && interval="$WARN_INTERVAL"
+
+  prev=$(state_get "$key")
+  if [ -n "$prev" ] && [ $((NOW_EPOCH - prev)) -lt "$interval" ]; then
+    printf '%s %s\n' "$key" "$prev" >> "$STATE_NEW"
+    SUPPRESSED=$((SUPPRESSED + 1))
+    return
   fi
 
   # severity and reported_at are generated here, so they need no escaping.

--- a/endpoint/macos/README.md
+++ b/endpoint/macos/README.md
@@ -29,11 +29,13 @@ reports as `warn`; everything else is `info`.
 
 ## Reporting behaviour
 
-- `warn` findings report on every run.
-- `info` findings report at most once per 24 hours (state kept in
-  `/Library/Application Support/ai-guard/`), so you can schedule the policy
-  frequently without flooding your logs. A new tool or an account change
-  reports immediately.
+- `warn` findings (personal accounts) report at most once per hour. A
+  personal account is a persistent state rather than an event, so repeating
+  it at every check-in adds volume without adding information.
+- `info` findings report at most once per 24 hours. State for both is kept in
+  `/Library/Application Support/ai-guard/`, so you can schedule the policy
+  frequently without flooding your logs. A new tool or an account change is a
+  new key and reports immediately at either severity.
 - If the registry cannot be fetched or parsed, the script exits 1 and reports
   nothing, on the principle that an empty scan is indistinguishable from a
   clean machine. The failure is visible in the policy log and as a failed

--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -43,14 +43,17 @@ CORP_DOMAINS="${6:-}"
 SUMMARY_DIR="/Library/Application Support/ai-guard"
 SUMMARY_FILE="$SUMMARY_DIR/last_scan.txt"
 
-# Report throttling. The policy runs at every recurring check-in (~20 min)
-# so personal-account findings surface fast, but unchanged inventory (info)
-# findings only need reporting once a day. STATE_FILE holds one line per
-# already-reported info finding: "<key> <epoch>". warn findings are never
-# throttled. A finding not yet in the state file (new tool, new account)
-# reports immediately, so a fresh install surfaces within one check-in.
+# Report throttling. The policy runs at every recurring check-in (~20 min).
+# Unchanged inventory (info) findings only need reporting once a day; warn
+# findings (personal accounts) report hourly, since a personal account is a
+# persistent state rather than an event and the first report already said it.
+# STATE_FILE holds one line per already-reported finding: "<key> <epoch>".
+# A finding not yet in the state file (new tool, new account) reports
+# immediately at any severity, so a fresh install or an account switch
+# surfaces within one check-in.
 STATE_FILE="$SUMMARY_DIR/reported.state"
 INFO_REPORT_INTERVAL=$(( 24 * 3600 ))
+WARN_REPORT_INTERVAL=$(( 3600 ))
 NOW_EPOCH=$(/bin/date +%s)
 STATE_OLD=""
 [ -f "$STATE_FILE" ] && STATE_OLD=$(/bin/cat "$STATE_FILE" 2>/dev/null)
@@ -153,21 +156,24 @@ report() {
     esac
   fi
 
-  # Throttle: info findings already reported within the interval are
-  # suppressed; warns always go. Key includes the account domain, so a
-  # tool switching from corporate to personal account is a NEW key and
-  # reports immediately even though the tool itself was known.
+  # Report throttling. The policy runs at every recurring check-in (~20 min).
+  # Unchanged inventory (info) findings only need reporting once a day; warn
+  # findings (personal accounts) report hourly, since a personal account is a
+  # persistent state rather than an event and the first report already told us.
+  # Throttle by severity: info daily, warn hourly. A key with no previous
+  # timestamp falls through regardless, so new findings are never delayed.
   local key="${surface}|${tool}|${acct}"
-  if [ "$severity" = "info" ]; then
-    local last
-    last=$(state_lookup "$key")
-    if [ -n "$last" ] && [ $(( NOW_EPOCH - last )) -lt "$INFO_REPORT_INTERVAL" ]; then
-      STATE_NEW="${STATE_NEW}${key} ${last}
+  local interval="$INFO_REPORT_INTERVAL"
+  [ "$severity" = "warn" ] && interval="$WARN_REPORT_INTERVAL"
+
+  local last
+  last=$(state_lookup "$key")
+  if [ -n "$last" ] && [ $(( NOW_EPOCH - last )) -lt "$interval" ]; then
+    STATE_NEW="${STATE_NEW}${key} ${last}
 "
-      SUPPRESSED=$((SUPPRESSED + 1))
-      if [ -n "$acct" ]; then SUMMARY_PARTS+=("$tool($acct)"); else SUMMARY_PARTS+=("$tool"); fi
-      return 0
-    fi
+    SUPPRESSED=$((SUPPRESSED + 1))
+    if [ -n "$acct" ]; then SUMMARY_PARTS+=("$tool($acct)"); else SUMMARY_PARTS+=("$tool"); fi
+    return 0
   fi
 
   # severity and reported_at are generated here, so they need no escaping.

--- a/endpoint/windows/README.md
+++ b/endpoint/windows/README.md
@@ -93,10 +93,9 @@ after a sync, check:
 
 ## Reporting behaviour
 
-Identical to macOS: warn findings post every run, info findings at most
-once per 24 hours (state in `C:\ProgramData\ai-guard\`), new tools and
-account changes post immediately. Parse failures are loud: they mark the
-breadcrumb, and the script exits 1.
+Identical to macOS: warn findings post at most once per hour, info findings
+at most once per 24 hours, state in C:\ProgramData\ai-guard\. A new tool or
+an account change reports immediately at either severity.
 
 One Windows-specific note: some AI tool config files cannot be parsed
 whole (Claude Code stores per-project state whose keys differ only in

--- a/endpoint/windows/ai-guard-collector.ps1
+++ b/endpoint/windows/ai-guard-collector.ps1
@@ -16,8 +16,12 @@
       the Jamf /var/root bug that silently produced an empty pilot.
     * Fail loudly. A collector that swallows POST errors across a fleet
       produces a healthy-looking dashboard and false confidence.
-    * Throttle info findings to one report per day; warns (personal
-      accounts) and never-seen findings report on every run.
+    * Throttle info findings to one report per day and warn findings
+      (personal accounts) to one per hour. A personal account is a
+      persistent state, not an event, so repeating it at every check-in
+      adds volume without adding information. Never-seen findings report
+      immediately at any severity, so an account switch still surfaces on
+      the next run.
     * Report the account domain in account_domain; the console username is
       sent in the user field. Both are already known to IT through the MDM.
 
@@ -44,6 +48,7 @@ $StateDir  = 'C:\ProgramData\ai-guard'
 $StateFile = Join-Path $StateDir 'reported.state.json'
 $Breadcrumb = Join-Path $StateDir 'last_scan.txt'
 $InfoReportIntervalHours = 24
+$WarnReportIntervalHours = 1
 
 $Endpoint = ''
 if ($ReceiverBase) { $Endpoint = ($ReceiverBase.TrimEnd('/')) + '/report' }
@@ -190,9 +195,12 @@ function Send-Finding {
 
     if ($Account) { $SummaryParts.Add("$Tool($Account)") } else { $SummaryParts.Add($Tool) }
 
+    # Throttle by severity: info daily, warn hourly. A key with no previous
+    # timestamp falls through regardless, so new findings are never delayed.
     $key = "$Surface|$Tool|$Account"
-    if ($severity -eq 'info' -and $StateOld.ContainsKey($key)) {
-        if (($NowEpoch - $StateOld[$key]) -lt ($InfoReportIntervalHours * 3600)) {
+    $intervalHours = if ($severity -eq 'warn') { $WarnReportIntervalHours } else { $InfoReportIntervalHours }
+    if ($StateOld.ContainsKey($key)) {
+        if (($NowEpoch - $StateOld[$key]) -lt ($intervalHours * 3600)) {
             $StateNew[$key] = $StateOld[$key]
             $script:Suppressed++
             return


### PR DESCRIPTION
All three collectors threw the info throttle away for warns, on the reasoning that a personal-account finding should surface fast rather than waiting a day. That reasoning was right but the mechanism was doubled up: a key with no previous timestamp already falls through the throttle at any severity, so a new tool or an account switch surfaces on the next check-in regardless. The severity bypass only made an already-reported warn repeat forever.

A personal account is a persistent state, not an event. At a 20 minute check-in that is about 72 findings a day per person per tool, indefinitely. Observed on a live fleet: one user, one tool, one device, four figures of findings in a week, against single figures each for three other tools on the same device that happened to be on corporate accounts and were therefore throttled.

The cost is not only volume. Every aggregate the platform produces was weighted by how long someone had been on a personal account rather than by usage, so top-tools and per-user counts were ranking on throttle behaviour. Where ALERTMANAGER_URL is set it was also the alert cadence.

Adds a warn interval of one hour alongside the existing 24 hour info interval, in macOS, Linux and Windows. Header comments and all three READMEs updated: they documented the behaviour being removed. Found by querying real findings in Loki while checking whether the schema could support an entity model, not by a test or a bug report.

Closes #52.
