### PR TITLE
fix device identity, Intune app matching and MCP tool naming

### DIFF
--- a/endpoint/linux/ai-guard-collector.sh
+++ b/endpoint/linux/ai-guard-collector.sh
@@ -602,7 +602,12 @@ while IFS="$SEP" read -r _kind tool path os; do
   f=$(resolve_under_home "$HOME_DIR/$path") || continue
   [ -f "$f" ] || continue
   servers=$(json_keys "$f" mcpServers)
-  [ -n "$servers" ] && report_once "mcp" "${tool}-mcp:$servers" "" "$path mcpServers"
+  # The tool is the tool. The server list is evidence, not identity: folding it
+  # into the name made every distinct combination of servers a separate tool,
+  # so a machine with figma and context7 looked unrelated to a machine with
+  # figma alone. About twenty two near-identical rows where there should have
+  # been three.
+  [ -n "$servers" ] && report_once "mcp" "${tool}-mcp" "" "$path mcpServers: $servers"
 done <<EOF
 $(printf '%s\n' "$REG_TSV" | grep "^mcp${SEP}")
 EOF

--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -588,7 +588,12 @@ while IFS="$SEP" read -r _kind tool path os; do
   f=$(resolve_under_home "$HOME_DIR/$path") || continue
   [ -f "$f" ] || continue
   servers=$(json_keys "$f" mcpServers)
-  [ -n "$servers" ] && report_once "mcp" "${tool}-mcp:$servers" "" "$path mcpServers"
+  # The tool is the tool. The server list is evidence, not identity: folding it
+  # into the name made every distinct combination of servers a separate tool,
+  # so a machine with figma and context7 looked unrelated to a machine with
+  # figma alone. About twenty two near-identical rows where there should have
+  # been three.
+  [ -n "$servers" ] && report_once "mcp" "${tool}-mcp" "" "$path mcpServers: $servers"
 done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^mcp${SEP}")
 
 # ---------------------------------------------------------------- summary ---

--- a/endpoint/windows/ai-guard-collector.ps1
+++ b/endpoint/windows/ai-guard-collector.ps1
@@ -579,8 +579,14 @@ foreach ($m in $Registry.mcp) {
     try {
         $names = Get-McpServerNames -Path $f
         if ($names) {
-            Send-FindingOnce -Surface 'mcp' -Tool "$($m.tool)-mcp:$names" -Account '' `
-                -Evidence "$($m.path) mcpServers"
+            # The tool is the tool. The server list is evidence, not
+            # identity: folding it into the name made every distinct
+            # combination of servers a separate tool, so a machine with
+            # figma and context7 looked unrelated to a machine with figma
+            # alone. About twenty two near-identical rows where there
+            # should have been three.
+            Send-FindingOnce -Surface 'mcp' -Tool "$($m.tool)-mcp" -Account '' `
+                -Evidence "$($m.path) mcpServers: $names"
         }
     } catch {
         Write-Output "ai-guard PARSE-FAILED: mcp $f ($($_.Exception.Message))"

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -120,7 +120,13 @@ Required Graph API application permissions:
 | `Application.Read.All` | Entra | List service principals and consent grants |
 | `Mail.ReadBasic.All` | Exchange | Message metadata only, for signup email detection |
 | `DeviceManagementApps.Read.All` | Intune | Read discovered apps inventory |
+| `DeviceManagementManagedDevices.Read.All` | Intune | Per-device attribution: serials, users and sync times |
 | `User.Read.All` | All | Enumerate users |
+
+Without `DeviceManagementManagedDevices.Read.All` the Intune scanner still
+runs, but every finding degrades to an aggregate device count with no user and
+no device, and the scan reports that it happened. A permissions gap should not
+be indistinguishable from an estate where nobody can be attributed.
 
 ## Policy configuration
 

--- a/scanner/ai_guard/scanners/intune.py
+++ b/scanner/ai_guard/scanners/intune.py
@@ -17,8 +17,10 @@ rather than passed off as a clean result.
 from __future__ import annotations
 from typing import Optional
 
+import asyncio
 import logging
-from datetime import datetime, timezone
+import re
+from datetime import datetime, timedelta, timezone
 
 from ai_guard.config import ScannerConfig
 from ai_guard.registry import Registry
@@ -33,6 +35,89 @@ from ai_guard.utils.graph import paginate
 
 logger = logging.getLogger(__name__)
 
+# Intune keeps a managed device record until someone removes it, so a laptop
+# that left with a leaver still reports the AI apps that were on it. Devices
+# whose last sync is older than this are counted, logged and skipped. Set
+# stale_device_days in the scanner options to tighten, or 0 to disable.
+#
+# The timestamp is read from the managed device record, never from the
+# detectedApps sub-resource. See _get_app_devices for why that distinction is
+# the whole point.
+DEFAULT_STALE_DEVICE_DAYS = 90
+
+# Seconds to wait between per-app device lookups. Graph throttles
+# detectedApps/{id}/managedDevices hard: twenty one matched apps queried back
+# to back had most of their calls refused, and paginate() had already spent
+# its four Retry-After attempts on each. A second between calls costs about
+# twenty seconds on a fleet this size and avoids the throttling entirely.
+#
+# Set app_lookup_delay_seconds in the scanner options to change it. 0 disables
+# the wait, which is right for a tenant small enough not to be throttled.
+DEFAULT_APP_LOOKUP_DELAY = 1.0
+
+
+def _parse_ts(value):
+    """Graph returns ISO 8601 with a Z suffix. None on anything unparseable,
+    which is treated as 'do not filter': dropping a device because of an
+    unexpected timestamp format would hide a real machine."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+# Version suffixes Intune appends to a display name: "LM Studio 0.3.20",
+# "LM Studio 0.4.20+1". Anything from the first digit-led token onwards.
+_VERSION_TAIL = re.compile(r"\s+v?\d[\d.+_-]*.*$", re.IGNORECASE)
+
+
+def _normalise_app_name(name: str) -> str:
+    """Reduce an app name to something two naming schemes can be compared on.
+
+    Intune reports display names, package ids and versioned display names; the
+    registry holds executables and .app bundles. Neither side is wrong, so both
+    are reduced rather than one being made to look like the other.
+    """
+    n = (name or "").strip()
+    if not n:
+        return ""
+    # Package id: Exafunction.Windsurf, Microsoft.Copilot. The last segment is
+    # the product; the first is the publisher. Only split when there is no
+    # space, so "LM Studio 0.3.20" is left alone.
+    if "." in n and " " not in n:
+        tail = n.rsplit(".", 1)[-1]
+        # .exe and .app are suffixes, not publishers.
+        if tail.lower() not in ("exe", "app"):
+            n = tail
+    for suffix in (".exe", ".app"):
+        if n.lower().endswith(suffix):
+            n = n[: -len(suffix)]
+    n = _VERSION_TAIL.sub("", n)
+    return n.strip().lower()
+
+
+def _windows_names(service) -> list:
+    """Every name this service might appear under on Windows.
+
+    Both lists, because a tool is usually called the same thing on either
+    platform once the .app and .exe suffixes are gone, and 21 of the shipped
+    registry's 30 tools have no windows list at all. Reading only those was
+    why Intune returned one finding from a fleet with twenty one AI app
+    records.
+    """
+    names = []
+    for key in ("windows", "macos"):
+        names.extend(service.desktop_apps.get(key) or [])
+    out, seen = [], set()
+    for n in names:
+        norm = _normalise_app_name(n)
+        if norm and norm not in seen:
+            seen.add(norm)
+            out.append(norm)
+    return out
+
 
 class IntuneScanner(BaseScanner):
     name = "intune"
@@ -40,6 +125,8 @@ class IntuneScanner(BaseScanner):
     def __init__(self, registry: Registry, config: ScannerConfig):
         super().__init__(registry, config)
         self._auth: Optional[MSGraphAuth] = None
+        # id -> managedDevice. See _build_device_map.
+        self._devices: dict = {}
 
     def check_prerequisites(self) -> tuple[bool, str]:
         try:
@@ -57,6 +144,11 @@ class IntuneScanner(BaseScanner):
         try:
             client = await self._auth.graph_client()
 
+            # Fetched once, before anything else needs it. Everything the
+            # per-app lookup claims about a device is a stub, so this is where
+            # device attributes actually come from.
+            self._devices = await self._build_device_map(client)
+
             app_findings, app_errors = await self._scan_discovered_apps(client)
             result.findings.extend(app_findings)
             result.errors.extend(app_errors)
@@ -68,6 +160,39 @@ class IntuneScanner(BaseScanner):
 
         result.duration_seconds = (datetime.now(timezone.utc) - start).total_seconds()
         return result
+
+    async def _build_device_map(self, client) -> dict:
+        """Every managed device, keyed on the id the app lookup returns.
+
+        The detectedApps sub-resource returns a device id and a device name and
+        stubs the rest, so the real attributes have to come from the devices
+        resource itself. One page covers a fleet of a few hundred; paginate
+        handles anything larger and honours Retry-After on the way.
+
+        An empty map is not fatal. The caller falls back to what the sub
+        resource gave it, which is the behaviour this replaces, and says so.
+        """
+        url = (
+            "/deviceManagement/managedDevices"
+            "?$select=id,deviceName,serialNumber,userPrincipalName,"
+            "lastSyncDateTime,operatingSystem&$top=999"
+        )
+        try:
+            devices = await paginate(client, url)
+        except Exception as e:
+            logger.warning(
+                "Intune: could not read managed devices (%s). Findings will "
+                "carry the device name rather than the serial, and the stale "
+                "filter cannot run.", e,
+            )
+            return {}
+        out = {}
+        for d in devices:
+            did = d.get("id")
+            if did:
+                out[did] = d
+        logger.info("Intune: %d managed device(s) in inventory", len(out))
+        return out
 
     async def _scan_discovered_apps(
         self, client
@@ -95,26 +220,56 @@ class IntuneScanner(BaseScanner):
         failed_lookups: list[str] = []
         first_reason: Optional[str] = None
 
+        stale_days = int(self.config.options.get(
+            "stale_device_days", DEFAULT_STALE_DEVICE_DAYS))
+        lookup_delay = float(self.config.options.get(
+            "app_lookup_delay_seconds", DEFAULT_APP_LOOKUP_DELAY))
+        lookups_made = 0
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=stale_days)
+                  if stale_days > 0 else None)
+        stale_skipped = 0
+
         for app in apps:
             app_name = app.get("displayName", "")
             device_count = app.get("deviceCount", 0)
 
             service = self.registry.match_desktop_app(app_name)
             if not service:
-                # Fuzzy: check if app name contains any known service name
-                for svc in self.registry.services:
-                    win_apps = svc.desktop_apps.get("windows", [])
-                    for known_app in win_apps:
-                        if known_app.lower() in app_name.lower():
-                            service = svc
-                            break
-                    if service:
-                        break
+                # Exact lookup failed, which is the normal case here: it is
+                # keyed on the registry's own strings, and Intune reports a
+                # different scheme. Compare both sides normalised instead.
+                #
+                # Longest known name first, so "Claude Code" is not claimed by
+                # "Claude" when both are in the registry.
+                norm_app = _normalise_app_name(app_name)
+                if norm_app:
+                    best = None
+                    best_len = 0
+                    for svc in self.registry.services:
+                        for known in _windows_names(svc):
+                            if len(known) <= best_len:
+                                continue
+                            # Equality only, after both sides are normalised.
+                            # Prefix matching looks tempting and is wrong:
+                            # "Claude Code" would be attributed to Claude,
+                            # because claude-code is detected through its CLI
+                            # config and carries no desktop app names. A
+                            # finding against the wrong tool is worse than no
+                            # finding, and the version stripping above already
+                            # handles "LM Studio 0.3.20".
+                            if norm_app == known:
+                                best, best_len = svc, len(known)
+                    service = best
 
             if not service:
                 continue
 
             app_id = app.get("id", "")
+            # Before the call rather than after, and skipped for the first, so
+            # a single matched app costs nothing.
+            if lookup_delay > 0 and lookups_made:
+                await asyncio.sleep(lookup_delay)
+            lookups_made += 1
             devices, lookup_error = await self._get_app_devices(client, app_id)
 
             if lookup_error:
@@ -124,18 +279,44 @@ class IntuneScanner(BaseScanner):
 
             if devices:
                 for device in devices:
+                    # The sub-resource gives a usable id and a usable name and
+                    # stubs everything else, so the real record is looked up
+                    # here. Missing means the device is not in the inventory
+                    # any more, which is worth reporting rather than dropping:
+                    # the app is still installed somewhere.
+                    real = self._devices.get(device.get("id")) or {}
+
+                    # Skip devices that stopped syncing long ago. Counted and
+                    # logged below rather than dropped silently. Only the
+                    # inventory timestamp is trusted: the sub-resource returns
+                    # year one for every device, which is older than any
+                    # cutoff and skipped the entire fleet.
+                    if cutoff is not None and real:
+                        last_sync = _parse_ts(real.get("lastSyncDateTime"))
+                        if last_sync is not None and last_sync < cutoff:
+                            stale_skipped += 1
+                            continue
                     findings.append(
                         Finding(
                             service=service,
                             source=DetectionSource.INTUNE_APP,
                             risk_tier=service.risk_tier,
-                            user_upn=device.get("upn"),
-                            device_name=device.get("device_name"),
+                            user_upn=(real.get("userPrincipalName")
+                                      or device.get("upn")),
+                            # Device identity is the hardware serial, the same
+                            # rule jamf.py follows: the endpoint collector on
+                            # this machine reports its BIOS serial, so a device
+                            # keyed on its computer name appears twice on any
+                            # view that joins on device.
+                            device_name=((real.get("serialNumber") or "").strip()
+                                         or device.get("device_name")),
                             detail=f"{app_name} installed on {device.get('device_name', 'unknown')}",
                             raw_evidence={
                                 "app_name": app_name,
-                                "device_name": device.get("device_name"),
+                                "device_name": (real.get("deviceName")
+                                                or device.get("device_name")),
                                 "managed_device_id": device.get("id"),
+                                "last_sync": real.get("lastSyncDateTime"),
                             },
                         )
                     )
@@ -177,6 +358,13 @@ class IntuneScanner(BaseScanner):
                 f"per-device attribution."
             )
 
+        if stale_skipped:
+            logger.info(
+                "Intune: skipped %d device record(s) with no sync in %d days. "
+                "Set stale_device_days in the scanner options to change this.",
+                stale_skipped, stale_days,
+            )
+
         return findings, errors
 
     async def _get_app_devices(
@@ -194,7 +382,13 @@ class IntuneScanner(BaseScanner):
         """
         url = (
             f"/deviceManagement/detectedApps/{app_id}/managedDevices"
-            f"?$select=deviceName,userPrincipalName,id"
+            # serialNumber and lastSyncDateTime are deliberately not asked
+            # for: this endpoint answers 200 and returns null and year one for
+            # them, which is worse than refusing, and trusting them skipped
+            # the entire fleet as stale. userPrincipalName is null here too on
+            # at least one tenant, but it costs nothing to ask and it keeps
+            # the fallback below real when the device map is unavailable.
+            f"?$select=deviceName,id,userPrincipalName"
         )
         try:
             devices = await paginate(client, url)
@@ -206,9 +400,14 @@ class IntuneScanner(BaseScanner):
 
         return [
             {
+                # Device identity is the hardware serial, the same rule
+                # jamf.py follows: the endpoint collector on this machine
+                # reports its BIOS serial, so a device keyed here on its
+                # computer name appears twice on any view that joins on
+                # device. The friendly name is kept for display.
                 "device_name": d.get("deviceName"),
-                "upn": d.get("userPrincipalName"),
                 "id": d.get("id"),
+                "upn": d.get("userPrincipalName"),
             }
             for d in devices
         ], None

--- a/scanner/ai_guard/scanners/sentinelone.py
+++ b/scanner/ai_guard/scanners/sentinelone.py
@@ -98,6 +98,8 @@ class SentinelOneScanner(BaseScanner):
         super().__init__(registry, config)
         self._auth: Optional[SentinelOneAuth] = None
         self._endpoint_users: dict[str, str] = {}
+        # computer name -> hardware serial. See _device_id below for why.
+        self._endpoint_serials: dict[str, str] = {}
 
     def check_prerequisites(self) -> tuple[bool, str]:
         try:
@@ -117,8 +119,10 @@ class SentinelOneScanner(BaseScanner):
                 self.config.options.get("lookback_days", 14), 14
             )
 
-            # Build endpoint -> user map from Agents API
-            self._endpoint_users = await self._build_endpoint_user_map(client)
+            # Build endpoint -> user and endpoint -> serial maps from the
+            # Agents API. Both come from the same call.
+            self._endpoint_users, self._endpoint_serials = (
+                await self._build_endpoint_user_map(client))
 
             # Shared seen set: tracks (endpoint, matched_domain) pairs
             # across both scans so we record at most one finding per
@@ -141,12 +145,20 @@ class SentinelOneScanner(BaseScanner):
         return result
 
     # ─────────────────────────────────────────────
-    # Agent inventory (endpoint -> user mapping)
+    # Agent inventory (endpoint -> user and serial mapping)
     # ─────────────────────────────────────────────
 
-    async def _build_endpoint_user_map(self, client) -> dict[str, str]:
-        """Build a map of endpoint name -> last logged in user via Agents API."""
+    async def _build_endpoint_user_map(
+        self, client
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """Endpoint name -> last logged in user, and -> hardware serial.
+
+        Both from the same Agents call, because the serial is what every
+        other source keys a device on and the DV events only carry the
+        computer name.
+        """
         endpoint_users = {}
+        endpoint_serials = {}
         cursor = None
         while True:
             params = {
@@ -164,13 +176,33 @@ class SentinelOneScanner(BaseScanner):
             for agent in data.get("data", []):
                 name = agent.get("computerName", "")
                 user = agent.get("lastLoggedInUserName", "")
+                serial = (agent.get("serialNumber") or "").strip()
                 if name and user:
                     endpoint_users[name] = user
+                if name and serial:
+                    endpoint_serials[name] = serial
 
             cursor = data.get("pagination", {}).get("nextCursor")
             if not cursor:
                 break
-        return endpoint_users
+        return endpoint_users, endpoint_serials
+
+    def _device_id(self, endpoint_name: str) -> str:
+        """The serial for an endpoint, or its computer name if unknown.
+
+        Device identity is the hardware serial, the same rule jamf.py
+        follows and for the same reason: the endpoint collectors and the
+        browser extension both report serials, so a machine reported here
+        by computer name appears twice on any view that joins on device.
+
+        The fallback is the computer name rather than nothing, because a
+        finding with no device at all is worse than one that joins
+        imperfectly. The agents call filters on isActive, so an endpoint
+        whose agent has gone quiet will not be in the map.
+        """
+        if not endpoint_name:
+            return endpoint_name
+        return self._endpoint_serials.get(endpoint_name, endpoint_name)
 
     # ─────────────────────────────────────────────
     # Scan 1: Shadow AI discovery
@@ -253,7 +285,7 @@ class SentinelOneScanner(BaseScanner):
                         source=DetectionSource.SENTINELONE_DNS,
                         risk_tier=service.risk_tier,
                         user_upn=self._normalize_user(user, endpoint_name),
-                        device_name=endpoint_name,
+                        device_name=self._device_id(endpoint_name),
                         detail=detail,
                         timestamp=_parse_ts(ts),
                         raw_evidence={
@@ -357,7 +389,7 @@ class SentinelOneScanner(BaseScanner):
                         source=DetectionSource.SENTINELONE_BRIDGE,
                         risk_tier="high",
                         user_upn=self._normalize_user(user, endpoint_name),
-                        device_name=endpoint_name,
+                        device_name=self._device_id(endpoint_name),
                         detail=f'Bridge: "{process_name}" resolving {dns_request}',
                         timestamp=_parse_ts(ts),
                         raw_evidence={

--- a/scanner/policy.yaml
+++ b/scanner/policy.yaml
@@ -41,10 +41,24 @@ scanners:
   # Intune — discovered apps on Windows devices (optional)
   # SentinelOne already catches active usage, so this is supplementary
   # Uses the same app registration as Entra
+  #
+  # Needs DeviceManagementManagedDevices.Read.All as well as
+  # DeviceManagementApps.Read.All. Without it, findings degrade to aggregate
+  # counts with no user or device, and the scan says so rather than passing
+  # them off as a clean result.
   intune:
     enabled: true
     credential_env_prefix: AIGUARD_ENTRA
-    options: {}
+    options:
+      # Skip devices whose last sync is older than this. Intune keeps a device
+      # record until someone removes it, so a laptop that left with a leaver
+      # still reports the AI apps that were on it. 0 disables the filter.
+      stale_device_days: 90
+      # Seconds between per-app device lookups. Graph throttles
+      # detectedApps/{id}/managedDevices hard: twenty one matched apps queried
+      # back to back had most of their calls refused. Costs about a second per
+      # matched app. 0 is right for a tenant small enough not to be throttled.
+      app_lookup_delay_seconds: 1.0
 
   # JAMF Pro — app inventory on Macs (optional)
   # SentinelOne already catches active usage, so this is supplementary

--- a/scanner/tests/test_intune_app_matching.py
+++ b/scanner/tests/test_intune_app_matching.py
@@ -1,0 +1,268 @@
+"""Intune reports display names; the registry holds executables.
+
+detectedApps returns whatever the installer wrote, and one inventory carries
+four naming schemes at once:
+
+    display name            Claude
+    versioned display name  LM Studio 0.3.20
+    package id              Exafunction.Windsurf
+    executable              ChatGPT.exe
+
+The registry's windows lists are exe_names. Intune says Claude, the registry
+says claude.exe, and an exact lookup matches neither. Twenty one AI app records
+produced one finding, and the only hit was Microsoft.Copilot because the
+registry happened to hold a package id for it.
+
+Both sides are normalised instead. The comparison is equality after
+normalising, deliberately not prefix: see test_prefix_matching_is_not_used.
+"""
+
+import asyncio
+
+import pytest
+
+from ai_guard.config import ScannerConfig
+from ai_guard.registry import AIService
+from ai_guard.scanners.intune import (
+    IntuneScanner,
+    _normalise_app_name,
+    _windows_names,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Executables and bundles: the suffix is not part of the name.
+        ("ChatGPT.exe", "chatgpt"),
+        ("Claude.app", "claude"),
+        # Package ids: last segment is the product, first is the publisher.
+        ("Exafunction.Windsurf", "windsurf"),
+        ("Microsoft.Copilot", "copilot"),
+        # Versioned display names, including the build-suffixed form.
+        ("LM Studio 0.3.20", "lm studio"),
+        ("LM Studio 0.4.20+1", "lm studio"),
+        ("Cursor v1.2.3", "cursor"),
+        # Plain display names survive untouched apart from case.
+        ("Claude", "claude"),
+        ("Claude Code", "claude code"),
+        # A dotted name with a space is a display name, not a package id.
+        ("Adobe Acrobat 2.0", "adobe acrobat"),
+        # Nothing in, nothing out.
+        ("", ""),
+        (None, ""),
+    ],
+)
+def test_normalise_app_name(raw, expected):
+    assert _normalise_app_name(raw) == expected
+
+
+def test_leading_digit_in_a_product_name_is_not_a_version():
+    """The version pattern needs whitespace before the digit.
+
+    Otherwise 1Password normalises to the empty string and matches everything
+    or nothing, depending on which side of the comparison it lands.
+    """
+    assert _normalise_app_name("1Password") == "1password"
+
+
+def test_windows_names_reads_the_macos_list_too():
+    """21 of the shipped registry's 30 tools have no windows list at all.
+
+    Reading only the windows list was why Intune returned one finding. A tool
+    is usually called the same thing on either platform once .app and .exe are
+    gone, so both lists are read and normalised.
+    """
+    svc = AIService(
+        name="Claude",
+        vendor="Anthropic",
+        category="chatbot",
+        risk_tier="high",
+        desktop_apps={"macos": ["Claude.app"]},
+    )
+    assert _windows_names(svc) == ["claude"]
+
+
+def test_windows_names_deduplicates_across_platforms():
+    svc = AIService(
+        name="Cursor",
+        vendor="Anysphere",
+        category="copilot",
+        risk_tier="medium",
+        desktop_apps={"windows": ["Cursor.exe"], "macos": ["Cursor.app"]},
+    )
+    assert _windows_names(svc) == ["cursor"]
+
+
+# ─────────────────────────────────────────────
+# End to end through the scanner
+# ─────────────────────────────────────────────
+
+CLAUDE = AIService(
+    name="Claude",
+    vendor="Anthropic",
+    category="chatbot",
+    risk_tier="high",
+    desktop_apps={"macos": ["Claude.app"]},
+)
+WINDSURF = AIService(
+    name="Windsurf",
+    vendor="Codeium",
+    category="copilot",
+    risk_tier="medium",
+    desktop_apps={"windows": ["Windsurf.exe"]},
+)
+LM_STUDIO = AIService(
+    name="LM Studio",
+    vendor="LM Studio",
+    category="chatbot",
+    risk_tier="high",
+    desktop_apps={"windows": ["LM Studio.exe"]},
+)
+# Detected through its CLI config, so it carries no desktop app names at all.
+CLAUDE_CODE = AIService(
+    name="Claude Code",
+    vendor="Anthropic",
+    category="agent",
+    risk_tier="high",
+    desktop_apps={},
+)
+
+
+class FakeRegistry:
+    services = [CLAUDE, WINDSURF, LM_STUDIO, CLAUDE_CODE]
+
+    def match_desktop_app(self, app_name):
+        # Exact lookup on the registry's own strings, which is what the real
+        # registry does. It misses every Intune display name, which is the
+        # whole reason the normalised path exists.
+        for svc in self.services:
+            for names in svc.desktop_apps.values():
+                if app_name in names:
+                    return svc
+        return None
+
+
+def _run(apps, devices=None):
+    devices = devices if devices is not None else []
+    scanner = IntuneScanner(
+        FakeRegistry(),
+        ScannerConfig(enabled=True, options={"app_lookup_delay_seconds": 0}),
+    )
+
+    async def fake_paginate(client, url, max_pages=20):
+        if "detectedApps?" in url:
+            return apps
+        return devices
+
+    import ai_guard.scanners.intune as mod
+
+    original = mod.paginate
+    mod.paginate = fake_paginate
+    try:
+        return asyncio.run(scanner._scan_discovered_apps(client=None))
+    finally:
+        mod.paginate = original
+
+
+def _app(display_name, count=1, app_id="a1"):
+    return {"id": app_id, "displayName": display_name, "deviceCount": count}
+
+
+def test_display_name_matches_a_macos_only_registry_entry():
+    findings, _ = _run([_app("Claude")])
+    assert len(findings) == 1
+    assert findings[0].service.name == "Claude"
+
+
+def test_package_id_matches():
+    findings, _ = _run([_app("Exafunction.Windsurf")])
+    assert len(findings) == 1
+    assert findings[0].service.name == "Windsurf"
+
+
+def test_versioned_display_name_matches():
+    findings, _ = _run([_app("LM Studio 0.3.20")])
+    assert len(findings) == 1
+    assert findings[0].service.name == "LM Studio"
+
+
+def test_prefix_matching_is_not_used():
+    """The rule is equality after normalising, and this is why.
+
+    Prefix matching would attribute an installed "Claude Code" to Claude,
+    because claude-code is detected through its CLI config and carries no
+    desktop app names of its own. A finding against the wrong tool is worse
+    than no finding: it is a confident answer that sends someone to the wrong
+    owner.
+    """
+    findings, _ = _run([_app("Claude Code")])
+    assert findings == []
+
+
+def test_unrelated_app_does_not_match():
+    findings, _ = _run([_app("iCloud Drive")])
+    assert findings == []
+
+
+def test_substring_does_not_match():
+    """The old fuzzy fallback was `known_app.lower() in app_name.lower()`.
+
+    "Claude" is a substring of "Claude Sync Helper", which is not Claude.
+    """
+    findings, _ = _run([_app("Claude Sync Helper")])
+    assert findings == []
+
+
+def test_longest_known_name_wins():
+    """Two services whose normalised names could both be reached.
+
+    Only one can be right, and the more specific one is.
+    """
+    cursor = AIService(
+        name="Cursor",
+        vendor="Anysphere",
+        category="copilot",
+        risk_tier="medium",
+        desktop_apps={"windows": ["Cursor.exe"]},
+    )
+    cursor_tab = AIService(
+        name="Cursor Tab",
+        vendor="Anysphere",
+        category="copilot",
+        risk_tier="low",
+        desktop_apps={"windows": ["Cursor Tab.exe"]},
+    )
+
+    class TwoServices:
+        services = [cursor, cursor_tab]
+
+        def match_desktop_app(self, app_name):
+            return None
+
+    scanner = IntuneScanner(
+        TwoServices(),
+        ScannerConfig(enabled=True, options={"app_lookup_delay_seconds": 0}),
+    )
+
+    async def fake_paginate(client, url, max_pages=20):
+        return [_app("Cursor Tab")] if "detectedApps?" in url else []
+
+    import ai_guard.scanners.intune as mod
+
+    original = mod.paginate
+    mod.paginate = fake_paginate
+    try:
+        findings, _ = asyncio.run(scanner._scan_discovered_apps(client=None))
+    finally:
+        mod.paginate = original
+
+    assert len(findings) == 1
+    assert findings[0].service.name == "Cursor Tab"
+
+
+def test_exact_registry_hit_still_wins_without_normalising():
+    """The normalised path is a fallback, not a replacement."""
+    findings, _ = _run([_app("Claude.app")])
+    assert len(findings) == 1
+    assert findings[0].service.name == "Claude"

--- a/scanner/tests/test_intune_device_map.py
+++ b/scanner/tests/test_intune_device_map.py
@@ -1,0 +1,279 @@
+"""Intune device attributes come from the devices resource, not the app lookup.
+
+The failure mode this guards against is specific and it answers 200.
+
+`GET /deviceManagement/detectedApps/{id}/managedDevices` honours $select for
+deviceName and id and stubs everything else: null for strings, year one for
+lastSyncDateTime. Nothing errors. A stale-device filter reading that timestamp
+finds every device older than any cutoff and skips the entire fleet, and a
+scanner keyed on that serialNumber gets null for every machine.
+
+Observed: nineteen apps resolved their devices, thirty nine device records came
+back, none survived the filter, and Intune reported two aggregate findings from
+a fleet with fourteen machines that had checked in that morning.
+
+So device attributes are read from /deviceManagement/managedDevices, fetched
+once into an id-keyed map, and the sub-resource is asked only for the two fields
+it answers honestly.
+"""
+
+import asyncio
+
+from ai_guard.config import ScannerConfig
+from ai_guard.registry import AIService
+from ai_guard.scanners import intune as intune_mod
+from ai_guard.scanners.intune import IntuneScanner
+
+SERVICE = AIService(
+    name="ChatGPT",
+    vendor="OpenAI",
+    category="chatbot",
+    risk_tier="high",
+    desktop_apps={"windows": ["ChatGPT.exe"]},
+)
+
+
+class FakeRegistry:
+    services = [SERVICE]
+
+    def match_desktop_app(self, app_name):
+        return SERVICE if app_name == "ChatGPT.exe" else None
+
+
+APPS = [{"id": "app-1", "displayName": "ChatGPT.exe", "deviceCount": 2}]
+
+# What the sub-resource actually returns. deviceName and id are real; the rest
+# is stubbed despite the 200. This is the trap, written out as a fixture.
+STUBBED_SUB_RESOURCE = [
+    {
+        "deviceName": "LAPTOP-01",
+        "id": "d1",
+        "userPrincipalName": None,
+        "serialNumber": None,
+        "lastSyncDateTime": "0001-01-01T00:00:00Z",
+    },
+    {
+        "deviceName": "LAPTOP-02",
+        "id": "d2",
+        "userPrincipalName": None,
+        "serialNumber": None,
+        "lastSyncDateTime": "0001-01-01T00:00:00Z",
+    },
+]
+
+# What the devices resource returns for the same two machines: real serials,
+# real users, and sync times from this morning.
+INVENTORY = [
+    {
+        "id": "d1",
+        "deviceName": "LAPTOP-01",
+        "serialNumber": "PF2ABCDE",
+        "userPrincipalName": "alice@example.com",
+        "lastSyncDateTime": "2026-08-10T06:14:00Z",
+        "operatingSystem": "Windows",
+    },
+    {
+        "id": "d2",
+        "deviceName": "LAPTOP-02",
+        "serialNumber": "PF3FGHIJ",
+        "userPrincipalName": "bob@example.com",
+        "lastSyncDateTime": "2026-08-10T07:02:00Z",
+        "operatingSystem": "Windows",
+    },
+]
+
+
+def _scanner(**options):
+    # No delay: the default is a real one second sleep per app after the first,
+    # which is right against Graph and wasted in a test.
+    options.setdefault("app_lookup_delay_seconds", 0)
+    return IntuneScanner(
+        FakeRegistry(), ScannerConfig(enabled=True, options=options)
+    )
+
+
+def _patch(monkeypatch, inventory=INVENTORY, sub=STUBBED_SUB_RESOURCE):
+    """Route each URL to the resource it actually represents.
+
+    inventory or sub may be an Exception, which is raised instead.
+    """
+    seen_urls = []
+
+    async def fake_paginate(client, url, max_pages=20):
+        seen_urls.append(url)
+        if "detectedApps?" in url:
+            return APPS
+        if "managedDevices?" in url and "detectedApps" not in url:
+            if isinstance(inventory, Exception):
+                raise inventory
+            return inventory
+        if isinstance(sub, Exception):
+            raise sub
+        return sub
+
+    monkeypatch.setattr(intune_mod, "paginate", fake_paginate)
+    return seen_urls
+
+
+async def _run(scanner):
+    """Build the device map then scan, which is what scan() does in order."""
+    scanner._devices = await scanner._build_device_map(client=None)
+    return await scanner._scan_discovered_apps(client=None)
+
+
+def test_stubbed_timestamps_do_not_skip_the_fleet(monkeypatch):
+    """The regression. Year one from the sub-resource must not be trusted.
+
+    Both devices synced this morning. Reading lastSyncDateTime from the app
+    lookup would date them to 0001-01-01, older than any cutoff, and drop both.
+    """
+    _patch(monkeypatch)
+    findings, errors = asyncio.run(_run(_scanner(stale_device_days=90)))
+
+    assert errors == []
+    assert len(findings) == 2, (
+        "devices that synced today were skipped as stale, which means a "
+        "timestamp is being read from the sub-resource"
+    )
+
+
+def test_serial_is_the_device_identity(monkeypatch):
+    """Device identity is the hardware serial, matching jamf.py.
+
+    The Windows collector on these machines reports its BIOS serial. A finding
+    keyed on LAPTOP-01 cannot be joined to one keyed on PF2ABCDE, so the
+    same machine appears twice on any view that groups by device.
+    """
+    _patch(monkeypatch)
+    findings, _ = asyncio.run(_run(_scanner()))
+
+    assert {f.device_name for f in findings} == {"PF2ABCDE", "PF3FGHIJ"}
+
+
+def test_friendly_name_is_kept_as_evidence(monkeypatch):
+    """Keying on the serial must not cost the human-readable name."""
+    _patch(monkeypatch)
+    findings, _ = asyncio.run(_run(_scanner()))
+
+    assert {f.raw_evidence["device_name"] for f in findings} == {
+        "LAPTOP-01",
+        "LAPTOP-02",
+    }
+
+
+def test_upn_comes_from_the_inventory_not_the_stub(monkeypatch):
+    """The sub-resource returns null for userPrincipalName on some tenants."""
+    _patch(monkeypatch)
+    findings, _ = asyncio.run(_run(_scanner()))
+
+    assert {f.user_upn for f in findings} == {
+        "alice@example.com",
+        "bob@example.com",
+    }
+
+
+def test_stale_device_is_skipped_on_the_inventory_timestamp(monkeypatch):
+    """The filter still has to work. One device last synced in 2019."""
+    old = [dict(INVENTORY[0]), dict(INVENTORY[1])]
+    old[0]["lastSyncDateTime"] = "2019-01-01T00:00:00Z"
+    _patch(monkeypatch, inventory=old)
+    findings, errors = asyncio.run(_run(_scanner(stale_device_days=90)))
+
+    assert errors == []
+    assert {f.device_name for f in findings} == {"PF3FGHIJ"}
+
+
+def test_stale_filter_can_be_disabled(monkeypatch):
+    old = [dict(INVENTORY[0]), dict(INVENTORY[1])]
+    old[0]["lastSyncDateTime"] = "2019-01-01T00:00:00Z"
+    _patch(monkeypatch, inventory=old)
+    findings, _ = asyncio.run(_run(_scanner(stale_device_days=0)))
+
+    assert len(findings) == 2
+
+
+def test_unparseable_timestamp_does_not_drop_a_device(monkeypatch):
+    """An unexpected format means do not filter, not discard.
+
+    Dropping a device because Graph returned something unfamiliar would hide a
+    real machine, which is the same class of error as the trap above.
+    """
+    odd = [dict(INVENTORY[0]), dict(INVENTORY[1])]
+    odd[0]["lastSyncDateTime"] = "not a timestamp"
+    _patch(monkeypatch, inventory=odd)
+    findings, _ = asyncio.run(_run(_scanner(stale_device_days=90)))
+
+    assert len(findings) == 2
+
+
+def test_inventory_failure_degrades_rather_than_aborts(monkeypatch):
+    """No device map is a worse result, not a dead scan.
+
+    Findings fall back to the name the sub-resource gave, which is the
+    behaviour the map replaced.
+    """
+    _patch(monkeypatch, inventory=PermissionError("403 Forbidden"))
+    findings, errors = asyncio.run(_run(_scanner(stale_device_days=90)))
+
+    assert len(findings) == 2
+    assert {f.device_name for f in findings} == {"LAPTOP-01", "LAPTOP-02"}
+
+
+def test_device_missing_from_inventory_is_still_reported(monkeypatch):
+    """The app is installed somewhere even if the record has been removed."""
+    _patch(monkeypatch, inventory=[INVENTORY[0]])
+    findings, _ = asyncio.run(_run(_scanner(stale_device_days=90)))
+
+    assert {f.device_name for f in findings} == {"PF2ABCDE", "LAPTOP-02"}
+
+
+def test_inventory_is_asked_for_the_fields_the_sub_resource_stubs(monkeypatch):
+    seen = _patch(monkeypatch)
+    asyncio.run(_run(_scanner()))
+
+    inventory_url = next(
+        u for u in seen if "managedDevices?" in u and "detectedApps" not in u
+    )
+    for field in ("serialNumber", "lastSyncDateTime", "userPrincipalName"):
+        assert field in inventory_url
+
+
+def test_sub_resource_is_not_asked_for_fields_it_stubs(monkeypatch):
+    """Asking costs nothing and returns a lie, which is worse than not asking.
+
+    Keeping them out of the $select is the documentation of the trap that
+    survives contact with a future edit.
+    """
+    seen = _patch(monkeypatch)
+    asyncio.run(_run(_scanner()))
+
+    sub_url = next(u for u in seen if "detectedApps/" in u)
+    assert "serialNumber" not in sub_url
+    assert "lastSyncDateTime" not in sub_url
+
+
+def test_inventory_is_fetched_once_not_per_app(monkeypatch):
+    """Graph rejects $expand=detectedApps on managedDevices, so the map is the
+    only way to avoid a per-app device call. It should not become per-app
+    itself."""
+    many = [
+        {"id": f"app-{i}", "displayName": "ChatGPT.exe", "deviceCount": 2}
+        for i in range(5)
+    ]
+    seen = []
+
+    async def fake_paginate(client, url, max_pages=20):
+        seen.append(url)
+        if "detectedApps?" in url:
+            return many
+        if "managedDevices?" in url and "detectedApps" not in url:
+            return INVENTORY
+        return STUBBED_SUB_RESOURCE
+
+    monkeypatch.setattr(intune_mod, "paginate", fake_paginate)
+    asyncio.run(_run(_scanner()))
+
+    inventory_calls = [
+        u for u in seen if "managedDevices?" in u and "detectedApps" not in u
+    ]
+    assert len(inventory_calls) == 1

--- a/scanner/tests/test_intune_devices.py
+++ b/scanner/tests/test_intune_devices.py
@@ -89,6 +89,11 @@ def test_genuinely_empty_is_not_reported_as_an_error(monkeypatch):
 
 
 def test_successful_lookup_produces_per_device_findings(monkeypatch):
+    """Note this exercises the fallback: _scan_discovered_apps is called
+    without a device map, so findings carry the sub-resource's device name
+    rather than a serial. Serial identity is covered in
+    test_intune_device_map.py, which builds the map first as scan() does.
+    """
     _patch_paginate(monkeypatch, DEVICES)
     findings, errors = asyncio.run(_scanner()._scan_discovered_apps(client=None))
 

--- a/scanner/tests/test_sentinelone_device_identity.py
+++ b/scanner/tests/test_sentinelone_device_identity.py
@@ -1,0 +1,157 @@
+"""SentinelOne reports device identity as the hardware serial.
+
+Deep Visibility events carry the computer name and nothing else, so findings
+used to be keyed on it. The endpoint collectors and the browser extension both
+report serials. The same machine therefore arrived twice, once as C02XK1ABCDEF
+from its collector and once as JANES-MBP from the scanner, and a fleet of about
+65 counted 73 devices.
+
+jamf.py had done this correctly since it was written and says why in its module
+docstring. This is the same rule applied to the other two sources.
+
+The serial comes from the Agents call the scanner already makes for the user
+map, so this costs no extra API calls.
+"""
+
+import asyncio
+
+from ai_guard.config import ScannerConfig
+from ai_guard.scanners.sentinelone import SentinelOneScanner
+
+
+class FakeRegistry:
+    services = []
+
+
+AGENTS = [
+    {
+        "computerName": "JANES-MBP",
+        "lastLoggedInUserName": "jane",
+        "serialNumber": "C02XK1ABCDEF",
+    },
+    {
+        "computerName": "LAPTOP-01",
+        "lastLoggedInUserName": "sam",
+        "serialNumber": "PF2ABCDE",
+    },
+]
+
+
+class FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class FakeClient:
+    """Returns one page of agents, then no cursor."""
+
+    def __init__(self, agents):
+        self.agents = agents
+        self.calls = 0
+
+    async def get(self, url, params=None):
+        self.calls += 1
+        return FakeResponse({"data": self.agents, "pagination": {}})
+
+
+def _scanner():
+    return SentinelOneScanner(FakeRegistry(), ScannerConfig(enabled=True))
+
+
+def test_agents_call_yields_both_maps():
+    scanner = _scanner()
+    users, serials = asyncio.run(
+        scanner._build_endpoint_user_map(FakeClient(AGENTS))
+    )
+
+    assert users == {"JANES-MBP": "jane", "LAPTOP-01": "sam"}
+    assert serials == {
+        "JANES-MBP": "C02XK1ABCDEF",
+        "LAPTOP-01": "PF2ABCDE",
+    }
+
+
+def test_both_maps_come_from_one_call():
+    """The serial must not cost a second pass over the agent inventory."""
+    scanner = _scanner()
+    client = FakeClient(AGENTS)
+    asyncio.run(scanner._build_endpoint_user_map(client))
+
+    assert client.calls == 1
+
+
+def test_device_id_returns_the_serial():
+    scanner = _scanner()
+    scanner._endpoint_serials = {"JANES-MBP": "C02XK1ABCDEF"}
+
+    assert scanner._device_id("JANES-MBP") == "C02XK1ABCDEF"
+
+
+def test_unknown_endpoint_falls_back_to_the_computer_name():
+    """A finding that joins imperfectly beats one with no device at all.
+
+    The agents call filters on isActive, so an endpoint whose agent has gone
+    quiet is absent from the map while its DV events are still in the lookback
+    window.
+    """
+    scanner = _scanner()
+    scanner._endpoint_serials = {}
+
+    assert scanner._device_id("RETIRED-LAPTOP") == "RETIRED-LAPTOP"
+
+
+def test_empty_endpoint_name_passes_through():
+    scanner = _scanner()
+    assert scanner._device_id("") == ""
+
+
+def test_agent_with_no_serial_is_absent_rather_than_blank():
+    """A blank serial must not become the device identity.
+
+    Every agent missing a serial would collapse to one device called "".
+    """
+    scanner = _scanner()
+    agents = [
+        {
+            "computerName": "NO-SERIAL",
+            "lastLoggedInUserName": "sam",
+            "serialNumber": "   ",
+        },
+        {
+            "computerName": "NULL-SERIAL",
+            "lastLoggedInUserName": "sam",
+            "serialNumber": None,
+        },
+    ]
+    users, serials = asyncio.run(
+        scanner._build_endpoint_user_map(FakeClient(agents))
+    )
+
+    assert serials == {}
+    assert users == {"NO-SERIAL": "sam", "NULL-SERIAL": "sam"}
+    assert scanner._device_id("NO-SERIAL") == "NO-SERIAL"
+
+
+def test_serial_is_recorded_even_when_the_user_is_unknown():
+    """The two maps are independent. An agent with no logged in user still
+    has a serial worth keying on."""
+    scanner = _scanner()
+    agents = [
+        {
+            "computerName": "KIOSK-01",
+            "lastLoggedInUserName": "",
+            "serialNumber": "PF9ZZZZZ",
+        }
+    ]
+    users, serials = asyncio.run(
+        scanner._build_endpoint_user_map(FakeClient(agents))
+    )
+
+    assert users == {}
+    assert serials == {"KIOSK-01": "PF9ZZZZZ"}


### PR DESCRIPTION
Four fixes found by running against a live fleet. None are specific to that deployment; all of them apply to anyone running this.

Intune device attributes now come from /deviceManagement/managedDevices, fetched once into an id-keyed map. The detectedApps sub-resource answers 200 and stubs everything it was not asked for: null for serialNumber and userPrincipalName, 0001-01-01 for lastSyncDateTime. Nothing errors. Year one is older than any cutoff, so a stale-device filter reading it drops the whole fleet. Apps resolved their devices, device records came back, none survived, and Intune reported two aggregate findings from a fleet whose machines had checked in that morning. $expand=detectedApps on managedDevices would avoid the per-app calls entirely, but Graph rejects it; the relationship is not navigable that way. The sub-resource is now asked only for deviceName and id, the two fields it answers honestly.

Intune app matching rewritten. detectedApps reports display names and the registry holds executables: Intune says Claude, the registry says claude.exe. One inventory carries four naming schemes at once, display names, versioned display names, package ids and executables, so both sides are normalised rather than one being made to look like the other. Strip .exe and .app, take the last dotted segment of a package id, strip a trailing version. The comparison is equality after normalising, not prefix: prefix attributes an installed "Claude Code" to Claude, because claude-code is detected through its CLI config and carries no desktop app names of its own, and a finding against the wrong tool is worse than no finding. Names are read from the macos list too, since 21 of the shipped registry's 30 tools have no windows list at all.

Device identity is the hardware serial on SentinelOne and Intune, which is what jamf.py has done since it was written and says why in its module docstring. DV events carry only the computer name and Intune sends deviceName, so the same machine arrived as a serial from its collector and a hostname from the scanner: more device rows than the fleet had machines. SentinelOne builds a name to serial map from the same Agents call it already makes for users, so this costs no extra requests. Both fall back to the old name when no serial is available, because a finding that joins imperfectly beats one with no device at all.

A second between per-app device lookups, configurable with app_lookup_delay_seconds and disabled at 0. Graph throttles detectedApps/{id}/managedDevices hard enough that paginate() spent all four of its Retry-After attempts on most calls when twenty one apps were queried back to back.

MCP tool identity: the tool is the tool, and the server list is evidence. All three collectors built the tool as <tool>-mcp:<servers>, so every distinct combination of servers became a separate tool and a machine with figma and context7 looked unrelated to a machine with figma alone. About twenty two near-identical rows where there should have been three. The server list moves into the evidence string. No portal change needed: derive.py already parses both formats, which matters because a lookback window holds findings from before and after collectors are updated.

Tests: 64 to 106. The Intune suite was green throughout the work above and covered none of it, because every test called _scan_discovered_apps directly and never built a device map, so the stale filter never ran and device_name always took the fallback. That is the same failure as a scan summary reading "reported 124 findings, 0 failed" while a module contributes nothing. The new tests build the map first, as scan() does, and all twelve fail against the previous implementation.

Two new scanner options documented in policy.yaml, since the port introduces them and they were otherwise reachable only by reading the source, and DeviceManagementManagedDevices.Read.All added to the permissions table in scanner/README.md. The module docstring has always required it; without it the device map returns nothing and every finding silently takes the degraded path this commit exists to fix.
