### PR TITLE
charts: appVersion 0.5.0 for the release

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.3.1
+version: 0.3.2
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.4.0"
+appVersion: "0.5.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard


### PR DESCRIPTION
appVersion is what a default helm install pulls, so it has to name the release being cut. CI fails the tag build if the two disagree, which is the check that exists because this field sat a release behind through 0.3.0.

Chart version moves too: charts/ changed, and a chart change that leaves it alone is a change nobody is offered.