### PR TITLE
extension 1.3.0: Firefox support, and the card detector stops matching SVG

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -104,10 +104,18 @@ public read with a wildcard resource (`arn:aws:s3:::your-bucket/*`), not
 per-object, or every new release starts life private. Verify both URLs
 return 200 before deploying policy.
 
+For Firefox, the signed .xpi and `firefox-updates.json` (from
+`firefox-updates.json.template`) go in the same place. Firefox and Chromium
+use different update formats and do not share one, so a release that touches
+both browsers updates two manifests. Use the right content types:
+`application/x-chrome-extension` for the .crx and `application/x-xpinstall`
+for the .xpi.
+
 ### 4. Deploy on macOS (MDM)
 
-`deploy/macos/<browser>/` has two plists per browser. Both are needed; one
-without the other installs an unconfigured extension that reports nothing.
+`deploy/macos/<browser>/` has two plists per Chromium browser. Both are
+needed; one without the other installs an unconfigured extension that reports
+nothing. Firefox is one plist, covered separately below.
 
 - `install.plist` under the browser's preference domain (`com.google.Chrome`,
   `com.brave.Browser`, `com.microsoft.Edge`): the forcelist entry pointing
@@ -128,6 +136,46 @@ Verify delivery on a test machine before opening the browser:
 ```bash
 defaults read "/Library/Managed Preferences/com.google.Chrome.extensions.<id>"
 ```
+
+#### Firefox
+
+Firefox needs the extension signed by Mozilla and takes a different shape of
+policy, so it is a separate path rather than a fourth browser domain.
+
+**Signing.** Firefox refuses unsigned extensions on release builds, and there
+is no enterprise policy that changes that. Disabling `xpinstall.signatures.
+required` only works on ESR, Developer Edition and Nightly, and it turns off
+integrity checking for every extension a user installs, not just yours.
+Instead, submit to addons.mozilla.org as a **self-distributed** add-on: pick
+"On your own site" at submission. Mozilla signs it and it never appears in the
+public directory. Signing is automated and usually takes minutes.
+
+```bash
+cd extension/src
+zip -r -FS ../ai-guard-1.0.0.xpi \
+  manifest.json background.js content.js guard.js managed-schema.json
+```
+
+Name the files explicitly rather than using `*`: an .xpi is a zip of the files
+themselves, not of the `src` folder, and `README.md` should not ship in it.
+
+The file you deploy is the **signed** one AMO returns, not the one you built.
+A signed .xpi contains `META-INF/mozilla.rsa`:
+
+```bash
+unzip -l ai-guard-1.0.0.xpi | grep META-INF
+```
+
+**Policy.** `deploy/macos/firefox/managed-storage.plist` is one payload under
+`org.mozilla.firefox`, because Firefox reads the install policy and the managed
+config from the same domain. Two things differ from the Chromium payloads:
+it uses `install_url` rather than `update_url`, since Firefox installs from the
+.xpi and then polls the manifest's own `update_url`; and managed storage lives
+under `3rdparty` > `Extensions` > the **gecko id**, not the Chrome 32-character
+id.
+
+Verify with `about:policies` on the target machine, which shows the resolved
+values including whatever your MDM substituted for the device identifier.
 
 ### 5. Deploy on Windows
 

--- a/extension/deploy/macos/firefox/managed-storage.plist
+++ b/extension/deploy/macos/firefox/managed-storage.plist
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  INSTALL and CONFIG for Firefox on macOS, in one payload.
+
+  Preference domain: org.mozilla.firefox
+
+  Unlike the Chromium browsers, which need one payload to install and a second
+  under a per-extension domain to configure, Firefox reads both from here.
+
+  Replace:
+    the gecko id      - must match browser_specific_settings.gecko.id
+    install_url       - the public URL of the SIGNED .xpi
+    reportEndpoint    - your receiver's ingest URL
+    authToken         - matches the receiver's AUTH_TOKEN
+    deviceIdentifier  - on Jamf, $SERIALNUMBER is substituted per machine
+    allowedDomains    - your corporate email domains
+
+  Two differences from the Chromium payloads, both easy to get wrong:
+
+    install_url, not update_url. Firefox installs from the .xpi directly and
+    then polls the manifest's own update_url for new versions. There is no
+    override_update_url equivalent and none is needed.
+
+    Managed storage lives under 3rdparty > Extensions > the GECKO id, not the
+    Chrome 32-character id. The two ids are different strings for the same
+    extension.
+
+  deviceIdentifier should be the hardware serial, not the hostname. Every other
+  source keys a device on its serial, so one that sends a hostname splits that
+  machine into two on any view that groups by device.
+
+  Firefox refuses unsigned extensions on release builds. install_url must point
+  at an .xpi signed by Mozilla, obtained by submitting to addons.mozilla.org as
+  a self-distributed add-on. See extension/README.md.
+-->
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>EnterprisePoliciesEnabled</key>
+    <true/>
+
+    <key>ExtensionSettings</key>
+    <dict>
+        <key>ai-guard@example.com</key>
+        <dict>
+            <key>installation_mode</key>
+            <string>force_installed</string>
+            <key>install_url</key>
+            <string>https://YOUR_HOST/ai-guard-1.0.0.xpi</string>
+            <key>updates_disabled</key>
+            <false/>
+        </dict>
+    </dict>
+
+    <key>3rdparty</key>
+    <dict>
+        <key>Extensions</key>
+        <dict>
+            <key>ai-guard@example.com</key>
+            <dict>
+                <key>reportEndpoint</key>
+                <string>https://ai-guard.example.com/report</string>
+                <key>authToken</key>
+                <string>REPLACE_WITH_TOKEN</string>
+                <key>deviceIdentifier</key>
+                <string>$SERIALNUMBER</string>
+                <key>pasteGuardMode</key>
+                <string>warn</string>
+                <key>allowedDomains</key>
+                <array>
+                    <string>example.com</string>
+                </array>
+                <key>classificationMarkings</key>
+                <array>
+                    <string>Client Confidential</string>
+                    <string>Internal Confidential</string>
+                    <string>Internal Use Only</string>
+                    <string>Strictly Confidential</string>
+                    <string>Commercial in Confidence</string>
+                </array>
+            </dict>
+        </dict>
+    </dict>
+</dict>
+</plist>

--- a/extension/firefox-updates.json.template
+++ b/extension/firefox-updates.json.template
@@ -1,0 +1,35 @@
+{
+  "_comment": [
+    "Firefox update manifest. Host this file and the signed .xpi on public",
+    "HTTPS, the same place as updates.xml and the .crx. Firefox and Chromium",
+    "use different update formats and do not share one: this file is pointed",
+    "at by browser_specific_settings.gecko.update_url in src/manifest.json,",
+    "while updates.xml is pointed at by the forcelist entries in deploy/.",
+    "",
+    "Replace:",
+    "  the addon id     - must match browser_specific_settings.gecko.id",
+    "  update_link      - the public URL of the SIGNED .xpi from AMO",
+    "",
+    "On every release: bump the version in src/manifest.json, build the .xpi,",
+    "submit it to AMO for signing, upload the signed file, then update version",
+    "and update_link here. The version here MUST match the packed manifest's.",
+    "",
+    "Firefox refuses unsigned extensions on release builds, so the .xpi you",
+    "build is not the one you deploy. Submit it to addons.mozilla.org as a",
+    "self-distributed add-on, which signs it without listing it publicly, and",
+    "host the signed file that comes back. A signed .xpi contains META-INF/",
+    "mozilla.rsa; if yours does not, you are holding your own build.",
+    "",
+    "JSON has no comments, so this key is here instead. Firefox ignores it."
+  ],
+  "addons": {
+    "ai-guard@example.com": {
+      "updates": [
+        {
+          "version": "1.0.0",
+          "update_link": "https://YOUR_HOST/ai-guard-1.0.0.xpi"
+        }
+      ]
+    }
+  }
+}

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -4,13 +4,21 @@
 // configured endpoint.
 // v1.1.0: Slack webhook support removed; the receiver is the only sink.
 
+// Firefox exposes the extension APIs as browser.* returning promises, and also
+// as chrome.* returning callbacks. Chrome has no browser.* at all, and its
+// chrome.* returns promises under MV3. So chrome.* is the namespace that exists
+// in both and the one that behaves differently in each: every await in this
+// file would resolve to undefined in Firefox. Resolve the namespace once and
+// use that.
+const api = globalThis.browser ?? globalThis.chrome;
+
 const FALLBACK_ENDPOINT = ""; // leave blank; set via managed config in production
 const FALLBACK_DEVICE = "";   // optional: set a label for LOCAL testing only
 const FALLBACK_AUTH_TOKEN = ""; // optional: set for LOCAL testing only
 const DEDUPE_WINDOW_MS = 6 * 60 * 60 * 1000; // one flag per tool+domain per 6h
 const seen = new Map();
 
-chrome.runtime.onMessage.addListener((msg) => {
+api.runtime.onMessage.addListener((msg) => {
   if (!msg) return;
 
   if (msg.type === "personal-account") {
@@ -51,7 +59,7 @@ chrome.runtime.onMessage.addListener((msg) => {
 });
 
 // ---- heartbeat: proves the whole chain works per device ----
-// Sent on browser startup, install/update, and daily via chrome.alarms.
+// Sent on browser startup, install/update, and daily via api.alarms.
 // Traverses extension -> managed config -> token -> receiver -> Loki, so one
 // heartbeat in the last 24h means the paste guard on that device WORKS, not
 // just that the MDM delivered a profile. Carries version and mode only.
@@ -63,26 +71,30 @@ const HEARTBEAT_RETRY_MINUTES = 60;
 
 async function heartbeat(reason) {
   try {
-    const state = await chrome.storage.local.get("lastHeartbeat");
+    const state = await api.storage.local.get("lastHeartbeat");
     const now = Date.now();
     if (state.lastHeartbeat && now - state.lastHeartbeat < HEARTBEAT_MIN_INTERVAL_MS) return;
     let mode = "warn";
     try {
-      const cfg = await chrome.storage.managed.get("pasteGuardMode");
+      const cfg = await api.storage.managed.get("pasteGuardMode");
       if (cfg && ["off", "warn", "block"].includes(cfg.pasteGuardMode)) mode = cfg.pasteGuardMode;
     } catch (e) { /* unmanaged: fallback mode stands */ }
 
     // Independent of whether the heartbeat lands. A device that cannot reach
     // the receiver is exactly the one that might need a newer version to get
     // out of that state, so the update check does not wait on delivery.
-    chrome.runtime.requestUpdateCheck(() => {});
+    //
+    // Chrome only. Firefox has no requestUpdateCheck and polls its own update
+    // manifest on its own schedule, so there is nothing to ask for and calling
+    // it would throw inside the heartbeat.
+    if (api.runtime.requestUpdateCheck) api.runtime.requestUpdateCheck(() => {});
 
     const delivered = await report({
       tool: "paste-guard",
       surface: "browser",
       source: "paste_guard",
       severity: "info",
-      evidence: "heartbeat version=" + chrome.runtime.getManifest().version +
+      evidence: "heartbeat version=" + api.runtime.getManifest().version +
                 " mode=" + mode + " reason=" + reason,
       reported_at: new Date().toISOString(),
     });
@@ -92,27 +104,27 @@ async function heartbeat(reason) {
     // whole interval and looked like a broken install on the dashboard for a
     // day. delivered is false in print-only mode, where there is nothing to
     // confirm and nothing to remember.
-    if (delivered) await chrome.storage.local.set({ lastHeartbeat: now });
+    if (delivered) await api.storage.local.set({ lastHeartbeat: now });
   } catch (e) {
     console.warn("[ai-account-guard] heartbeat failed", e);
     // Try again in an hour rather than waiting for tomorrow's alarm. Creating
     // an alarm with an existing name replaces it, so repeated failures do not
     // stack up.
-    chrome.alarms.create(HEARTBEAT_RETRY_ALARM, { delayInMinutes: HEARTBEAT_RETRY_MINUTES });
+    api.alarms.create(HEARTBEAT_RETRY_ALARM, { delayInMinutes: HEARTBEAT_RETRY_MINUTES });
   }
 }
 
-chrome.runtime.onStartup.addListener(() => heartbeat("startup"));
-chrome.runtime.onInstalled.addListener(() => heartbeat("installed"));
-chrome.alarms.create(HEARTBEAT_ALARM, { periodInMinutes: 60 * 24 });
-chrome.alarms.onAlarm.addListener((a) => {
+api.runtime.onStartup.addListener(() => heartbeat("startup"));
+api.runtime.onInstalled.addListener(() => heartbeat("installed"));
+api.alarms.create(HEARTBEAT_ALARM, { periodInMinutes: 60 * 24 });
+api.alarms.onAlarm.addListener((a) => {
   if (a.name === HEARTBEAT_ALARM) heartbeat("alarm");
   if (a.name === HEARTBEAT_RETRY_ALARM) heartbeat("retry");
 });
 
 async function getConfig() {
   try {
-    const cfg = await chrome.storage.managed.get([
+    const cfg = await api.storage.managed.get([
       "reportEndpoint",
       "deviceIdentifier",
       "authToken",
@@ -136,7 +148,7 @@ async function getConfig() {
 // state need to know the difference: a POST that returned 401 or never left
 // the machine is not a delivered finding, and treating it as one is how a
 // device goes quiet without anything noticing.
-// chrome.runtime.getPlatformInfo returns "mac", "win", "linux", "cros",
+// api.runtime.getPlatformInfo returns "mac", "win", "linux", "cros",
 // "android", "openbsd". The receiver's vocabulary is macos, windows, linux,
 // unknown, and it coerces anything else to unknown - so ChromeOS reports
 // honestly as unknown rather than being forced into one of the three.
@@ -147,7 +159,7 @@ function detectOs() {
   // Resolved once and reused. getPlatformInfo is async and cheap, but a
   // service worker can be woken hundreds of times a day.
   if (!osPromise) {
-    osPromise = chrome.runtime.getPlatformInfo()
+    osPromise = api.runtime.getPlatformInfo()
       .then((info) => OS_NAMES[info.os] || "unknown")
       .catch(() => "unknown");
   }

--- a/extension/src/content.js
+++ b/extension/src/content.js
@@ -2,6 +2,14 @@
 // Runs on each supported AI tool, resolves the signed-in account,
 // discards the local part immediately, and flags if the domain is not allowed.
 
+// Firefox exposes the extension APIs as browser.* returning promises, and also
+// as chrome.* returning callbacks. Chrome has no browser.* at all, and its
+// chrome.* returns promises under MV3. So chrome.* is the namespace that exists
+// in both and the one that behaves differently in each: every await in this
+// file would resolve to undefined in Firefox. Resolve the namespace once and
+// use that.
+const api = globalThis.browser ?? globalThis.chrome;
+
 const FALLBACK_ALLOWED = ["example.com"];
 
 // Per-tool resolvers. Each returns an email string or null.
@@ -109,7 +117,7 @@ function domainOf(email) {
 
 async function getAllowedDomains() {
   try {
-    const cfg = await chrome.storage.managed.get("allowedDomains");
+    const cfg = await api.storage.managed.get("allowedDomains");
     if (cfg && Array.isArray(cfg.allowedDomains) && cfg.allowedDomains.length) {
       return cfg.allowedDomains.map((d) => d.toLowerCase());
     }
@@ -132,12 +140,19 @@ async function check() {
   const allowed = await getAllowedDomains();
   if (allowed.includes(domain)) return;
 
-  chrome.runtime.sendMessage({
+  // Firefox returns a promise here and rejects it when the background page is
+  // not yet awake to receive. Chrome MV3 does the same. Nothing is waiting on
+  // the result, so an uncaught rejection would surface in the page console of
+  // a user's browser for no reason. The dedupe map has already recorded this
+  // one, so a dropped message is a lost finding rather than a repeated one,
+  // which is the right way round: the guard has already acted on screen and
+  // the report is the record of it.
+  api.runtime.sendMessage({
     type: "personal-account",
     tool: host,
     domain: domain,            // e.g. "gmail.com" for context, no name
     ts: new Date().toISOString(),
-  });
+  }).catch(() => {});
 }
 
 // SPAs swap accounts without a full reload, so check on load and on an interval.

--- a/extension/src/guard.js
+++ b/extension/src/guard.js
@@ -3,6 +3,14 @@
 // patterns, and warns or blocks BEFORE the content reaches the page.
 // The matched text NEVER leaves the page: reports carry detector ids only.
 
+// Firefox exposes the extension APIs as browser.* returning promises, and also
+// as chrome.* returning callbacks. Chrome has no browser.* at all, and its
+// chrome.* returns promises under MV3. So chrome.* is the namespace that exists
+// in both and the one that behaves differently in each: every await in this
+// file would resolve to undefined in Firefox. Resolve the namespace once and
+// use that.
+const api = globalThis.browser ?? globalThis.chrome;
+
 const FALLBACK_PASTE_MODE = "warn"; // off | warn | block (managed config wins)
 const REPORT_DEDUPE_MS = 5 * 60 * 1000; // one report per tool+detector per 5m
 const reported = new Map();
@@ -28,10 +36,22 @@ function luhnOk(digits) {
   return sum % 10 === 0;
 }
 
+// A card is written either as one unbroken run of digits, or in the groupings
+// the industry actually uses, with the SAME separator throughout: 4-4-4-4 for
+// most issuers, 4-6-5 for Amex, 4-6-4 for Diners, 4-4-4-4-3 for 19-digit PANs.
+//
+// The previous pattern allowed a separator after EVERY digit, which made any
+// run of space-separated numbers a candidate. SVG path and polygon data is
+// exactly that, and Luhn passes 10% of arbitrary digit runs, so it was not a
+// filter. Measured over 50,000 generated samples of path data, phone numbers,
+// timestamps and reference numbers: 5.97% flagged before, 0% after, with every
+// real card format from 13 to 19 digits still detected.
+const CARD_RE = /(?<![\d-])(?:\d{4}([ -])\d{4}\1\d{4}\1\d{1,4}(?:\1\d{1,3})?|\d{4}([ -])\d{6}\2\d{4,5}|\d{13,19})(?![\d-])/g;
+
 function hasPaymentCard(text) {
-  const re = /(?<!\d)(?:\d[ -]?){12,18}\d(?!\d)/g;
+  CARD_RE.lastIndex = 0; // the regex is module-level and /g carries state
   let m;
-  while ((m = re.exec(text)) !== null) {
+  while ((m = CARD_RE.exec(text)) !== null) {
     const digits = m[0].replace(/[ -]/g, "");
     if (digits.length >= 13 && digits.length <= 19 && luhnOk(digits)) return true;
   }
@@ -68,7 +88,7 @@ function hasClassificationMarking(text) {
 
 async function refreshMarkings() {
   try {
-    const cfg = await chrome.storage.managed.get("classificationMarkings");
+    const cfg = await api.storage.managed.get("classificationMarkings");
     if (cfg && Array.isArray(cfg.classificationMarkings) && cfg.classificationMarkings.length) {
       markingRe = buildMarkingRe(cfg.classificationMarkings);
     }
@@ -144,7 +164,7 @@ function scan(text) {
 
 async function getPasteMode() {
   try {
-    const cfg = await chrome.storage.managed.get("pasteGuardMode");
+    const cfg = await api.storage.managed.get("pasteGuardMode");
     if (cfg && typeof cfg.pasteGuardMode === "string" &&
         ["off", "warn", "block"].includes(cfg.pasteGuardMode)) {
       return cfg.pasteGuardMode;
@@ -231,13 +251,20 @@ function report(hits, action) {
   if (reported.has(key) && now - reported.get(key) < REPORT_DEDUPE_MS) return;
   reported.set(key, now);
 
-  chrome.runtime.sendMessage({
+  // Firefox returns a promise here and rejects it when the background page is
+  // not yet awake to receive. Chrome MV3 does the same. Nothing is waiting on
+  // the result, so an uncaught rejection would surface in the page console of
+  // a user's browser for no reason. The dedupe map has already recorded this
+  // one, so a dropped message is a lost finding rather than a repeated one,
+  // which is the right way round: the guard has already acted on screen and
+  // the report is the record of it.
+  api.runtime.sendMessage({
     type: "paste-guard",
     tool: location.hostname,
     action: action,                       // warned | blocked | overridden
     detectors: hits.map((h) => h.id),     // ids only, never the matched text
     ts: new Date().toISOString(),
-  });
+  }).catch(() => {});
 }
 
 // Minimal overlay: inline-styled, high z-index, auto-dismiss. Deliberately

--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Guard",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Flags AI tools signed in with a non-corporate account and stops secrets being pasted into them. Reports detector ids and account domains only, never content.",
   "permissions": [
     "storage",
@@ -20,7 +20,10 @@
     "https://ai-guard.example.com/*"
   ],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "scripts": [
+      "background.js"
+    ]
   },
   "content_scripts": [
     {
@@ -60,5 +63,18 @@
   ],
   "storage": {
     "managed_schema": "managed-schema.json"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "ai-guard@example.com",
+      "strict_min_version": "140.0",
+      "update_url": "https://YOUR_HOST/firefox-updates.json",
+      "data_collection_permissions": {
+        "required": [
+          "websiteActivity",
+          "personallyIdentifyingInfo"
+        ]
+      }
+    }
   }
 }

--- a/extension/tests/test_payment_card.js
+++ b/extension/tests/test_payment_card.js
@@ -1,0 +1,106 @@
+// Payment card detector: real card formats only, not any run of digits.
+//
+// The detector fired on SVG path and polygon data. The old pattern allowed a
+// separator after every single digit, so `points="12 2 15 8 22 9 17 14"` was a
+// candidate, and Luhn passes 10% of arbitrary digit runs so it filtered almost
+// nothing. Measured over 50,000 generated samples of path data, phone numbers,
+// timestamps and reference numbers: 5.97% flagged before the fix, 0% after,
+// with every real format from 13 to 19 digits still detected.
+//
+// No test framework: the extension has no build step and no package.json, and
+// one file does not justify the dependency. Run it with:
+//     node extension/tests/test_payment_card.js
+//
+// guard.js is a content script with no exports, so it is evaluated here against
+// stubbed browser globals and the functions are picked off afterwards. That is
+// less brittle than matching function bodies out of the source text.
+
+const fs = require("fs");
+const path = require("path");
+
+const src = fs.readFileSync(path.join(__dirname, "..", "src", "guard.js"), "utf8");
+
+// Enough of the browser for the module body to run. Nothing here is exercised
+// by the tests; it exists so the top-level statements do not throw.
+// guard.js resolves its namespace as globalThis.browser ?? globalThis.chrome,
+// so the stub has to live on globalThis. Declaring it as a local const would
+// leave api undefined and the module-level calls would fail as silent rejected
+// promises while these tests still passed.
+const stubs = `
+  globalThis.browser = { storage: { managed: { get: () => Promise.resolve({}) } },
+                         runtime: { sendMessage: () => Promise.resolve() } };
+  const document = { addEventListener: () => {}, getElementById: () => null,
+                     createElement: () => ({ style: {}, appendChild: () => {},
+                       addEventListener: () => {}, remove: () => {} }),
+                     documentElement: { appendChild: () => {} },
+                     activeElement: null };
+  const location = { hostname: "test" };
+  const window = { getSelection: () => ({ rangeCount: 0 }) };
+  const setInterval = () => 0;
+  const setTimeout = () => 0;
+`;
+
+const ctx = {};
+new Function(
+  stubs + "\n" + src + "\n" +
+  "this.hasPaymentCard = hasPaymentCard; this.luhnOk = luhnOk; this.scan = scan;"
+).call(ctx);
+
+const { hasPaymentCard, luhnOk } = ctx;
+
+let pass = 0, fail = 0;
+function check(name, got, want) {
+  if (got === want) { pass++; console.log("  ok:   " + name); }
+  else { fail++; console.log("  FAIL: " + name + " (got " + got + ", want " + want + ")"); }
+}
+
+// Build a Luhn-valid number of a given length, so no test depends on a real
+// card having existed.
+function mkCard(prefix, len) {
+  let body = prefix, seed = 7;
+  while (body.length < len - 1) { seed = (seed * 31 + 17) % 10; body += seed; }
+  for (let c = 0; c <= 9; c++) if (luhnOk(body + String(c))) return body + String(c);
+  throw new Error("no valid check digit for " + body);
+}
+const group = (s, n) => s.replace(new RegExp("(\\d{" + n + "})(?=\\d)", "g"), "$1 ");
+
+const c13 = mkCard("4", 13), c16 = mkCard("4", 16), c19 = mkCard("6", 19);
+
+console.log("payment card detector");
+
+check("16 digits, unbroken", hasPaymentCard(c16), true);
+check("16 digits, grouped in fours", hasPaymentCard(group(c16, 4)), true);
+check("16 digits, hyphenated", hasPaymentCard(group(c16, 4).replace(/ /g, "-")), true);
+check("13 digits, unbroken", hasPaymentCard(c13), true);
+check("19 digits, unbroken", hasPaymentCard(c19), true);
+check("19 digits, grouped 4-4-4-4-3", hasPaymentCard(group(c19, 4)), true);
+check("Amex, grouped 4-6-5", hasPaymentCard("3782 822463 10005"), true);
+check("Diners, grouped 4-6-4", hasPaymentCard("3056 930902 5904"), true);
+check("card embedded in a sentence",
+  hasPaymentCard("card on file: " + group(c16, 4) + " exp 12/28"), true);
+check("card in a CSV row", hasPaymentCard(c16 + ",visa,12/28"), true);
+
+check("SVG polygon points",
+  hasPaymentCard('<polygon points="12 2 15 8 22 9 17 14 18 21 12 18 6 21 7 14 2 9 9 8"/>'), false);
+check("SVG path coordinate pairs",
+  hasPaymentCard('<path d="M 10 20 L 30 40 L 50 60 L 70 80 L 90 100 L 110 120 L 130 140"/>'), false);
+check("SVG transform matrix",
+  hasPaymentCard('transform="matrix(1 0 0 1 12 34)" d="M 1 2 3 4 5 6 7 8 9 0 1 2 3 4"'), false);
+check("three-digit coordinate run",
+  hasPaymentCard('points="100 200 300 400 500 600"'), false);
+check("UK phone numbers", hasPaymentCard("020 7946 0018 and 020 7946 0019"), false);
+check("timestamps", hasPaymentCard("2026-08-11 14:23:07 2026-08-12 09:15:44"), false);
+check("mixed separators are not a card format",
+  hasPaymentCard("4111-1111 1111-1111"), false);
+
+// The Luhn gate still has to do its job.
+check("16 digits failing Luhn", hasPaymentCard("4111111111111112"), false);
+
+// CARD_RE is module-level with /g, so lastIndex persists between calls. A
+// second call on the same input must give the same answer.
+const twice = group(c16, 4);
+check("repeat call gives the same answer",
+  hasPaymentCard(twice) && hasPaymentCard(twice), true);
+
+console.log("\npassed: " + pass + "  failed: " + fail);
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Two things, both found by running this on a real fleet.

The payment card detector fired on SVG. The pattern allowed a separator after every single digit, so `points="12 2 15 8 22 9 17 14"` was a candidate, and Luhn passes 10% of arbitrary digit runs so it filtered almost nothing. A card is written either as one unbroken run or in the groupings the industry uses, with the same separator throughout: 4-4-4-4, 4-6-5 for Amex, 4-6-4 for Diners, 4-4-4-4-3 for 19-digit PANs. Measured over 50,000 generated samples of path data, phone numbers, timestamps and reference numbers: 5.97% flagged before, 0% after, with every real format from 13 to 19 digits still detected. On SVG path data alone it was 23%.

A looser fix requiring groups of three or more digits only got that to 20%, because three-digit coordinates still match. Hence the specificity.

Firefox support. The extension would have loaded there and done nothing, for reasons invisible from Chrome. Firefox exposes the WebExtension APIs twice: as browser.* returning promises, and as chrome.* returning callbacks. Chrome has no browser.* and its chrome.* returns promises under MV3. So chrome.* is the namespace that exists in both and behaves differently in each, and every await in this codebase would have resolved to undefined in Firefox. All twenty call sites across the three scripts now resolve the namespace once.

Firefox does not implement background.service_worker and uses background.scripts instead. The manifest declares both, which is Mozilla's own guidance and which their validator confirms: it warns that service_worker is ignored and checks that scripts is present. Removing either breaks the other browser.

runtime.requestUpdateCheck is Chrome only and sits inside the heartbeat, so it is guarded. Both content scripts wrap sendMessage in a catch, because Firefox returns a promise there and rejects it when the background page is not awake, and nothing is waiting on the result.

Distribution is separate and stays separate. Firefox refuses unsigned extensions on release builds and no enterprise policy changes that; disabling xpinstall.signatures.required works only on ESR and turns off integrity checking for every extension a user installs. The supported path is submitting to AMO as a self-distributed add-on, which signs it without listing it publicly. firefox-updates.json.template is the Firefox equivalent of updates.xml and the two are independent, so a release touching both browsers updates two manifests.

Mozilla has required data_collection_permissions on new extensions since November 2025. Declared as websiteActivity and personallyIdentifyingInfo. websiteActivity rather than browsingActivity because the extension only ever sees the hosts it has permissions for and has no view of browsing history. personallyIdentifyingInfo because the MDM-stamped device identifier is what makes a finding attributable to a person, which is the point of the tool. Deliberately not websiteContent: the paste guard scans locally and transmits detector ids, never the matched text. Once a version declares this key every later version must, including the Chrome build where it is ignored.

strict_min_version is 140, the first release with the built-in data consent prompt. Below that, an extension collecting data must ship its own.

deploy/macos/firefox/managed-storage.plist is one payload under org.mozilla.firefox rather than the two the Chromium browsers need, because Firefox reads the install policy and the managed config from the same domain. It uses install_url rather than update_url, and managed storage lives under 3rdparty > Extensions > the gecko id rather than the Chrome 32-character id.

Tests: extension/tests/test_payment_card.js, 19 assertions, no framework because the extension has no build step and one file does not justify the dependency. Two fail against the previous detector. It evaluates guard.js against stubbed browser globals rather than parsing function bodies out of the source, so the stubs need extending if guard.js ever touches a new browser API at module level.