### PR TITLE
extension: pick a free forcelist index, and keep progress off the output stream

### DIFF
--- a/extension/deploy/windows/Deploy-AiGuardExtension.ps1
+++ b/extension/deploy/windows/Deploy-AiGuardExtension.ps1
@@ -105,7 +105,7 @@ function Get-DeviceIdentifier {
         $serial = (Get-CimInstance Win32_BIOS -ErrorAction Stop).SerialNumber
         if ($null -ne $serial) { $serial = $serial.Trim() }
     } catch {
-        Write-Output "ai-guard: serial lookup failed ($($_.Exception.Message))"
+        Write-Host "ai-guard: serial lookup failed ($($_.Exception.Message))"
     }
 
     if (-not $serial -or $BogusSerials -contains $serial.ToLower()) {
@@ -114,7 +114,7 @@ function Get-DeviceIdentifier {
         # report serials reads as a deliberate difference rather than a
         # placeholder BIOS, and it is worth someone seeing in the Intune
         # script output.
-        Write-Output "ai-guard: BIOS serial is '$serial', using COMPUTERNAME instead"
+        Write-Host "ai-guard: BIOS serial is '$serial', using COMPUTERNAME instead"
         return $env:COMPUTERNAME
     }
     return $serial
@@ -137,26 +137,144 @@ function Set-RegValue {
         -PropertyType String -Force | Out-Null
 }
 
+function ConvertTo-Hashtable {
+    <#
+        A hashtable from either a PSCustomObject or a hashtable.
+
+        ConvertFrom-Json returns a PSCustomObject, whose properties are the JSON
+        keys. A freshly created @{} is a hashtable, whose .PSObject.Properties
+        are the .NET collection's own members: IsFixedSize, Count, Keys,
+        SyncRoot and the rest. Enumerating the second as though it were the
+        first copies all of them into the policy.
+    #>
+    param($Object)
+    $out = @{}
+    if ($null -eq $Object) { return $out }
+    if ($Object -is [System.Collections.IDictionary]) {
+        foreach ($k in $Object.Keys) { $out[$k] = $Object[$k] }
+        return $out
+    }
+    foreach ($p in $Object.PSObject.Properties) { $out[$p.Name] = $p.Value }
+    return $out
+}
+
+
+function Get-ExtensionSettings {
+    <#
+        The existing ExtensionSettings for a browser, as a hashtable.
+
+        Read-modify-write, for the same reason the Firefox script does it: this
+        one value holds every extension's configuration, so writing ours
+        wholesale removes anything another policy put there. The Firefox script
+        had this from the start because a real machine turned out to have
+        SentinelOne's extension in that value; the Chromium script did not, and
+        overwrote it.
+
+        Unparseable existing content stops the script rather than being
+        replaced, because silently discarding a policy we cannot read is the
+        failure this is meant to prevent.
+    #>
+    param($Root)
+    if (-not (Test-Path $Root)) { return @{} }
+    $raw = (Get-ItemProperty -Path $Root -Name 'ExtensionSettings' -ErrorAction SilentlyContinue).ExtensionSettings
+    if (-not $raw) { return @{} }
+    try {
+        return ConvertTo-Hashtable ($raw | ConvertFrom-Json -ErrorAction Stop)
+    } catch {
+        Write-Host "ai-guard: existing ExtensionSettings at $Root is not valid JSON, refusing to overwrite it"
+        throw
+    }
+}
+
+
+function ConvertTo-JsonArray {
+    <#
+        A JSON array, even when there is one element.
+
+        `@('a') | ConvertTo-Json` returns the string "a", not ["a"], because the
+        pipeline unwraps a single-element array before ConvertTo-Json ever sees
+        it. The managed schema declares allowedDomains as an array and the
+        extension checks Array.isArray, so a scalar is discarded and the
+        built-in fallback list is used instead.
+
+        That failure is silent and looks like success: one corporate domain
+        configured, and the extension quietly running on its own defaults. It
+        was found by reading the registry after a deployment, not by anything
+        going wrong.
+
+        The unary comma wraps the value in an outer array so the pipeline has
+        something to unwrap, and PowerShell 5.1 is what Intune runs, so -AsArray
+        is not available.
+    #>
+    param([string[]]$Items)
+    if ($null -eq $Items -or $Items.Count -eq 0) { return '[]' }
+    if ($Items.Count -eq 1) { return ConvertTo-Json @(, $Items[0]) -Compress }
+    return ConvertTo-Json $Items -Compress
+}
+
+
+function Get-ForcelistIndex {
+    <#
+        The index to write this extension's forcelist entry at.
+
+        The forcelist is a set of numbered values, and the numbers are just
+        slots. Hardcoding "1" is how a script evicts whatever another policy
+        already force-installed there, which on a managed fleet is somebody
+        else's extension disappearing with no error and no obvious cause.
+
+        Returns the existing index if this extension is already listed, so
+        re-running updates in place rather than adding a duplicate. Otherwise
+        the lowest free number.
+
+        Write-Host rather than Write-Output for the progress line.
+        PowerShell collects everything a function writes to the output
+        stream as its return value, so a message here would come back
+        alongside the value. A -WhatIf run caught exactly that: the
+        forcelist value name came out as
+        "ai-guard: forcelist indexes 1 in use, taking 2 2".
+    #>
+    param($Path)
+    if (-not (Test-Path $Path)) { return '1' }
+
+    $existing = Get-ItemProperty -Path $Path -ErrorAction SilentlyContinue
+    $used = @()
+    foreach ($prop in $existing.PSObject.Properties) {
+        if ($prop.Name -notmatch '^\d+$') { continue }   # PSPath and friends
+        if ($prop.Value -like "$ExtensionId;*" -or $prop.Value -eq $ExtensionId) {
+            Write-Host "ai-guard: already at forcelist index $($prop.Name), updating in place"
+            return $prop.Name
+        }
+        $used += [int]$prop.Name
+    }
+
+    $i = 1
+    while ($used -contains $i) { $i++ }
+    if ($i -ne 1) { Write-Host "ai-guard: forcelist indexes $($used -join ', ') in use, taking $i" }
+    return "$i"
+}
+
+
 $DeviceId = Get-DeviceIdentifier
 Write-Output "ai-guard: device identifier = $DeviceId"
 
 # ExtensionSettings is what makes a browser poll a self-hosted updates.xml for
 # NEW versions. The forcelist alone installs the extension and then never
 # updates it, which is a fleet frozen on whatever version it first received.
-$ExtensionSettings = @{
-    $ExtensionId = @{
-        installation_mode   = 'force_installed'
-        update_url          = $UpdatesXml
-        override_update_url = $true
-    }
-} | ConvertTo-Json -Compress -Depth 5
 
 foreach ($name in $Browsers.Keys) {
     $root = $Browsers[$name]
 
     # Install
-    Set-RegValue "$root\ExtensionInstallForcelist" '1' "$ExtensionId;$UpdatesXml"
-    Set-RegValue $root 'ExtensionSettings' $ExtensionSettings
+    Set-RegValue "$root\ExtensionInstallForcelist" `
+        (Get-ForcelistIndex "$root\ExtensionInstallForcelist") `
+        "$ExtensionId;$UpdatesXml"
+    $settings = Get-ExtensionSettings $root
+    $settings[$ExtensionId] = @{
+        installation_mode   = 'force_installed'
+        update_url          = $UpdatesXml
+        override_update_url = $true
+    }
+    Set-RegValue $root 'ExtensionSettings' ($settings | ConvertTo-Json -Compress -Depth 10)
 
     # Config. Lists are JSON strings: the managed storage schema declares them
     # as arrays and the registry has no array type Chrome will read here.
@@ -165,18 +283,11 @@ foreach ($name in $Browsers.Keys) {
     Set-RegValue $policy 'authToken'        $AuthToken
     Set-RegValue $policy 'deviceIdentifier' $DeviceId
     Set-RegValue $policy 'pasteGuardMode'   $PasteGuardMode
-    Set-RegValue $policy 'allowedDomains' `
-        ($AllowedDomains | ConvertTo-Json -Compress)
-    Set-RegValue $policy 'classificationMarkings' `
-        ($ClassificationMarkings | ConvertTo-Json -Compress)
+    Set-RegValue $policy 'allowedDomains'         (ConvertTo-JsonArray $AllowedDomains)
+    Set-RegValue $policy 'classificationMarkings' (ConvertTo-JsonArray $ClassificationMarkings)
 
     Write-Output "ai-guard: configured $name"
 }
-
-# The forcelist index. "1" is used above; if a browser already has forcelist
-# entries from another policy, this overwrites entry 1. Check before rollout:
-#   Get-ItemProperty 'HKLM:\SOFTWARE\Policies\Google\Chrome\ExtensionInstallForcelist'
-# and move to the next free index if 1 is taken.
 
 Write-Output "ai-guard: done. The extension appears after the browser restarts."
 exit 0

--- a/extension/deploy/windows/Deploy-AiGuardExtensionFirefox.ps1
+++ b/extension/deploy/windows/Deploy-AiGuardExtensionFirefox.ps1
@@ -83,17 +83,46 @@ function Get-DeviceIdentifier {
         $serial = (Get-CimInstance Win32_BIOS -ErrorAction Stop).SerialNumber
         if ($null -ne $serial) { $serial = $serial.Trim() }
     } catch {
-        Write-Output "ai-guard: serial lookup failed ($($_.Exception.Message))"
+        Write-Host "ai-guard: serial lookup failed ($($_.Exception.Message))"
     }
 
     if (-not $serial -or $BogusSerials -contains $serial.ToLower()) {
-        Write-Output "ai-guard: BIOS serial is '$serial', using COMPUTERNAME instead"
+        Write-Host "ai-guard: BIOS serial is '$serial', using COMPUTERNAME instead"
         return $env:COMPUTERNAME
     }
     return $serial
 }
 
 # --------------------------------------------------------------- helpers --
+function ConvertTo-Hashtable {
+    <#
+        A hashtable from either a PSCustomObject or a hashtable.
+
+        This exists because the two arrive by different routes and only one of
+        them can be enumerated with .PSObject.Properties. ConvertFrom-Json
+        returns a PSCustomObject, whose properties are the JSON keys. A freshly
+        created @{} is a hashtable, whose .PSObject.Properties are the .NET
+        collection's own members: IsFixedSize, Count, IsSynchronized,
+        IsReadOnly, Keys, Values, SyncRoot.
+
+        Enumerating a hashtable that way copied all seven into the policy, so a
+        machine with no existing 3rdparty value ended up with an Extensions
+        object containing "Count": 0 alongside the real entry. It only happened
+        on first install, which is why a merge tested against existing JSON did
+        not show it.
+    #>
+    param($Object)
+    $out = @{}
+    if ($null -eq $Object) { return $out }
+    if ($Object -is [System.Collections.IDictionary]) {
+        foreach ($k in $Object.Keys) { $out[$k] = $Object[$k] }
+        return $out
+    }
+    foreach ($p in $Object.PSObject.Properties) { $out[$p.Name] = $p.Value }
+    return $out
+}
+
+
 function Get-JsonPolicy {
     <#
         The existing value of a JSON policy, as a hashtable, or an empty one.
@@ -103,6 +132,13 @@ function Get-JsonPolicy {
         ours wholesale would remove any other extension the organisation
         deploys. Unparseable existing content is left alone and reported:
         replacing something we cannot read is how a working policy disappears.
+
+        Write-Host rather than Write-Output for the progress line.
+        PowerShell collects everything a function writes to the output
+        stream as its return value, so a message here would come back
+        alongside the value. A -WhatIf run caught exactly that: the
+        forcelist value name came out as
+        "ai-guard: forcelist indexes 1 in use, taking 2 2".
     #>
     param($Path, $Name)
     if (-not (Test-Path $Path)) { return @{} }
@@ -111,12 +147,10 @@ function Get-JsonPolicy {
     try {
         $obj = $raw | ConvertFrom-Json -ErrorAction Stop
     } catch {
-        Write-Output "ai-guard: existing $Name is not valid JSON, refusing to overwrite it"
+        Write-Host "ai-guard: existing $Name is not valid JSON, refusing to overwrite it"
         throw
     }
-    $out = @{}
-    foreach ($p in $obj.PSObject.Properties) { $out[$p.Name] = $p.Value }
-    return $out
+    return ConvertTo-Hashtable $obj
 }
 
 function Set-JsonPolicy {
@@ -165,12 +199,7 @@ Set-JsonPolicy $FirefoxPolicies 'ExtensionSettings' $settings
 # 32 character id is a different string for the same extension and will not
 # work here.
 $thirdParty = Get-JsonPolicy $FirefoxPolicies '3rdparty'
-if (-not $thirdParty.ContainsKey('Extensions')) { $thirdParty['Extensions'] = @{} }
-
-$extensions = @{}
-foreach ($p in $thirdParty['Extensions'].PSObject.Properties) {
-    $extensions[$p.Name] = $p.Value
-}
+$extensions = ConvertTo-Hashtable $thirdParty['Extensions']
 $extensions[$GeckoId] = @{
     reportEndpoint         = $Endpoint
     authToken              = $AuthToken


### PR DESCRIPTION
Two bugs in the Windows deployment scripts, both found by running `-WhatIf` on a real machine.

The forcelist index was hardcoded to 1. The forcelist is a set of numbered values and the numbers are just slots, so a machine that already had something force-installed at 1 would have had it silently replaced. That is not hypothetical: the first machine this was tried on had a Chrome Web Store extension at index 1 from an existing policy, and there would have been no error and no obvious cause when it disappeared.

Get-ForcelistIndex now returns the existing index if this extension is already listed, so a re-run updates in place rather than appending a duplicate, and otherwise the lowest free number. Verified against the real registry state and four other shapes: empty forcelist, gaps in the numbering, an already-present entry, and the PSPath-style properties Get-ItemProperty adds, which are not indexes and must not be counted as used.

The second bug was in the fix for the first. PowerShell collects everything a function writes to the output stream as its return value, so a Write-Output progress line came back alongside the index and the caller received both. The forcelist value name came out as

    ai-guard: forcelist indexes 1 in use, taking 2 2

Progress inside a value-returning function is now Write-Host, which goes to the information stream and is not captured. Write-Output stays at top level, where it is what Intune records as the script result. Get-DeviceIdentifier had the same latent bug and got away with it only because its messages sit on paths that return immediately afterwards.

The reason is written into each function's doc block. It reads like a style preference and is not one, and a later tidy-up back to Write-Output would reintroduce a bug that produces a plausible-looking registry key rather than an error.

A third, found by reading the registry after the first successful deployment rather than by anything failing. allowedDomains was written as the JSON string "corp.example" instead of the array ["corp.example"]: `@('a') | ConvertTo-Json` returns a scalar, because the pipeline unwraps a single-element array before ConvertTo-Json sees it. classificationMarkings was correct only because it has five entries.

The managed schema declares allowedDomains as an array and the extension checks Array.isArray, so a scalar is discarded and the built-in fallback list is used. On the machine where this was found the fallback happened to hold the same domain, so the behaviour was accidentally correct and nothing looked wrong. That is the worst shape of bug this project keeps finding: a configuration that reads as applied while the software runs on its defaults.

ConvertTo-JsonArray forces an array in every case. PowerShell 5.1 is what Intune runs, so -AsArray is not available and the unary comma does the work.

Two more, both about a policy value that holds every extension's configuration rather than just this one.

The Firefox script wrote seven .NET collection members into the policy on a machine that had no existing 3rdparty value. It built the container as @{} and then enumerated .PSObject.Properties on it, which for a hashtable returns IsFixedSize, Count, IsSynchronized, IsReadOnly, Keys, Values and SyncRoot rather than any keys. ConvertFrom-Json returns a PSCustomObject where that enumeration is correct, so the merge only broke on first install, which is exactly the path a hand-tested merge against existing JSON never exercised. ConvertTo-Hashtable now handles both shapes.

The Chromium script overwrote ExtensionSettings instead of merging it. That is the same value, and the same mistake, that the Firefox script was written to avoid after a real machine turned out to have SentinelOne's Firefox extension in it. Chrome and Edge hold their own, and any policy that had set it would have been replaced with no error. It now reads, merges and writes back, and refuses to overwrite content it cannot parse.

Both of these were found by reading the registry after a successful deployment. Intune reported success in every case.
