### PR TITLE
fixes from the first real deployment

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.3.0
+version: 0.3.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/README.md
+++ b/charts/ai-guard/README.md
@@ -70,6 +70,35 @@ Deployment with a generated password. It is additive - nothing about the
 receiver changes - and its ingress is off by default, so nothing new is exposed
 until you decide to expose it.
 
+Use `--reset-then-reuse-values`, not `--reuse-values`:
+
+    helm upgrade ai-guard charts/ai-guard --reset-then-reuse-values \
+      --set portal.lokiUrl=http://loki.monitoring.svc.cluster.local:3100
+
+`--reuse-values` keeps only the values you set previously and discards
+everything underneath them, including defaults a newer chart added. So the
+portal either silently does not appear - `portal.enabled` defaults to true, but
+that default is one of the ones dropped - or the templates fail on the gaps.
+The chart detects the second case and says this rather than failing on a nil
+pointer.
+
+### Adding Grafana panels later
+
+You will not know the panel ids until Grafana is running with data in it, so
+this is normally a second pass rather than something set at install:
+
+    helm upgrade ai-guard charts/ai-guard --reset-then-reuse-values \
+      --set portal.grafana.url=https://grafana.example.com \
+      --set-string 'portal.grafana.panels=ai-guard:19:Devices reporting'
+
+`--set-string` because the value contains colons and commas that `--set` would
+try to parse as structure.
+
+The uid is in the dashboard URL after `/d/`. The panel id is the
+`viewPanel=<n>` at the end of a panel's Share link. `portal/README.md` covers
+what Grafana itself needs before it will allow the frame - three settings, one
+of which locks you out of Grafana if you miss it.
+
 The portal uses its own `app.kubernetes.io/name` rather than a component label
 on the shared one. A Deployment's selector is immutable, so adding a label to
 the receiver's selector would fail every upgrade from a release that predates

--- a/charts/ai-guard/templates/NOTES.txt
+++ b/charts/ai-guard/templates/NOTES.txt
@@ -32,8 +32,15 @@ Read the bearer token every source authenticates with:
 The portal is deployed too: devices, tools, people, and which of your sources
 are reporting versus silent.
 {{- if .Values.portal.ingress.enabled }}
+{{- if eq .Values.portal.ingress.className "tailscale" }}
+
+  Portal: https://{{ .Values.portal.ingress.host }}.<your-tailnet>.ts.net
+  (the Tailscale operator appends the tailnet name and issues the cert;
+  kubectl get ingress {{ include "ai-guard.portal.fullname" . }} shows the full address)
+{{- else }}
 
   Portal: https://{{ .Values.portal.ingress.host }}
+{{- end }}
 {{- else }}
 
   No ingress on the portal. Port-forward to reach it:

--- a/charts/ai-guard/templates/portal-deployment.yaml
+++ b/charts/ai-guard/templates/portal-deployment.yaml
@@ -1,4 +1,17 @@
 {{- if .Values.portal.enabled }}
+{{/*
+  helm upgrade --reuse-values keeps only the values previously set and drops
+  every chart default underneath them, so .Values.portal can arrive as a map
+  containing nothing but whatever the last install happened to override. The
+  templates below then fail on a nil pointer several frames deep, which tells
+  the operator nothing about what they did.
+
+  Helm's own answer is --reset-then-reuse-values. This says so rather than
+  crashing.
+*/}}
+{{- if not .Values.portal.service }}
+{{- fail (printf "\n\nThe portal values are incomplete: portal.service is missing, so the chart defaults were dropped.\n\nThis is what `helm upgrade --reuse-values` does - it keeps only the values you set previously and discards everything underneath them, including defaults added by a newer chart.\n\nUse --reset-then-reuse-values instead, which resets to the chart defaults and then reapplies your stored values on top:\n\n  helm upgrade %s charts/ai-guard --reset-then-reuse-values --set portal.enabled=true\n" .Release.Name) }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -117,7 +117,10 @@ portal:
   # stops a seven-day query being rerun on every page load; it is not state,
   # since it rebuilds on restart.
   lookbackHours: 168
-  cacheTtlSeconds: 300
+  # Short enough that a finding which just arrived is not invisible, long
+  # enough to absorb a page refresh. The portal shows how old the data is and
+  # has a refresh control, so this is a comfort setting rather than a limit.
+  cacheTtlSeconds: 30
 
   # Optional. A ConfigMap with key identity-map.csv, mapping people to the
   # machines they use, where the key is a device identifier or a local
@@ -132,10 +135,18 @@ portal:
   # Optional. Embeds Grafana panels on the portal's dashboard tab.
   #
   # Grafana refuses to be framed by default, deliberately: framing a session
-  # someone is logged into is how clickjacking works. It needs
-  # allow_embedding, a cookie SameSite that permits the frame, and a decision
-  # about how the frame authenticates. url is the URL a BROWSER reaches
-  # Grafana on, not one resolvable inside the cluster.
+  # someone is logged into is how clickjacking works. On the Grafana side it
+  # needs allow_embedding, cookie_samesite=none, and - if your Grafana has a
+  # login at all - cookie_secure=true. That last one is easy to miss and locks
+  # you out of Grafana when it is: SameSite=None is only valid alongside
+  # Secure, so the browser silently discards the session cookie and every
+  # login bounces back to the login screen.
+  #
+  # url is the URL a BROWSER reaches Grafana on, not one resolvable inside the
+  # cluster: the frames are loaded by the browser.
+  #
+  # Panel ids are not knowable until Grafana is running with data, so this is
+  # usually a second pass. See the chart README.
   grafana:
     url: ""
     # dashboardUid:panelId:Title, semicolon separated. Semicolons because

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -63,7 +63,7 @@ PORTAL_USER=admin
 # How far back the portal looks, and how long a derived graph is reused. The
 # default cache means a seven-day query is not rerun on every page load.
 LOOKBACK_HOURS=168
-CACHE_TTL_SECONDS=300
+CACHE_TTL_SECONDS=30
 
 # Optional. A CSV of key,identity attaching people to devices, where the key is
 # a device identifier or a local username. Path INSIDE the container; mount it
@@ -82,6 +82,11 @@ GRAFANA_URL=
 # dashboardUid:panelId:Title, separated by semicolons. Semicolons because panel
 # titles contain commas: "Top tools (devices, 7d)" splits into two broken
 # entries otherwise. The title is the frame's accessible name, not a caption.
+#
+# The uid is in the dashboard URL after /d/. The panel id is the viewPanel=<n>
+# at the end of a panel's Share link. You will not know either until Grafana is
+# running with data in it, so this is usually filled in later - edit this file
+# and run `docker compose up -d portal`, since a restart does not reread it.
 GRAFANA_PANELS=
 
 # Or embed a whole dashboard in one frame, which needs no panel ids and
@@ -107,8 +112,14 @@ DISPLAY_TZ=UTC
 # Grafana. If you already run either, do not start the profile.
 GRAFANA_ADMIN_PASSWORD=
 
-# Grafana refuses to be framed by default, deliberately. Set both to embed
+# Grafana refuses to be framed by default, deliberately. Set all three to embed
 # panels in the portal, and understand what you are turning off first: framing
 # a session someone is logged into is how clickjacking works.
+#
+# The third is the one that gets missed. SameSite=None is only valid on a
+# cookie that also carries Secure, so without it the browser discards the
+# session cookie: you log in, it succeeds, and you land back on the login
+# screen. It requires HTTPS in front of Grafana.
 GRAFANA_ALLOW_EMBEDDING=false
 GRAFANA_COOKIE_SAMESITE=lax
+GRAFANA_COOKIE_SECURE=false

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -146,6 +146,11 @@ services:
       # login screen no amount of allow_embedding fixes.
       GF_SECURITY_ALLOW_EMBEDDING: ${GRAFANA_ALLOW_EMBEDDING:-false}
       GF_SECURITY_COOKIE_SAMESITE: ${GRAFANA_COOKIE_SAMESITE:-lax}
+      # SameSite=None is only valid on a cookie that also carries Secure, so
+      # without this the browser discards the session cookie and every login
+      # bounces back to the login screen with nothing explaining why. Requires
+      # HTTPS in front of Grafana, which a reverse proxy is providing anyway.
+      GF_SECURITY_COOKIE_SECURE: ${GRAFANA_COOKIE_SECURE:-false}
     volumes:
       - grafana-data:/var/lib/grafana
       - ../../dashboards:/var/lib/grafana/dashboards:ro

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,13 +48,30 @@ Pick the OS of your test machine and follow its README:
 - Linux: [`endpoint/linux/README.md`](../endpoint/linux/README.md) (any RMM,
   cron, or config management)
 
-For a first test you can run the script directly as root or admin, with no MDM
-at all, by setting three values (each README shows how per platform):
+Each needs the same three values:
 
 - the receiver base URL
 - the bearer token
 - your corporate domains, comma separated. Accounts on these are "work";
   everything else is a personal-account finding.
+
+**How you pass them differs per platform**, because each matches its delivery
+mechanism, and this is the thing most likely to stop a first run:
+
+- **macOS** takes them as positional parameters, because that is how Jamf
+  passes script parameters. Environment variables are ignored. Running it by
+  hand means passing three empty strings first, since `$1`-`$3` are Jamf's own:
+
+      sudo ./ai-guard-collector.sh "" "" "" \
+        https://receiver.example.com <token> example.com
+
+- **Linux** takes environment variables: `AIGUARD_RECEIVER_BASE`,
+  `AIGUARD_TOKEN`, `AIGUARD_CORP_DOMAINS`.
+- **Windows** takes them at the top of the script or as Intune script
+  parameters.
+
+You can run any of them directly as root or admin with no MDM at all, which is
+the fastest way to see a finding.
 
 Run it once. The collector reads the AI tool config files in the user's home
 directory and POSTs findings to the receiver.

--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -317,6 +317,27 @@ registry_tsv() {
 }
 
 if ! fetch_registry; then
+  # Distinguish "no receiver configured" from "the receiver did not answer".
+  # Both used to print the same line, which reads as a network problem when it
+  # is a missing parameter - and prints a URL with no host in front of it,
+  # which is the giveaway nobody notices. This script takes its configuration
+  # as positional parameters because Jamf passes script parameters, not
+  # environment variables; running it by hand needs the same shape.
+  if [ -z "$RECEIVER_BASE" ]; then
+    echo "[ai-guard] no receiver configured. This script reads its settings as"
+    echo "[ai-guard] positional parameters, because that is how Jamf passes"
+    echo "[ai-guard] them. Environment variables are ignored."
+    echo "[ai-guard]"
+    echo "[ai-guard]   Jamf: set parameters 4, 5 and 6 on the policy."
+    echo "[ai-guard]   By hand: \$1-\$3 are Jamf's own, so pass three empty"
+    echo "[ai-guard]   strings first:"
+    echo "[ai-guard]"
+    echo "[ai-guard]     sudo ./ai-guard-collector.sh \"\" \"\" \"\" \\"
+    echo "[ai-guard]       https://receiver.example.com <token> example.com"
+    echo "[ai-guard]"
+    echo "[ai-guard] Refusing to scan: an empty scan looks like a clean machine."
+    exit 1
+  fi
   echo "[ai-guard] registry fetch failed: ${RECEIVER_BASE%/}/registry/collector"
   echo "[ai-guard] refusing to scan without an identifier list - an empty scan looks like a clean machine"
   exit 1

--- a/portal/README.md
+++ b/portal/README.md
@@ -75,7 +75,7 @@ about the estate.
 | `GRAFANA_URL` | no | a Grafana that permits embedding; unset shows a note |
 | `GRAFANA_PANELS` | no | `dashboardUid:panelId:Title`, semicolon separated |
 | `GRAFANA_DASHBOARD_UID` | no | embed a whole dashboard instead of panels |
-| `CACHE_TTL_SECONDS` | no | how long a derived graph is reused, default 300 |
+| `CACHE_TTL_SECONDS` | no | how long a derived graph is reused, default 30 |
 
 ## Identity
 
@@ -145,7 +145,7 @@ assessment calls for it. The portal only reads it.
       --from-file=identity-map.csv=./identity-map.csv
 
 The file is re-read whenever the derived graph is rebuilt, so an edit takes
-effect within `CACHE_TTL_SECONDS` (default 300) without a restart.
+effect within `CACHE_TTL_SECONDS` (default 30) without a restart.
 
 ## Setup view
 
@@ -169,10 +169,21 @@ It needs, on the Grafana side:
 
     GF_SECURITY_ALLOW_EMBEDDING=true
     GF_SECURITY_COOKIE_SAMESITE=none
+    GF_SECURITY_COOKIE_SECURE=true      # if your Grafana has a login
 
 The second is easy to miss. A framed page is cross-site as far as the browser
 is concerned, so the default `Lax` cookie is not sent and the frame renders a
 login screen that no amount of `allow_embedding` will fix.
+
+**The third locks you out of Grafana if you skip it.** `SameSite=None` is only
+valid on a cookie that also has `Secure`, so a browser silently discards the
+session cookie: you log in, it succeeds, and you land back on the login screen
+with nothing to explain why. Setting `cookie_secure` requires Grafana to be
+behind HTTPS, which it should be anyway.
+
+You only need it if your Grafana authenticates. An anonymous, read-only
+Grafana issues no session cookie, so the first two settings are enough - which
+is why the demo works without it and a real instance does not.
 
 Then decide how the frame authenticates: anonymous access on a Grafana that is
 locked down and read-only, or an auth proxy. The demo takes the first route
@@ -194,9 +205,45 @@ The title is the frame's accessible name rather than a visible caption:
 Grafana renders the panel title inside the frame already, and showing it twice
 reads as a mistake.
 
-Panel ids come from the dashboard JSON. `GRAFANA_URL` is the URL a browser
-reaches Grafana on, not the one the portal container would use: the frames are
-loaded by the browser, not by the portal.
+`GRAFANA_URL` is the URL a browser reaches Grafana on, not the one the portal
+container would use: the frames are loaded by the browser, not by the portal.
+
+### Finding the ids
+
+You will not know these until Grafana is running with data in it, so this is
+normally something you come back and do rather than set up front.
+
+Open the dashboard. The address bar gives you the uid:
+
+    https://grafana.example.com/d/ai-guard/ai-guard-shadow-ai-visibility
+                                   ^^^^^^^^ uid
+
+Then any panel's menu, Share, Link. That URL ends with `viewPanel=<n>`, and
+that number is the panel id:
+
+    ...?orgId=1&from=now-7d&to=now&viewPanel=19
+                                              ^^ panel id
+
+So that panel is `ai-guard:19:Whatever you want to call it`.
+
+### Applying them afterwards
+
+**Docker Compose:** edit `.env`, then recreate the container. A restart does
+not reread the file.
+
+    docker compose up -d portal
+
+**Helm:**
+
+    helm upgrade ai-guard charts/ai-guard --reset-then-reuse-values \
+      --set portal.grafana.url=https://grafana.example.com \
+      --set-string 'portal.grafana.panels=ai-guard:19:Devices reporting'
+
+Two things there matter. `--reset-then-reuse-values`, not `--reuse-values`:
+the latter keeps only the values you previously set, so any chart default you
+have not overridden goes missing, and the templates fail on the gaps. And
+`--set-string`, because the value contains colons and commas that `--set`
+would try to parse as structure.
 
 If a frame stays blank, Grafana is refusing to be framed rather than the panel
 being wrong. Check the two settings above before the panel id.

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -49,7 +49,13 @@ encryption.
                     set embeds the whole dashboard in one frame instead, which
                     needs no panel ids and survives someone rearranging them
   GRAFANA_DASHBOARD_UID  dashboard to embed whole, when no panels are listed
-  CACHE_TTL_SECONDS how long a derived graph is reused, default 300
+  CACHE_TTL_SECONDS how long a derived graph is reused, default 30. It exists
+                    to absorb a page refresh and clicking between tabs, not to
+                    reduce load: Grafana runs one query per panel on every
+                    refresh, so a portal page load was already the lighter of
+                    the two. It started at 300, which meant a fresh install
+                    showed nothing for five minutes after the first collector
+                    ran, with nothing on screen saying the view was stale.
 """
 
 import logging
@@ -153,7 +159,7 @@ IDENTITY_MAP = os.environ.get("IDENTITY_MAP", "")
 GRAFANA_URL = os.environ.get("GRAFANA_URL", "").rstrip("/")
 GRAFANA_PANELS = os.environ.get("GRAFANA_PANELS", "")
 GRAFANA_DASHBOARD_UID = os.environ.get("GRAFANA_DASHBOARD_UID", "")
-CACHE_TTL = int(os.environ.get("CACHE_TTL_SECONDS", "300"))
+CACHE_TTL = int(os.environ.get("CACHE_TTL_SECONDS", "30"))
 
 STATIC = Path(__file__).parent / "static"
 
@@ -241,8 +247,13 @@ def config(_=Depends(require_auth)):
 
 @app.get("/api/graph")
 def graph(hours: float = Query(default=None, gt=0, le=24 * 90),
+          refresh: bool = Query(default=False),
           _=Depends(require_auth)):
+    """refresh=true skips the cache. A cache you cannot see past is
+    indistinguishable from a portal that is not working."""
     hours = hours or LOOKBACK_HOURS
+    if refresh:
+        _cache.pop("graph", None)
     def build():
         findings = _findings(hours)
         domain_map = derive.load_domain_map(REGISTRY_PATH)
@@ -255,8 +266,11 @@ def graph(hours: float = Query(default=None, gt=0, le=24 * 90),
 
 @app.get("/api/status")
 def status(hours: float = Query(default=None, gt=0, le=24 * 90),
+           refresh: bool = Query(default=False),
            _=Depends(require_auth)):
     hours = hours or LOOKBACK_HOURS
+    if refresh:
+        _cache.pop("status", None)
     def build():
         return derive.status_from(_findings(hours))
 

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -46,26 +46,48 @@ input{background:var(--sf2);border:1px solid var(--bd);color:var(--fg);border-ra
     <button data-v="dashboard">Dashboard</button>
   </nav>
   <input id="q" placeholder="filter…">
+  <span id="freshness" class="mono" style="font-size:11px;color:var(--mut)"></span>
+  <button id="refresh" class="back" style="margin:0">refresh</button>
 </header>
 <main id="app"></main>
 <script>
 let G = {devices:{},identities:{},tools:{},bridges:{},unattributed:[],counts:{}};
 let S = null, CFG = {}, loadError = '';
 
-async function load() {
+async function load(force) {
   app.innerHTML = '<p class="lede">Reading findings…</p>';
+  const q = force ? '?refresh=true' : '';
   try {
     CFG = await (await fetch('/api/config')).json();
-    const gr = await fetch('/api/graph');
+    const gr = await fetch('/api/graph' + q);
     if (!gr.ok) throw new Error((await gr.json()).detail || gr.statusText);
     G = await gr.json();
-    const sr = await fetch('/api/status');
+    const sr = await fetch('/api/status' + q);
     if (sr.ok) S = await sr.json();
     loadError = '';
   } catch (e) {
     loadError = String(e.message || e);
   }
   render();
+  showFreshness();
+}
+
+// The graph is cached, and a cache you cannot see is indistinguishable from a
+// portal that is not working: a finding that arrived a minute ago simply is
+// not there, with nothing on screen to say why.
+function showFreshness() {
+  const el = document.getElementById('freshness');
+  if (!el) return;
+  if (loadError || !G.derived_at) { el.textContent = ''; return; }
+  const tick = () => {
+    const age = Math.max(0, Math.round(Date.now() / 1000 - G.derived_at));
+    el.textContent = age < 5 ? 'just now'
+      : age < 90 ? age + 's ago'
+      : Math.round(age / 60) + 'm ago';
+  };
+  tick();
+  clearInterval(window._freshTimer);
+  window._freshTimer = setInterval(tick, 5000);
 }
 const app = document.getElementById('app'), q = document.getElementById('q');
 let view = 'setup', detail = null, filter = '';
@@ -338,5 +360,6 @@ document.querySelectorAll('nav button').forEach(b => b.onclick = () => {
   b.classList.add('on'); view = b.dataset.v; detail = null; render();
 });
 q.oninput = e => { filter = e.target.value.toLowerCase(); detail = null; render(); };
+document.getElementById('refresh').onclick = () => load(true);
 load();
 </script>


### PR DESCRIPTION
Deployed the chart to a live k3s cluster behind Tailscale, ran a collector on a real Mac, and embedded Grafana panels. Everything that went wrong doing it is fixed here.

cookie_secure was missing from the Grafana embedding instructions everywhere it appeared. Following them exactly locks you out of Grafana: SameSite=None is only valid alongside Secure, so the browser silently discards the session cookie and every login bounces back to the login screen with nothing explaining why. The demo hid this because its Grafana is anonymous and issues no session cookie, which is now stated rather than left as a coincidence.

helm upgrade --reuse-values crashed the chart on a nil pointer when enabling the portal on an existing release: it keeps only the values previously set and drops the defaults underneath, so portal.service and the rest simply did not exist. It now fails with the flag to use instead. Documented in the chart README, because the first symptom was the portal silently not appearing at all.

The NOTES printed https://ai-guard-portal with no tailnet suffix, while the receiver block next to it handled Tailscale properly.

The cache defaulted to 300 seconds, so a fresh install showed nothing for five minutes after the first collector ran, with nothing on screen saying the view was stale. Now 30, with the age of the data in the header and a refresh control. The original reasoning - avoid rerunning a seven day query on every page load - did not survive contact with the fact that Grafana runs one query per panel on every refresh, so a portal page load was already the lighter of the two.

The macOS collector printed "registry fetch failed: /registry/collector" when no receiver was configured, which reads as a network problem rather than a missing parameter, and prints a URL with no host in front of it that nobody notices. It now says what is wrong and gives the exact command, including the three empty positional parameters that running a Jamf script by hand needs.

And getting-started now says the three collectors take configuration three different ways - positional on macOS because Jamf passes script parameters, environment variables on Linux, in-script on Windows. That difference is the thing most likely to stop a first run, and it was one clause in a sentence.

Chart version 0.3.0 to 0.3.1.