### PR TITLE
collectors: send device_name, and stop failing silently on a missing …

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ it works with everything downstream:
   "os": "macos",
   "account_domain": "gmail.com",
   "device": "SERIAL123",
+  "device_name": "ASK-SERIAL123",
   "user": "aman.test",
   "evidence": "~/.claude.json",
   "severity": "warn",
@@ -165,6 +166,12 @@ it works with everything downstream:
 domains, `info` otherwise. The `user` field carries an account name so a
 finding can be followed up with the right person; see
 [privacy](docs/deployment-privacy.md) for exactly when it is populated.
+
+`device` carries the most stable identifier the source could get, usually a
+hardware serial, because that is what Jamf, Intune, SentinelOne and most RMMs
+key on. `device_name` carries the hostname, which is what a human recognises
+and what a platform with no serial can still join on. Dashboards prefer
+`device_name` and fall back to `device`.
 
 ## What you need
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,6 +131,7 @@ enforcement, and it rides the same pipeline.
   "os": "linux",
   "account_domain": "gmail.com",
   "device": "SERIAL123",
+  "device_name": "ASK-SERIAL123",
   "user": "jane.doe",
   "evidence": "~/.claude.json",
   "severity": "warn",

--- a/endpoint/linux/ai-guard-collector.sh
+++ b/endpoint/linux/ai-guard-collector.sh
@@ -93,14 +93,27 @@ fi
 # keeps it to one subshell for the whole run.
 HOME_REAL=$(cd "$HOME_DIR" 2>/dev/null && pwd -P) || HOME_REAL="$HOME_DIR"
 
-# Stable device identifier. Prefer the DMI product serial (root can read it),
-# fall back to machine-id, then hostname. Never blank.
+# device carries the most stable identifier available: the DMI product serial
+# (root can read it), then machine-id, then hostname. That is what Jamf,
+# Intune, SentinelOne and most RMMs key on. device_name carries the hostname,
+# which is what a human recognises and what platforms with no serial can join
+# on. The dashboard prefers device_name and falls back to device, so a
+# collector sending only the serial shows a serial where scanners show a name.
+DEVICE_NAME=$(hostname 2>/dev/null || echo "")
+
 DEVICE=""
 if [ -r /sys/class/dmi/id/product_serial ]; then
   DEVICE=$(tr -d ' \n' < /sys/class/dmi/id/product_serial 2>/dev/null)
 fi
 [ -z "$DEVICE" ] && [ -r /etc/machine-id ] && DEVICE=$(cat /etc/machine-id 2>/dev/null)
-[ -z "$DEVICE" ] && DEVICE=$(hostname)
+# Said out loud. Falling back to the hostname changes what every finding from
+# this machine is keyed on, and a hostname is mutable where a serial is not.
+# Silence would make it indistinguishable from a machine that reported a real
+# serial, which is how one device becomes two on a dashboard that groups by it.
+if [ -z "$DEVICE" ]; then
+  echo "[ai-guard] no DMI serial or machine-id readable, using hostname for device"
+  DEVICE="$DEVICE_NAME"
+fi
 
 # --------------------------------------------------------------- helpers ---
 # domain_of <email> - strip local-part, lowercase. Never reports local-part.
@@ -254,9 +267,10 @@ report() {
   # severity and reported_at are generated here, so they need no escaping.
   # Everything else came from the registry, the machine or a config file.
   local payload
-  payload=$(printf '{"tool":"%s","surface":"%s","os":"linux","account_domain":"%s","device":"%s","user":"%s","evidence":"%s","severity":"%s","reported_at":"%s","source":"collector-linux"}' \
+  payload=$(printf '{"tool":"%s","surface":"%s","os":"linux","account_domain":"%s","device":"%s","device_name":"%s","user":"%s","evidence":"%s","severity":"%s","reported_at":"%s","source":"collector-linux"}' \
     "$(json_escape "$tool")" "$(json_escape "$surface")" "$(json_escape "$acct")" \
-    "$(json_escape "$DEVICE")" "$(json_escape "$CONSOLE_USER")" "$(json_escape "$evidence")" \
+    "$(json_escape "$DEVICE")" "$(json_escape "$DEVICE_NAME")" \
+    "$(json_escape "$CONSOLE_USER")" "$(json_escape "$evidence")" \
     "$severity" "$NOW")
   if [ -z "$ENDPOINT" ]; then
     echo "[ai-guard] FLAG (no endpoint set): $payload"

--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -80,6 +80,22 @@ HOME_DIR=$(/usr/bin/dscl . -read "/Users/$CONSOLE_USER" NFSHomeDirectory 2>/dev/
 HOME_REAL=$(cd "$HOME_DIR" 2>/dev/null && pwd -P) || HOME_REAL="$HOME_DIR"
 
 SERIAL=$(/usr/sbin/ioreg -rd1 -c IOPlatformExpertDevice | /usr/bin/awk -F'"' '/IOPlatformSerialNumber/{print $4}')
+
+# device carries the serial: immutable, and what Jamf, Intune, SentinelOne and
+# most RMMs key on. device_name carries the hostname, which is what a human
+# recognises and what platforms that have no serial can still join on. The
+# dashboard prefers device_name and falls back to device, so a collector that
+# sends only the serial shows a serial where the scanners show a name.
+DEVICE_NAME=$(/usr/sbin/scutil --get ComputerName 2>/dev/null || /bin/hostname -s 2>/dev/null || echo "")
+
+# Said out loud, because an empty serial changes what every finding from this
+# machine is keyed on. Silence here would look identical to a machine with no
+# AI tools on it.
+if [ -z "$SERIAL" ]; then
+  echo "[ai-guard] serial lookup failed via ioreg, falling back to hostname for device"
+  SERIAL="$DEVICE_NAME"
+fi
+
 NOW=$(/bin/date -u +%Y-%m-%dT%H:%M:%SZ)
 
 # ---------------------------------------------------------------- helpers ---
@@ -179,9 +195,10 @@ report() {
   # severity and reported_at are generated here, so they need no escaping.
   # Everything else came from the registry, the machine or a config file.
   local payload
-  payload=$(/usr/bin/printf '{"tool":"%s","surface":"%s","os":"macos","account_domain":"%s","device":"%s","user":"%s","evidence":"%s","severity":"%s","reported_at":"%s"}' \
+  payload=$(/usr/bin/printf '{"tool":"%s","surface":"%s","os":"macos","account_domain":"%s","device":"%s","device_name":"%s","user":"%s","evidence":"%s","severity":"%s","reported_at":"%s"}' \
     "$(json_escape "$tool")" "$(json_escape "$surface")" "$(json_escape "$acct")" \
-    "$(json_escape "$SERIAL")" "$(json_escape "$CONSOLE_USER")" "$(json_escape "$evidence")" \
+    "$(json_escape "$SERIAL")" "$(json_escape "$DEVICE_NAME")" \
+    "$(json_escape "$CONSOLE_USER")" "$(json_escape "$evidence")" \
     "$severity" "$NOW")
 
   local delivered=false

--- a/endpoint/windows/ai-guard-collector.ps1
+++ b/endpoint/windows/ai-guard-collector.ps1
@@ -89,6 +89,13 @@ if (-not $Console) {
 $UserHome = $Console.Home
 $ConsoleUser = $Console.User
 
+# device carries the serial: immutable, and what Jamf, Intune, SentinelOne and
+# most RMMs key on. device_name carries the hostname, which is what a human
+# recognises and what platforms with no serial can still join on. The dashboard
+# prefers device_name and falls back to device, so a collector that sends only
+# the serial shows a serial where the scanners show a name.
+$DeviceName = $env:COMPUTERNAME
+
 $Serial = ''
 try {
     $Serial = (Get-CimInstance Win32_BIOS -ErrorAction Stop).SerialNumber.Trim()
@@ -100,7 +107,7 @@ try {
     # that groups by device.
     Write-Output "ai-guard: serial lookup failed ($($_.Exception.Message)), using COMPUTERNAME"
 }
-if (-not $Serial) { $Serial = $env:COMPUTERNAME }
+if (-not $Serial) { $Serial = $DeviceName }
 
 $Now = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')
 $NowEpoch = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
@@ -209,7 +216,8 @@ function Send-Finding {
 
     $payload = @{
         tool = $Tool; surface = $Surface; os = 'windows'
-        account_domain = $Account; device = $Serial; user = $ConsoleUser
+        account_domain = $Account; device = $Serial; device_name = $DeviceName
+        user = $ConsoleUser
         evidence = $Evidence; severity = $severity; reported_at = $Now
         source = 'collector-windows'
     } | ConvertTo-Json -Compress


### PR DESCRIPTION
…serial

device_name has been in the receiver model and the dashboard since 0.1.4, populated by the SentinelOne scanner, which knows hostnames. None of the three endpoint collectors sent it. The dashboard renders device_name and falls back to device, so scanner findings showed a hostname and collector findings from the same machine showed a serial. On a real fleet that reads as inconsistent data rather than two sources with different enrichment.

All three collectors now send both: device carries the most stable identifier available, usually a hardware serial, because that is what Jamf, Intune, SentinelOne and most RMMs key on; device_name carries the hostname, which is what a human recognises and what a platform with no serial can still join on. Neither is a schema change: the receiver has accepted device_name for six releases.

Also fixes a silent failure on macOS. If ioreg returned no serial the collector sent an empty device and said nothing, which is indistinguishable from a machine with no AI tools on it. It now logs and falls back to the hostname, matching what Windows already did. The Linux hostname fallback now logs too: falling back changes what every finding from that machine is keyed on, and a hostname is mutable where a serial is not, so one device can become two on any dashboard that groups by it.

The finding schema in README.md and docs/architecture.md documented device but not device_name at all, which predates this change. Both now carry it and say why the two differ.

Ten delivery-state tests pass against the changed Linux collector on amd64 and arm64.