### PR TITLE
stop exception detail and Loki credentials reaching HTTP responses

### DIFF
--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -62,6 +62,7 @@ import logging
 import os
 import secrets
 import time
+import urllib.parse
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, HTTPException, Query
@@ -198,6 +199,31 @@ _last_loki_ok: float = 0.0
 _last_loki_error: str = ""
 
 
+def _redact_url(url):
+    """A URL with any embedded credentials removed.
+
+    LOKI_URL is operator-supplied and http://user:pass@host is a legal way to
+    supply it. Naming which Loki failed is genuinely useful in an error, so the
+    host stays and only the userinfo goes. Returns a placeholder rather than
+    the raw string if it will not parse, because a URL that cannot be parsed
+    cannot be confirmed safe to echo.
+    """
+    if not url:
+        return ""
+    try:
+        parts = urllib.parse.urlsplit(url)
+    except ValueError:
+        return "<unparseable url>"
+    if not parts.hostname:
+        return "<redacted>"
+    netloc = parts.hostname
+    if parts.port:
+        netloc = "%s:%d" % (netloc, parts.port)
+    return urllib.parse.urlunsplit(
+        (parts.scheme, netloc, parts.path, "", "")
+    )
+
+
 def _cached(key, hours, builder):
     now = time.time()
     hit = _cache.get(key)
@@ -222,13 +248,24 @@ def _findings(hours):
         _last_loki_error = ""
         return out
     except Exception as e:
-        _last_loki_error = str(e)
+        # The detail goes to the log, not to the caller. An exception message
+        # is written for an operator reading a stack trace, not for an HTTP
+        # body, and LOKI_URL may carry credentials in its userinfo.
+        log.warning(
+            "Loki read failed for %s: %s", _redact_url(LOKI_URL), e,
+            exc_info=True,
+        )
+        _last_loki_error = type(e).__name__
         # Say which of the two this is. A portal that shows an empty graph
         # when it cannot reach Loki is indistinguishable from one reporting a
-        # clean estate, which is the failure this project keeps finding.
+        # clean estate, which is the failure this project keeps finding. The
+        # redacted host and the exception type carry that distinction; the
+        # message behind it is one kubectl logs away.
         raise HTTPException(
             status_code=502,
-            detail="Could not read findings from Loki at %s: %s" % (LOKI_URL, e),
+            detail="Could not read findings from Loki at %s (%s). "
+                   "See the portal logs for detail."
+                   % (_redact_url(LOKI_URL), type(e).__name__),
         )
 
 
@@ -332,7 +369,14 @@ def diagnostics(_=Depends(require_auth)):
         reg_ok = bool(dm)
         reg_tools = len(set(dm.values())) if dm else 0
     except Exception as e:  # pragma: no cover - defensive
-        reg_err = str(e)
+        # A parse failure names the file, the line and the column. That is the
+        # right thing in a log and the wrong thing in a response body: the path
+        # is operator-supplied through REGISTRY_PATH. registry_loaded already
+        # carries the signal, so the type is enough to act on.
+        log.warning(
+            "registry load failed from %s: %s", REGISTRY_PATH, e, exc_info=True
+        )
+        reg_err = type(e).__name__
 
     return {
         "runtime": {

--- a/portal/tests/test_error_disclosure.py
+++ b/portal/tests/test_error_disclosure.py
@@ -1,0 +1,165 @@
+"""Exception detail and credentials must not reach an HTTP response.
+
+CodeQL flagged the diagnostics return as information exposure through an
+exception (CWE-209, CWE-497). It was right, and it found one of three.
+
+The one it missed was the worst: the 502 raised when Loki cannot be read
+interpolated LOKI_URL straight into the response body. LOKI_URL is
+operator-supplied and http://user:pass@host is a legal way to supply it, so a
+Loki outage would have put a credential in an error page. urllib's own
+exception strings are terse and do not carry the URL, which is why nothing
+surfaced it.
+
+The endpoints are behind require_auth, but PORTAL_AUTH=none is a supported and
+documented mode, so "authenticated only" is not the guarantee it looks like.
+
+What these tests hold to: the response says which Loki and what class of
+failure, because a portal that cannot distinguish "Loki is unreachable" from
+"the estate is clean" is the exact failure this project exists to catch. The
+message behind it goes to the log.
+"""
+
+import os
+
+os.environ.setdefault("PORTAL_AUTH", "none")
+
+import pytest
+from app.main import _redact_url
+from fastapi import HTTPException
+
+# ─────────────────────────────────────────────
+# URL redaction
+# ─────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # The case that matters: credentials in userinfo.
+        (
+            "http://svcuser:s3cr3t@loki.internal.example.com:3100",
+            "http://loki.internal.example.com:3100",
+        ),
+        # A username with no password still identifies an account.
+        (
+            "http://svcuser@loki.internal.example.com:3100",
+            "http://loki.internal.example.com:3100",
+        ),
+        # No credentials: the URL should survive intact, because naming which
+        # Loki failed is the useful half of the message.
+        (
+            "http://loki.monitoring.svc.cluster.local:3100",
+            "http://loki.monitoring.svc.cluster.local:3100",
+        ),
+        # Path preserved, query and fragment dropped: neither belongs in an
+        # error and a query string can carry anything.
+        (
+            "https://loki.example.com/prefix?token=abc#frag",
+            "https://loki.example.com/prefix",
+        ),
+        ("", ""),
+    ],
+)
+def test_redact_url(raw, expected):
+    assert _redact_url(raw) == expected
+
+
+def test_a_url_with_no_host_is_not_echoed():
+    """Something unparseable as a host must not be passed through verbatim.
+
+    A value that cannot be parsed cannot be confirmed safe to echo, so it is
+    replaced rather than trusted.
+    """
+    assert _redact_url("not-a-url-at-all") == "<redacted>"
+
+
+def test_password_never_survives_redaction():
+    """Belt and braces: assert on the secret, not on the expected output.
+
+    An implementation change that reformats the host would still be caught
+    here if it stopped stripping userinfo.
+    """
+    out = _redact_url("http://user:hunter2@loki.example.com:3100/path")
+    assert "hunter2" not in out
+    assert "user" not in out
+    # Equality rather than a containment check on the host: what survives
+    # matters as much as what does not, and asserting the whole result catches
+    # a redaction that dropped the port or mangled the path.
+    assert out == "http://loki.example.com:3100/path"
+
+
+# ─────────────────────────────────────────────
+# What reaches the caller
+# ─────────────────────────────────────────────
+
+def test_loki_failure_names_the_host_and_the_failure_type(monkeypatch):
+    """The 502 must stay diagnostic without carrying the exception message."""
+    from app import derive
+    from app import main as portal_main
+
+    monkeypatch.setattr(
+        portal_main, "LOKI_URL", "http://svcuser:s3cr3t@loki.example.com:3100"
+    )
+
+    def boom(*a, **kw):
+        raise RuntimeError("connection refused to 10.3.1.44 as svcuser/s3cr3t")
+
+    monkeypatch.setattr(derive, "fetch_from_loki", boom)
+
+    with pytest.raises(HTTPException) as exc:
+        portal_main._findings(1)
+
+    detail = exc.value.detail
+    assert "s3cr3t" not in detail, "credentials must not reach the response"
+    assert "svcuser" not in detail
+    assert "10.3.1.44" not in detail, "the message body must not be echoed"
+    # Compared against what _redact_url produces rather than a hardcoded host,
+    # so this stays coupled to the contract instead of to one example URL.
+    assert _redact_url(portal_main.LOKI_URL) in detail, \
+        "say which Loki, that is the point"
+    assert "RuntimeError" in detail, "say what class of failure it was"
+
+
+def test_loki_last_error_records_the_type_not_the_message(monkeypatch):
+    """loki_last_error is served by /api/diagnostics, so it is a response
+    field like any other."""
+    from app import derive
+    from app import main as portal_main
+
+    monkeypatch.setattr(portal_main, "LOKI_URL", "http://loki.example.com:3100")
+
+    def boom(*a, **kw):
+        raise RuntimeError("secret detail nobody should see over HTTP")
+
+    monkeypatch.setattr(derive, "fetch_from_loki", boom)
+
+    with pytest.raises(HTTPException):
+        portal_main._findings(1)
+
+    assert portal_main._last_loki_error == "RuntimeError"
+
+
+def test_a_successful_read_clears_the_recorded_error(monkeypatch):
+    """A stale error string on a working portal is its own kind of lie."""
+    from app import derive
+    from app import main as portal_main
+
+    monkeypatch.setattr(portal_main, "LOKI_URL", "http://loki.example.com:3100")
+    portal_main._last_loki_error = "RuntimeError"
+    monkeypatch.setattr(derive, "fetch_from_loki", lambda *a, **kw: [])
+
+    portal_main._findings(1)
+
+    assert portal_main._last_loki_error == ""
+
+
+def test_missing_loki_url_still_says_so(monkeypatch):
+    """The 503 for unconfigured Loki names a variable, not a value, so it was
+    never the problem and must not regress into silence."""
+    from app import main as portal_main
+
+    monkeypatch.setattr(portal_main, "LOKI_URL", "")
+
+    with pytest.raises(HTTPException) as exc:
+        portal_main._findings(1)
+
+    assert "LOKI_URL" in exc.value.detail


### PR DESCRIPTION
CodeQL alert #32 flagged the diagnostics return as information exposure through an exception, CWE-209 and CWE-497. It was right, and it found one of three.

The one it missed was the worst. The 502 raised when Loki cannot be read interpolated LOKI_URL straight into the response body. LOKI_URL is operator-supplied and http://user:pass@host is a legal way to supply it, so a Loki outage would have served a credential in an error page. Nothing surfaced it because urllib's own exception strings are terse and never carry the URL, so the leak only appears when the URL is interpolated by hand, which is exactly what that line did.

The other two both feed /api/diagnostics. registry_error carried a parse failure naming the file, line and column, and REGISTRY_PATH is operator-set. loki_last_error carried whatever the read raised.

All three now log the detail and return the exception type. The 502 keeps saying which Loki and what class of failure, because a portal that cannot distinguish "Loki is unreachable" from "the estate is clean" is the failure this project exists to catch, and that distinction survives without the message behind it. registry_loaded already carried the same signal for the registry, so the type is enough to act on there too.

_redact_url strips userinfo and keeps the host, since naming which Loki failed is the useful half. Query and fragment go too. A value that will not parse is replaced rather than echoed, because a URL that cannot be parsed cannot be confirmed safe to print.

These endpoints are behind require_auth, but PORTAL_AUTH=none is a supported and documented mode, so "authenticated only" was never the guarantee it looked like.

Tests: 33 to 43. The new ones assert on the secret rather than the expected string, so a reformat that stopped stripping userinfo would still fail. The pre-fix code was run against the same input to confirm it leaked: the 502 body contained both the password and an internal IP from the exception message.