### PR TITLE
Intune version suffix stripped from the end, and stop escaping the fallback markup

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.5.1
+version: 0.5.2
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.6.1"
+appVersion: "0.6.2"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -428,7 +428,7 @@ function personal() {
   <tr><th>who</th><th>account domain</th><th>tool</th><th>device</th>
   <th>surface</th><th>first seen</th><th>last seen</th><th>source</th></tr>
   ${rows.map(r => `<tr>
-    <td>${esc(r.user || '<span class="pill p-mut">no identity</span>')}</td>
+    <td>${r.user ? esc(r.user) : '<span class="pill p-mut">no identity</span>'}</td>
     <td><span class="pill p-warn">${esc(r.account_domain)}</span></td>
     <td>${esc(r.tool)}</td>
     <td>${esc(r.device_name || r.device || '—')}</td>

--- a/scanner/ai_guard/scanners/intune.py
+++ b/scanner/ai_guard/scanners/intune.py
@@ -69,8 +69,35 @@ def _parse_ts(value):
 
 
 # Version suffixes Intune appends to a display name: "LM Studio 0.3.20",
-# "LM Studio 0.4.20+1". Anything from the first digit-led token onwards.
-_VERSION_TAIL = re.compile(r"\s+v?\d[\d.+_-]*.*$", re.IGNORECASE)
+# "LM Studio 0.4.20+1", "LM Studio 0.3.20-beta", "Notion 3.0 (x64)",
+# "ChatGPT 1.2024.021 (Machine - MSI)". A version token, an optional alpha
+# build suffix, and an optional trailing parenthetical, anchored to the end.
+#
+# It used to be ".*$" after the version token, which swallowed the rest of the
+# name, so any display name shaped "<word> <digits> <words>" collapsed to its
+# first word. Measured against 985 detectedApps display names from a live
+# tenant, that folded 31 localisations of Microsoft 365 onto the single key
+# "microsoft", plus 12 Visual C++ redistributables, 6 .NET SDKs and 3 SQL
+# Server LocalDBs.
+#
+# Nothing was misattributed on that tenant, because no registry entry happened
+# to claim those keys. That is luck rather than design: "Microsoft 365 Copilot"
+# normalises to "microsoft" under the old pattern, so adding an exe_name for it
+# would have attributed every Office install on the estate to Copilot, and it
+# would have looked like a finding rather than a bug.
+#
+# Anchoring to the end rather than consuming to it also leaves an unrelated app
+# whose name merely begins with a tool name whole: "Cursor 2024 Backup Utility"
+# stays itself instead of becoming "cursor".
+_VERSION_TAIL = re.compile(
+    r"\s+v?\d[\d.+_-]*(?:-[a-z][a-z0-9.]*)?(?:\s*\([^)]*\))?$",
+    re.IGNORECASE,
+)
+
+# Stripping a version can leave a dangling separator: "Microsoft Windows
+# Desktop Runtime - 6.0.25 (x64)" would otherwise key on "...runtime -". A key
+# ending in punctuation matches nothing and reads as a bug wherever it appears.
+_TRAILING_SEP = re.compile(r"[\s,\-]+$")
 
 
 def _normalise_app_name(name: str) -> str:
@@ -94,7 +121,7 @@ def _normalise_app_name(name: str) -> str:
     for suffix in (".exe", ".app"):
         if n.lower().endswith(suffix):
             n = n[: -len(suffix)]
-    n = _VERSION_TAIL.sub("", n)
+    n = _TRAILING_SEP.sub("", _VERSION_TAIL.sub("", n))
     return n.strip().lower()
 
 

--- a/scanner/tests/test_intune_version_tail.py
+++ b/scanner/tests/test_intune_version_tail.py
@@ -1,0 +1,140 @@
+"""The version suffix is stripped from the end, not consumed to it.
+
+_VERSION_TAIL used to be `\\s+v?\\d[\\d.+_-]*.*$`. The `.*$` swallowed everything
+after the first digit-led token, so any display name shaped `<word> <digits>
+<words>` collapsed to its first word.
+
+Measured against 985 detectedApps display names from a real tenant, that folded
+31 localisations of Microsoft 365 onto the single key "microsoft", plus 12
+Visual C++ redistributables, 6 .NET SDKs and 3 SQL Server LocalDBs. Nothing was
+misattributed to an AI tool at the time, because no registry entry happened to
+claim those keys. But "Microsoft 365 Copilot" normalises to "microsoft" under
+the old pattern, and adding an exe_name for it would have attributed every
+Office install on the estate to Copilot.
+
+A looser fix requiring groups of three or more digits was also tried and
+rejected: it left 20% of the disagreements intact because three-digit version
+segments still matched.
+
+The names below are all real shapes from that inventory. They are vendor
+product names, not anything belonging to a particular deployment.
+"""
+
+import pytest
+
+from ai_guard.scanners.intune import _normalise_app_name
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Versions still come off, in every form Intune produces.
+        ("LM Studio 0.3.20", "lm studio"),
+        ("LM Studio 0.4.20+1", "lm studio"),
+        ("LM Studio 0.3.20-beta", "lm studio"),
+        ("Cursor v1.2.3", "cursor"),
+        # A trailing parenthetical is part of the version suffix. This is the
+        # common Windows shape and the reason a stricter end-anchored pattern
+        # is not enough on its own.
+        ("Notion 3.0 (x64)", "notion"),
+        ("Python 3.12.3 (64-bit)", "python"),
+        ("7-Zip 24.07 (x64)", "7-zip"),
+        ("TortoiseGit 2.17.0.2 (64 bit)", "tortoisegit"),
+        ("ChatGPT 1.2024.021 (Machine - MSI)", "chatgpt"),
+        # Package ids and suffixes are unaffected by this change.
+        ("ChatGPT.exe", "chatgpt"),
+        ("Claude.app", "claude"),
+        ("Exafunction.Windsurf", "windsurf"),
+        ("Microsoft.Copilot", "copilot"),
+        ("Claude", "claude"),
+        ("", ""),
+    ],
+)
+def test_version_suffixes_are_still_stripped(raw, expected):
+    assert _normalise_app_name(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        # The 31-name case. Every localisation of Microsoft 365 used to become
+        # "microsoft".
+        "Microsoft 365 Apps for business - en-us",
+        "Microsoft 365 - en-us",
+        # Words after a digit-led token are part of the name, not the version.
+        "Microsoft SQL Server 2019 LocalDB",
+        "Microsoft ODBC Driver 17 for SQL Server",
+        "CanoScan LiDE 400 Scanner Driver",
+        "IIS 10.0 Express",
+        "Microsoft Visual Studio 2010 Tools for Office Runtime (x64)",
+        # An unrelated app whose name begins with a tool name must not collapse
+        # onto that tool. This is the false positive the change exists to stop.
+        "Cursor 2024 Backup Utility",
+        "Copilot 2 Helper Service",
+        "Claude 3 Sync Agent",
+    ],
+)
+def test_names_that_are_not_versioned_stay_whole(raw):
+    assert _normalise_app_name(raw) == raw.strip().lower()
+
+
+def test_a_leading_digit_is_not_a_version():
+    """The pattern needs whitespace before the digit.
+
+    Otherwise 1Password normalises to the empty string and matches either
+    everything or nothing, depending which side of the comparison it lands on.
+    """
+    assert _normalise_app_name("1Password") == "1password"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # Stripping the version leaves a dangling separator behind.
+        (
+            "Microsoft Windows Desktop Runtime - 6.0.25 (x64)",
+            "microsoft windows desktop runtime",
+        ),
+        (
+            "Microsoft Visual C++ 2015-2022 Redistributable (x86) - 14.51.36231",
+            "microsoft visual c++ 2015-2022 redistributable (x86)",
+        ),
+        (
+            "Azul Zulu JDK 21.42.19 (21.0.7), 64-bit",
+            "azul zulu jdk 21.42.19 (21.0.7)",
+        ),
+    ],
+)
+def test_trailing_separators_are_removed(raw, expected):
+    """A key ending in punctuation matches nothing and reads as a bug."""
+    assert _normalise_app_name(raw) == expected
+
+
+def test_every_version_of_one_product_shares_a_key():
+    """The point of stripping the version at all.
+
+    Ten Windows Desktop Runtime versions were installed across the tenant. They
+    are one product and should key as one, which is the behaviour that must
+    survive making the pattern stricter.
+    """
+    versions = [
+        "Microsoft Windows Desktop Runtime - 6.0.25 (x64)",
+        "Microsoft Windows Desktop Runtime - 8.0.11 (x64)",
+        "Microsoft Windows Desktop Runtime - 8.0.16 (x86)",
+        "Microsoft Windows Desktop Runtime - 9.0.18 (x64)",
+    ]
+    assert len({_normalise_app_name(v) for v in versions}) == 1
+
+
+def test_distinct_products_do_not_share_a_key():
+    """The complement, and the actual regression.
+
+    Under the old pattern these four all became "microsoft".
+    """
+    products = [
+        "Microsoft 365 Apps for business - en-us",
+        "Microsoft SQL Server 2019 LocalDB",
+        "Microsoft ODBC Driver 17 for SQL Server",
+        "Microsoft Visual Studio 2010 Tools for Office Runtime (x64)",
+    ]
+    assert len({_normalise_app_name(p) for p in products}) == len(products)


### PR DESCRIPTION
Two unrelated fixes, both small, released together as 0.6.2.

_VERSION_TAIL was `\s+v?\d[\d.+_-]*.*$`. The `.*$` swallowed everything after the first digit-led token, so any display name shaped `<word> <digits> <words>` collapsed to its first word.

Measured against all 985 detectedApps display names on a live tenant: 90 names normalise differently under the old and new patterns. The old one folded 31 localisations of Microsoft 365 onto the single key "microsoft", plus 12 Visual C++ redistributables, 6 .NET SDKs and 3 SQL Server LocalDBs.

Nothing was misattributed there. Every inventory name that resolved onto a registry key resolved onto the right one, under the old pattern as well as the new. So this is preventative rather than a fix for wrong findings anyone is looking at, and it is worth saying so rather than implying otherwise.

What makes it worth doing is how close the failure sits. "Microsoft 365 Copilot" normalises to "microsoft" under the old pattern, and that id is already in the registry with no exe_names. Adding one would have attributed every Office install on an estate to Copilot, and it would have looked like a finding rather than a bug.

The new pattern anchors the version to the end instead of consuming to it: a version token, an optional alpha build suffix, an optional trailing parenthetical. Every real form still reduces, including "Notion 3.0 (x64)" and "ChatGPT 1.2024.021 (Machine - MSI)", the shape "Python 3.12.3 (64-bit)" and "7-Zip 24.07 (x64)" already have in the wild. An unrelated app whose name merely begins with a tool name now stays whole, so "Cursor 2024 Backup Utility" stays itself instead of becoming "cursor".

A looser fix requiring groups of three or more digits was tried and rejected: it left 20% of the disagreements intact, because three-digit version segments still matched.

_TRAILING_SEP removes the separator a stripped version leaves behind. Without it "Microsoft Windows Desktop Runtime - 6.0.25 (x64)" keys on "...runtime -", and a key ending in punctuation matches nothing and reads as a bug wherever it appears.

Separately, the Personal accounts view escaped its own fallback markup: esc(r.user || '<span ...>') escaped the whole expression, so a finding with no identity rendered the raw HTML as text in the table. Every other view already uses the correct shape, cond ? esc(x) : '<markup>'. Not a security issue: the value was escaped before and still is, and the fallback is a constant with nothing interpolated into it. The escaping was applied one level too high.

Tests: 106 to 137. Thirteen of the new ones fail against the previous pattern. The two that matter are a pair: one holds four Windows Desktop Runtime versions to a single key, which is the reason to strip versions at all, and one holds four different Microsoft products apart, which is what broke. Getting either without the other is the trap.