### PR TITLE
collectors: macOS was not sending source

### DIFF
--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -195,7 +195,7 @@ report() {
   # severity and reported_at are generated here, so they need no escaping.
   # Everything else came from the registry, the machine or a config file.
   local payload
-  payload=$(/usr/bin/printf '{"tool":"%s","surface":"%s","os":"macos","account_domain":"%s","device":"%s","device_name":"%s","user":"%s","evidence":"%s","severity":"%s","reported_at":"%s"}' \
+  payload=$(/usr/bin/printf '{"tool":"%s","surface":"%s","os":"macos","account_domain":"%s","device":"%s","device_name":"%s","user":"%s","evidence":"%s","severity":"%s","reported_at":"%s","source":"collector-macos"}' \
     "$(json_escape "$tool")" "$(json_escape "$surface")" "$(json_escape "$acct")" \
     "$(json_escape "$SERIAL")" "$(json_escape "$DEVICE_NAME")" \
     "$(json_escape "$CONSOLE_USER")" "$(json_escape "$evidence")" \


### PR DESCRIPTION
Linux sends collector-linux and Windows sends collector-windows. macOS sent nothing, so the receiver applied its empty-string default. On one live fleet that is four figures of findings in a week with no way to tell what produced them.

source is how a consumer separates an endpoint collector's finding from a scanner's when both carry a device, and therefore which lookup resolves a person from that device. The dashboard mostly gets by on surface instead, which is why this went unnoticed.

The finding schema in README.md has documented macOS as sending collector-macos since it was written. This makes that true rather than requiring the doc to be corrected.

Found by querying findings with an empty source while checking whether the schema supports a device-keyed entity model. The other 6,389 are the browser extension, which predates both source and os; that needs an extension release rather than a script change and is not in scope here.
