### PR TITLE
extension: report the source and the OS

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -10,11 +10,24 @@ The browser surface does two jobs on the pages of known AI tools:
   markings, and warns or blocks. Reports carry detector ids only; the pasted
   content never leaves the machine.
 
-Findings arrive at the receiver with `surface: browser`. Account flags use
-the site as the tool (e.g. `chatgpt.com`); paste-guard events additionally
-carry `source: paste_guard` and an `evidence` field of the form
-`paste <warned|blocked|overridden>: <detector ids>`. No receiver change is
-needed: both map onto the standard finding schema.
+Findings arrive at the receiver with `surface: browser` and the operating
+system the browser is running on. Two sources, because they answer different
+questions:
+
+- `browser_extension` - which account is signed into an AI tool. Account flags
+  use the site as the tool (e.g. `chatgpt.com`); the receiver resolves that to
+  the registry id, so it lands as `chatgpt` alongside every other source.
+- `paste_guard` - pastes stopped or flagged, with an `evidence` field of the
+  form `paste <warned|blocked|overridden>: <detector ids>`, plus a daily
+  heartbeat. The pasted content never leaves the machine.
+
+Both map onto the standard finding schema, so no receiver change is needed.
+
+Before 1.2.0, account flags carried no `source` and nothing carried `os`. The
+receiver defaulted the missing fields, so the findings looked correct while
+being untraceable to a detector: on one fleet that was thousands a week. If
+you are running an older build, expect those two fields to start appearing
+rather than to change.
 
 ## What the paste guard detects
 

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -20,6 +20,14 @@ chrome.runtime.onMessage.addListener((msg) => {
     seen.set(key, now);
     report({
       tool: msg.tool,
+      // Absent until 1.2.0. The receiver defaults surface to "browser" and
+      // severity to "warn", so these findings looked right while carrying no
+      // source at all: on one fleet that was thousands a week that could not
+      // be traced to a detector. Defaults that happen to be correct are not
+      // the same as fields that are set.
+      surface: "browser",
+      source: "browser_extension",
+      severity: "warn",
       account_domain: msg.domain,
       reported_at: msg.ts,
     }).catch((e) => console.warn("[ai-account-guard] report failed", e));
@@ -128,9 +136,33 @@ async function getConfig() {
 // state need to know the difference: a POST that returned 401 or never left
 // the machine is not a delivered finding, and treating it as one is how a
 // device goes quiet without anything noticing.
+// chrome.runtime.getPlatformInfo returns "mac", "win", "linux", "cros",
+// "android", "openbsd". The receiver's vocabulary is macos, windows, linux,
+// unknown, and it coerces anything else to unknown - so ChromeOS reports
+// honestly as unknown rather than being forced into one of the three.
+const OS_NAMES = { mac: "macos", win: "windows", linux: "linux" };
+let osPromise = null;
+
+function detectOs() {
+  // Resolved once and reused. getPlatformInfo is async and cheap, but a
+  // service worker can be woken hundreds of times a day.
+  if (!osPromise) {
+    osPromise = chrome.runtime.getPlatformInfo()
+      .then((info) => OS_NAMES[info.os] || "unknown")
+      .catch(() => "unknown");
+  }
+  return osPromise;
+}
+
 async function report(payload) {
   const { endpoint, device, authToken } = await getConfig();
   payload.device = device;
+
+  // Set here rather than at each call site: three callers had three chances
+  // to forget it, and all three did. The receiver coerced the missing field
+  // to "unknown", so every browser finding was unattributable to an OS and
+  // nothing said why.
+  if (!payload.os) payload.os = await detectOs();
 
   if (!endpoint) {
     // No endpoint set (e.g. loaded unpacked with no MDM config). Surface the

--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Guard",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Flags AI tools signed in with a non-corporate account and stops secrets being pasted into them. Reports detector ids and account domains only, never content.",
   "permissions": [
     "storage",

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -492,10 +492,19 @@ def status_from(findings):
         ("endpoint", "collector-windows", "Windows collector", "endpoint/windows/README.md",
          "Deploy ai-guard-collector.ps1 as an Intune platform script. Same "
          "three variables, set at the top of the script or as parameters."),
-        ("browser", "paste_guard", "Browser extension", "extension/README.md",
+        ("browser", "browser_extension", "Browser extension: accounts",
+         "extension/README.md",
          "Push the extension by managed policy (Jamf for Chrome/Edge on macOS, "
          "Intune ADMX on Windows) with the receiver URL and token in the "
-         "managed configuration."),
+         "managed configuration. Reports which account is signed into an AI "
+         "tool in the browser."),
+        ("browser", "paste_guard", "Browser extension: paste guard",
+         "extension/README.md",
+         "Part of the same extension. Reports pastes it stopped or flagged, "
+         "and a daily heartbeat proving the whole chain works on that device. "
+         "Silent while the accounts row reports means nobody has pasted "
+         "anything matching a detector, which is a different thing from not "
+         "being deployed."),
         ("cloud", "entra_sign_in", "Entra sign-ins", "scanner/README.md",
          "Register an app in Entra with AuditLog.Read.All and Directory.Read.All, "
          "then set AIGUARD_ENTRA_TENANT_ID, _CLIENT_ID and _CLIENT_SECRET."),

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -20,6 +20,19 @@ os.environ.setdefault("PORTAL_AUTH", "none")
 from app import derive  # noqa: E402
 
 
+# Sources set by something other than a scanner: the three endpoint collectors,
+# and the browser extension's two. Kept beside the test that uses it so adding
+# a source and forgetting this list fails loudly rather than quietly widening
+# the exclusion.
+NON_SCANNER_SOURCES = {
+    "collector-macos",
+    "collector-linux",
+    "collector-windows",
+    "browser_extension",
+    "paste_guard",
+}
+
+
 def finding(**kw):
     """A finding with sensible defaults, so each test states only what it is
     about."""
@@ -281,9 +294,12 @@ def test_the_expected_sources_match_what_the_scanners_emit():
     assert emitted, "could not read any DetectionSource values from %s" % base
 
     listed = {r["source"] for r in derive.status_from([])["sources"]}
-    # Collector and extension sources are set directly, not via the enum.
-    listed -= {"collector-macos", "collector-linux", "collector-windows",
-               "paste_guard"}
+    # Collectors and the browser extension set their source directly rather
+    # than through DetectionSource, because neither is a scanner. They are
+    # named here rather than pattern-matched: a rule like "anything starting
+    # with collector-" would silently absorb a typo, which is the failure this
+    # test exists to catch.
+    listed -= NON_SCANNER_SOURCES
 
     missing = emitted - listed
     assert not missing, (
@@ -296,4 +312,16 @@ def test_the_expected_sources_match_what_the_scanners_emit():
     assert not stale, (
         "sources the portal lists that no scanner emits, so they would show as "
         "permanently not reporting: %s" % sorted(stale)
+    )
+
+def test_every_non_scanner_source_is_actually_listed():
+    """The exclusion list above is a hardcoded copy, and a hardcoded copy that
+    nothing checks is the thing this file keeps catching elsewhere. If a name
+    here is not in the portal's setup view, the exclusion is hiding a source
+    that would show as unrecognised in a real deployment."""
+    listed = {r["source"] for r in derive.status_from([])["sources"]}
+    missing = NON_SCANNER_SOURCES - listed
+    assert not missing, (
+        "excluded from the scanner cross-check but not listed in the setup "
+        "view either, so they would appear as unrecognised: %s" % sorted(missing)
     )


### PR DESCRIPTION
Account findings carried no source at all, and nothing carried os. The receiver defaults both, so the findings looked correct while being untraceable to a detector: on one live fleet that was 6,389 a week. A default that happens to be right is not the same as a field that is set.

os is set in report() rather than at each call site. Three callers had three chances to include it and all three did not, so it belongs in the one function they share. Resolved once and cached, since a service worker wakes constantly. ChromeOS reports as unknown rather than being forced into one of the three the receiver knows, which is what unknown is for.

Two sources now, because they answer different questions: browser_extension for which account is signed into an AI tool, paste_guard for pastes stopped or flagged and the daily heartbeat. The setup view can show one reporting while the other is silent, and that is meaningful - nobody pasting anything matching a detector is a different state from the extension not being deployed.

Tool naming is deliberately unchanged. The extension sends the hostname and the receiver resolves it to the registry id on ingest, which is the right place: the registry is the source of truth for domain-to-tool, and hardcoding that map in a content script would make it the third copy.

The portal's scanner cross-check caught browser_extension as a source no scanner emits, correctly. Its exclusion list is now a named constant, with a test that every name in it appears in the setup view - the list is a hardcoded copy, and a hardcoded copy nothing checks is what this file exists to catch. Verified to fail in both directions.

Extension 1.1.1 to 1.2.0. This needs a managed-update cycle across two browsers, so a fleet will report the old shape until it lands.