### PR TITLE
portal: drop the duplicate panel title, keep the view on reload

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -155,6 +155,15 @@ services:
       # wants the default 300 so a seven-day query is not rerun per page load.
       CACHE_TTL_SECONDS: "10"
       LOOKBACK_HOURS: "168"
+      # Which widgets the overview draws, in order. Set here so the demo shows
+      # the feature rather than the default, and overridable from the shell:
+      #   OVERVIEW_WIDGETS=stat_row,top_tools docker compose up -d --force-recreate portal
+      #
+      # A grafana: entry refers to a panel in GRAFANA_PANELS below, by title or
+      # by panel id. Prefer the id where a title contains a comma, because this
+      # list is comma separated and the title would split into two entries that
+      # match nothing. GRAFANA_PANELS uses semicolons for that same reason.
+      OVERVIEW_WIDGETS: ${OVERVIEW_WIDGETS:-stat_row,top_tools,recent_personal_accounts,detection_coverage,source_health,grafana:31}
       # The browser loads these frames, so this is the URL you reach Grafana
       # on, not the one the portal container would use.
       GRAFANA_URL: "http://localhost:3000"

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -120,7 +120,17 @@ function showFreshness() {
   window._freshTimer = setInterval(tick, 5000);
 }
 const app = document.getElementById('app'), q = document.getElementById('q');
-let view = 'setup', detail = null, filter = '';
+// The view lives in the URL fragment. A reload landing back on Setup loses
+// where you were, and storing it would need somewhere to store it; the
+// fragment is free, survives a reload, and makes a view linkable to a
+// colleague. An unknown fragment falls back rather than rendering nothing.
+const VIEWS = ['overview','tools','people','devices','personal','mcp',
+               'setup','coverage','dashboard','settings'];
+const fromHash = () => {
+  const h = (location.hash || '').replace(/^#/, '');
+  return VIEWS.includes(h) ? h : 'setup';
+};
+let view = fromHash(), detail = null, filter = '';
 
 const esc = s => String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
 const ents = o => Object.entries(o || {});
@@ -201,9 +211,13 @@ const WIDGETS = {
       "${esc(w.ref)}". Named here but not defined there, so there is nothing
       to draw.</div></div>`;
     const q = 'orgId=1&theme=dark&from=now-7d&to=now&kiosk';
-    return `<div class="wcard w4"><h3>${esc(p.title || w.ref)}</h3>
+    // No heading of our own. The panel draws its own, from the dashboard, so a
+    // second one is both duplicated and less trustworthy: ours comes from
+    // GRAFANA_PANELS, which is a snapshot of a title someone can rename in
+    // Grafana at any time.
+    return `<div class="wcard w4" style="padding:10px">
       <iframe src="${esc(base)}/d-solo/${esc(p.uid)}/?${q}&panelId=${esc(p.panel_id)}"
-        style="width:100%;height:190px;border:0;border-radius:6px;background:var(--sf2)"
+        style="width:100%;height:210px;border:0;border-radius:6px;background:var(--sf2)"
         title="${esc(p.title || 'Grafana panel')}"></iframe></div>`;
   },
 
@@ -636,7 +650,11 @@ function drawNav() {
     }).join('')
   ).join('');
   n.querySelectorAll('button').forEach(b => b.onclick = () => {
-    view = b.dataset.v; detail = null; drawNav(); render();
+    view = b.dataset.v; detail = null;
+    // Replace rather than push: clicking through the nav should not fill the
+    // back button with every tab you glanced at.
+    history.replaceState(null, '', '#' + view);
+    drawNav(); render();
   });
   const fv = document.getElementById('footver');
   if (fv && CFG.version) fv.textContent = 'v' + CFG.version;
@@ -655,6 +673,11 @@ async function render() {
                     dashboard, personal, mcp})[view]();
 }
 function open_(kind, key) { detail = kind ? [kind, key] : null; render(); window.scrollTo(0,0); }
+// Someone editing the fragment, or arriving on a link to a view.
+window.addEventListener('hashchange', () => {
+  const h = fromHash();
+  if (h !== view) { view = h; detail = null; drawNav(); render(); }
+});
 q.oninput = e => { filter = e.target.value.toLowerCase(); detail = null; render(); };
 document.getElementById('refresh').onclick = () => load(true);
 load();


### PR DESCRIPTION
A Grafana widget drew its own heading above a panel that already draws one, so the title appeared twice. Ours comes from GRAFANA_PANELS, which is a snapshot of a title someone can rename in Grafana at any time, so the one to keep is the panel's own.

The view now lives in the URL fragment. A reload landing back on Setup loses where you were, and storing it would need somewhere to store it; the fragment is free, survives a reload, and makes a view linkable to a colleague. An unknown fragment falls back rather than rendering nothing, and replaceState rather than push keeps the back button from filling with every tab glanced at.

The demo now sets OVERVIEW_WIDGETS rather than falling back to the default four, so the overview being configurable is visible rather than only documented. Its grafana entry refers to the panel by id rather than title, deliberately: this list is comma separated and several panel titles contain commas, which is why GRAFANA_PANELS uses semicolons. A title would split into two entries matching nothing.