### PR TITLE
receiver, portal: report the version they were built from

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -329,8 +329,10 @@ jobs:
       # is the same either way.
       - name: build the images this commit would publish
         run: |
-          docker build -t ghcr.io/amansk5/shadow-ai-guard/receiver:ci receiver
-          docker build -t ghcr.io/amansk5/shadow-ai-guard/portal:ci portal
+          docker build --build-arg APP_VERSION=ci-test \
+            -t ghcr.io/amansk5/shadow-ai-guard/receiver:ci receiver
+          docker build --build-arg APP_VERSION=ci-test \
+            -t ghcr.io/amansk5/shadow-ai-guard/portal:ci portal
 
       - name: set up secrets and config the way the README says
         working-directory: deploy/compose
@@ -376,6 +378,15 @@ jobs:
             echo "::error::the receiver never became reachable"
             docker compose --profile with-logs ps -a
             docker compose --profile with-logs logs
+            exit 1
+          fi
+          # The build arg has to actually reach the running process. A version
+          # that silently falls back to "dev" in every published image is
+          # exactly the drift this replaced.
+          echo
+          if ! curl -fsS http://127.0.0.1:8080/healthz | grep -q '"version":"ci-test"'; then
+            echo "::error::the receiver did not report the version it was built with"
+            curl -fsS http://127.0.0.1:8080/healthz
             exit 1
           fi
 
@@ -702,6 +713,23 @@ jobs:
       # requirements.lock already carries the aarch64 wheel hashes:
       # pip-compile --generate-hashes records every distribution for a
       # version, not just the one the build host happens to need.
+      # The version the image reports on /healthz. A tag build says the
+      # release; a build off main says the commit, because "0.4.0" on a
+      # main build would claim to be a release it is not.
+      #
+      # This used to be a hardcoded constant in the source, and it drifted:
+      # the receiver reported 0.1.6 while the release was 0.4.0, so the one
+      # endpoint an operator checks to answer "am I running what I think I
+      # am" answered a different question.
+      - name: the version this image will report
+        id: appversion
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=main-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         if: steps.gate.outputs.build == 'true'
         with:
@@ -709,6 +737,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}
+          build-args: |
+            APP_VERSION=${{ steps.appversion.outputs.value }}
 
       - name: confirm the manifest carries both architectures
         if: steps.gate.outputs.build == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,10 +250,17 @@ jobs:
 
       # A chart change with an unchanged version is a change nobody is offered:
       # a repo index compares this field to decide whether an upgrade exists.
+      #
+      # README excluded. It is not in what a repo index compares and not in
+      # what gets installed, so a corrected sentence is not an upgrade. The
+      # first version of this check fired on a one-line documentation fix,
+      # and a guard that fires on prose gets bypassed rather than obeyed -
+      # bump-the-version-to-quiet-CI becomes the reflex, and then it is not
+      # guarding anything.
       - name: the chart version moved if the chart did
         if: github.event_name == 'pull_request'
         run: |
-          if ! git diff --quiet origin/${{ github.base_ref }} HEAD -- charts/; then
+          if ! git diff --quiet origin/${{ github.base_ref }} HEAD -- charts/ ':!charts/**/README.md'; then
             base=$(git show origin/${{ github.base_ref }}:charts/ai-guard/Chart.yaml \
                    | grep -E '^version:' | awk '{print $2}')
             head=$(grep -E '^version:' charts/ai-guard/Chart.yaml | awk '{print $2}')

--- a/charts/ai-guard/README.md
+++ b/charts/ai-guard/README.md
@@ -32,7 +32,7 @@ nothing said which was which, so:
 | the git tag, e.g. `v0.4.0` | the release. What CI publishes images under. |
 | `Chart.yaml` `appVersion` | the release this chart installs. `image.tag` defaults to it, so **this is what gets pulled**. CI fails a tag build if it disagrees with the tag. |
 | `Chart.yaml` `version` | the chart's own version. Bump it whenever anything under `charts/` changes: a repo index compares it to decide whether an upgrade exists. |
-| the receiver's `/healthz` version | the receiver component's own number, maintained independently of the release. Useful for telling two builds apart; not a release version. |
+| `/healthz` version | what the image was built from: the release on a tag build, `main-<sha>` on a build off main, `dev` on a local one. Set at build time, so it cannot drift from what is running. |
 
 `appVersion` sat at `0.2.0` through the `0.3.0` release, so a default
 `helm install` deployed a receiver a full release behind while reporting

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -3,6 +3,13 @@ WORKDIR /srv
 COPY requirements.lock .
 RUN pip install --no-cache-dir --require-hashes -r requirements.lock
 COPY app/ app/
+
+# Passed by CI from the release tag, or the commit for a build off main. A
+# local build leaves it as "dev", which is honest: a hardcoded version drifts,
+# and /healthz is the one place an operator looks to answer "am I running what
+# I think I am".
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 EXPOSE 8091
 USER 65532:65532
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8091"]

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -157,7 +157,12 @@ CACHE_TTL = int(os.environ.get("CACHE_TTL_SECONDS", "300"))
 
 STATIC = Path(__file__).parent / "static"
 
-app = FastAPI(title="ai-guard portal", docs_url=None, redoc_url=None)
+# Set at build time from the release tag, or the commit for a build off main.
+# "dev" for a local build, which is honest.
+APP_VERSION = os.environ.get("APP_VERSION", "dev")
+
+app = FastAPI(title="ai-guard portal", version=APP_VERSION,
+              docs_url=None, redoc_url=None)
 
 # A derived graph, kept briefly. Not state in any meaningful sense: it rebuilds
 # from Loki on the next miss and on every restart. Without it, a 7 day query
@@ -198,7 +203,7 @@ def _findings(hours):
 # probe that fails for the wrong reason. It returns nothing about the estate.
 @app.get("/healthz")
 def healthz():
-    return {"ok": True}
+    return {"ok": True, "version": APP_VERSION}
 
 
 @app.get("/api/config")
@@ -230,6 +235,7 @@ def config(_=Depends(require_auth)):
         "lookback_hours": LOOKBACK_HOURS,
         "identity_map_configured": bool(IDENTITY_MAP and Path(IDENTITY_MAP).exists()),
         "cache_ttl_seconds": CACHE_TTL,
+        "version": APP_VERSION,
     }
 
 

--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -3,6 +3,13 @@ WORKDIR /srv
 COPY requirements.lock .
 RUN pip install --no-cache-dir --require-hashes -r requirements.lock
 COPY app/ app/
+
+# Passed by CI from the release tag, or the commit for a build off main. A
+# local build leaves it as "dev", which is honest: a hardcoded version drifts,
+# and /healthz is the one place an operator looks to answer "am I running what
+# I think I am".
+ARG APP_VERSION=dev
+ENV APP_VERSION=${APP_VERSION}
 EXPOSE 8080
 USER 65532:65532
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -12,7 +12,7 @@ lists at runtime instead of carrying hardcoded copies.
 
 | method | path | auth | what |
 |--------|------|------|------|
-| GET  | `/healthz` | none | liveness and version |
+| GET  | `/healthz` | none | liveness, and the version the image was built from |
 | GET  | `/metrics` | none | Prometheus metrics |
 | GET  | `/registry` | bearer | the full compiled registry |
 | GET  | `/registry/collector` | bearer | the collector view of the registry |

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -262,7 +262,17 @@ class Finding(BaseModel):
 
 # --------------------------------------------------------------------- app --
 
-app = FastAPI(title="ai-guard-receiver", version="0.1.6")
+# Set at build time from the release tag, or the commit for a build off main.
+# It was a hand-maintained constant, which drifted the way hand-maintained
+# constants do: /healthz reported 0.1.6 while the release was 0.4.0, so the
+# one endpoint an operator would check to answer "am I running what I think
+# I am" answered a different question.
+#
+# "dev" is the honest answer for a local build, and more useful than a stale
+# number that looks authoritative.
+APP_VERSION = os.environ.get("APP_VERSION", "dev")
+
+app = FastAPI(title="ai-guard-receiver", version=APP_VERSION)
 
 
 # Paths that require the bearer token. /healthz and /metrics stay open:


### PR DESCRIPTION
The receiver's version was a hardcoded constant in the source, and it drifted the way hardcoded constants do: /healthz reported 0.1.6 while the release was 0.4.0. That is the one endpoint an operator checks to answer "am I running what I think I am", and it answered a different question. The portal had no version at all.

Both now read APP_VERSION, set at build time. A tag build reports the release, a build off main reports main-<sha> - reporting 0.4.0 from an unreleased main build would claim to be a release it is not - and a local build reports dev, which is honest and more useful than a stale number that looks authoritative.

compose-smoke builds with APP_VERSION=ci-test and fails if /healthz does not report it back. A build arg that silently does not reach the process would put dev in every published image, which is the same drift wearing different clothes.

The portal also carries it on /api/config, so the UI can show what it is running. Verified by building both images and checking the endpoint rather than trusting the Dockerfile.