### PR TITLE
portal: AI register

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -218,6 +218,17 @@ telemetry are one laptop. The portal derives those relationships on request
 and holds no database, so like the dashboard it is a view rather than a store,
 and losing it loses nothing.
 
+The AI register is that argument applied to governance. It lists every tool in
+the registry joined to what was observed, which means a tool nothing reported
+still gets a row: not seeing it means nothing reported it inside the lookback
+window, which is not the same as nobody using it. A tool observed and absent
+from the registry gets a row too, flagged, because something in use that
+governance has never considered is the more urgent direction of the same gap.
+Owner, review date and risk decision are organisational records rather than
+observations, so the register shows them as not set rather than leaving the
+columns blank. It holds no decisions of its own, and the `approved` flag it
+displays is the registry's, reported as it stands.
+
 Its entry points differ because the sources do. Endpoint findings carry a
 device and a local username, and the username is a hint rather than a key: it
 is firstname.lastname on one enrolment, a local account on another, whatever

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -26,6 +26,8 @@ first-class state and not an error - a small team with no MDM still gets
 useful without a name on it.
 """
 
+import csv
+import io
 import json
 import os
 import sys
@@ -747,3 +749,180 @@ def status_from(findings):
         "reporting": sum(1 for r in rows if r["reporting"]),
         "total": len(rows),
     }
+
+def load_registry(path):
+    """The whole registry, not just the domain map.
+
+    load_domain_map reduces the file to domain -> id, which is all tool
+    normalisation needs. The register needs the rest of it: vendor, category,
+    risk tier, and above all the full list of tools, because a tool the
+    registry knows about and nothing has ever reported is a register row in its
+    own right.
+
+    Returns {} rather than raising. A register built from observations alone is
+    a worse register, not a broken portal.
+    """
+    if not path or not os.path.exists(path):
+        return {}
+    try:
+        with open(path) as fh:
+            if path.endswith(".json"):
+                return json.load(fh) or {}
+            import yaml
+            return yaml.safe_load(fh) or {}
+    except Exception as e:
+        print("could not read registry (%s): the register will be built from "
+              "observations only" % e, file=sys.stderr)
+        return {}
+
+
+def _base_tool(tool):
+    """The tool itself, with any MCP suffix removed.
+
+    MCP findings name the tool as <tool>-mcp, and collectors older than the
+    current ones folded the server list in as <tool>-mcp:<servers>. Both are
+    correct for the MCP view, where a row is a server and the suffix says which
+    tool configured it.
+
+    They are wrong for a tool inventory. claude-code-mcp is not a different
+    tool from claude-code, it is evidence claude-code is on that machine. Left
+    alone it becomes a permanent "not in registry" row that can never be
+    resolved, because nobody would add claude-code-mcp to a registry of tools.
+    """
+    base = tool.split("-mcp:", 1)[0] if "-mcp:" in tool else tool
+    if base.endswith("-mcp"):
+        base = base[:-4]
+    return base or tool
+
+
+def register_from(findings, reg=None, domain_map=None):
+    """One row per tool: what the registry knows, joined to what was observed.
+
+    Two things make this more than a list of observed tools.
+
+    A tool in the registry that nothing reported still gets a row, with its
+    counts empty. "We know this exists and have not seen it here" is a real
+    register entry, and dropping it would let an estate look smaller than the
+    set of things it is watching for. It is also the honest form of the
+    project's own rule: absence of a finding is not evidence a tool is unused,
+    it may be used somewhere nothing is reporting from.
+
+    A tool that was observed and is NOT in the registry gets a row too, flagged
+    as unknown. That is the more urgent direction of the same gap: something is
+    in use that governance has never considered.
+
+    Governance fields (owner, review date, risk decision) are not derivable and
+    are absent here. The page shows them as not set rather than hiding them,
+    because a register that looks complete while missing the decisions is worse
+    than one with visible gaps.
+    """
+    domain_map = domain_map or {}
+    reg = reg or {}
+
+    observed = defaultdict(lambda: {
+        "devices": set(), "users": set(), "surfaces": set(), "sources": set(),
+        "corporate_accounts": set(), "personal_accounts": set(),
+        "findings": 0, "first_seen": "", "last_seen": "",
+    })
+
+    for f in findings:
+        tool = f.get("tool") or ""
+        if not tool or tool in NOT_A_TOOL:
+            continue
+        if (f.get("source") or "") in BRIDGE_SOURCES:
+            continue
+        tool = normalise_tool(_base_tool(tool), domain_map)
+
+        o = observed[tool]
+        o["findings"] += 1
+        for key, val in (("devices", (f.get("device") or "").strip()),
+                         ("users", (f.get("user") or "").strip()),
+                         ("surfaces", f.get("surface") or ""),
+                         ("sources", f.get("source") or "")):
+            if val:
+                o[key].add(val)
+
+        acct = (f.get("account_domain") or "").strip().lower()
+        if acct:
+            # Same rule personal_accounts_from uses: the reporter decided, at
+            # the point of detection, with the corporate domain list it was
+            # given. The portal does not re-derive it, because it may not hold
+            # the same list and two definitions that disagree is worse than one
+            # that is occasionally coarse.
+            if (f.get("severity") or "") == "warn":
+                o["personal_accounts"].add(acct)
+            else:
+                o["corporate_accounts"].add(acct)
+
+        ts = f.get("reported_at") or ""
+        if ts:
+            if not o["first_seen"] or ts < o["first_seen"]:
+                o["first_seen"] = ts
+            if ts > o["last_seen"]:
+                o["last_seen"] = ts
+
+    known = {}
+    for t in reg.get("tools", []) or []:
+        tid = t.get("id")
+        if tid:
+            known[tid] = t
+
+    rows = []
+    for tid in sorted(set(known) | set(observed)):
+        meta = known.get(tid, {})
+        o = observed.get(tid)
+        rows.append({
+            "id": tid,
+            "name": meta.get("name") or tid,
+            "vendor": meta.get("vendor") or "",
+            "category": meta.get("category") or "",
+            "risk_tier": meta.get("risk_tier") or "",
+            # The registry's own boolean, reported as it stands. The portal
+            # does not decide approval and must not imply it has.
+            "approved": meta.get("approved"),
+            "in_registry": tid in known,
+            "observed": o is not None,
+            "devices": len(o["devices"]) if o else 0,
+            "users": len(o["users"]) if o else 0,
+            "surfaces": sorted(o["surfaces"]) if o else [],
+            "sources": sorted(o["sources"]) if o else [],
+            "corporate_accounts": len(o["corporate_accounts"]) if o else 0,
+            "personal_accounts": len(o["personal_accounts"]) if o else 0,
+            "findings": o["findings"] if o else 0,
+            "first_seen": o["first_seen"] if o else "",
+            "last_seen": o["last_seen"] if o else "",
+        })
+
+    # Observed first, then by exposure. An unobserved tool is a real row but it
+    # is not what someone opening this page needs to look at first.
+    rows.sort(key=lambda r: (not r["observed"], -r["devices"],
+                             -r["personal_accounts"], r["name"].lower()))
+    return rows
+
+
+REGISTER_COLUMNS = [
+    "id", "name", "vendor", "category", "risk_tier", "approved",
+    "in_registry", "observed", "devices", "users", "corporate_accounts",
+    "personal_accounts", "findings", "surfaces", "sources",
+    "first_seen", "last_seen",
+]
+
+
+def register_csv(rows):
+    """CSV of the register, for spreadsheets and ad-hoc review.
+
+    Deliberately not an evidence artifact: no manifest, no checksum, no
+    reproducibility guarantee. The provenance that matters, when it was taken
+    and over what window, is carried in the filename by the endpoint, because a
+    filename survives being emailed around and a header comment does not.
+    """
+    out = io.StringIO()
+    w = csv.writer(out)
+    w.writerow(REGISTER_COLUMNS)
+    for r in rows:
+        w.writerow([
+            ";".join(r[c]) if isinstance(r.get(c), list)
+            else ("" if r.get(c) is None else r.get(c))
+            for c in REGISTER_COLUMNS
+        ])
+    return out.getvalue()

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -444,6 +444,57 @@ def status(hours: float = Query(default=None, gt=0, le=24 * 90),
     return JSONResponse(dict(value, derived_at=at, hours=hours))
 
 
+@app.get("/api/register")
+def register(hours: float = Query(default=None, gt=0, le=24 * 90),
+             fmt: str = Query(default="json", pattern="^(json|csv)$"),
+             refresh: bool = Query(default=False),
+             _=Depends(require_auth)):
+    """The AI register: every tool the registry knows, joined to what was seen.
+
+    Read-only and derived. The portal holds no governance state, so owner,
+    review date and risk decision are absent rather than empty-but-editable.
+
+    csv is a convenience export, not an evidence artifact. The filename carries
+    when it was taken and over what window, because a register with no
+    provenance is a screenshot with extra steps, and a filename survives being
+    emailed around in a way a header comment does not.
+    """
+    hours = hours or LOOKBACK_HOURS
+    if refresh:
+        _cache.pop("register", None)
+
+    def build():
+        findings = _findings(hours)
+        reg = derive.load_registry(REGISTRY_PATH)
+        return derive.register_from(findings, reg,
+                                    derive.load_domain_map_from(reg))
+
+    rows, at = _cached("register", hours, build)
+
+    if fmt == "csv":
+        stamp = time.strftime("%Y-%m-%dT%H%MZ", time.gmtime())
+        window = ("%dh" % hours) if float(hours).is_integer() else ("%sh" % hours)
+        name = "ai-register-%s-%s.csv" % (stamp, window)
+        return PlainTextResponse(
+            derive.register_csv(rows),
+            headers={"Content-Disposition": 'attachment; filename="%s"' % name},
+        )
+
+    return JSONResponse({
+        "rows": rows,
+        "derived_at": at,
+        "hours": hours,
+        # Both counts, deliberately. A register that reported only what it
+        # found would let an estate with a silent source look complete.
+        "tools_observed": sum(1 for r in rows if r["observed"]),
+        "tools_known": sum(1 for r in rows if r["in_registry"]),
+        "observed_not_in_registry": sum(
+            1 for r in rows if r["observed"] and not r["in_registry"]),
+        "known_not_observed": sum(
+            1 for r in rows if r["in_registry"] and not r["observed"]),
+    })
+
+
 @app.get("/api/suggest-identities")
 def suggest_identities(hours: float = Query(default=None, gt=0, le=24 * 90),
                        fmt: str = Query(default="json", pattern="^(json|csv)$"),

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -57,7 +57,8 @@ main{padding:22px 24px;max-width:1440px;margin:0 auto}
 .card:hover{border-color:color-mix(in oklch,var(--pri) 50%,transparent)}
 .card h3{margin:0 0 6px;font-size:15px;font-family:ui-monospace,monospace}
 .card .sub{color:var(--mut);font-size:12px}
-.pill{display:inline-block;border:1px solid currentColor;border-radius:999px;padding:1px 8px;font-size:11px;margin:2px 4px 2px 0;font-family:ui-monospace,monospace}
+.pill{display:inline-block;white-space:nowrap;border:1px solid currentColor;border-radius:999px;padding:1px 8px;font-size:11px;margin:2px 4px 2px 0;font-family:ui-monospace,monospace}
+.nw{white-space:nowrap}
 .p-warn{color:var(--dstr)} .p-ok{color:var(--pri)} .p-mut{color:var(--mut)} .p-acc{color:var(--acc)}
 table{width:100%;border-collapse:collapse;font-size:13px}
 th{text-align:left;font-weight:400;color:var(--mut);border-bottom:1px solid var(--bd);padding:6px 10px 6px 0;font-size:12px}
@@ -65,7 +66,10 @@ td{padding:7px 10px 7px 0;border-bottom:1px solid color-mix(in oklch,var(--bd) 4
 .note{background:color-mix(in oklch,var(--warn) 10%,transparent);border:1px solid color-mix(in oklch,var(--warn) 40%,transparent);color:var(--warn);border-radius:8px;padding:12px 14px;margin-bottom:18px;font-size:13px}
 .back{background:none;border:1px solid var(--bd);color:var(--mut);border-radius:6px;padding:5px 10px;cursor:pointer;font:inherit;margin-bottom:14px}
 h2{font-size:19px;margin:0 0 4px}
-.lede{color:var(--mut);font-size:13px;margin:0 0 16px;max-width:80ch}
+.lede{color:var(--mut);font-size:13px;margin:0 0 16px}
+/* No max-width here. main is already capped and centred, so a second
+   constraint on the prose only makes it stop short of the table it
+   introduces, which reads as a broken line rather than a measure. */
 input{background:var(--sf2);border:1px solid var(--bd);color:var(--fg);border-radius:6px;padding:6px 10px;font:inherit;min-width:220px}
 </style>
 <div class="shell">
@@ -89,11 +93,20 @@ input{background:var(--sf2);border:1px solid var(--bd);color:var(--fg);border-ra
 </div>
 <script>
 let G = {devices:{},identities:{},tools:{},bridges:{},unattributed:[],counts:{}};
+// Views that read a second endpoint, cached until refresh clears them.
+// Declared here rather than beside their views: load() clears them and let
+// is not hoisted, so declaring them lower down is a TDZ error on first
+// refresh.
+let DIAG = null;
+let REG = null;
 let S = null, CFG = {}, loadError = '';
 
 async function load(force) {
   app.innerHTML = '<p class="lede">Reading findings…</p>';
   const q = force ? '?refresh=true' : '';
+  // Refresh must clear the views that read a second endpoint too, or the
+  // button refreshes some of the page and silently not the rest.
+  if (force) { DIAG = null; REG = null; }
   try {
     CFG = await (await fetch('/api/config')).json();
     const gr = await fetch('/api/graph' + q);
@@ -442,7 +455,73 @@ function personal() {
   Setup page are reporting.</p>`}`;
 }
 
-let DIAG = null;
+
+async function register() {
+  if (!REG) {
+    try { REG = await (await fetch('/api/register')).json(); }
+    catch (e) { return `<h2>AI register</h2><div class="note">Could not build
+      the register: ${esc(String(e.message || e))}</div>`; }
+  }
+  const rows = (REG.rows || []).filter(r =>
+    match(r.name) || match(r.id) || match(r.vendor) || match(r.category));
+
+  const win = REG.hours >= 24 ? Math.round(REG.hours / 24) + ' days'
+                              : REG.hours + ' hours';
+  const dash = '<span class="pill p-mut">not set</span>';
+  const when = t => t ? `<span class="nw">${esc(String(t).slice(0, 10))}</span>` : '—';
+
+  const status = r => {
+    if (!r.in_registry) return '<span class="pill p-warn">not in registry</span>';
+    if (r.approved === true) return '<span class="pill p-ok">approved</span>';
+    if (r.approved === false) return '<span class="pill p-warn">not approved</span>';
+    return dash;
+  };
+
+  return `<h2>AI register</h2>
+  <p class="lede">Every tool the registry knows about, joined to what has
+  actually been observed. A tool with no observations is still listed: not
+  seeing it here means nothing reported it in the last ${esc(win)}, which is not
+  the same as nobody using it. A tool observed but absent from the registry is
+  the more urgent gap, and is flagged as such.</p>
+
+  <dl class="stats">
+    <div><dt>${REG.tools_observed}</dt><dd>observed</dd></div>
+    <div><dt>${REG.tools_known}</dt><dd>in registry</dd></div>
+    <div><dt style="color:var(--dstr)">${REG.observed_not_in_registry}</dt><dd>observed, not in registry</dd></div>
+    <div><dt>${REG.known_not_observed}</dt><dd>in registry, not observed</dd></div>
+  </dl>
+
+  <p class="lede">Owner, review date and risk decision are organisational
+  records. The portal holds no governance state, so they are shown as not set
+  rather than left blank: an empty column reads as "nothing to say", and the
+  honest reading is "nobody has decided yet".
+  <a href="/api/register?fmt=csv" style="color:var(--pri)">Download CSV</a></p>
+
+  ${rows.length ? `<table>
+  <tr><th>tool</th><th>vendor</th><th>status</th><th>risk</th>
+  <th>devices</th><th>users</th><th>corp</th><th>personal</th><th>surfaces</th>
+  <th>first seen</th><th>last seen</th><th>owner</th><th>review</th></tr>
+  ${rows.map(r => `<tr${r.observed ? '' : ' style="color:var(--mut)"'}>
+    <td>${esc(r.name)}<br><span class="mono" style="font-size:11px;color:var(--mut)">${esc(r.id)}</span></td>
+    <td>${r.vendor ? esc(r.vendor) : '—'}</td>
+    <td>${status(r)}</td>
+    <td>${r.risk_tier ? esc(r.risk_tier) : '—'}</td>
+    <td>${r.observed ? r.devices : '—'}</td>
+    <td>${r.observed ? r.users : '—'}</td>
+    <td>${r.observed ? r.corporate_accounts : '—'}</td>
+    <td>${!r.observed ? '—' : (r.personal_accounts
+        ? `<span class="pill p-warn">${r.personal_accounts}</span>` : '0')}</td>
+    <td>${r.surfaces.length ? esc(r.surfaces.join(', ')) : '—'}</td>
+    <td>${when(r.first_seen)}</td>
+    <td>${when(r.last_seen)}</td>
+    <td>${dash}</td>
+    <td>${dash}</td>
+  </tr>`).join('')}
+  </table>` : `<p class="lede">No tools in the register. Either the registry did
+  not load or nothing has reported: check Settings for the registry status
+  before reading this as an empty estate.</p>`}`;
+}
+
 async function settings() {
   if (!DIAG) {
     try { DIAG = await (await fetch('/api/diagnostics')).json(); }
@@ -642,6 +721,7 @@ const NAV = [
                            ['devices','Devices'],['personal','Personal accounts'],
                            ['mcp','MCP servers']]},
   {grp:'Coverage',  items:[['setup','Setup'],['coverage','Uncovered devices']]},
+  {grp:'Governance',items:[['register','AI register']]},
   {grp:'Analytics', items:[['dashboard','Dashboard']]},
   {grp:'System',    items:[['settings','Settings']]},
 ];
@@ -675,7 +755,9 @@ async function render() {
     return;
   }
   // settings reads a second endpoint, so it is the one async view.
+  // settings and register each read a second endpoint, so they are async.
   if (view === 'settings') { app.innerHTML = await settings(); return; }
+  if (view === 'register') { app.innerHTML = await register(); return; }
   app.innerHTML = ({setup, overview, devices, people, tools, coverage,
                     dashboard, personal, mcp})[view]();
 }

--- a/portal/tests/test_register.py
+++ b/portal/tests/test_register.py
@@ -1,0 +1,303 @@
+"""The register lists what the registry knows, not only what was seen.
+
+A register built from observations alone is the same mistake as a dashboard
+that counts reporting sources and not silent ones: an estate looks complete
+because the thing you cannot see is also the thing you did not list.
+
+Two directions of gap, and the register has to show both.
+
+A tool in the registry that nothing reported is not evidence it is unused. It
+may be in use somewhere nothing reports from, and it may simply not have been
+used in the lookback window. It gets a row with empty counts.
+
+A tool observed that is NOT in the registry is the more urgent one: something
+is in use that governance has never considered. It gets a row and a flag.
+
+Governance fields are absent rather than empty. The portal holds no governance
+state in this release, and an empty owner column reads as "nothing to say" when
+the honest reading is "nobody has decided yet".
+"""
+
+from app.derive import (
+    REGISTER_COLUMNS,
+    load_domain_map_from,
+    register_csv,
+    register_from,
+)
+
+REGISTRY = {
+    "tools": [
+        {
+            "id": "claude",
+            "name": "Claude",
+            "vendor": "Anthropic",
+            "category": "assistant",
+            "risk_tier": "high",
+            "approved": False,
+            "domains": ["claude.ai", "anthropic.com"],
+        },
+        {
+            "id": "copilot",
+            "name": "GitHub Copilot",
+            "vendor": "GitHub",
+            "category": "copilot",
+            "risk_tier": "medium",
+            "approved": True,
+        },
+        {
+            # In the registry, never reported.
+            "id": "grok",
+            "name": "Grok",
+            "vendor": "xAI",
+            "category": "assistant",
+            "risk_tier": "high",
+            "approved": False,
+        },
+    ]
+}
+DOMAIN_MAP = load_domain_map_from(REGISTRY)
+
+
+def _f(**kw):
+    base = {
+        "tool": "claude", "device": "D1", "surface": "browser",
+        "source": "browser_extension", "severity": "info",
+        "reported_at": "2026-08-10T09:00:00Z",
+    }
+    base.update(kw)
+    return base
+
+
+def _row(rows, tool_id):
+    return next(r for r in rows if r["id"] == tool_id)
+
+
+# ─────────────────────────────────────────────
+# The two gaps
+# ─────────────────────────────────────────────
+
+def test_a_registry_tool_with_no_findings_is_still_listed():
+    """The regression. Building from findings alone would drop this row."""
+    rows = register_from([_f()], REGISTRY, DOMAIN_MAP)
+
+    grok = _row(rows, "grok")
+    assert grok["in_registry"] is True
+    assert grok["observed"] is False
+    assert grok["devices"] == 0
+    assert grok["first_seen"] == ""
+
+
+def test_an_observed_tool_missing_from_the_registry_is_flagged():
+    """Something in use that governance has never considered."""
+    rows = register_from([_f(tool="notion-ai")], REGISTRY, DOMAIN_MAP)
+
+    notion = _row(rows, "notion-ai")
+    assert notion["observed"] is True
+    assert notion["in_registry"] is False
+    assert notion["approved"] is None, "unknown, not 'not approved'"
+
+
+def test_observed_rows_sort_above_unobserved_ones():
+    """An unobserved tool is a real row but not the first thing to read."""
+    rows = register_from([_f()], REGISTRY, DOMAIN_MAP)
+    observed = [r["observed"] for r in rows]
+    assert observed == sorted(observed, reverse=True)
+
+
+# ─────────────────────────────────────────────
+# Joining observations to the registry
+# ─────────────────────────────────────────────
+
+def test_a_tool_reported_by_domain_and_by_id_is_one_row():
+    """The browser extension reports the domain, everything else the id."""
+    rows = register_from(
+        [_f(tool="claude.ai", device="D1"), _f(tool="claude", device="D2")],
+        REGISTRY, DOMAIN_MAP,
+    )
+    claude = _row(rows, "claude")
+    assert claude["devices"] == 2
+    assert not any(r["id"] == "claude.ai" for r in rows)
+
+
+def test_registry_metadata_is_carried_through():
+    rows = register_from([_f()], REGISTRY, DOMAIN_MAP)
+    claude = _row(rows, "claude")
+    assert claude["name"] == "Claude"
+    assert claude["vendor"] == "Anthropic"
+    assert claude["risk_tier"] == "high"
+    assert claude["approved"] is False
+
+
+def test_approved_is_reported_not_decided():
+    """The portal has no governance state and must not imply otherwise.
+
+    approved comes from the registry as it stands: True, False, or None when
+    the tool is not in the registry at all. Three states, and None is not the
+    same as False.
+    """
+    rows = register_from([_f(tool="copilot"), _f(tool="unknown-tool")],
+                         REGISTRY, DOMAIN_MAP)
+    assert _row(rows, "copilot")["approved"] is True
+    assert _row(rows, "claude")["approved"] is False
+    assert _row(rows, "unknown-tool")["approved"] is None
+
+
+def test_first_and_last_seen_span_the_findings():
+    rows = register_from([
+        _f(reported_at="2026-08-01T00:00:00Z"),
+        _f(reported_at="2026-08-12T00:00:00Z"),
+        _f(reported_at="2026-08-05T00:00:00Z"),
+    ], REGISTRY, DOMAIN_MAP)
+    claude = _row(rows, "claude")
+    assert claude["first_seen"] == "2026-08-01T00:00:00Z"
+    assert claude["last_seen"] == "2026-08-12T00:00:00Z"
+
+
+# ─────────────────────────────────────────────
+# Accounts
+# ─────────────────────────────────────────────
+
+def test_corporate_and_personal_accounts_are_counted_separately():
+    """The same tool on a corporate account and a personal one is the
+    distinction this platform exists for. Collapsing them into one number
+    would lose it."""
+    rows = register_from([
+        _f(account_domain="example.com", severity="info"),
+        _f(account_domain="gmail.com", severity="warn"),
+        _f(account_domain="outlook.com", severity="warn"),
+    ], REGISTRY, DOMAIN_MAP)
+
+    claude = _row(rows, "claude")
+    assert claude["corporate_accounts"] == 1
+    assert claude["personal_accounts"] == 2
+
+
+def test_personal_follows_the_reporter_not_the_portal():
+    """severity == warn with an account domain, the same rule the personal
+    accounts view uses. The portal does not re-derive it from a domain list it
+    may not hold, because two definitions that disagree is worse than one that
+    is occasionally coarse."""
+    rows = register_from(
+        [_f(account_domain="gmail.com", severity="info")],
+        REGISTRY, DOMAIN_MAP,
+    )
+    claude = _row(rows, "claude")
+    assert claude["personal_accounts"] == 0
+    assert claude["corporate_accounts"] == 1
+
+
+def test_a_tool_seen_with_no_account_is_observed_with_no_accounts():
+    """A software inventory finding proves presence and says nothing about
+    the account. That is not the same as no accounts existing."""
+    rows = register_from([_f(source="intune_app", account_domain="")],
+                         REGISTRY, DOMAIN_MAP)
+    claude = _row(rows, "claude")
+    assert claude["observed"] is True
+    assert claude["corporate_accounts"] == 0
+    assert claude["personal_accounts"] == 0
+
+
+# ─────────────────────────────────────────────
+# Exclusions, consistent with the rest of the portal
+# ─────────────────────────────────────────────
+
+def test_the_platforms_own_agents_are_not_tools():
+    rows = register_from([_f(tool="paste-guard"), _f(tool="ai-guard-collector")],
+                         REGISTRY, DOMAIN_MAP)
+    assert not any(r["observed"] for r in rows)
+
+
+def test_bridge_findings_are_not_a_tool_inventory():
+    """The bridge records where an AI tool was reached, not that someone
+    installed it."""
+    rows = register_from([_f(tool="openai", source="sentinelone_bridge")],
+                         REGISTRY, DOMAIN_MAP)
+    assert not any(r["id"] == "openai" and r["observed"] for r in rows)
+
+
+def test_no_registry_still_produces_a_register():
+    """A registry that failed to load degrades to observations only, which is
+    a worse register rather than a broken page."""
+    rows = register_from([_f(tool="claude")], None, {})
+    assert len(rows) == 1
+    assert rows[0]["in_registry"] is False
+
+
+# ─────────────────────────────────────────────
+# CSV
+# ─────────────────────────────────────────────
+
+def test_csv_has_a_header_and_a_row_per_tool():
+    rows = register_from([_f()], REGISTRY, DOMAIN_MAP)
+    out = register_csv(rows).splitlines()
+    assert out[0] == ",".join(REGISTER_COLUMNS)
+    assert len(out) == len(rows) + 1
+
+
+def test_csv_includes_unobserved_tools():
+    """The export has to carry the same gaps as the page. A CSV of observed
+    tools only, handed to someone reviewing coverage, is the exact thing this
+    register exists to stop."""
+    rows = register_from([_f()], REGISTRY, DOMAIN_MAP)
+    out = register_csv(rows)
+    assert "grok" in out
+
+
+def test_csv_flattens_lists_without_breaking_columns():
+    rows = register_from([_f(surface="browser"), _f(surface="ide")],
+                         REGISTRY, DOMAIN_MAP)
+    line = [r for r in register_csv(rows).splitlines() if r.startswith("claude,")][0]
+    assert "browser;ide" in line
+    assert line.count(",") == len(REGISTER_COLUMNS) - 1
+
+
+def test_csv_renders_an_absent_approval_as_empty_not_false():
+    """None means the tool is not in the registry. Writing it as False would
+    assert a decision nobody made."""
+    rows = register_from([_f(tool="unknown-tool")], REGISTRY, DOMAIN_MAP)
+    line = [r for r in register_csv(rows).splitlines()
+            if r.startswith("unknown-tool,")][0]
+    assert ",," in line
+    assert "False" not in line.split(",")[5:6]
+
+
+# ─────────────────────────────────────────────
+# MCP findings are evidence of a tool, not a tool
+# ─────────────────────────────────────────────
+
+def test_mcp_findings_fold_into_the_tool_that_configured_them():
+    """claude-code-mcp is not a different tool from claude-code.
+
+    Left as its own row it is a permanent "not in registry" entry that can
+    never be resolved, because nobody would add claude-code-mcp to a registry
+    of tools. The MCP view is where a row is a server; here it is evidence the
+    tool is on that machine.
+    """
+    reg = {"tools": [{"id": "claude-code", "name": "Claude Code",
+                      "approved": False}]}
+    rows = register_from([
+        _f(tool="claude-code", surface="cli", device="D1"),
+        _f(tool="claude-code-mcp", surface="mcp", device="D2"),
+    ], reg, {})
+
+    assert [r["id"] for r in rows] == ["claude-code"]
+    assert rows[0]["devices"] == 2
+    assert rows[0]["in_registry"] is True
+
+
+def test_the_older_mcp_name_format_folds_too():
+    """Collectors older than the current ones put the server list in the tool
+    name. Loki holds both formats for as long as the lookback window."""
+    reg = {"tools": [{"id": "claude-code", "name": "Claude Code",
+                      "approved": False}]}
+    rows = register_from(
+        [_f(tool="claude-code-mcp:atlassian,figma", surface="mcp")], reg, {})
+
+    assert [r["id"] for r in rows] == ["claude-code"]
+    assert rows[0]["surfaces"] == ["mcp"]
+
+
+def test_a_tool_named_only_mcp_is_left_alone():
+    """Stripping the suffix must not produce an empty tool id."""
+    rows = register_from([_f(tool="-mcp")], {}, {})
+    assert [r["id"] for r in rows] == ["-mcp"]


### PR DESCRIPTION
A register of every tool the registry knows about, joined to what has actually been observed. Read-only and derived: the portal still holds no state.

The design decision is what it lists rather than what it shows. A register built from findings alone would have shown nine tools on the demo estate and looked complete, while the registry was watching for thirty. So a tool nothing reported still gets a row with its counts empty. Not seeing it means nothing reported it inside the lookback window, which is not the same as nobody using it, and the difference is the same one this project already makes about silent sources.

The other direction of that gap is more urgent and also gets a row: a tool observed and absent from the registry is something in use that governance has never considered. It is flagged, and its approval reads as unknown rather than false, because nobody decided it.

Owner, review date and risk decision are organisational records, not observations. They are shown as not set rather than left blank: an empty column reads as "nothing to say" when the honest reading is "nobody has decided yet". The approved flag is the registry's, reported as it stands. The portal does not decide approval and must not imply it has.

MCP findings fold into the tool that configured them. They name the tool as <tool>-mcp, and collectors older than the current ones folded the server list in as <tool>-mcp:<servers>. Both are correct for the MCP view, where a row is a server and the suffix says which tool configured it. Both are wrong for a tool inventory: claude-code-mcp is not a different tool from claude-code, it is evidence claude-code is on that machine, and left alone it becomes a permanent "not in registry" row that can never be resolved because nobody would add claude-code-mcp to a registry of tools.

CSV export is a per-page convenience, deliberately not an evidence artifact. The provenance that matters, when it was taken and over what window, is in the filename rather than a header comment, because a filename survives being emailed around: ai-register-2026-08-12T0930Z-168h.csv. An evidence pack with a manifest and checksums is a different thing and is not this.

Two styling fixes the register surfaced, both affecting every page. Pills no longer wrap: "not approved" broken across two lines reads as a layout fault, and it only showed up here because more columns squeeze each cell. And the 80ch cap on lede text is gone, because main is already capped and centred, so a second constraint only made the prose stop short of the table it introduces. That cap was added in 0.6.1 when main was uncapped, and it stopped being right the moment main was capped.

Tests: 43 to 63. Three fail against a register built from observations alone and two against one that treats an MCP finding as its own tool.