### PR TITLE
charts: deploy the portal alongside the receiver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,14 +270,21 @@ jobs:
       - name: lint and render the chart
         run: |
           helm lint charts/ai-guard
-          # Render both shapes: the default, and with an ingress, since the
-          # ingress template is the only conditional block of any size.
+          # Render every shape with a conditional block of any size: the
+          # default, the receiver ingress, the portal turned off, the portal
+          # with its own ingress, and the portal with authentication disabled.
           #
           # helm renders an undefined value as the string <no value> and exits
           # zero, so a missing default reaches the cluster as a manifest that
           # is valid YAML and wrong. Grep for it rather than trust the exit
           # code.
-          for args in "" "--set ingress.enabled=true"; do
+          for args in "" \
+                      "--set ingress.enabled=true" \
+                      "--set portal.enabled=false" \
+                      "--set portal.ingress.enabled=true --set portal.lokiUrl=http://loki:3100" \
+                      "--set portal.auth.mode=none" \
+                      "--set portal.identityMap.existingConfigMap=my-map" \
+                      "--set portal.grafana.url=https://grafana.example.com --set portal.grafana.panels=a:1:B"; do
             # shellcheck disable=SC2086
             rendered=$(helm template ai-guard charts/ai-guard $args)
             if grep -q '<no value>' <<<"$rendered"; then

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.2.0
+version: 0.3.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/README.md
+++ b/charts/ai-guard/README.md
@@ -38,10 +38,42 @@ nothing said which was which, so:
 `helm install` deployed a receiver a full release behind while reporting
 success. That is why CI checks it now.
 
-The portal is not in this chart yet. The Kubernetes route deploys the receiver;
-the portal is available on the Docker Compose route
-([../../deploy/compose/README.md](../../deploy/compose/README.md)) and is
-optional either way.
+## The portal
+
+Enabled by default. Deploying the receiver should give you somewhere to look at
+what it collected, rather than a service with no face until you find a second
+document.
+
+It needs one thing set:
+
+    --set portal.lokiUrl=http://loki.monitoring.svc.cluster.local:3100
+
+That is the **base** URL, not the push endpoint - the portal appends its own
+query path, unlike `loki.pushUrl` which the receiver POSTs to verbatim.
+
+The portal refuses to start without authentication, because it names who runs
+what on which machine. The chart generates a password on first install and
+keeps it across upgrades, the same way it handles the bearer token:
+
+    kubectl get secret <release>-ai-guard-portal \
+      -o jsonpath='{.data.password}' | base64 -d; echo
+
+Basic auth is one shared credential with no per-user trail. If your ingress can
+do OIDC or mTLS, do it there and set `portal.auth.mode=none` behind it - that
+logs a warning on every start, so an unauthenticated deployment is never
+something nobody noticed.
+
+`portal.enabled=false` if you only want the receiver.
+
+**Upgrading from a release before 0.4.0:** the portal appears as a new
+Deployment with a generated password. It is additive - nothing about the
+receiver changes - and its ingress is off by default, so nothing new is exposed
+until you decide to expose it.
+
+The portal uses its own `app.kubernetes.io/name` rather than a component label
+on the shared one. A Deployment's selector is immutable, so adding a label to
+the receiver's selector would fail every upgrade from a release that predates
+the portal.
 
 ## Values
 

--- a/charts/ai-guard/templates/NOTES.txt
+++ b/charts/ai-guard/templates/NOTES.txt
@@ -27,5 +27,39 @@ Read the bearer token every source authenticates with:
   kubectl -n {{ .Release.Namespace }} get secret {{ include "ai-guard.secretName" . }} \
     -o jsonpath='{.data.authToken}' | base64 -d; echo
 
-Next: import dashboards/ai-guard.json into Grafana, then roll out one
-collector (docs/getting-started.md step 3).
+{{- if .Values.portal.enabled }}
+
+The portal is deployed too: devices, tools, people, and which of your sources
+are reporting versus silent.
+{{- if .Values.portal.ingress.enabled }}
+
+  Portal: https://{{ .Values.portal.ingress.host }}
+{{- else }}
+
+  No ingress on the portal. Port-forward to reach it:
+
+    kubectl -n {{ .Release.Namespace }} port-forward svc/{{ include "ai-guard.portal.fullname" . }} 8091:{{ .Values.portal.service.port }}
+{{- end }}
+{{- if eq .Values.portal.auth.mode "none" }}
+
+  It is running WITHOUT AUTHENTICATION (portal.auth.mode=none). It shows which
+  people use which AI tools on which machines. Correct behind something that
+  authenticates for it; wrong on anything reachable.
+{{- else }}
+
+  Log in as {{ .Values.portal.auth.username }}. Read the password:
+
+    kubectl -n {{ .Release.Namespace }} get secret {{ include "ai-guard.portal.secretName" . }} \
+      -o jsonpath='{.data.password}' | base64 -d; echo
+
+  Basic auth is one shared credential with no per-user trail. If your ingress
+  can do OIDC or mTLS, do it there and set portal.auth.mode=none behind it.
+{{- end }}
+
+  It opens on a setup view showing which sources are reporting and what each
+  silent one needs. Right now that is almost all of them, which is the honest
+  picture rather than a broken one.
+{{- end }}
+
+Next: roll out one collector (docs/getting-started.md), then import
+dashboards/ai-guard.json into Grafana if you want the time-series view too.

--- a/charts/ai-guard/templates/_helpers.tpl
+++ b/charts/ai-guard/templates/_helpers.tpl
@@ -41,3 +41,40 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- printf "%s-registry" (include "ai-guard.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+  The portal gets its own name rather than a component label on the shared
+  one. A Deployment's selector is immutable, so adding a label to the
+  receiver's selector would fail every upgrade from a release that predates
+  the portal with "field is immutable". A distinct name keeps the receiver
+  untouched and keeps its Service from matching portal pods.
+*/}}
+{{- define "ai-guard.portal.name" -}}
+{{- printf "%s-portal" (include "ai-guard.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ai-guard.portal.fullname" -}}
+{{- printf "%s-portal" (include "ai-guard.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "ai-guard.portal.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ai-guard.portal.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "ai-guard.portal.labels" -}}
+{{ include "ai-guard.portal.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/component: portal
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version }}
+{{- end -}}
+
+{{/* Name of the Secret holding the portal's basic auth password. */}}
+{{- define "ai-guard.portal.secretName" -}}
+{{- if .Values.portal.auth.existingSecret -}}
+{{- .Values.portal.auth.existingSecret -}}
+{{- else -}}
+{{- include "ai-guard.portal.fullname" . -}}
+{{- end -}}
+{{- end -}}

--- a/charts/ai-guard/templates/portal-deployment.yaml
+++ b/charts/ai-guard/templates/portal-deployment.yaml
@@ -1,0 +1,124 @@
+{{- if .Values.portal.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ai-guard.portal.fullname" . }}
+  labels:
+    {{- include "ai-guard.portal.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.portal.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ai-guard.portal.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ai-guard.portal.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: portal
+          image: "{{ .Values.portal.image.repository }}{{ if .Values.portal.image.digest }}@{{ .Values.portal.image.digest }}{{ else }}:{{ .Values.portal.image.tag | default .Chart.AppVersion }}{{ end }}"
+          imagePullPolicy: {{ .Values.portal.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: 8091
+          env:
+            # Not enforced at template time. The portal starts without it and
+            # says what is missing, which is how the rest of it behaves: its
+            # setup view exists precisely to tell an operator what is not
+            # configured yet. A template that refuses to render is a worse
+            # version of the same message, delivered before anyone can see it.
+            - name: LOKI_URL
+              value: {{ .Values.portal.lokiUrl | quote }}
+            {{- if eq .Values.portal.auth.mode "none" }}
+            # Deliberate, and it logs a warning on every start. Correct behind
+            # something that authenticates for it; wrong on anything reachable.
+            - name: PORTAL_AUTH
+              value: "none"
+            {{- else }}
+            - name: PORTAL_USER
+              value: {{ .Values.portal.auth.username | quote }}
+            - name: PORTAL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "ai-guard.portal.secretName" . }}
+                  key: password
+            {{- end }}
+            - name: REGISTRY_PATH
+              value: /etc/ai-guard/registry.json
+            - name: LOOKBACK_HOURS
+              value: {{ .Values.portal.lookbackHours | quote }}
+            - name: CACHE_TTL_SECONDS
+              value: {{ .Values.portal.cacheTtlSeconds | quote }}
+            {{- with .Values.portal.identityMap.existingConfigMap }}
+            - name: IDENTITY_MAP
+              value: /etc/ai-guard-identity/identity-map.csv
+            {{- end }}
+            {{- with .Values.portal.grafana.url }}
+            - name: GRAFANA_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.portal.grafana.panels }}
+            - name: GRAFANA_PANELS
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.portal.grafana.dashboardUid }}
+            - name: GRAFANA_DASHBOARD_UID
+              value: {{ . | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: registry
+              mountPath: /etc/ai-guard
+              readOnly: true
+            {{- with .Values.portal.identityMap.existingConfigMap }}
+            - name: identity-map
+              mountPath: /etc/ai-guard-identity
+              readOnly: true
+            {{- end }}
+            - name: tmp
+              mountPath: /tmp
+          readinessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            httpGet: { path: /healthz, port: http }
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.portal.resources | nindent 12 }}
+      volumes:
+        - name: registry
+          configMap:
+            name: {{ include "ai-guard.registryConfigMap" . }}
+        {{- with .Values.portal.identityMap.existingConfigMap }}
+        # Maps named people to the machines they use. Personal data: a Secret
+        # is a defensible choice here too, and the portal only reads it.
+        - name: identity-map
+          configMap:
+            name: {{ . }}
+        {{- end }}
+        - name: tmp
+          emptyDir: {}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/ai-guard/templates/portal-ingress.yaml
+++ b/charts/ai-guard/templates/portal-ingress.yaml
@@ -1,0 +1,33 @@
+{{- if and .Values.portal.enabled .Values.portal.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "ai-guard.portal.fullname" . }}
+  labels:
+    {{- include "ai-guard.portal.labels" . | nindent 4 }}
+  {{- with .Values.portal.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.portal.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.portal.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "ai-guard.portal.fullname" . }}
+                port:
+                  number: {{ .Values.portal.service.port }}
+  {{- if .Values.portal.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ .Values.portal.ingress.host | quote }}
+      secretName: {{ .Values.portal.ingress.tls.secretName }}
+  {{- end }}
+{{- end }}

--- a/charts/ai-guard/templates/portal-secret.yaml
+++ b/charts/ai-guard/templates/portal-secret.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.portal.enabled (not .Values.portal.auth.existingSecret) }}
+{{/*
+  Same precedence as the bearer token: an explicit value wins; otherwise reuse
+  what is already in the cluster so an upgrade does not lock the operator out
+  of a portal they were using; otherwise generate one.
+
+  The portal refuses to start without a password, so generating one matters
+  more here than convenience: without it, enabling the portal would add a
+  workload that crash-loops until someone reads the logs to find out why.
+*/}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (include "ai-guard.portal.fullname" .) -}}
+{{- $password := "" -}}
+{{- if .Values.portal.auth.password -}}
+{{- $password = .Values.portal.auth.password -}}
+{{- else if and $existing $existing.data.password -}}
+{{- $password = ($existing.data.password | b64dec) -}}
+{{- else -}}
+{{- $password = randAlphaNum 32 -}}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ai-guard.portal.fullname" . }}
+  labels:
+    {{- include "ai-guard.portal.labels" . | nindent 4 }}
+type: Opaque
+data:
+  password: {{ $password | b64enc | quote }}
+{{- end }}

--- a/charts/ai-guard/templates/portal-service.yaml
+++ b/charts/ai-guard/templates/portal-service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.portal.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-guard.portal.fullname" . }}
+  labels:
+    {{- include "ai-guard.portal.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.portal.service.type }}
+  selector:
+    {{- include "ai-guard.portal.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.portal.service.port }}
+      targetPort: http
+{{- end }}

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -64,6 +64,109 @@ ingress:
   # a short name like "ai-guard": the operator issues the cert and serves it
   # at https://ai-guard.<tailnet>.ts.net.
 
+# ---------------------------------------------------------------- portal ----
+#
+# A governance view over the findings the receiver already collects: which
+# tools a device has, which devices a person uses, which of your sources are
+# reporting and which are silent. It reads and never writes, holds no
+# database, and is not in the ingest path, so it can be removed at any time
+# and collection carries on.
+#
+# On by default: deploying the receiver should give you somewhere to look at
+# what it collected. Set enabled: false if you only want the receiver.
+portal:
+  enabled: true
+
+  image:
+    repository: ghcr.io/amansk5/shadow-ai-guard/portal
+    tag: ""          # defaults to the chart's appVersion
+    digest: ""
+    pullPolicy: IfNotPresent
+
+  replicaCount: 1
+
+  # Where the portal reads findings back from: the same log store the receiver
+  # writes to, reachable from inside the cluster. Leave it empty and the portal
+  # still starts and tells you it is missing, rather than failing to install.
+  # This is the BASE url; the portal appends its own query path, unlike
+  # loki.pushUrl above which is the full push endpoint.
+  #   e.g. http://loki.monitoring.svc.cluster.local:3100
+  lokiUrl: ""
+
+  # The portal names who runs what on which machine, so it refuses to start
+  # without authentication.
+  #
+  #   mode: basic   username plus a password, generated if you do not set one
+  #   mode: none    no authentication. Correct behind a proxy or a mesh that
+  #                 authenticates for it; wrong on anything reachable. Logs a
+  #                 warning on every start.
+  #
+  # Basic auth is one shared credential with no per-user trail. If your
+  # ingress can do OIDC or mTLS, do it there and set mode: none.
+  #
+  # Leave password unset and the chart generates one on first install and
+  # keeps it across upgrades. Read it back with:
+  #   kubectl get secret <release>-ai-guard-portal -o jsonpath='{.data.password}' | base64 -d
+  auth:
+    mode: basic
+    username: admin
+    password: ""
+    existingSecret: ""     # a Secret you created yourself, with key `password`
+
+  # How far back it looks, and how long a derived graph is reused. The cache
+  # stops a seven-day query being rerun on every page load; it is not state,
+  # since it rebuilds on restart.
+  lookbackHours: 168
+  cacheTtlSeconds: 300
+
+  # Optional. A ConfigMap with key identity-map.csv, mapping people to the
+  # machines they use, where the key is a device identifier or a local
+  # username. The portal proposes one at /api/suggest-identities?fmt=csv and
+  # will not apply it: these are string matches, and a mapping the platform
+  # invented and then acted on is how the wrong name lands on a report.
+  #
+  # This is personal data. A Secret is a defensible choice instead.
+  identityMap:
+    existingConfigMap: ""
+
+  # Optional. Embeds Grafana panels on the portal's dashboard tab.
+  #
+  # Grafana refuses to be framed by default, deliberately: framing a session
+  # someone is logged into is how clickjacking works. It needs
+  # allow_embedding, a cookie SameSite that permits the frame, and a decision
+  # about how the frame authenticates. url is the URL a BROWSER reaches
+  # Grafana on, not one resolvable inside the cluster.
+  grafana:
+    url: ""
+    # dashboardUid:panelId:Title, semicolon separated. Semicolons because
+    # panel titles contain commas.
+    panels: ""
+    # Or embed a whole dashboard in one frame, which needs no panel ids.
+    dashboardUid: ""
+
+  service:
+    type: ClusterIP
+    port: 8091
+
+  # Unlike the receiver, nothing has to reach the portal except people. Leave
+  # this off and reach it with kubectl port-forward until you have decided how
+  # it should be exposed and authenticated.
+  ingress:
+    enabled: false
+    className: ""
+    host: ai-guard-portal.example.com
+    annotations: {}
+    tls:
+      enabled: true
+      secretName: ai-guard-portal-tls
+
+  resources:
+    requests:
+      cpu: 50m
+      memory: 96Mi
+    limits:
+      memory: 256Mi
+
 # The receiver never calls the Kubernetes API, so it has no use for a
 # ServiceAccount token. Mounting one anyway hands a credential to anything
 # that gets code execution in the pod.


### PR DESCRIPTION
The compose route shipped the portal and the chart did not, so the two deployment routes were not the same product. Enabled by default: deploying the receiver should give you somewhere to look at what it collected, rather than a service with no face until you find a second document. portal.enabled=false if you only want the receiver.

The portal refuses to start without authentication, so the chart generates a password on first install and keeps it across upgrades, the same way it handles the bearer token, and NOTES.txt prints the command to read it. Without that, enabling it by default would add a workload that crash-loops until someone dug through logs to learn it needed a credential.

The portal uses its own app.kubernetes.io/name rather than a component label on the shared one. A Deployment's selector is immutable, so adding a label to the receiver's selector would fail every upgrade from a release that predates the portal, and a shared selector would have the receiver's Service matching portal pods.

Its ingress is off by default. Nothing has to reach the portal except people, and an upgrade that exposes a new authenticated web service without anyone choosing to is the kind of surprise that erodes trust in a chart.

The CI render matrix goes from two shapes to seven, covering every conditional block in the new templates: portal off, portal ingress, auth disabled, identity map mounted, Grafana panels set. The first version used a required guard on portal.lokiUrl, which would have failed the helm job on a correct chart since it renders with defaults, and was the wrong behaviour anyway - the portal starts without a log store and says what is missing, which is what its setup view is for.

Chart version 0.2.0 to 0.3.0. These templates were checked statically but never rendered: helm would not install in the environment they were written in, so the helm job is the first real validation.