### PR TITLE
charts: 0.5.0 for the v0.6.0 application

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.4.0
+version: 0.5.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.5.0"
+appVersion: "0.6.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard


### PR DESCRIPTION
appVersion moves to 0.6.0 so a fresh install defaults to the restructured portal rather than the previous release. The chart's own version is a minor bump: nothing in its interface breaks, an existing values file installs unchanged.

Tagged as v0.6.0 from this commit, so the tag's Chart.yaml agrees with the release it names.