### PR TITLE
charts: appVersion was a release behind, and nothing looked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # The chart-version check diffs against the base branch, which needs
+          # more than the default single commit.
+          fetch-depth: 0
       - name: ensure helm
         run: |
           if command -v helm >/dev/null 2>&1; then
@@ -225,6 +229,44 @@ jobs:
             tar xzf "helm-${V}-linux-amd64.tar.gz"
             sudo install linux-amd64/helm /usr/local/bin/helm
           fi
+      # appVersion decides which image tag a default `helm install` pulls, so
+      # a stale one deploys the wrong thing while reporting success. It sat at
+      # 0.2.0 through the 0.3.0 release because nothing looked at it.
+      #
+      # Only enforced on a tag build: on main it is normal for the chart to
+      # name the release being prepared rather than the last one cut.
+      - name: appVersion matches the tag being released
+        if: github.ref_type == 'tag'
+        run: |
+          want="${GITHUB_REF_NAME#v}"
+          have=$(grep -E '^appVersion:' charts/ai-guard/Chart.yaml \
+                 | sed -E 's/^appVersion:[[:space:]]*"?([^"]+)"?/\1/')
+          if [ "$have" != "$want" ]; then
+            echo "::error::charts/ai-guard/Chart.yaml appVersion is $have but the tag is $want."
+            echo "A default helm install would deploy $have while the release claims $want."
+            exit 1
+          fi
+          echo "appVersion $have matches tag $want."
+
+      # A chart change with an unchanged version is a change nobody is offered:
+      # a repo index compares this field to decide whether an upgrade exists.
+      - name: the chart version moved if the chart did
+        if: github.event_name == 'pull_request'
+        run: |
+          if ! git diff --quiet origin/${{ github.base_ref }} HEAD -- charts/; then
+            base=$(git show origin/${{ github.base_ref }}:charts/ai-guard/Chart.yaml \
+                   | grep -E '^version:' | awk '{print $2}')
+            head=$(grep -E '^version:' charts/ai-guard/Chart.yaml | awk '{print $2}')
+            if [ "$base" = "$head" ]; then
+              echo "::error::charts/ changed but Chart.yaml version is still $head."
+              echo "Bump it, or a repo index will not offer the change as an upgrade."
+              exit 1
+            fi
+            echo "chart changed, version moved $base -> $head."
+          else
+            echo "charts/ unchanged."
+          fi
+
       - name: lint and render the chart
         run: |
           helm lint charts/ai-guard

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.2.0
+version: 0.1.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -2,8 +2,18 @@ apiVersion: v2
 name: ai-guard
 description: Receiver for shadow-ai-guard, the AI tool detection platform
 type: application
-version: 0.1.0
-appVersion: "0.2.0"
+# The chart's own version. Bump it whenever anything under charts/ changes,
+# independently of appVersion: a repo index uses this to decide whether an
+# upgrade exists, so a chart change that leaves it alone is a change nobody
+# is offered.
+version: 0.2.0
+# The application version this chart installs by default. values.yaml derives
+# image.tag from it, so this IS what gets pulled unless someone overrides it.
+#
+# It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
+# install` quietly deployed a receiver a full release behind what the tag
+# claimed. CI now fails a tag build if this and the tag disagree.
+appVersion: "0.4.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.1.0
+version: 0.2.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/README.md
+++ b/charts/ai-guard/README.md
@@ -22,6 +22,27 @@ kubectl get secret ai-guard -o jsonpath='{.data.authToken}' | base64 -d; echo
 Then import `dashboards/ai-guard.json` into Grafana and roll out one
 collector. See [../../docs/getting-started.md](../../docs/getting-started.md).
 
+## Versions
+
+Three numbers exist and they mean different things. They drifted once because
+nothing said which was which, so:
+
+| where | what it is |
+|---|---|
+| the git tag, e.g. `v0.4.0` | the release. What CI publishes images under. |
+| `Chart.yaml` `appVersion` | the release this chart installs. `image.tag` defaults to it, so **this is what gets pulled**. CI fails a tag build if it disagrees with the tag. |
+| `Chart.yaml` `version` | the chart's own version. Bump it whenever anything under `charts/` changes: a repo index compares it to decide whether an upgrade exists. |
+| the receiver's `/healthz` version | the receiver component's own number, maintained independently of the release. Useful for telling two builds apart; not a release version. |
+
+`appVersion` sat at `0.2.0` through the `0.3.0` release, so a default
+`helm install` deployed a receiver a full release behind while reporting
+success. That is why CI checks it now.
+
+The portal is not in this chart yet. The Kubernetes route deploys the receiver;
+the portal is available on the Docker Compose route
+([../../deploy/compose/README.md](../../deploy/compose/README.md)) and is
+optional either way.
+
 ## Values
 
 | key | default | what it does |


### PR DESCRIPTION
Chart.yaml had one commit, from when the chart was written, and appVersion sat at 0.2.0 through the 0.3.0 release. values.yaml derives image.tag from appVersion, so a default helm install deployed a receiver a full release behind while reporting success. Nobody would notice: the install works, the receiver runs, it is just older code than the release claims.

appVersion now names the release being prepared, and CI fails a tag build if the two disagree. The chart's own version moves too, and CI fails a PR that changes anything under charts/ without moving it, because a repo index compares that field to decide whether an upgrade exists - a chart change that leaves it alone is a change nobody is offered.

The chart README gains a table of the four version numbers in play and what each one means. They drifted because nothing said which was which: the git tag is the release, appVersion is what gets pulled, the chart version is the packaging, and the receiver's own number on /healthz is a component version rather than a release.

Also states that the portal is not in this chart. The Kubernetes route deploys the receiver; the portal is on the compose route. Better said than discovered.