### PR TITLE
extension: Intune deployment scripts for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,11 @@ jobs:
             if (-not $ok) { Write-Host "::error::could not install PSScriptAnalyzer $version"; exit 1 }
           }
           Import-Module PSScriptAnalyzer -RequiredVersion $version
-          $r = Invoke-ScriptAnalyzer -Path endpoint/windows/ -Recurse -Severity Warning,Error
+          # Both paths. The collector lives in endpoint/windows and the
+          # extension's Intune deployment script in extension/deploy/windows,
+          # and a linter pointed at one of them lets the other ship unchecked.
+          $r = @('endpoint/windows/', 'extension/deploy/windows/') |
+               ForEach-Object { Invoke-ScriptAnalyzer -Path $_ -Recurse -Severity Warning,Error }
           $r | Format-Table -AutoSize
           if ($r | Where-Object Severity -eq 'Error') { exit 1 }
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -179,6 +179,41 @@ values including whatever your MDM substituted for the device identifier.
 
 ### 5. Deploy on Windows
 
+Two Intune platform scripts, for the same reason macOS needs two shapes of
+payload. `deploy/windows/Deploy-AiGuardExtension.ps1` covers Chrome, Edge and
+Brave: forcelist, `ExtensionSettings` with `override_update_url`, and the
+managed config. `Deploy-AiGuardExtensionFirefox.ps1` covers Firefox, which
+shares almost nothing with them: it installs the Mozilla-signed `.xpi` from
+`install_url` rather than polling an update manifest, keys managed storage on
+the gecko id rather than the 32 character Chrome id, and stores its whole
+policy as JSON in single registry values rather than as individual ones. The
+Firefox script reads those values before writing, because one value holds every
+extension's configuration and overwriting it would silently remove somebody
+else's.
+
+The `.reg` files alongside are the Chromium policy in registry form, for GPO or
+an RMM.
+
+A script rather than an Intune ADMX policy, for two reasons. The managed
+config lives under `3rdparty\extensions\<id>\policy`, which is arbitrary
+registry defined by the extension's own managed schema rather than a Chrome
+policy, so no ADMX setting covers it. And the device identifier has to be read
+from the machine: `%COMPUTERNAME%` in a `.reg` file is a literal string to
+Chrome, and even expanded it would be the hostname, where every other source
+keys a device on its hardware serial.
+
+The script reads the BIOS serial and rejects the placeholder values OEMs ship
+in that field. That matters more than it sounds: a hostname splits one machine
+into two on a view that groups by device, but fifty machines all reporting
+`To Be Filled By O.E.M.` collapse into one and the other forty nine vanish
+from every count.
+
+In Intune, set **Run this script using the logged on credentials** to No,
+because every key is under HKLM, and **Run script in 64 bit PowerShell Host**
+to Yes.
+
+
+
 `deploy/windows/<browser>/` has the equivalent registry blueprints:
 `install.reg` (forcelist) and `managed-storage.reg` (the
 `3rdparty\extensions\<id>\policy` key; list values are JSON strings).

--- a/extension/deploy/windows/Deploy-AiGuardExtension.ps1
+++ b/extension/deploy/windows/Deploy-AiGuardExtension.ps1
@@ -1,0 +1,182 @@
+<#
+    ai-guard browser extension: install and configure on Windows.
+
+    Deploy as an Intune platform script (Devices > Scripts and remediations >
+    Platform scripts). Settings that matter:
+
+        Run this script using the logged on credentials   No
+        Enforce script signature check                    No
+        Run script in 64 bit PowerShell Host              Yes
+
+    The first must be No: every key here is under HKLM and a user context
+    cannot write them. The third should be Yes. HKLM\SOFTWARE\Policies is one
+    of the keys shared between the 32 and 64 bit registry views rather than
+    redirected, so a 32 bit host would probably work, and "probably" is not
+    worth carrying on a fleet-wide policy.
+
+    This does what two Jamf payloads do on macOS. Chromium browsers read the
+    install policy from the browser's own policy key and the managed config
+    from a 3rdparty subkey, and neither is expressible as an Intune ADMX
+    setting: the 3rdparty path is arbitrary registry defined by the
+    extension's own managed schema, not a Chrome policy. So it is a script.
+
+    A script is also the only way to get the device identifier right.
+    %COMPUTERNAME% in a .reg file is a literal string to Chrome, not an
+    environment variable, and even expanded it would be the hostname. Every
+    other source keys a device on its hardware serial, and one that sends a
+    hostname splits that machine into two on any view that groups by device.
+
+    Idempotent. Safe to re-run, and re-running is how a changed token reaches
+    a machine that was already configured.
+#>
+
+# SupportsShouldProcess on the script itself, so -WhatIf reaches the helpers
+# below: $WhatIfPreference propagates to functions called in the same session,
+# but only because the caller declared it. Run it before a fleet rollout:
+#
+#     .\Deploy-AiGuardExtension.ps1 -WhatIf
+#
+# and it prints every key it would write and writes none of them.
+[CmdletBinding(SupportsShouldProcess)]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------- config --
+# Replace all three. EXTENSION_ID is the 32 character id Chrome derives from
+# the manifest key: read it from chrome://extensions on a machine that already
+# has it, not from anywhere else.
+$ExtensionId = 'REPLACE_WITH_EXTENSION_ID'
+$UpdatesXml  = 'https://REPLACE_WITH_HOST/updates.xml'
+$Endpoint    = 'https://REPLACE_WITH_HOST/report'
+$AuthToken   = 'REPLACE_WITH_TOKEN'
+
+$AllowedDomains = @('example.com')
+$PasteGuardMode = 'warn'
+$ClassificationMarkings = @(
+    'Client Confidential'
+    'Internal Confidential'
+    'Internal Use Only'
+    'Strictly Confidential'
+    'Commercial in Confidence'
+)
+
+# Chromium browsers on Windows, by policy root. All three read the same
+# schema, so they differ only in where the policy lives.
+#
+# Writing policy for a browser that is not installed is harmless: the key sits
+# unread until someone installs it, at which point the extension arrives with
+# it. That is the right default for a fleet where any of the three might be
+# installed later.
+#
+# Firefox is not here. It does not read extension policy from these keys, it
+# needs the Mozilla-signed .xpi rather than a .crx, and its managed storage is
+# keyed on the gecko id rather than the 32 character Chrome id. See
+# Deploy-AiGuardExtensionFirefox.ps1.
+$Browsers = @{
+    'Chrome' = 'HKLM:\SOFTWARE\Policies\Google\Chrome'
+    'Edge'   = 'HKLM:\SOFTWARE\Policies\Microsoft\Edge'
+    'Brave'  = 'HKLM:\SOFTWARE\Policies\BraveSoftware\Brave'
+}
+
+# ------------------------------------------------------------ device id --
+# Serials that are not serials. OEMs ship these in the BIOS field on machines
+# that were never given one, and they are worse than a hostname: a hostname
+# splits one machine into two, whereas fifty machines all reporting
+# "To Be Filled By O.E.M." collapse into one device and the other forty nine
+# disappear from every count.
+$BogusSerials = @(
+    'to be filled by o.e.m.'
+    'to be filled by oem'
+    'default string'
+    'system serial number'
+    'not specified'
+    'not applicable'
+    'none'
+    'invalid'
+    'o.e.m.'
+    '0'
+    '123456789'
+)
+
+function Get-DeviceIdentifier {
+    $serial = ''
+    try {
+        $serial = (Get-CimInstance Win32_BIOS -ErrorAction Stop).SerialNumber
+        if ($null -ne $serial) { $serial = $serial.Trim() }
+    } catch {
+        Write-Output "ai-guard: serial lookup failed ($($_.Exception.Message))"
+    }
+
+    if (-not $serial -or $BogusSerials -contains $serial.ToLower()) {
+        # Said out loud, because this changes what every finding from this
+        # machine is keyed on. One device reporting a hostname where the rest
+        # report serials reads as a deliberate difference rather than a
+        # placeholder BIOS, and it is worth someone seeing in the Intune
+        # script output.
+        Write-Output "ai-guard: BIOS serial is '$serial', using COMPUTERNAME instead"
+        return $env:COMPUTERNAME
+    }
+    return $serial
+}
+
+# --------------------------------------------------------------- helpers --
+function Set-RegValue {
+    <#
+        SupportsShouldProcess so the script can be dry-run. This writes policy
+        that applies to every browser on the machine, and being able to see
+        what it would do before it does it is worth four lines:
+
+            .\Deploy-AiGuardExtension.ps1 -WhatIf
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param($Path, $Name, $Value)
+    if (-not $PSCmdlet.ShouldProcess("$Path\$Name", 'Set registry value')) { return }
+    if (-not (Test-Path $Path)) { New-Item -Path $Path -Force | Out-Null }
+    New-ItemProperty -Path $Path -Name $Name -Value $Value `
+        -PropertyType String -Force | Out-Null
+}
+
+$DeviceId = Get-DeviceIdentifier
+Write-Output "ai-guard: device identifier = $DeviceId"
+
+# ExtensionSettings is what makes a browser poll a self-hosted updates.xml for
+# NEW versions. The forcelist alone installs the extension and then never
+# updates it, which is a fleet frozen on whatever version it first received.
+$ExtensionSettings = @{
+    $ExtensionId = @{
+        installation_mode   = 'force_installed'
+        update_url          = $UpdatesXml
+        override_update_url = $true
+    }
+} | ConvertTo-Json -Compress -Depth 5
+
+foreach ($name in $Browsers.Keys) {
+    $root = $Browsers[$name]
+
+    # Install
+    Set-RegValue "$root\ExtensionInstallForcelist" '1' "$ExtensionId;$UpdatesXml"
+    Set-RegValue $root 'ExtensionSettings' $ExtensionSettings
+
+    # Config. Lists are JSON strings: the managed storage schema declares them
+    # as arrays and the registry has no array type Chrome will read here.
+    $policy = "$root\3rdparty\extensions\$ExtensionId\policy"
+    Set-RegValue $policy 'reportEndpoint'   $Endpoint
+    Set-RegValue $policy 'authToken'        $AuthToken
+    Set-RegValue $policy 'deviceIdentifier' $DeviceId
+    Set-RegValue $policy 'pasteGuardMode'   $PasteGuardMode
+    Set-RegValue $policy 'allowedDomains' `
+        ($AllowedDomains | ConvertTo-Json -Compress)
+    Set-RegValue $policy 'classificationMarkings' `
+        ($ClassificationMarkings | ConvertTo-Json -Compress)
+
+    Write-Output "ai-guard: configured $name"
+}
+
+# The forcelist index. "1" is used above; if a browser already has forcelist
+# entries from another policy, this overwrites entry 1. Check before rollout:
+#   Get-ItemProperty 'HKLM:\SOFTWARE\Policies\Google\Chrome\ExtensionInstallForcelist'
+# and move to the next free index if 1 is taken.
+
+Write-Output "ai-guard: done. The extension appears after the browser restarts."
+exit 0

--- a/extension/deploy/windows/Deploy-AiGuardExtensionFirefox.ps1
+++ b/extension/deploy/windows/Deploy-AiGuardExtensionFirefox.ps1
@@ -1,0 +1,187 @@
+<#
+    ai-guard browser extension: install and configure on Firefox for Windows.
+
+    Separate from the Chromium script because almost nothing is shared. Firefox
+    needs the Mozilla-signed .xpi rather than a .crx, installs from the file
+    directly rather than polling an update manifest, keys managed storage on
+    the gecko id rather than the 32 character Chrome id, and stores policy as
+    JSON in a single registry value rather than as individual values.
+
+    Deploy as an Intune platform script alongside the Chromium one. Same
+    settings:
+
+        Run this script using the logged on credentials   No
+        Enforce script signature check                    No
+        Run script in 64 bit PowerShell Host              Yes
+
+    Firefox reads enterprise policy from one of three places, in order:
+    HKLM\SOFTWARE\Policies\Mozilla\Firefox, a policies.json next to the
+    binary, or the same key under HKCU. This writes the HKLM key, which
+    survives a Firefox reinstall where policies.json does not.
+
+    Idempotent, and deliberately a read-modify-write: another policy may
+    already own ExtensionSettings or 3rdparty, and clobbering it would silently
+    remove someone else's extension.
+#>
+
+# SupportsShouldProcess on the script itself, so -WhatIf reaches the helpers
+# below: $WhatIfPreference propagates to functions called in the same session,
+# but only because the caller declared it. Run it before a fleet rollout:
+#
+#     .\Deploy-AiGuardExtensionFirefox.ps1 -WhatIf
+#
+# and it prints every key it would write and writes none of them.
+[CmdletBinding(SupportsShouldProcess)]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------- config --
+# GeckoId must match browser_specific_settings.gecko.id in the manifest.
+# XpiUrl is the SIGNED .xpi returned by addons.mozilla.org, not the one you
+# built: Firefox refuses unsigned extensions on release builds.
+$GeckoId   = 'REPLACE_WITH_GECKO_ID'
+$XpiUrl    = 'https://REPLACE_WITH_HOST/ai-guard-1.0.0.xpi'
+$Endpoint  = 'https://REPLACE_WITH_HOST/report'
+$AuthToken = 'REPLACE_WITH_TOKEN'
+
+$AllowedDomains = @('example.com')
+$PasteGuardMode = 'warn'
+$ClassificationMarkings = @(
+    'Client Confidential'
+    'Internal Confidential'
+    'Internal Use Only'
+    'Strictly Confidential'
+    'Commercial in Confidence'
+)
+
+$FirefoxPolicies = 'HKLM:\SOFTWARE\Policies\Mozilla\Firefox'
+
+# ------------------------------------------------------------ device id --
+# Serials that are not serials. OEMs ship these in the BIOS field on machines
+# that were never given one, and they are worse than a hostname: a hostname
+# splits one machine into two, whereas fifty machines all reporting
+# "To Be Filled By O.E.M." collapse into one device and the other forty nine
+# disappear from every count.
+$BogusSerials = @(
+    'to be filled by o.e.m.'
+    'to be filled by oem'
+    'default string'
+    'system serial number'
+    'not specified'
+    'not applicable'
+    'none'
+    'invalid'
+    'o.e.m.'
+    '0'
+    '123456789'
+)
+
+function Get-DeviceIdentifier {
+    $serial = ''
+    try {
+        $serial = (Get-CimInstance Win32_BIOS -ErrorAction Stop).SerialNumber
+        if ($null -ne $serial) { $serial = $serial.Trim() }
+    } catch {
+        Write-Output "ai-guard: serial lookup failed ($($_.Exception.Message))"
+    }
+
+    if (-not $serial -or $BogusSerials -contains $serial.ToLower()) {
+        Write-Output "ai-guard: BIOS serial is '$serial', using COMPUTERNAME instead"
+        return $env:COMPUTERNAME
+    }
+    return $serial
+}
+
+# --------------------------------------------------------------- helpers --
+function Get-JsonPolicy {
+    <#
+        The existing value of a JSON policy, as a hashtable, or an empty one.
+
+        Read-modify-write rather than overwrite. ExtensionSettings and 3rdparty
+        are single values holding every extension's configuration, so writing
+        ours wholesale would remove any other extension the organisation
+        deploys. Unparseable existing content is left alone and reported:
+        replacing something we cannot read is how a working policy disappears.
+    #>
+    param($Path, $Name)
+    if (-not (Test-Path $Path)) { return @{} }
+    $raw = (Get-ItemProperty -Path $Path -Name $Name -ErrorAction SilentlyContinue).$Name
+    if (-not $raw) { return @{} }
+    try {
+        $obj = $raw | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        Write-Output "ai-guard: existing $Name is not valid JSON, refusing to overwrite it"
+        throw
+    }
+    $out = @{}
+    foreach ($p in $obj.PSObject.Properties) { $out[$p.Name] = $p.Value }
+    return $out
+}
+
+function Set-JsonPolicy {
+    <#
+        SupportsShouldProcess so the script can be dry-run. This rewrites a
+        policy value that holds every extension's configuration, so seeing what
+        it would write before it writes it is worth having:
+
+            .\Deploy-AiGuardExtensionFirefox.ps1 -WhatIf
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param($Path, $Name, $Value)
+    if (-not $PSCmdlet.ShouldProcess("$Path\$Name", 'Set policy value')) { return }
+    if (-not (Test-Path $Path)) { New-Item -Path $Path -Force | Out-Null }
+    New-ItemProperty -Path $Path -Name $Name `
+        -Value ($Value | ConvertTo-Json -Compress -Depth 10) `
+        -PropertyType String -Force | Out-Null
+}
+
+$DeviceId = Get-DeviceIdentifier
+Write-Output "ai-guard: device identifier = $DeviceId"
+
+# Policies must be switched on at all, or every setting below is ignored.
+if ($PSCmdlet.ShouldProcess($FirefoxPolicies, 'Enable enterprise policies')) {
+    if (-not (Test-Path $FirefoxPolicies)) {
+        New-Item -Path $FirefoxPolicies -Force | Out-Null
+    }
+    New-ItemProperty -Path $FirefoxPolicies -Name 'EnterprisePoliciesEnabled' `
+        -Value 1 -PropertyType DWord -Force | Out-Null
+}
+
+# ---- install ----
+# install_url, not update_url. Firefox installs from the .xpi and then polls
+# the manifest's own gecko.update_url for new versions, so there is no
+# override_update_url equivalent and none is needed.
+$settings = Get-JsonPolicy $FirefoxPolicies 'ExtensionSettings'
+$settings[$GeckoId] = @{
+    installation_mode = 'force_installed'
+    install_url       = $XpiUrl
+    updates_disabled  = $false
+}
+Set-JsonPolicy $FirefoxPolicies 'ExtensionSettings' $settings
+
+# ---- config ----
+# Managed storage lives under 3rdparty > Extensions > the GECKO id. The Chrome
+# 32 character id is a different string for the same extension and will not
+# work here.
+$thirdParty = Get-JsonPolicy $FirefoxPolicies '3rdparty'
+if (-not $thirdParty.ContainsKey('Extensions')) { $thirdParty['Extensions'] = @{} }
+
+$extensions = @{}
+foreach ($p in $thirdParty['Extensions'].PSObject.Properties) {
+    $extensions[$p.Name] = $p.Value
+}
+$extensions[$GeckoId] = @{
+    reportEndpoint         = $Endpoint
+    authToken              = $AuthToken
+    deviceIdentifier       = $DeviceId
+    pasteGuardMode         = $PasteGuardMode
+    allowedDomains         = $AllowedDomains
+    classificationMarkings = $ClassificationMarkings
+}
+$thirdParty['Extensions'] = $extensions
+Set-JsonPolicy $FirefoxPolicies '3rdparty' $thirdParty
+
+Write-Output "ai-guard: configured Firefox"
+Write-Output "ai-guard: done. Check about:policies on the device after a restart."
+exit 0


### PR DESCRIPTION
Chrome, Edge and Brave in one script; Firefox in another, because it shares almost nothing with them. Firefox installs the Mozilla-signed .xpi from install_url rather than polling an update manifest, keys managed storage on the gecko id rather than the 32 character Chrome id, and stores its whole policy as JSON in single registry values rather than as individual ones.

A script rather than an Intune ADMX policy for two reasons. The managed config lives under 3rdparty, which is arbitrary registry defined by the extension's own managed schema rather than a browser policy, so no ADMX setting covers it. And the device identifier has to be read from the machine: %COMPUTERNAME% in a .reg file is a literal string to Chrome, and even expanded it would be a hostname where every other source keys a device on its hardware serial.

Both scripts reject the placeholder values OEMs ship in the BIOS serial field. That failure is worse than the one the collector already handles: a hostname splits one machine into two on a view that groups by device, but fifty machines all reporting 'To Be Filled By O.E.M.' collapse into one and the other forty nine vanish from every count. Worth back-porting to endpoint/windows/ai-guard-collector.ps1, which guards a failed WMI query but not a bogus answer.

The Firefox script reads before it writes. ExtensionSettings and 3rdparty each hold every extension's configuration in one registry value, so writing ours wholesale would silently remove somebody else's, and an existing value that will not parse as JSON stops the script rather than being replaced.

psscriptanalyzer now lints extension/deploy/windows as well as endpoint/windows. It covered one of them, which would have let these ship unchecked.