### PR TITLE
portal: AI register

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -218,15 +218,19 @@ telemetry are one laptop. The portal derives those relationships on request
 and holds no database, so like the dashboard it is a view rather than a store,
 and losing it loses nothing.
 
-The AI register is that argument applied to governance. It lists every tool in
-the registry joined to what was observed, which means a tool nothing reported
-still gets a row: not seeing it means nothing reported it inside the lookback
-window, which is not the same as nobody using it. A tool observed and absent
-from the registry gets a row too, flagged, because something in use that
-governance has never considered is the more urgent direction of the same gap.
-Owner, review date and risk decision are organisational records rather than
-observations, so the register shows them as not set rather than leaving the
-columns blank. It holds no decisions of its own, and the `approved` flag it
+The AI register is that view pointed at governance: the AI tools actually in
+use, with what the registry knows about each. The registry itself is a
+watchlist rather than an inventory, so a tool it knows about and nothing has
+reported is reported as a count rather than a row. A register padded with
+tools nobody in the organisation uses is a worse record of what that
+organisation does, not a more complete one, and it puts vendor defaults in
+front of a management review as though someone had taken a position on them.
+Coverage is a different question with its own answer in Setup and Uncovered
+devices. A tool observed and absent from the registry does get a row, flagged,
+because something in use that governance has never considered is worth acting
+on. Owner, review date and risk decision are organisational records rather
+than observations, so the register shows them as not set rather than leaving
+the columns blank. It holds no decisions of its own, and the `approved` flag it
 displays is the registry's, reported as it stands.
 
 Its entry points differ because the sources do. Endpoint findings carry a

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -798,23 +798,34 @@ def _base_tool(tool):
 def register_from(findings, reg=None, domain_map=None):
     """One row per tool: what the registry knows, joined to what was observed.
 
-    Two things make this more than a list of observed tools.
+    Returns the full join, observed and not. Callers decide what to show: the
+    register itself is the observed set, and the rest is the count of what is
+    being watched for.
 
-    A tool in the registry that nothing reported still gets a row, with its
-    counts empty. "We know this exists and have not seen it here" is a real
-    register entry, and dropping it would let an estate look smaller than the
-    set of things it is watching for. It is also the honest form of the
-    project's own rule: absence of a finding is not evidence a tool is unused,
-    it may be used somewhere nothing is reporting from.
+    That distinction matters and it took a wrong turn to find. A register is a
+    record of what an organisation actually uses. Listing every entry in a
+    shipped registry makes it a worse record, not a more complete one: it puts
+    tools nobody there has heard of in front of a management review as though
+    the organisation has a position on them. The registry is a watchlist, and a
+    watchlist is context rather than inventory.
 
-    A tool that was observed and is NOT in the registry gets a row too, flagged
-    as unknown. That is the more urgent direction of the same gap: something is
-    in use that governance has never considered.
+    The project's rule that silence is not evidence of safety applies to
+    sources, not to this. A collector that stops reporting looks identical to a
+    clean machine, so silent sources must be listed. A registry entry is not a
+    source: a tool absent from findings is the registry correctly not matching
+    something that is not there, and coverage gaps are answered by Setup and
+    Uncovered devices.
+
+    A tool observed and NOT in the registry is the row that matters most.
+    Something is in use that governance has never considered, and it is flagged
+    rather than quietly folded in.
 
     Governance fields (owner, review date, risk decision) are not derivable and
     are absent here. The page shows them as not set rather than hiding them,
     because a register that looks complete while missing the decisions is worse
-    than one with visible gaps.
+    than one with visible gaps. When those decisions exist, an unobserved tool
+    carrying one becomes a register row again: at that point it is a record of
+    something the organisation decided, rather than a default nobody chose.
     """
     domain_map = domain_map or {}
     reg = reg or {}

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -449,15 +449,25 @@ def register(hours: float = Query(default=None, gt=0, le=24 * 90),
              fmt: str = Query(default="json", pattern="^(json|csv)$"),
              refresh: bool = Query(default=False),
              _=Depends(require_auth)):
-    """The AI register: every tool the registry knows, joined to what was seen.
+    """The AI register: the AI tools actually in use, and what is known of them.
+
+    Rows are the observed set. A register is a record of what an organisation
+    uses, and padding it with every entry of a shipped registry makes it a
+    worse record: it presents tools nobody there has heard of as things the
+    organisation has a position on. The registry is a watchlist, and its size
+    is returned as a count rather than as rows.
+
+    A tool observed and absent from the registry is included and flagged. That
+    is the anomaly worth acting on.
 
     Read-only and derived. The portal holds no governance state, so owner,
     review date and risk decision are absent rather than empty-but-editable.
 
-    csv is a convenience export, not an evidence artifact. The filename carries
-    when it was taken and over what window, because a register with no
-    provenance is a screenshot with extra steps, and a filename survives being
-    emailed around in a way a header comment does not.
+    csv is a convenience export, not an evidence artifact, and it carries the
+    same rows as the page. The filename carries when it was taken and over what
+    window, because a register with no provenance is a screenshot with extra
+    steps, and a filename survives being emailed around in a way a header
+    comment does not.
     """
     hours = hours or LOOKBACK_HOURS
     if refresh:
@@ -469,7 +479,10 @@ def register(hours: float = Query(default=None, gt=0, le=24 * 90),
         return derive.register_from(findings, reg,
                                     derive.load_domain_map_from(reg))
 
-    rows, at = _cached("register", hours, build)
+    all_rows, at = _cached("register", hours, build)
+    # The register is what is in use. The rest of the join is the watchlist,
+    # and it is reported as a count below rather than as rows.
+    rows = [r for r in all_rows if r["observed"]]
 
     if fmt == "csv":
         stamp = time.strftime("%Y-%m-%dT%H%MZ", time.gmtime())
@@ -486,12 +499,12 @@ def register(hours: float = Query(default=None, gt=0, le=24 * 90),
         "hours": hours,
         # Both counts, deliberately. A register that reported only what it
         # found would let an estate with a silent source look complete.
-        "tools_observed": sum(1 for r in rows if r["observed"]),
-        "tools_known": sum(1 for r in rows if r["in_registry"]),
+        "tools_observed": len(rows),
+        "tools_known": sum(1 for r in all_rows if r["in_registry"]),
         "observed_not_in_registry": sum(
-            1 for r in rows if r["observed"] and not r["in_registry"]),
+            1 for r in rows if not r["in_registry"]),
         "known_not_observed": sum(
-            1 for r in rows if r["in_registry"] and not r["observed"]),
+            1 for r in all_rows if r["in_registry"] and not r["observed"]),
     })
 
 

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -478,17 +478,17 @@ async function register() {
   };
 
   return `<h2>AI register</h2>
-  <p class="lede">Every tool the registry knows about, joined to what has
-  actually been observed. A tool with no observations is still listed: not
-  seeing it here means nothing reported it in the last ${esc(win)}, which is not
-  the same as nobody using it. A tool observed but absent from the registry is
-  the more urgent gap, and is flagged as such.</p>
+  <p class="lede">The AI tools actually in use, from findings in the last
+  ${esc(win)}. The registry is a watchlist rather than an inventory, so a tool
+  it knows about and nothing has reported is counted below rather than listed.
+  A tool observed and absent from the registry is the row worth acting on, and
+  is flagged as such.</p>
 
   <dl class="stats">
-    <div><dt>${REG.tools_observed}</dt><dd>observed</dd></div>
-    <div><dt>${REG.tools_known}</dt><dd>in registry</dd></div>
-    <div><dt style="color:var(--dstr)">${REG.observed_not_in_registry}</dt><dd>observed, not in registry</dd></div>
-    <div><dt>${REG.known_not_observed}</dt><dd>in registry, not observed</dd></div>
+    <div><dt>${REG.tools_observed}</dt><dd>in use</dd></div>
+    <div><dt style="color:var(--dstr)">${REG.observed_not_in_registry}</dt><dd>not in registry</dd></div>
+    <div><dt>${REG.tools_known}</dt><dd>watched for</dd></div>
+    <div><dt>${REG.known_not_observed}</dt><dd>watched for, not seen</dd></div>
   </dl>
 
   <p class="lede">Owner, review date and risk decision are organisational
@@ -501,25 +501,26 @@ async function register() {
   <tr><th>tool</th><th>vendor</th><th>status</th><th>risk</th>
   <th>devices</th><th>users</th><th>corp</th><th>personal</th><th>surfaces</th>
   <th>first seen</th><th>last seen</th><th>owner</th><th>review</th></tr>
-  ${rows.map(r => `<tr${r.observed ? '' : ' style="color:var(--mut)"'}>
+  ${rows.map(r => `<tr>
     <td>${esc(r.name)}<br><span class="mono" style="font-size:11px;color:var(--mut)">${esc(r.id)}</span></td>
     <td>${r.vendor ? esc(r.vendor) : '—'}</td>
     <td>${status(r)}</td>
     <td>${r.risk_tier ? esc(r.risk_tier) : '—'}</td>
-    <td>${r.observed ? r.devices : '—'}</td>
-    <td>${r.observed ? r.users : '—'}</td>
-    <td>${r.observed ? r.corporate_accounts : '—'}</td>
-    <td>${!r.observed ? '—' : (r.personal_accounts
-        ? `<span class="pill p-warn">${r.personal_accounts}</span>` : '0')}</td>
+    <td>${r.devices}</td>
+    <td>${r.users}</td>
+    <td>${r.corporate_accounts}</td>
+    <td>${r.personal_accounts
+        ? `<span class="pill p-warn">${r.personal_accounts}</span>` : '0'}</td>
     <td>${r.surfaces.length ? esc(r.surfaces.join(', ')) : '—'}</td>
     <td>${when(r.first_seen)}</td>
     <td>${when(r.last_seen)}</td>
     <td>${dash}</td>
     <td>${dash}</td>
   </tr>`).join('')}
-  </table>` : `<p class="lede">No tools in the register. Either the registry did
-  not load or nothing has reported: check Settings for the registry status
-  before reading this as an empty estate.</p>`}`;
+  </table>` : `<p class="lede">No AI tools observed in the last ${esc(win)}.
+  That is a real answer for a small estate, and it is also what a fleet with no
+  collectors deployed looks like: check Setup before reading it as a clean
+  one.</p>`}`;
 }
 
 async function settings() {

--- a/portal/tests/test_register.py
+++ b/portal/tests/test_register.py
@@ -1,17 +1,21 @@
-"""The register lists what the registry knows, not only what was seen.
+"""The register is what is in use. The registry is a watchlist.
 
-A register built from observations alone is the same mistake as a dashboard
-that counts reporting sources and not silent ones: an estate looks complete
-because the thing you cannot see is also the thing you did not list.
+register_from returns the full join, observed and not, and the endpoint shows
+the observed set. That split is the point of these tests.
 
-Two directions of gap, and the register has to show both.
+A register is a record of what an organisation actually uses. Listing every
+entry of a shipped registry makes it a worse record: it puts tools nobody there
+has heard of in front of a management review as though the organisation has a
+position on them. The watchlist is context, and its size belongs in a count.
 
-A tool in the registry that nothing reported is not evidence it is unused. It
-may be in use somewhere nothing reports from, and it may simply not have been
-used in the lookback window. It gets a row with empty counts.
+The project's rule that silence is not evidence of safety applies to sources,
+not to this. A collector that stops reporting looks identical to a clean
+machine, so silent sources must be listed. A registry entry is not a source: a
+tool absent from findings is the registry correctly not matching something that
+is not there, and coverage is answered by Setup and Uncovered devices.
 
-A tool observed that is NOT in the registry is the more urgent one: something
-is in use that governance has never considered. It gets a row and a flag.
+A tool observed and NOT in the registry is the row that matters. Something is
+in use that governance has never considered.
 
 Governance fields are absent rather than empty. The portal holds no governance
 state in this release, and an empty owner column reads as "nothing to say" when
@@ -76,8 +80,15 @@ def _row(rows, tool_id):
 # The two gaps
 # ─────────────────────────────────────────────
 
-def test_a_registry_tool_with_no_findings_is_still_listed():
-    """The regression. Building from findings alone would drop this row."""
+def test_the_full_join_carries_unobserved_tools_for_counting():
+    """register_from returns everything so the watchlist can be counted.
+
+    The caller shows the observed set. Keeping the unobserved rows here rather
+    than dropping them early is what lets the page say "30 watched for, 29 not
+    seen" without a second pass over the registry, and it is where an
+    unobserved tool carrying a real decision will come back into the register
+    once decisions exist.
+    """
     rows = register_from([_f()], REGISTRY, DOMAIN_MAP)
 
     grok = _row(rows, "grok")
@@ -85,6 +96,17 @@ def test_a_registry_tool_with_no_findings_is_still_listed():
     assert grok["observed"] is False
     assert grok["devices"] == 0
     assert grok["first_seen"] == ""
+
+
+def test_the_observed_set_is_what_a_register_shows():
+    """The filter the endpoint applies, asserted on the shape it produces.
+
+    One tool in use on this fixture, not three, and not the whole registry.
+    """
+    rows = register_from([_f()], REGISTRY, DOMAIN_MAP)
+    in_use = [r for r in rows if r["observed"]]
+
+    assert [r["id"] for r in in_use] == ["claude"]
 
 
 def test_an_observed_tool_missing_from_the_registry_is_flagged():
@@ -234,13 +256,19 @@ def test_csv_has_a_header_and_a_row_per_tool():
     assert len(out) == len(rows) + 1
 
 
-def test_csv_includes_unobserved_tools():
-    """The export has to carry the same gaps as the page. A CSV of observed
-    tools only, handed to someone reviewing coverage, is the exact thing this
-    register exists to stop."""
-    rows = register_from([_f()], REGISTRY, DOMAIN_MAP)
+def test_csv_carries_the_same_rows_as_the_page():
+    """The export is the register, so it is the observed set.
+
+    A CSV that quietly contained more than the page it was downloaded from
+    would be worse than useless in a review: the two would disagree and nobody
+    would know which was the register.
+    """
+    rows = [r for r in register_from([_f()], REGISTRY, DOMAIN_MAP)
+            if r["observed"]]
     out = register_csv(rows)
-    assert "grok" in out
+
+    assert "claude," in out
+    assert "grok" not in out
 
 
 def test_csv_flattens_lists_without_breaking_columns():
@@ -301,3 +329,31 @@ def test_a_tool_named_only_mcp_is_left_alone():
     """Stripping the suffix must not produce an empty tool id."""
     rows = register_from([_f(tool="-mcp")], {}, {})
     assert [r["id"] for r in rows] == ["-mcp"]
+
+
+def test_an_unobserved_tool_is_not_in_the_endpoints_rows():
+    """The filter lives in the endpoint, not in register_from, so a unit test
+    of the derivation alone would miss it.
+
+    Calls the endpoint function rather than going over HTTP. TestClient would
+    read better, but it pulls in httpx, which is not in the portal's lockfile
+    and which starlette is currently migrating away from in favour of httpx2.
+    A test that needs a dependency the thing it tests does not is a test that
+    breaks for reasons unrelated to the code.
+    """
+    import json
+    from unittest.mock import patch
+
+    from app import derive
+    from app import main as pm
+
+    with patch.object(pm, "_findings", lambda h: [_f()]), \
+            patch.object(derive, "load_registry", lambda p: REGISTRY):
+        pm._cache.clear()
+        body = json.loads(bytes(pm.register(hours=168).body))
+
+    assert [r["id"] for r in body["rows"]] == ["claude"]
+    # The watchlist is still reported, as a count.
+    assert body["tools_known"] == 3
+    assert body["known_not_observed"] == 2
+    assert body["tools_observed"] == 1


### PR DESCRIPTION
A register of every tool the registry knows about, joined to what has actually been observed. Read-only and derived: the portal still holds no state.

Rows are the tools actually in use. The registry is a watchlist rather than an inventory, so a tool it knows about and nothing has reported is a count rather than a row.

That distinction took a wrong turn to find, and the wrong version shipped as far as a homelab before it was obvious. The first cut listed every registry entry on the grounds that silence is not evidence of safety. On an estate with one tool in use that produced one row and twenty nine rows of dashes, which is not a more complete record but a worse one: it puts vendor defaults in front of a management review as though the organisation had taken a position on them.

The rule about silence applies to sources, not to this. A collector that stops reporting looks identical to a clean machine, so silent sources must be listed. A registry entry is not a source: a tool absent from findings is the registry correctly not matching something that is not there, and coverage has its own answers in Setup and Uncovered devices.

A tool observed and absent from the registry does get a row, flagged, and its approval reads as unknown rather than false because nobody decided it. That is the anomaly worth acting on: something in use that governance has never considered.

register_from still returns the full join. The endpoint shows the observed set and reports the rest as a count, which is also where an unobserved tool carrying a real decision will come back into the register once decisions exist. A default nobody chose is not a record; a decision is.

Owner, review date and risk decision are organisational records, not observations. They are shown as not set rather than left blank: an empty column reads as "nothing to say" when the honest reading is "nobody has decided yet". The approved flag is the registry's, reported as it stands. The portal does not decide approval and must not imply it has.

MCP findings fold into the tool that configured them. They name the tool as <tool>-mcp, and collectors older than the current ones folded the server list in as <tool>-mcp:<servers>. Both are correct for the MCP view, where a row is a server and the suffix says which tool configured it. Both are wrong for a tool inventory: claude-code-mcp is not a different tool from claude-code, it is evidence claude-code is on that machine, and left alone it becomes a permanent "not in registry" row that can never be resolved because nobody would add claude-code-mcp to a registry of tools.

CSV export is a per-page convenience, deliberately not an evidence artifact. The provenance that matters, when it was taken and over what window, is in the filename rather than a header comment, because a filename survives being emailed around: ai-register-2026-08-12T0930Z-168h.csv. An evidence pack with a manifest and checksums is a different thing and is not this.

Two styling fixes the register surfaced, both affecting every page. Pills no longer wrap: "not approved" broken across two lines reads as a layout fault, and it only showed up here because more columns squeeze each cell. And the 80ch cap on lede text is gone, because main is already capped and centred, so a second constraint only made the prose stop short of the table it introduces. That cap was added in 0.6.1 when main was uncapped, and it stopped being right the moment main was capped.

Tests: 43 to 65. Two fail against a register that treats an MCP finding as its own tool, and one against an endpoint that returns the whole registry.