### PR TITLE
governance decisions: approvals, owners, review dates and expiry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,28 @@ jobs:
           $r | Format-Table -AutoSize
           if ($r | Where-Object Severity -eq 'Error') { exit 1 }
 
+  governance-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with: { python-version: '3.12' }
+      - run: pip install --require-hashes -r .github/requirements-ci.txt
+      - name: validate the governance example and the demo file
+        # Both, because they are the two files in the repo anyone will copy.
+        # The example is what a deployer starts from and the demo file is what
+        # the register renders when someone tries the project, so a broken one
+        # is a broken first impression either way.
+        #
+        # The validator exits non-zero on a schema error and warns without
+        # failing on a tool id the registry does not know. That asymmetry is
+        # deliberate: a decision about a tool that is not registered yet is
+        # legitimate, and it is also what a typo looks like, so it is reported
+        # rather than either accepted silently or treated as an error.
+        run: |
+          python governance/validate.py governance/governance.yaml.example
+          python governance/validate.py demo/governance.yaml
+
   registry-validate:
     runs-on: ubuntu-latest
     steps:
@@ -668,7 +690,8 @@ jobs:
       contents: read
       packages: write
     needs: [placeholder-guard, shellcheck, collector-delivery-state,
-            registry-validate, receiver-test, scanner-test, portal-test,
+            registry-validate, governance-validate,
+            receiver-test, scanner-test, portal-test,
             helm, demo-smoke, compose-smoke,
             windows-path-containment]
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,11 @@ registry/dist/
 .env
 .DS_Store
 
+# A real governance file is one organisation's approval decisions, and it is
+# not ours to hold. Only the example is tracked. Anchored to the root so
+# demo/governance.yaml, which is fake and deliberately committed, still is.
+/governance/governance.yaml
+
 # Secrets. The compose route reads these from files rather than the
 # environment, so the files exist on a deployer's disk and must never be here.
 deploy/compose/secrets/

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.6.2
+version: 0.7.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.7.2"
+appVersion: "0.8.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/templates/portal-deployment.yaml
+++ b/charts/ai-guard/templates/portal-deployment.yaml
@@ -91,6 +91,10 @@ spec:
             - name: IDENTITY_MAP
               value: /etc/ai-guard-identity/identity-map.csv
             {{- end }}
+            {{- with .Values.portal.governance.existingConfigMap }}
+            - name: GOVERNANCE_PATH
+              value: /etc/ai-guard-governance/governance.yaml
+            {{- end }}
             {{- with .Values.portal.grafana.url }}
             - name: GRAFANA_URL
               value: {{ . | quote }}
@@ -110,6 +114,11 @@ spec:
             {{- with .Values.portal.identityMap.existingConfigMap }}
             - name: identity-map
               mountPath: /etc/ai-guard-identity
+              readOnly: true
+            {{- end }}
+            {{- with .Values.portal.governance.existingConfigMap }}
+            - name: governance
+              mountPath: /etc/ai-guard-governance
               readOnly: true
             {{- end }}
             - name: tmp
@@ -132,6 +141,11 @@ spec:
         # Maps named people to the machines they use. Personal data: a Secret
         # is a defensible choice here too, and the portal only reads it.
         - name: identity-map
+          configMap:
+            name: {{ . }}
+        {{- end }}
+        {{- with .Values.portal.governance.existingConfigMap }}
+        - name: governance
           configMap:
             name: {{ . }}
         {{- end }}

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -132,6 +132,31 @@ portal:
   identityMap:
     existingConfigMap: ""
 
+  # Optional. Approval decisions, owners and review dates, as governance.yaml
+  # in a ConfigMap. Without it the register falls back to the registry's own
+  # approved flag, every tool reads as undecided, and the owner and review
+  # columns show as not set.
+  #
+  # Separate from the registry on purpose. The registry answers what a tool is
+  # and how to detect it, and it ships with the project. This answers what your
+  # organisation decided, which is nobody else's to ship. It also never reaches
+  # a detector: approval used to be compiled into the browser extension's own
+  # config, which had no use for it.
+  #
+  # Approval records a governance position and does NOT change finding
+  # severity. Severity depends on the account domain: a personal account is a
+  # warn whether or not the tool is approved. Approval must never come to mean
+  # safe.
+  #
+  # Create it from your own file:
+  #   kubectl create configmap ai-guard-governance --from-file=governance.yaml
+  #
+  # Validate it first, with governance/validate.py from the repo. An approval
+  # with no review date is a schema error, because an approval with no expiry
+  # is the one that outlives the person who made it.
+  governance:
+    existingConfigMap: ""
+
   # Optional. Embeds Grafana panels on the portal's dashboard tab.
   #
   # Grafana refuses to be framed by default, deliberately: framing a session

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -151,6 +151,11 @@ services:
       # than shipping a credential someone might carry into production.
       PORTAL_AUTH: "none"
       REGISTRY_PATH: "/etc/ai-guard/registry.json"
+      # Governance decisions. Optional everywhere, including here: comment
+      # this out and the register falls back to the registry's own approved
+      # flag, which is what a deployment that has not adopted this looks
+      # like.
+      GOVERNANCE_PATH: "/etc/ai-guard-governance.yaml"
       # Short, because the demo is for clicking around. A real deployment
       # wants the default 300 so a seven-day query is not rerun per page load.
       CACHE_TTL_SECONDS: "10"
@@ -183,6 +188,10 @@ services:
         ai-guard:31:Pastes stopped (7d)
     volumes:
       - registry-dist:/etc/ai-guard:ro
+      # A distinct path rather than inside the registry volume: /etc/ai-guard
+      # is a named volume the builder writes, and a bind mount nested in it
+      # depends on mount ordering that is not worth relying on.
+      - ./governance.yaml:/etc/ai-guard-governance.yaml:ro
     depends_on:
       loki:
         condition: service_healthy

--- a/demo/governance.yaml
+++ b/demo/governance.yaml
@@ -1,0 +1,53 @@
+# Governance decisions for the demo. Fake, like everything else here.
+#
+# Written to show the four states the register can display, because a demo
+# with no governance file shows only the fallback and the feature looks like
+# an empty column.
+#
+# In a real deployment this file is yours, lives wherever you put it, and is
+# pointed at by GOVERNANCE_PATH. It never ships with the project: an upstream
+# registry has no business implying that a particular tool is approved.
+
+version: 1
+
+tools:
+
+  # Current approval. Reads as approved, with an owner and a date.
+  claude:
+    status: approved
+    owner: Engineering
+    review_due: 2027-06-01
+    reason: Enterprise tenant, DPA in place
+
+  # EXPIRED approval. The stored decision is still "approved" and the register
+  # shows "reviewing", "approval expired N days ago", and "was approved". This
+  # is the case worth looking at: an approval nobody has revisited is not
+  # evidence a tool is safe, it is evidence nobody looked.
+  chatgpt:
+    status: approved
+    owner: Security
+    review_due: 2026-01-31
+    reason: Enterprise workspace, reviewed at onboarding
+
+  # Under review.
+  cursor:
+    status: reviewing
+    owner: Engineering
+    review_due: 2027-03-15
+    reason: Waiting on the vendor's sub-processor list
+
+  # A refusal. No review date needed.
+  ollama:
+    status: not_approved
+    owner: Security
+    reason: Local models, no visibility into what is loaded
+
+  # A decision naming a tool the registry does not know. The register reports
+  # it rather than dropping it, because that is also exactly what a typo looks
+  # like, and a decision that silently matches nothing is how an organisation
+  # believes it has decided something it has not.
+  some-unregistered-tool:
+    status: not_approved
+    owner: Security
+    review_due: 2027-09-30
+    reason: Seen on two machines, no vendor assessment yet

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -230,8 +230,28 @@ devices. A tool observed and absent from the registry does get a row, flagged,
 because something in use that governance has never considered is worth acting
 on. Owner, review date and risk decision are organisational records rather
 than observations, so the register shows them as not set rather than leaving
-the columns blank. It holds no decisions of its own, and the `approved` flag it
-displays is the registry's, reported as it stands.
+the columns blank. Owner, review date and the decision itself come from an optional governance
+file, described in [governance.md](governance.md), and the portal holds no
+governance state of its own: it reads the file and joins it at request time,
+the same way it joins findings.
+
+That file is deliberately not the registry. The registry answers what a tool is
+and how to detect it, and it ships with the project; governance answers what an
+organisation decided, which is nobody else's to ship. The separation is also
+physical, because approval used to be compiled into the browser extension's and
+the scanner's own config, neither of which had any use for it.
+
+Approval records a position and does not change severity. Severity is decided
+at the point of detection and depends on the account domain, so an approved
+tool signed into a personal account is still a warn, and an unapproved tool on
+a corporate account is still info. Those are independent dimensions and the
+portal keeps them that way: approval must never come to mean safe.
+
+An approval past its review date reports as reviewing, with the previous
+decision alongside, and the stored record is never rewritten. That is the same
+rule the platform applies to a source that has stopped reporting, turned on the
+decision instead: an approval nobody has revisited is not evidence a tool is
+safe, it is evidence that nobody looked.
 
 Its entry points differ because the sources do. Endpoint findings carry a
 device and a local username, and the username is a hint rather than a key: it

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,173 @@
+# Governance decisions
+
+The register shows what AI tools are in use. This is where you record what your
+organisation has decided about them: approved, not approved, or under review,
+with an owner and a date to revisit it.
+
+Optional. Without it the portal falls back to the registry's own `approved`
+flag, every tool reads as undecided, and the owner and review columns show as
+not set. Nothing else changes.
+
+## Why it is a separate file
+
+The registry answers *what is this tool and how do I detect it*. It ships with
+the project, and it is the same for everyone.
+
+Governance answers *what did we decide about it*. That is yours, and it is
+nobody else's to ship: an upstream project has no business implying that Claude
+is approved or that Engineering owns ChatGPT.
+
+The separation is also physical. Approval used to be compiled into
+`extension.json` and `scanner.json` and sent to detectors that never read it. A
+browser extension has no use for your approval decisions, and now does not
+receive them.
+
+## Approval is not safety
+
+**Approval records a governance position. It does not change finding
+severity.**
+
+Severity is decided by the reporter at the point of detection and depends on
+the account domain. A personal account is a `warn` on any surface. The presence
+of a tool is `info`. Neither changes because you approved something.
+
+So both of these are correct and normal:
+
+    Claude, corporate account      severity info     governance approved
+    Claude, personal account       severity warn     governance approved
+
+The second is still the thing to act on, because the risky part is the account,
+not the tool. Approval must never quietly come to mean safe.
+
+## The file
+
+```yaml
+version: 1
+
+tools:
+  claude:
+    status: approved
+    owner: Engineering
+    review_due: 2026-11-01
+    reason: Enterprise tenant, DPA in place
+
+  deepseek:
+    status: not_approved
+    owner: Security
+    reason: No data processing agreement
+```
+
+Start from `governance/governance.yaml.example`, which has a worked entry for
+each state.
+
+### Fields
+
+| field | required | notes |
+|---|---|---|
+| `status` | yes | `approved`, `not_approved` or `reviewing` |
+| `review_due` | **on `approved`** | `YYYY-MM-DD`. Strongly expected on `reviewing`, optional on `not_approved` |
+| `owner` | no | A team or a person. Not resolved against anything |
+| `reason` | no | Free text, shown with the decision |
+
+`review_due` is required on an approval and not on a refusal because that is
+where the risk is. An approval with no expiry is the one that outlives the
+person who made it and the reason it was made. A decision not to use something
+does not rot in the same way.
+
+### Three states, not five
+
+`Restricted`, `Deprecated` and `Exception approved` are all defensible, and none
+of them is needed to find out whether this model is useful. Start with three.
+
+## Expiry
+
+An approval past its `review_due` reports as **reviewing**, with the reason and
+the previous decision alongside:
+
+```
+Claude
+REVIEWING
+approval expired 12 days ago
+was approved
+```
+
+The record itself is never rewritten. A clock ticking over is not a decision,
+and the history has to keep saying what a human decided on a date. The stored
+status stays `approved`; only the derived status moves.
+
+This is the same rule the platform already applies to detection sources. A
+collector that has stopped reporting is not evidence a machine is clean, and an
+approval nobody has revisited in eighteen months is not evidence a tool is safe.
+It is evidence that nobody looked.
+
+Expiry is evaluated when the page is rendered. There is no job to run and no
+window where the stored value is right and the display is stale.
+
+## Tool ids
+
+Keys are tool ids as they appear in the registry. They are also **governance
+subjects**, which is not quite the same thing: you can record a decision about a
+tool the registry has never heard of. That is deliberate, because the tool most
+urgently in need of a decision is often the one the register has just flagged as
+observed and not registered.
+
+A decision naming an id the registry does not know is **shown, not dropped**:
+
+```
+1 decision names a tool the registry does not know: github_copilot
+```
+
+Usually that is a typo. Occasionally it is an upstream rename that has quietly
+un-made an approval you recorded. Both look identical from here, and both need
+saying out loud: a decision that silently matches nothing is how an
+organisation believes it has decided something it has not.
+
+Treat tool ids as stable keys for this reason. Display names and metadata can
+change; an id is what a decision is attached to.
+
+## Validating
+
+```bash
+python governance/validate.py path/to/governance.yaml
+```
+
+Exits non-zero on a schema error. Warns without failing on an id the registry
+does not know, and on an approval with no owner.
+
+Write dates however you like. YAML parses a bare `2026-11-01` as a date rather
+than a string, and the validator normalises it, so quoting is optional rather
+than a trap.
+
+## Deploying
+
+### Kubernetes
+
+```bash
+kubectl create configmap ai-guard-governance --from-file=governance.yaml
+```
+
+```yaml
+portal:
+  governance:
+    existingConfigMap: ai-guard-governance
+```
+
+### Compose
+
+Mount the file and point `GOVERNANCE_PATH` at it. `demo/docker-compose.yml`
+does exactly that, and `demo/governance.yaml` is a worked example you can see
+rendered by running the demo.
+
+## The audit trail
+
+There is no write path. Decisions are edited in the file, and the file goes
+through whatever review your repository already has.
+
+That is not a limitation to be apologised for. A merge request is signed,
+timestamped, reviewable, and carries a diff of exactly what changed and who
+approved the change. Most governance portals build something weaker and call it
+an audit log.
+
+If, after living with it, the recurring thought is *I wish I could change this
+in the portal*, that is evidence for a write path. If editing the file turns
+out to be fine, a great deal of engineering has been avoided.

--- a/governance/governance.yaml.example
+++ b/governance/governance.yaml.example
@@ -1,0 +1,77 @@
+# Governance decisions: what THIS organisation has decided about the AI tools
+# it uses. Copy this to governance.yaml, edit it, and point GOVERNANCE_PATH at
+# it. Nothing here ships with the project, and nothing here is a default.
+#
+# Optional. Without it the portal behaves exactly as it did before this file
+# existed: the registry's own `approved` flag stands, and owner and review date
+# show as not set.
+#
+# Separate from registry.yaml on purpose. The registry answers "what is this
+# tool and how do I detect it" and it ships with the project. This answers
+# "what did we decide", and an upstream project has no business implying that
+# Claude is approved or that Engineering owns ChatGPT.
+#
+# Approval records a governance position and does NOT change finding severity.
+# Severity is decided at the point of detection and depends on the account
+# domain: a personal account is a warn on any surface whether or not the tool
+# is approved, and the presence of a tool is info whether or not it is. An
+# approved tool signed into a personal account is still the thing to act on,
+# because the risky part is the account. Approval must never come to mean safe.
+#
+# Edit it, raise a merge request, merge it. That is the audit trail, and it is
+# a better one than most portals build: signed, timestamped, reviewable, with a
+# diff of exactly what changed and who approved the change.
+
+version: 1
+
+tools:
+
+  # A current approval. review_due is REQUIRED on an approved tool: an approval
+  # with no expiry is the one that outlives the person who made it and the
+  # reason it was made.
+  claude:
+    status: approved
+    owner: Engineering
+    review_due: 2026-11-01
+    reason: Enterprise tenant, data processing agreement in place
+
+  # An expired approval. The stored decision stays exactly as written, and the
+  # portal reports it as REVIEWING with "approval expired N days ago" and the
+  # previous decision alongside. Nothing rewrites this record: a clock ticking
+  # over is not a decision, and the history has to keep saying what a human
+  # decided on a date.
+  chatgpt:
+    status: approved
+    owner: Security
+    review_due: 2026-07-31
+    reason: Enterprise workspace, reviewed at onboarding
+
+  # Under review. review_due is strongly expected here, because a review with
+  # no date is the state things get parked in.
+  cursor:
+    status: reviewing
+    owner: Engineering
+    review_due: 2026-09-15
+    reason: Waiting on the vendor's sub-processor list
+
+  # A refusal. review_due is optional: a decision not to use something does not
+  # rot in the same way, though a date is useful if the reason might change.
+  deepseek:
+    status: not_approved
+    owner: Security
+    reason: No data processing agreement, hosting outside the UK and EU
+
+  # A tool the registry does not know about, recorded deliberately. The
+  # register flags tools it observes that are not in the registry, and this is
+  # the same gap from the other side: something was found, someone looked at
+  # it, and the decision is written down before it is a registry entry.
+  #
+  # The portal shows this as a decision whose tool is not registered. That is
+  # also what a typo looks like, which is the point: write github_copilot for
+  # github-copilot and the mistake is visible rather than silently doing
+  # nothing.
+  some-internal-ai-tool:
+    status: not_approved
+    owner: Security
+    review_due: 2026-09-30
+    reason: Found on two machines, no vendor assessment yet

--- a/governance/schema.json
+++ b/governance/schema.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "ai-guard governance decisions",
+  "description": "What an organisation has decided about the AI tools it uses. Deployment-specific: this file is never shipped with the project, because an upstream registry has no business implying that a particular tool is approved or that a particular team owns it. Optional; without it the registry's own approved flag stands as the default.",
+  "type": "object",
+  "required": [
+    "version",
+    "tools"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "version": {
+      "type": "integer",
+      "const": 1
+    },
+    "tools": {
+      "type": "object",
+      "description": "Keyed on tool id. Keys are governance subjects rather than necessarily registered tools: the tool most urgently in need of a decision is often the one the register has just flagged as observed and not in the registry. An id the registry does not know validates, and the portal reports it rather than dropping it, because a decision that silently matches nothing is how an organisation believes it has decided something it has not.",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "status": {
+            "enum": [
+              "approved",
+              "not_approved",
+              "reviewing"
+            ],
+            "description": "The decision as recorded. Deliberately three: Restricted, Deprecated and Exception approved are all defensible and none is needed to find out whether this model is useful. Records a governance position and has no effect on finding severity, which depends on the account domain."
+          },
+          "owner": {
+            "type": "string",
+            "description": "Who owns the decision. A team or a person; the portal does not resolve it against anything."
+          },
+          "review_due": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "description": "When this decision should be revisited, as YYYY-MM-DD. An approval past this date reports as reviewing, with the reason attached. The stored decision is never rewritten: a clock ticking over is not a decision, and the history has to keep saying what a human decided on a date. Write it unquoted if you like; YAML parses a bare 2026-11-01 as a date object and the validator normalises it back to a string before checking, so both forms work and neither is a trap."
+          },
+          "reason": {
+            "type": "string",
+            "description": "Why. Free text, shown alongside the decision."
+          }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "status": {
+                  "const": "approved"
+                }
+              },
+              "required": [
+                "status"
+              ]
+            },
+            "then": {
+              "required": [
+                "review_due"
+              ],
+              "$comment": "An approval with no expiry is the dangerous record: it is the one that outlives the person who made it and the reason it was made. The constraint sits here rather than on every status, because requiring a date on a refusal would be box-ticking."
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/governance/validate.py
+++ b/governance/validate.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Validate a governance file against the schema.
+
+Run over the shipped example in CI, and by a deployer over their own file:
+
+    python governance/validate.py path/to/governance.yaml
+
+Two things this does that a bare schema check does not.
+
+It normalises dates. YAML parses an unquoted 2026-11-01 as a date object rather
+than a string, so a schema that only accepts strings would reject the exact
+format the file is written in. Requiring quotes instead would be a trap that
+catches everyone once.
+
+It warns rather than fails on a tool id the registry does not know. A decision
+about an unregistered tool is legitimate, because the tool most urgently in
+need of one is often the tool the register has just flagged as observed and not
+registered. But it is also what a typo looks like, so it is reported either
+way: a decision that silently matches nothing is how an organisation believes
+it has decided something it has not.
+"""
+
+import json
+import sys
+from datetime import date
+from pathlib import Path
+
+HERE = Path(__file__).parent
+SCHEMA = HERE / "schema.json"
+REGISTRY = HERE.parent / "registry" / "registry.yaml"
+
+
+def normalise(doc):
+    """Dates back to ISO strings, so both YAML forms validate."""
+    for rec in (doc.get("tools") or {}).values():
+        if isinstance(rec, dict) and isinstance(rec.get("review_due"), date):
+            rec["review_due"] = rec["review_due"].isoformat()
+    return doc
+
+
+def known_tool_ids():
+    try:
+        import yaml
+        reg = yaml.safe_load(REGISTRY.read_text()) or {}
+    except Exception:
+        return None
+    return {t.get("id") for t in reg.get("tools", []) if t.get("id")}
+
+
+def main(path):
+    import yaml
+    from jsonschema import Draft202012Validator
+
+    doc = normalise(yaml.safe_load(Path(path).read_text()) or {})
+    validator = Draft202012Validator(json.loads(SCHEMA.read_text()))
+
+    errors = sorted(validator.iter_errors(doc), key=lambda e: list(e.path))
+    for e in errors:
+        where = " > ".join(str(p) for p in e.path) or "(root)"
+        print("error: %s: %s" % (where, e.message), file=sys.stderr)
+    if errors:
+        return 1
+
+    tools = doc.get("tools") or {}
+    print("%s valid: %d decision%s" % (path, len(tools), "" if len(tools) == 1 else "s"))
+
+    known = known_tool_ids()
+    if known is not None:
+        unknown = sorted(set(tools) - known)
+        for tid in unknown:
+            print("warning: %s is not a tool id in the registry. That is fine "
+                  "for a deliberate decision about something not yet "
+                  "registered, and it is also what a typo looks like."
+                  % tid, file=sys.stderr)
+
+    approved_no_owner = sorted(
+        t for t, r in tools.items()
+        if r.get("status") == "approved" and not r.get("owner"))
+    for t in approved_no_owner:
+        print("warning: %s is approved with no owner. An approval nobody owns "
+              "is one nobody will review." % t, file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    sys.exit(main(sys.argv[1]))

--- a/portal/README.md
+++ b/portal/README.md
@@ -1,4 +1,4 @@
-# portal
+# Portal
 
 A governance view over the findings the receiver already collects. Devices,
 identities, tools, and the relationships between them.
@@ -72,6 +72,7 @@ about the estate.
 | `LOOKBACK_HOURS` | no | default window, default 168 |
 | `REGISTRY_PATH` | no | registry.yaml, for resolving domains to tool ids |
 | `IDENTITY_MAP` | no | CSV of `key,identity` attaching people to devices |
+| `GOVERNANCE_PATH` | no | YAML of approval decisions, owners and review dates. See [docs/governance.md](../docs/governance.md) |
 | `GRAFANA_URL` | no | a Grafana that permits embedding; unset shows a note |
 | `GRAFANA_PANELS` | no | `dashboardUid:panelId:Title`, semicolon separated |
 | `GRAFANA_DASHBOARD_UID` | no | embed a whole dashboard instead of panels |
@@ -161,10 +162,36 @@ effect within `CACHE_TTL_SECONDS` (default 30) without a restart.
 | Devices | one row per machine, with each tool paired to the account it uses |
 | Personal accounts | every personal account seen, with first and last seen |
 | MCP servers | which MCP servers are configured, on which machines, by which tool |
+| AI register | the tools actually in use, joined to what has been decided about each |
 | Setup | which detection sources are reporting and which are silent |
 | Uncovered devices | machines a scanner knows about that no collector reports from |
 | Dashboard | Grafana, embedded |
 | Settings | what the portal can say about itself, for a support conversation |
+
+## AI register
+
+The tools actually in use, from findings in the lookback window, joined to what
+the registry knows and what your organisation has decided.
+
+The registry is a watchlist rather than an inventory, so a tool it knows about
+and nothing has reported is a count rather than a row. A register padded with
+tools nobody here uses is a worse record of what an organisation does, not a
+more complete one. A tool observed and absent from the registry does get a row,
+flagged, because something in use that governance has never considered is the
+anomaly worth acting on.
+
+Status, owner and review date come from an optional governance file. Without
+one, everything reads as undecided, which is honest: every tool ships
+`approved: false` and presenting that as a refusal would assert a decision
+nobody made. See [docs/governance.md](../docs/governance.md).
+
+An approval past its review date reports as reviewing, says how long ago it
+expired, and shows the previous decision. The record is not rewritten: a clock
+ticking over is not a decision.
+
+`GET /api/register?fmt=csv` exports the same rows the page shows, with the
+timestamp and lookback window in the filename. It is a convenience export
+rather than an evidence artifact: no manifest, no checksum.
 
 ## Overview widgets
 

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -36,6 +36,8 @@ import urllib.parse
 import urllib.request
 from collections import defaultdict
 
+from app import governance
+
 # Surfaces that describe a machine. Anything else is identity-scoped and will
 # not carry a device.
 ENDPOINT_SURFACES = {"cli", "ide", "desktop", "mcp", "browser"}
@@ -795,7 +797,7 @@ def _base_tool(tool):
     return base or tool
 
 
-def register_from(findings, reg=None, domain_map=None):
+def register_from(findings, reg=None, domain_map=None, gov=None):
     """One row per tool: what the registry knows, joined to what was observed.
 
     Returns the full join, observed and not. Callers decide what to show: the
@@ -882,6 +884,12 @@ def register_from(findings, reg=None, domain_map=None):
     for tid in sorted(set(known) | set(observed)):
         meta = known.get(tid, {})
         o = observed.get(tid)
+        # The organisation's decision if one is recorded, otherwise the
+        # registry's own flag as a labelled default. governance.decide keeps
+        # the two distinguishable, because every tool ships not approved and a
+        # register that presented that as a position would be asserting a
+        # refusal nobody made.
+        g = governance.decide(tid, gov, meta.get("approved"))
         rows.append({
             "id": tid,
             "name": meta.get("name") or tid,
@@ -891,6 +899,13 @@ def register_from(findings, reg=None, domain_map=None):
             # The registry's own boolean, reported as it stands. The portal
             # does not decide approval and must not imply it has.
             "approved": meta.get("approved"),
+            "status": g["status"],
+            "stored_status": g["stored_status"],
+            "status_reason": g["reason"],
+            "status_source": g["source"],
+            "owner": g["owner"],
+            "review_due": g["review_due"],
+            "days_overdue": g["days_overdue"],
             "in_registry": tid in known,
             "observed": o is not None,
             "devices": len(o["devices"]) if o else 0,
@@ -912,7 +927,9 @@ def register_from(findings, reg=None, domain_map=None):
 
 
 REGISTER_COLUMNS = [
-    "id", "name", "vendor", "category", "risk_tier", "approved",
+    "id", "name", "vendor", "category", "risk_tier",
+    "status", "stored_status", "status_reason", "status_source",
+    "owner", "review_due", "days_overdue", "approved",
     "in_registry", "observed", "devices", "users", "corporate_accounts",
     "personal_accounts", "findings", "surfaces", "sources",
     "first_seen", "last_seen",

--- a/portal/app/governance.py
+++ b/portal/app/governance.py
@@ -1,0 +1,206 @@
+"""Governance decisions: what an organisation decided about a tool.
+
+Separate from the registry on purpose. The registry answers "what is this tool
+and how do I detect it", and it ships with the project. Governance answers
+"what did this organisation decide about it", and it cannot ship with anything:
+an upstream project has no business implying that Claude is approved or that
+Engineering owns ChatGPT.
+
+The separation is also physical. Approval used to be compiled into
+extension.json and scanner.json and shipped to detectors that never read it.
+Governance state has no reason to reach a browser extension, and now does not.
+
+Optional. A deployment with no governance file behaves as it did before this
+existed: the registry's own `approved` flag stands as the default, and owner
+and review date are simply not set.
+
+Two ideas do the work here.
+
+STORED AND EFFECTIVE ARE DIFFERENT. A decision is a record of what a human
+decided on a date, and it must not change because a clock ticked over. But an
+approval that has passed its review date is no longer a current decision
+either. So the stored decision is kept as written and the effective status is
+derived at read time, with the reason attached. That is the same separation the
+platform already applies to findings: Loki holds what was observed, governance
+is joined on top.
+
+A DECISION THAT MATCHES NOTHING IS SURFACED, NOT DROPPED. If a governance
+record names a tool the registry does not know, it is kept and flagged. The
+common case is a typo: someone writes github_copilot for github-copilot and
+their decision silently does nothing. The rarer case is an upstream rename,
+where an approval quietly becomes un-made by somebody else's edit. Both look
+identical from here and both need saying out loud.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import date
+
+# The three states. Deliberately few: Restricted, Deprecated and Exception
+# approved are all defensible and none of them is needed to find out whether
+# this model is useful.
+APPROVED = "approved"
+NOT_APPROVED = "not_approved"
+REVIEWING = "reviewing"
+VALID_STATUSES = {APPROVED, NOT_APPROVED, REVIEWING}
+
+# Why an effective status differs from the stored one. Empty when it does not.
+EXPIRED = "approval_expired"
+
+
+def load_governance(path):
+    """Governance decisions keyed on tool id, or {} when none are configured.
+
+    Returns {} rather than raising on a missing file, because governance is
+    optional and its absence is a valid state. A file that exists and cannot be
+    read is different: that is a deployment that meant to record decisions and
+    is not, so it complains to stderr rather than passing silently.
+    """
+    if not path:
+        return {}
+    if not os.path.exists(path):
+        print("governance file not found at %s: decisions will fall back to "
+              "the registry's approved flag" % path, file=sys.stderr)
+        return {}
+
+    try:
+        with open(path) as fh:
+            import yaml
+            doc = yaml.safe_load(fh) or {}
+    except ImportError:
+        print("pyyaml not installed: governance decisions will not be loaded",
+              file=sys.stderr)
+        return {}
+    except Exception as e:
+        print("could not read governance file (%s): decisions will fall back "
+              "to the registry's approved flag" % e, file=sys.stderr)
+        return {}
+
+    return load_governance_from(doc)
+
+
+def load_governance_from(doc):
+    """The mapping itself, separated from reading a file so it can be tested
+    without one."""
+    out = {}
+    for tool_id, rec in ((doc or {}).get("tools") or {}).items():
+        if not isinstance(rec, dict):
+            continue
+        status = str(rec.get("status") or "").strip().lower()
+        if status not in VALID_STATUSES:
+            # A status nobody recognises is not a decision. Saying so beats
+            # guessing, and beats treating it as approved.
+            print("governance: %s has unknown status %r, ignoring the record"
+                  % (tool_id, rec.get("status")), file=sys.stderr)
+            continue
+        out[str(tool_id)] = {
+            "status": status,
+            "owner": str(rec.get("owner") or "").strip(),
+            "review_due": _parse_date(rec.get("review_due")),
+            "reason": str(rec.get("reason") or "").strip(),
+        }
+    return out
+
+
+def _parse_date(value):
+    """A date, or None on anything unparseable.
+
+    None means "no review date", which for an approval is a schema error caught
+    at validation rather than something to guess about here. Treating an
+    unreadable date as expired would revoke an approval because of a typo.
+    """
+    if not value:
+        return None
+    if isinstance(value, date):
+        return value
+    try:
+        return date.fromisoformat(str(value).strip())
+    except (ValueError, TypeError):
+        print("governance: could not read review_due %r, treating it as unset"
+              % value, file=sys.stderr)
+        return None
+
+
+def effective(record, today=None):
+    """(status, reason) as it stands today, from a stored decision.
+
+    The stored decision is never modified. An approval past its review date
+    reports as reviewing with the reason attached, because an approval nobody
+    has revisited is not evidence a tool is safe, it is evidence that nobody
+    looked. That is the same rule the platform already applies to a source that
+    has stopped reporting.
+
+    Evaluated on every read rather than by a scheduled job. There is no window
+    where the stored value is right and the displayed one is stale, and no job
+    to notice has stopped running.
+    """
+    if not record:
+        return "", ""
+    status = record.get("status") or ""
+    due = record.get("review_due")
+    today = today or date.today()
+
+    if status == APPROVED and due and due < today:
+        return REVIEWING, EXPIRED
+    return status, ""
+
+
+def days_overdue(record, today=None):
+    """How long an approval has been expired, or 0. For display only."""
+    due = (record or {}).get("review_due")
+    if not due or (record or {}).get("status") != APPROVED:
+        return 0
+    today = today or date.today()
+    return max(0, (today - due).days)
+
+
+def decide(tool_id, governance, registry_approved, today=None):
+    """The whole governance position for one tool, ready to render.
+
+    Falls back to the registry's own flag when no decision has been recorded,
+    so a deployment with no governance file behaves exactly as it did before
+    this existed. That fallback is reported as such rather than dressed up as a
+    decision: `source` says whether a human recorded this or whether it is the
+    shipped default, and nobody should read "not approved by default" as
+    "somebody decided against it".
+    """
+    rec = (governance or {}).get(tool_id)
+    if rec:
+        status, reason = effective(rec, today)
+        return {
+            "status": status,
+            "stored_status": rec["status"],
+            "reason": reason,
+            "owner": rec.get("owner") or "",
+            "review_due": rec["review_due"].isoformat() if rec.get("review_due") else "",
+            "days_overdue": days_overdue(rec, today),
+            "source": "governance",
+        }
+
+    if registry_approved is None:
+        # Not in the registry either. Unknown, which is not the same as
+        # not approved: nobody has decided anything about this tool.
+        return {"status": "", "stored_status": "", "reason": "", "owner": "",
+                "review_due": "", "days_overdue": 0, "source": "unknown"}
+
+    status = APPROVED if registry_approved else NOT_APPROVED
+    return {"status": status, "stored_status": status, "reason": "",
+            "owner": "", "review_due": "", "days_overdue": 0,
+            "source": "registry_default"}
+
+
+def unmatched(governance, known_ids):
+    """Governance records naming a tool the registry does not know.
+
+    Kept and reported rather than dropped. A decision that matches nothing is
+    almost always a typo, and occasionally an upstream rename that has quietly
+    un-made somebody's approval. Silently ignoring it is how an organisation
+    believes it has decided something it has not.
+
+    A deliberate decision about a tool that is genuinely not in the registry
+    lands here too, which is correct: the register already flags observed tools
+    that are not registered, and this is the same gap seen from the other side.
+    """
+    return sorted(set(governance or {}) - set(known_ids or ()))

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -36,6 +36,7 @@ encryption.
   LOOKBACK_HOURS    default window, default 168
   REGISTRY_PATH     registry.yaml, for resolving domains to tool ids
   IDENTITY_MAP      CSV of key,identity for attaching people to devices
+  GOVERNANCE_PATH   YAML of approval decisions, owners and review dates
   GRAFANA_URL       base URL of a Grafana that allows embedding; unset means
                     the dashboard shows a note instead of a broken frame
   GRAFANA_PANELS    what to embed, as "dashboardUid:panelId:Title" entries.
@@ -69,7 +70,7 @@ from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
-from app import derive
+from app import derive, governance
 
 log = logging.getLogger("portal")
 
@@ -157,6 +158,9 @@ LOKI_TOKEN = _secret("LOKI_TOKEN") or None
 LOOKBACK_HOURS = float(os.environ.get("LOOKBACK_HOURS", "168"))
 REGISTRY_PATH = os.environ.get("REGISTRY_PATH", "/srv/registry/registry.yaml")
 IDENTITY_MAP = os.environ.get("IDENTITY_MAP", "")
+# Governance decisions. Optional: without it the registry's own approved
+# flag stands as the default and owner and review date show as not set.
+GOVERNANCE_PATH = os.environ.get("GOVERNANCE_PATH", "")
 GRAFANA_URL = os.environ.get("GRAFANA_URL", "").rstrip("/")
 GRAFANA_PANELS = os.environ.get("GRAFANA_PANELS", "")
 GRAFANA_DASHBOARD_UID = os.environ.get("GRAFANA_DASHBOARD_UID", "")
@@ -476,8 +480,9 @@ def register(hours: float = Query(default=None, gt=0, le=24 * 90),
     def build():
         findings = _findings(hours)
         reg = derive.load_registry(REGISTRY_PATH)
+        gov = governance.load_governance(GOVERNANCE_PATH)
         return derive.register_from(findings, reg,
-                                    derive.load_domain_map_from(reg))
+                                    derive.load_domain_map_from(reg), gov)
 
     all_rows, at = _cached("register", hours, build)
     # The register is what is in use. The rest of the join is the watchlist,
@@ -493,10 +498,19 @@ def register(hours: float = Query(default=None, gt=0, le=24 * 90),
             headers={"Content-Disposition": 'attachment; filename="%s"' % name},
         )
 
+    gov = governance.load_governance(GOVERNANCE_PATH)
     return JSONResponse({
         "rows": rows,
         "derived_at": at,
         "hours": hours,
+        "governance_configured": bool(GOVERNANCE_PATH),
+        # Decisions naming a tool the registry does not know. Reported rather
+        # than dropped: the likely cause is a typo, and a decision that
+        # silently matches nothing is how an organisation believes it has
+        # decided something it has not.
+        "governance_unmatched": governance.unmatched(
+            gov, [t.get("id") for t in (
+                derive.load_registry(REGISTRY_PATH).get("tools") or [])]),
         # Both counts, deliberately. A register that reported only what it
         # found would let an estate with a silent source look complete.
         "tools_observed": len(rows),

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -63,6 +63,60 @@ main{padding:22px 24px;max-width:1440px;margin:0 auto}
 table{width:100%;border-collapse:collapse;font-size:13px}
 th{text-align:left;font-weight:400;color:var(--mut);border-bottom:1px solid var(--bd);padding:6px 10px 6px 0;font-size:12px}
 td{padding:7px 10px 7px 0;border-bottom:1px solid color-mix(in oklch,var(--bd) 45%,transparent);font-family:ui-monospace,monospace;font-size:12px}
+/* The register, as cards.
+   -------------------------------------------------------------------------
+   Four table attempts failed, and the last measurement said why: the content
+   area is 1125px, not the ~1392px every one of those attempts was sized
+   against. Nine columns needed 1077px and fitted by 48px, which is not
+   fitting, it is scraping. Reducing to eight would have needed 1007px and
+   scraped by 118px instead.
+
+   A register is read one tool at a time as often as it is scanned, so the
+   table shape was never load-bearing. Cards drop the width problem entirely:
+   auto-fill gives two per row at 1125px, one on a narrow window and three on a
+   wide monitor, with no breakpoint to keep in step and no horizontal scrolling
+   at any width.
+
+   Fields that were columns are now labelled rows inside a card, which also
+   removes the thing no amount of width tuning fixed: a header three columns
+   away from the value it describes. */
+.cards{display:grid;gap:14px;grid-template-columns:repeat(auto-fill,minmax(400px,1fr))}
+.card{border:1px solid var(--bd);border-radius:10px;padding:14px 16px;min-width:0}
+/* Name and decision on one line, because those are the two things someone
+   scanning is looking for. */
+.card-top{display:flex;justify-content:space-between;align-items:flex-start;gap:14px}
+.card-name{font-size:15px;font-weight:600}
+.card-meta{font-family:ui-monospace,monospace;font-size:11px;color:var(--mut);
+           margin-top:2px;overflow-wrap:anywhere}
+.card hr{border:0;border-top:1px solid color-mix(in oklch,var(--bd) 55%,transparent);margin:12px 0}
+/* A quiet label rather than another box. The lower block is organisational
+   record rather than observation, and the two were reading as one list. */
+.card-section{font-size:11px;color:var(--mut);text-transform:uppercase;
+              letter-spacing:.08em;margin:0 0 8px}
+/* Label and value, with the label beside its own value rather than three
+   columns away from it. */
+.card-kv{display:grid;grid-template-columns:auto 1fr;gap:6px 14px;font-size:12px;
+         font-family:ui-monospace,monospace}
+.card-kv dt{color:var(--mut);white-space:nowrap}
+.card-kv dd{margin:0;overflow-wrap:anywhere}
+.card-kv dd .pill{margin:0 4px 0 0}
+
+.gov{display:flex;flex-direction:column;align-items:flex-start;gap:4px;min-width:0}
+.gov .pill{margin:0}
+.gov-sub{font-size:11px;color:var(--mut);white-space:nowrap}
+.gov-sub.over{color:var(--dstr)}
+.gov-owner{white-space:nowrap}
+/* No border, no fill. Absence of governance, not a state with equal weight to
+   approved or reviewing. */
+.none{color:color-mix(in oklch,var(--mut) 70%,transparent);font-family:ui-monospace,monospace;
+      font-size:11px;white-space:nowrap}
+/* A zero is the absence of something and should not compete with a real
+   count. Without this a row of zeros is as loud as a row of findings. */
+td.n .z{color:color-mix(in oklch,var(--mut) 55%,transparent)}
+/* The counts split into two questions: how widely is this used, and what is
+   it signed into. A rule rather than a gap, because a gap in a dense table
+   reads as a missing column. */
+th.grp,td.grp{border-left:1px solid color-mix(in oklch,var(--bd) 60%,transparent);padding-left:14px}
 .note{background:color-mix(in oklch,var(--warn) 10%,transparent);border:1px solid color-mix(in oklch,var(--warn) 40%,transparent);color:var(--warn);border-radius:8px;padding:12px 14px;margin-bottom:18px;font-size:13px}
 .back{background:none;border:1px solid var(--bd);color:var(--mut);border-radius:6px;padding:5px 10px;cursor:pointer;font:inherit;margin-bottom:14px}
 h2{font-size:19px;margin:0 0 4px}
@@ -484,13 +538,77 @@ async function register() {
   const win = REG.hours >= 24 ? Math.round(REG.hours / 24) + ' days'
                               : REG.hours + ' hours';
   const dash = '<span class="pill p-mut">not set</span>';
+  // A zero is the absence of a thing. Rendering it at full weight makes a
+  // row of zeros as loud as a row of findings, and the eye has nothing to
+  // land on.
+  // Risk tier as a pill. It is a meaningful attribute and read as ordinary
+  // metadata beside everything else. Restrained on purpose: status and the
+  // personal-account count already carry colour, and a third loud thing in the
+  // same card would leave nothing standing out.
+  const RISK = {high:'p-warn', medium:'p-acc', low:'p-mut'};
+  const risk = t => t
+    ? `<span class="pill ${RISK[t]||'p-mut'}">${esc(t)}</span>` : '—';
+  const num = n => n ? String(n) : '<span class="z">0</span>';
   const when = t => t ? `<span class="nw">${esc(String(t).slice(0, 10))}</span>` : '—';
 
+  // Effective status, with the stored decision alongside when they differ.
+  // An approval past its review date reads as reviewing and says why: a green
+  // pill turning amber leaves someone wondering, and an approval nobody has
+  // revisited is not evidence a tool is safe, it is evidence nobody looked.
+  const PILL = {approved:'p-ok', not_approved:'p-warn', reviewing:'p-acc'};
+  const LABEL = {approved:'approved', not_approved:'not approved',
+                 reviewing:'reviewing'};
+  // Status says what was decided, and at most one line of context. The expiry
+  // used to live here too, which put four lines in one cell and made every
+  // other row look ragged beside it. Expiry is a fact about the review date,
+  // so it belongs in the review column.
   const status = r => {
-    if (!r.in_registry) return '<span class="pill p-warn">not in registry</span>';
-    if (r.approved === true) return '<span class="pill p-ok">approved</span>';
-    if (r.approved === false) return '<span class="pill p-warn">not approved</span>';
-    return dash;
+    const wrap = inner => `<div class="gov">${inner}</div>`;
+
+    // Not in the registry at all is the row worth acting on: something is in
+    // use that governance has never considered.
+    if (!r.in_registry) {
+      return wrap('<span class="pill p-warn">not in registry</span>');
+    }
+
+    if (r.status_source === 'governance') {
+      let out = `<span class="pill ${PILL[r.status]||'p-mut'}">${LABEL[r.status]||esc(r.status)}</span>`;
+      if (r.status_reason === 'approval_expired') {
+        out += `<span class="gov-sub">was ${LABEL[r.stored_status]||''}</span>`;
+      }
+      return wrap(out);
+    }
+
+    // No governance record, so this is the registry's own flag. approved: true
+    // can only have been set deliberately, because every tool ships false, so
+    // it is a decision and reads as one. approved: false is ambiguous: it is
+    // what an untouched registry says about everything, and rendering it as a
+    // refusal would put a shipped default and a considered "no" in the same
+    // red pill.
+    if (r.approved === true) {
+      return wrap('<span class="pill p-ok">approved</span>'
+        + '<span class="gov-sub">from the registry</span>');
+    }
+    // Quieter than the other three. When half an estate has no decision, an
+    // outlined pill on every card repeats until it reads as a status somebody
+    // chose. It is the absence of one, and should look like it.
+    return wrap('<span class="none">no decision</span>');
+  };
+
+  // Review: the date, and how it stands relative to today. Overdue in the
+  // warning colour, upcoming in muted text. Computed here rather than passed
+  // through: the API already carries days_overdue for the expired case, and
+  // the countdown is arithmetic on a date the row already has.
+  const review = r => {
+    if (!r.review_due) return `<div class="gov">${dash}</div>`;
+    const days = Math.round(
+      (Date.parse(r.review_due + 'T00:00:00Z') - Date.now()) / 86400000);
+    const sub = r.days_overdue
+      ? `<span class="gov-sub over">${r.days_overdue}d overdue</span>`
+      : (days >= 0 ? `<span class="gov-sub">in ${days}d</span>` : '');
+    return `<div class="gov">
+      <span class="nw"${r.days_overdue ? ' style="color:var(--dstr)"' : ''}>${esc(r.review_due)}</span>
+      ${sub}</div>`;
   };
 
   return `<h2>AI register</h2>
@@ -507,33 +625,57 @@ async function register() {
     <div><dt>${REG.known_not_observed}</dt><dd>watched for, not seen</dd></div>
   </dl>
 
-  <p class="lede">Owner, review date and risk decision are organisational
-  records. The portal holds no governance state, so they are shown as not set
-  rather than left blank: an empty column reads as "nothing to say", and the
-  honest reading is "nobody has decided yet".
+  ${!REG.governance_configured ? `<p class="lede">No governance file is
+  configured, so status falls back to the registry's own flag and every tool
+  reads as not approved. That is a shipped default rather than a decision
+  anyone made. Set <span class="mono">GOVERNANCE_PATH</span> to record
+  approvals, owners and review dates.</p>` : ''}
+
+  ${(REG.governance_unmatched || []).length ? `<div class="note">
+    <b>${REG.governance_unmatched.length === 1
+      ? '1 decision names a tool the registry does not know:'
+      : REG.governance_unmatched.length + ' decisions name tools the registry does not know:'}</b>
+    ${REG.governance_unmatched.map(t => `<span class="pill p-warn">${esc(t)}</span>`).join('')}
+    <div style="margin-top:6px">That is fine for a deliberate decision about
+    something not yet registered, and it is also what a typo looks like. Either
+    way the decision is not being applied to anything, so it is shown rather
+    than dropped.</div>
+  </div>` : ''}
+
+  <p class="lede">One card per tool: what it is, how it is used, and what was
+  decided about it. First seen is in the CSV rather than here, because inside a
+  lookback window it is usually the same as last seen and Overview already
+  answers what is new this week.
   <a href="/api/register?fmt=csv" style="color:var(--pri)">Download CSV</a></p>
 
-  ${rows.length ? `<table>
-  <tr><th>tool</th><th>vendor</th><th>status</th><th>risk</th>
-  <th>devices</th><th>users</th><th>corp</th><th>personal</th><th>surfaces</th>
-  <th>first seen</th><th>last seen</th><th>owner</th><th>review</th></tr>
-  ${rows.map(r => `<tr>
-    <td>${esc(r.name)}<br><span class="mono" style="font-size:11px;color:var(--mut)">${esc(r.id)}</span></td>
-    <td>${r.vendor ? esc(r.vendor) : '—'}</td>
-    <td>${status(r)}</td>
-    <td>${r.risk_tier ? esc(r.risk_tier) : '—'}</td>
-    <td>${r.devices}</td>
-    <td>${r.users}</td>
-    <td>${r.corporate_accounts}</td>
-    <td>${r.personal_accounts
-        ? `<span class="pill p-warn">${r.personal_accounts}</span>` : '0'}</td>
-    <td>${r.surfaces.length ? esc(r.surfaces.join(', ')) : '—'}</td>
-    <td>${when(r.first_seen)}</td>
-    <td>${when(r.last_seen)}</td>
-    <td>${dash}</td>
-    <td>${dash}</td>
-  </tr>`).join('')}
-  </table>` : `<p class="lede">No AI tools observed in the last ${esc(win)}.
+  ${rows.length ? `<div class="cards">
+  ${rows.map(r => `<div class="card">
+    <div class="card-top">
+      <div style="min-width:0">
+        <div class="card-name">${esc(r.name)}</div>
+        <div class="card-meta">${r.vendor ? esc(r.vendor) + ' · ' : ''}${esc(r.id)}</div>
+      </div>
+      ${status(r)}
+    </div>
+    <hr>
+    <dl class="card-kv">
+      <dt>usage</dt><dd>${r.devices} device${r.devices === 1 ? '' : 's'},
+        ${r.users} user${r.users === 1 ? '' : 's'}</dd>
+      <dt>accounts</dt><dd>corp ${num(r.corporate_accounts)} ·
+        personal ${r.personal_accounts
+          ? `<span class="pill p-warn">${r.personal_accounts}</span>` : num(0)}</dd>
+      <dt>surfaces</dt><dd>${r.surfaces.length ? esc(r.surfaces.join(', ')) : '—'}</dd>
+      <dt>risk</dt><dd>${risk(r.risk_tier)}</dd>
+      <dt>last seen</dt><dd>${when(r.last_seen)}</dd>
+    </dl>
+    <hr>
+    <div class="card-section">governance</div>
+    <dl class="card-kv">
+      <dt>owner</dt><dd>${r.owner ? esc(r.owner) : dash}</dd>
+      <dt>review</dt><dd>${review(r)}</dd>
+    </dl>
+  </div>`).join('')}
+  </div>` : `<p class="lede">No AI tools observed in the last ${esc(win)}.
   That is a real answer for a small estate, and it is also what a fleet with no
   collectors deployed looks like: check Setup before reading it as a clean
   one.</p>`}`;

--- a/portal/tests/test_governance.py
+++ b/portal/tests/test_governance.py
@@ -1,0 +1,271 @@
+"""Governance decisions, expiry, and what happens when a decision matches nothing.
+
+Three things these hold to, and each exists because the obvious implementation
+gets it wrong.
+
+An approval that has passed its review date is not a current approval. Nobody
+decided anything on the day it expired, so the stored decision must not change,
+but the effective status must. Getting one without the other is the trap: a
+model that mutates the record loses the history, and a model that only stores
+loses the fact that the approval has lapsed.
+
+Approval never means safe. Severity depends on the account domain and nothing
+else, and no governance state changes that. An approved tool on a personal
+account is still a warn, because the risky part is the account.
+
+A decision that names a tool nothing recognises is surfaced, not dropped. The
+common case is a typo, and a silently ignored decision is worse than no
+decision: the organisation believes it has decided something it has not.
+"""
+
+from datetime import date
+
+import pytest
+
+from app.governance import (
+    APPROVED,
+    EXPIRED,
+    NOT_APPROVED,
+    REVIEWING,
+    days_overdue,
+    decide,
+    effective,
+    load_governance_from,
+    unmatched,
+)
+
+TODAY = date(2026, 8, 12)
+
+
+def _doc(**tools):
+    return {"tools": tools}
+
+
+# ─────────────────────────────────────────────
+# Expiry: stored and effective are different
+# ─────────────────────────────────────────────
+
+def test_an_approval_in_date_is_approved():
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "2026-11-01"}))
+    assert effective(gov["claude"], TODAY) == (APPROVED, "")
+
+
+def test_an_approval_expiring_today_is_still_approved():
+    """The boundary. Due today means due, not overdue."""
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "2026-08-12"}))
+    assert effective(gov["claude"], TODAY) == (APPROVED, "")
+
+
+def test_an_expired_approval_reads_as_reviewing():
+    """The regression. A model with no expiry returns approved here."""
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "2026-07-31"}))
+    assert effective(gov["claude"], TODAY) == (REVIEWING, EXPIRED)
+
+
+def test_the_stored_decision_is_not_rewritten_by_expiry():
+    """A clock ticking over is not a decision.
+
+    The history has to keep saying what a human decided on a date. Only the
+    derived status moves.
+    """
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "2026-07-31"}))
+    effective(gov["claude"], TODAY)
+
+    assert gov["claude"]["status"] == APPROVED
+
+
+def test_expiry_only_applies_to_approvals():
+    """A review date on a not_approved record is a reminder, not a trigger.
+
+    Expiring it into reviewing would silently soften a refusal.
+    """
+    gov = load_governance_from(_doc(
+        grok={"status": "not_approved", "review_due": "2026-07-31"}))
+    assert effective(gov["grok"], TODAY) == (NOT_APPROVED, "")
+
+
+def test_reviewing_does_not_expire_into_anything():
+    gov = load_governance_from(_doc(
+        cursor={"status": "reviewing", "review_due": "2026-07-31"}))
+    assert effective(gov["cursor"], TODAY) == (REVIEWING, "")
+
+
+def test_an_approval_with_no_review_date_does_not_expire():
+    """The schema requires review_due on an approval, so this is the shape of a
+    file that got past validation some other way, or a date that would not
+    parse. Revoking an approval because of a typo in a date is worse than
+    leaving it standing and letting validation complain."""
+    gov = load_governance_from(_doc(claude={"status": "approved"}))
+    assert effective(gov["claude"], TODAY) == (APPROVED, "")
+
+
+def test_an_unparseable_review_date_is_treated_as_unset():
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "next Tuesday"}))
+    assert gov["claude"]["review_due"] is None
+    assert effective(gov["claude"], TODAY) == (APPROVED, "")
+
+
+def test_days_overdue_counts_from_the_review_date():
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "2026-07-31"}))
+    assert days_overdue(gov["claude"], TODAY) == 12
+
+
+def test_days_overdue_is_zero_for_a_current_approval():
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "2026-11-01"}))
+    assert days_overdue(gov["claude"], TODAY) == 0
+
+
+# ─────────────────────────────────────────────
+# Falling back to the registry
+# ─────────────────────────────────────────────
+
+def test_no_governance_file_falls_back_to_the_registry_flag():
+    """A deployment that has not adopted this must behave exactly as before."""
+    assert decide("claude", {}, False, TODAY)["status"] == NOT_APPROVED
+    assert decide("claude", {}, True, TODAY)["status"] == APPROVED
+
+
+def test_the_fallback_is_labelled_as_a_fallback():
+    """Nobody should read the shipped default as somebody's decision.
+
+    Every tool ships not approved, and a register that presented that as a
+    governance position would be asserting a refusal nobody made.
+    """
+    assert decide("claude", {}, False, TODAY)["source"] == "registry_default"
+    assert decide("claude", {"claude": {"status": APPROVED, "review_due": None}},
+                  False, TODAY)["source"] == "governance"
+
+
+def test_a_tool_in_neither_place_is_unknown_not_refused():
+    """Unknown and not approved are different answers.
+
+    A tool observed and absent from the registry is the register's most urgent
+    row. Reporting it as not approved would imply a decision.
+    """
+    d = decide("mystery-ai", {}, None, TODAY)
+    assert d["status"] == ""
+    assert d["source"] == "unknown"
+
+
+def test_a_governance_decision_overrides_the_registry_default():
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "2026-11-01"}))
+    assert decide("claude", gov, False, TODAY)["status"] == APPROVED
+
+
+def test_an_expired_override_still_beats_the_registry_default():
+    """The compound case. An expired approval reads as reviewing, not as the
+    registry's not approved, because a lapsed decision is still a decision that
+    was made."""
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "2026-07-31"}))
+    d = decide("claude", gov, False, TODAY)
+
+    assert d["status"] == REVIEWING
+    assert d["stored_status"] == APPROVED
+    assert d["reason"] == EXPIRED
+    assert d["days_overdue"] == 12
+
+
+# ─────────────────────────────────────────────
+# Records that match nothing
+# ─────────────────────────────────────────────
+
+def test_a_decision_naming_an_unknown_tool_is_surfaced():
+    """The regression. Dropping it is how an organisation believes it has
+    decided something it has not.
+
+    The likely cause is a typo, and the rarer one is an upstream rename that
+    quietly un-made an approval somebody recorded. Both look the same from
+    here and both need saying.
+    """
+    gov = load_governance_from(_doc(
+        github_copilot={"status": "approved", "review_due": "2027-01-01"}))
+
+    assert unmatched(gov, ["github-copilot", "claude"]) == ["github_copilot"]
+
+
+def test_a_matched_decision_is_not_reported_as_unmatched():
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "2027-01-01"}))
+    assert unmatched(gov, ["claude"]) == []
+
+
+def test_no_governance_produces_no_unmatched_records():
+    assert unmatched({}, ["claude"]) == []
+    assert unmatched(None, None) == []
+
+
+# ─────────────────────────────────────────────
+# Loading
+# ─────────────────────────────────────────────
+
+@pytest.mark.parametrize("status", ["approved", "not_approved", "reviewing"])
+def test_the_three_states_load(status):
+    gov = load_governance_from(_doc(x={"status": status, "review_due": "2027-01-01"}))
+    assert gov["x"]["status"] == status
+
+
+def test_an_unrecognised_status_is_not_a_decision():
+    """Not silently coerced. Guessing which of three states somebody meant is
+    how a tool ends up approved by a typo."""
+    gov = load_governance_from(_doc(x={"status": "Approved-ish"}))
+    assert "x" not in gov
+
+
+def test_status_is_read_case_insensitively():
+    gov = load_governance_from(_doc(x={"status": "Approved", "review_due": "2027-01-01"}))
+    assert gov["x"]["status"] == APPROVED
+
+
+def test_a_malformed_record_is_skipped_not_fatal():
+    """One bad entry must not cost an organisation every other decision."""
+    gov = load_governance_from({"tools": {"good": {"status": "reviewing"},
+                                          "bad": "not a mapping"}})
+    assert set(gov) == {"good"}
+
+
+def test_an_empty_or_absent_file_loads_as_no_decisions():
+    assert load_governance_from({}) == {}
+    assert load_governance_from(None) == {}
+    assert load_governance_from({"tools": None}) == {}
+
+
+def test_owner_and_reason_are_carried_through():
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "2027-01-01",
+                "owner": "Engineering", "reason": "Enterprise tenant"}))
+    assert gov["claude"]["owner"] == "Engineering"
+    assert gov["claude"]["reason"] == "Enterprise tenant"
+
+
+# ─────────────────────────────────────────────
+# The boundary that must not move
+# ─────────────────────────────────────────────
+
+def test_governance_carries_no_severity():
+    """Detection severity and governance status are independent dimensions.
+
+    Severity describes what was observed and depends on the account domain.
+    Governance describes what the organisation decided. An approved tool on a
+    personal account is still warn, because the risky part is the account, and
+    an unapproved tool on a corporate account is still info, because nothing
+    risky was observed.
+
+    Asserted structurally: nothing this module returns is a severity, so
+    nothing downstream can read one out of it. The moment a severity key
+    appears here, approved has started to mean safe.
+    """
+    gov = load_governance_from(_doc(
+        claude={"status": "approved", "review_due": "2027-01-01"}))
+    d = decide("claude", gov, False, TODAY)
+
+    assert "severity" not in d
+    assert "severity" not in gov["claude"]

--- a/portal/tests/test_register.py
+++ b/portal/tests/test_register.py
@@ -357,3 +357,66 @@ def test_an_unobserved_tool_is_not_in_the_endpoints_rows():
     assert body["tools_known"] == 3
     assert body["known_not_observed"] == 2
     assert body["tools_observed"] == 1
+
+
+# ─────────────────────────────────────────────
+# Governance joined onto the register
+# ─────────────────────────────────────────────
+
+def _gov(**tools):
+    from app.governance import load_governance_from
+    return load_governance_from({"tools": tools})
+
+
+def test_a_decision_reaches_the_row():
+    gov = _gov(claude={"status": "approved", "owner": "Engineering",
+                       "review_due": "2027-01-01"})
+    row = _row(register_from([_f()], REGISTRY, DOMAIN_MAP, gov), "claude")
+
+    assert row["status"] == "approved"
+    assert row["owner"] == "Engineering"
+    assert row["review_due"] == "2027-01-01"
+    assert row["status_source"] == "governance"
+
+
+def test_an_expired_approval_reaches_the_row_as_reviewing():
+    """The compound case, end to end. A register that read stored_status here
+    would show a lapsed approval as current."""
+    gov = _gov(claude={"status": "approved", "review_due": "2020-01-01"})
+    row = _row(register_from([_f()], REGISTRY, DOMAIN_MAP, gov), "claude")
+
+    assert row["status"] == "reviewing"
+    assert row["stored_status"] == "approved"
+    assert row["status_reason"] == "approval_expired"
+    assert row["days_overdue"] > 0
+
+
+def test_no_governance_falls_back_to_the_registry_flag():
+    """A deployment that has not adopted governance must be unchanged."""
+    row = _row(register_from([_f()], REGISTRY, DOMAIN_MAP), "claude")
+
+    assert row["status"] == "not_approved"
+    assert row["status_source"] == "registry_default"
+    assert row["owner"] == ""
+
+
+def test_a_tool_outside_the_registry_is_undecided_not_refused():
+    row = _row(register_from([_f(tool="notion-ai")], REGISTRY, DOMAIN_MAP),
+               "notion-ai")
+
+    assert row["status"] == ""
+    assert row["status_source"] == "unknown"
+
+
+def test_the_csv_carries_the_decision():
+    """An export missing the decision is a list of tools, not a register."""
+    gov = _gov(claude={"status": "approved", "owner": "Engineering",
+                       "review_due": "2027-01-01"})
+    rows = [r for r in register_from([_f()], REGISTRY, DOMAIN_MAP, gov)
+            if r["observed"]]
+    out = register_csv(rows)
+
+    assert "status" in out.splitlines()[0]
+    assert "owner" in out.splitlines()[0]
+    assert "Engineering" in out
+    assert "2027-01-01" in out

--- a/registry/build.py
+++ b/registry/build.py
@@ -85,6 +85,12 @@ def _scanner_shape(registry) -> dict:
     never disagree.
     """
     tools = registry["tools"]
+    # No `approved` here, deliberately. It is a governance decision, and a
+    # scanner has no use for one: severity depends on the account domain and
+    # nothing else. It used to be emitted to this view and to extension.json,
+    # so an organisation's approval positions were compiled into a file shipped
+    # to a browser extension that never read them. Governance now lives in its
+    # own file and stays in the portal. See governance/.
     return {
     "services": [
         {
@@ -92,7 +98,6 @@ def _scanner_shape(registry) -> dict:
             "vendor": t["vendor"],
             "category": t["category"],
             "risk_tier": t.get("risk_tier", "medium"),
-            "approved": t["approved"],
             "domains": t.get("domains", []),
             "entra_app_ids": t.get("entra_app_ids", []),
             "email_domains": t.get("email_senders", []),
@@ -130,7 +135,6 @@ def emit(registry, write_fallback=True):
                 "tool": t["id"],
                 "domains": t.get("domains", []),
                 "login_selector": t.get("login_selector"),
-                "approved": t["approved"],
             }
             for t in tools
             if t.get("domains")

--- a/scanner/ai_guard/registry/ai_services.yaml
+++ b/scanner/ai_guard/registry/ai_services.yaml
@@ -12,7 +12,6 @@ services:
   vendor: Anthropic
   category: assistant
   risk_tier: high
-  approved: false
   domains:
   - claude.ai
   - anthropic.com
@@ -39,7 +38,6 @@ services:
   vendor: Anthropic
   category: coding
   risk_tier: high
-  approved: false
   domains: []
   entra_app_ids: []
   email_domains:
@@ -54,7 +52,6 @@ services:
   vendor: OpenAI
   category: assistant
   risk_tier: high
-  approved: false
   domains:
   - chat.openai.com
   - chatgpt.com
@@ -81,7 +78,6 @@ services:
   vendor: OpenAI
   category: coding
   risk_tier: medium
-  approved: false
   domains: []
   entra_app_ids: []
   email_domains: []
@@ -95,7 +91,6 @@ services:
   vendor: Google
   category: assistant
   risk_tier: high
-  approved: false
   domains:
   - gemini.google.com
   - aistudio.google.com
@@ -113,7 +108,6 @@ services:
   vendor: Google
   category: coding
   risk_tier: medium
-  approved: false
   domains: []
   entra_app_ids: []
   email_domains: []
@@ -127,7 +121,6 @@ services:
   vendor: GitHub
   category: coding
   risk_tier: medium
-  approved: false
   domains:
   - copilot-proxy.githubusercontent.com
   - api.githubcopilot.com
@@ -145,7 +138,6 @@ services:
   vendor: Anysphere
   category: coding
   risk_tier: high
-  approved: false
   domains:
   - cursor.com
   - cursor.sh
@@ -168,7 +160,6 @@ services:
   vendor: Cline Bot Inc
   category: coding
   risk_tier: medium
-  approved: false
   domains:
   - api.cline.bot
   entra_app_ids: []
@@ -183,7 +174,6 @@ services:
   vendor: Roo Veterinary Inc
   category: coding
   risk_tier: medium
-  approved: false
   domains: []
   entra_app_ids: []
   email_domains: []
@@ -197,7 +187,6 @@ services:
   vendor: Continue Dev
   category: coding
   risk_tier: medium
-  approved: false
   domains:
   - continue.dev
   entra_app_ids: []
@@ -212,7 +201,6 @@ services:
   vendor: Codeium
   category: coding
   risk_tier: high
-  approved: false
   domains:
   - codeium.com
   - windsurf.com
@@ -236,7 +224,6 @@ services:
   vendor: Tabnine
   category: coding
   risk_tier: medium
-  approved: false
   domains:
   - tabnine.com
   - api.tabnine.com
@@ -252,7 +239,6 @@ services:
   vendor: Otter.ai
   category: transcription
   risk_tier: high
-  approved: false
   domains:
   - otter.ai
   - api.otter.ai
@@ -275,7 +261,6 @@ services:
   vendor: Grammarly
   category: writing
   risk_tier: medium
-  approved: false
   domains:
   - grammarly.com
   - in.grammarly.com
@@ -302,7 +287,6 @@ services:
   vendor: Wispr
   category: voice
   risk_tier: high
-  approved: false
   domains:
   - wisprflow.ai
   - wisprflow.com
@@ -322,7 +306,6 @@ services:
   vendor: Perplexity AI
   category: search
   risk_tier: medium
-  approved: false
   domains:
   - perplexity.ai
   - api.perplexity.ai
@@ -345,7 +328,6 @@ services:
   vendor: Ollama
   category: local-model
   risk_tier: high
-  approved: false
   domains:
   - ollama.com
   - registry.ollama.ai
@@ -368,7 +350,6 @@ services:
   vendor: Element Labs
   category: local-model
   risk_tier: medium
-  approved: false
   domains:
   - lmstudio.ai
   entra_app_ids: []
@@ -385,7 +366,6 @@ services:
   vendor: DeepSeek
   category: assistant
   risk_tier: high
-  approved: false
   domains:
   - chat.deepseek.com
   - deepseek.com
@@ -403,7 +383,6 @@ services:
   vendor: Mistral AI
   category: assistant
   risk_tier: medium
-  approved: false
   domains:
   - chat.mistral.ai
   - mistral.ai
@@ -421,7 +400,6 @@ services:
   vendor: xAI
   category: assistant
   risk_tier: medium
-  approved: false
   domains:
   - grok.com
   entra_app_ids: []
@@ -437,7 +415,6 @@ services:
   vendor: Microsoft
   category: coding
   risk_tier: medium
-  approved: false
   domains:
   - copilot.microsoft.com
   - copilot.cloud.microsoft
@@ -457,7 +434,6 @@ services:
   vendor: Microsoft
   category: coding
   risk_tier: high
-  approved: false
   domains:
   - substrate.office.com
   entra_app_ids:
@@ -473,7 +449,6 @@ services:
   vendor: Atlassian
   category: productivity
   risk_tier: high
-  approved: false
   domains:
   - rovo.atlassian.com
   - api.atlassian.com
@@ -490,7 +465,6 @@ services:
   vendor: Notion Labs
   category: productivity
   risk_tier: medium
-  approved: false
   domains:
   - notion.so
   - api.notion.com
@@ -512,7 +486,6 @@ services:
   vendor: Fireflies
   category: productivity
   risk_tier: high
-  approved: false
   domains:
   - fireflies.ai
   - app.fireflies.ai
@@ -529,7 +502,6 @@ services:
   vendor: Midjourney
   category: assistant
   risk_tier: low
-  approved: false
   domains:
   - midjourney.com
   - www.midjourney.com
@@ -546,7 +518,6 @@ services:
   vendor: OpenAI
   category: platform
   risk_tier: high
-  approved: false
   domains:
   - platform.openai.com
   entra_app_ids: []
@@ -562,7 +533,6 @@ services:
   vendor: Hugging Face
   category: platform
   risk_tier: medium
-  approved: false
   domains:
   - huggingface.co
   - api-inference.huggingface.co


### PR DESCRIPTION
The register's owner and review columns stop saying "not set". An organisation can record what it decided about each tool, in a file, reviewed the way it reviews anything else.

Optional. A deployment with no governance file behaves exactly as before: the registry's own approved flag stands, and the columns show as unset. Nothing about detection, severity or alerting changes.

## A separate file, on purpose

governance.yaml is not registry.yaml. The registry answers what a tool is and how to detect it, and it ships with the project. Governance answers what an organisation decided, which is nobody else's to ship: an upstream project has no business implying that Claude is approved or that Engineering owns ChatGPT.

The separation is physical as well as conceptual. `approved` was compiled into extension.json and scanner.json and sent to detectors that never read it, so an organisation's approval positions travelled to a browser extension with no use for them. Both views lose the field. registry.json keeps it, because the portal reads it as the fallback when no decision has been recorded.

`approved` stays in registry.yaml deliberately, as that fallback. Removing it would be a breaking change for anyone who set it, and there is no reason to make people migrate on the day a feature arrives.

## Stored and effective are different

A decision is a record of what a human decided on a date, and it must not change because a clock ticked over. But an approval past its review date is not a current approval either. So the record is kept as written and the status is derived at read time:

    stored_status:    approved
    review_due:       2026-07-31
    effective_status: reviewing
    effective_reason: approval_expired

Evaluated on every request, not by a scheduled job. There is no window where the stored value is right and the display is stale, and no job to notice has stopped running.

This is the platform's own rule turned on the decision instead of the source. A collector that has stopped reporting is not evidence a machine is clean, and an approval nobody has revisited in eighteen months is not evidence a tool is safe. It is evidence that nobody looked. A governance layer that lets Approved sit there indefinitely manufactures exactly the blind spot the rest of this project exists to remove, which is why expiry is in the model from the start rather than added later.

review_due is required on an approval and optional on a refusal. The constraint sits where the risk is: an approval with no expiry is the one that outlives the person who made it and the reason it was made. A decision not to use something does not rot in the same way.

## Approval is not safety

Detection severity and governance status are independent dimensions, and this release does not couple them. Severity is decided at the point of detection and depends on the account domain, so an approved tool signed into a personal account is still a warn, because the risky part is the account. An unapproved tool on a corporate account is still info, because nothing risky was observed.

That was very nearly built the other way. Three places in the codebase claimed approval escalated severity and none of them was true, corrected in 0.7.2. The plan that came out of the false claim had a third state threading severity semantics through the scanner, the receiver and the collectors, which would have made Approved quietly mean Safe. test_governance asserts structurally that nothing this module returns is a severity.

## A decision that matches nothing is surfaced

A governance record naming a tool the registry does not know is kept and flagged rather than dropped. The common case is a typo: write github_copilot for github-copilot and the decision silently applies to nothing. The rarer case is an upstream rename, where an approval is quietly un-made by somebody else's edit. Both look identical from here and both need saying out loud, because a decision that matches nothing is how an organisation believes it has decided something it has not.

This is also why ids are documented as stable keys rather than given an alias mechanism. Aliases predict renames; surfacing the mismatch handles renames, typos and deliberate decisions about unregistered tools with one behaviour and no schema. If renames turn out to be frequent enough to be annoying, aliases can be earned then.

## In the portal

Four states that never look alike: a recorded decision in its own colour, an expired approval saying how long ago and what it was, a registry `approved: true` labelled as coming from the registry, and everything else as an explicit absence. The first attempt rendered the last of those as the registry's shipped "not approved", which put a considered refusal and an untouched default in the same red pill with the difference carried by a caption. Every tool ships not approved, so most of the register said it. No decision is now quiet text rather than a pill: when half an estate has none, an outlined pill on every entry repeats until it reads as a status somebody chose.

The register is cards rather than a table, which the governance columns forced. Owner, review and status brought the count to twelve columns needing 1309px in a content area that measured 1125px, so it scrolled sideways. Four attempts to make the columns fit all failed, and the last measurement said why: every one had been sized against arithmetic on the container's max-width rather than the rendered width, and was 270px optimistic.

Cards remove the constraint rather than working around it: auto-fill gives two per row on a laptop, one on a narrow window, three on a wide monitor, with no breakpoint to keep in step and no horizontal scrolling at any width. It also fixes something no amount of width tuning would have. In a twelve column table the owner header sat three columns from the value it named, and a reader assembled one tool from a strip. A card is one tool, with each label beside its own value.

## Also here

A validator that normalises dates before checking. YAML parses a bare 2026-11-01 as a date rather than a string, so a schema accepting only strings would reject the exact format the file is written in, and requiring quotes instead would be a trap that catches everyone once. It exits non-zero on a schema error and warns without failing on an unknown id or an approval with no owner. Wired into CI over both the shipped example and the demo file.

A demo governance file, so the register shows the feature rather than an empty column when somebody tries the project.

/governance/governance.yaml is gitignored, anchored to the root so the example and the demo file stay tracked. One organisation's approval decisions are not ours to hold.

docs/governance.md is the guide. architecture.md and the portal README carry the shape.

Tests: portal 65 to 97. Two of the new ones fail against a model with no expiry, three against a register that does not join governance, and three against an endpoint returning stored status where effective is meant.