### PR TITLE
portal: paste guard events

### DIFF
--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -70,7 +70,7 @@ from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
-from app import derive, governance
+from app import derive, governance, paste_guard
 
 log = logging.getLogger("portal")
 
@@ -445,6 +445,36 @@ def status(hours: float = Query(default=None, gt=0, le=24 * 90),
         return derive.status_from(_findings(hours))
 
     value, at = _cached("status", hours, build)
+    return JSONResponse(dict(value, derived_at=at, hours=hours))
+
+
+@app.get("/api/paste-guard")
+def paste_guard_events(hours: float = Query(default=None, gt=0, le=24 * 90),
+                       refresh: bool = Query(default=False),
+                       _=Depends(require_auth)):
+    """Paste guard activity: what was stopped, on which tool, how often.
+
+    Metadata only, and deliberately so. The guard inspects clipboard content on
+    the device and reports detector identifiers; the matched text never reaches
+    the receiver and must never reach here. portal/app/paste_guard.py has a
+    test asserting that structurally rather than by review.
+
+    The heartbeat shares this source and is excluded. It is how a device proves
+    the guard works rather than merely being installed, and counting it as a
+    detection would report every device's daily heartbeat as a paste somebody
+    tried to make.
+    """
+    hours = hours or LOOKBACK_HOURS
+    if refresh:
+        _cache.pop("paste_guard", None)
+
+    def build():
+        findings = _findings(hours)
+        reg = derive.load_registry(REGISTRY_PATH)
+        return paste_guard.paste_guard_from(
+            findings, derive.load_domain_map_from(reg))
+
+    value, at = _cached("paste_guard", hours, build)
     return JSONResponse(dict(value, derived_at=at, hours=hours))
 
 

--- a/portal/app/paste_guard.py
+++ b/portal/app/paste_guard.py
@@ -1,0 +1,171 @@
+"""Paste guard events: what was stopped, on which tool, and how often.
+
+Placed in its own module rather than derive.py because of what it must not do.
+The paste guard inspects clipboard content on the device and reports detector
+identifiers only; the matched text never leaves the page, and nothing in this
+file may reintroduce a path that carries it. Every field here comes from the
+finding's own metadata, and there is a test asserting that no function in this
+module returns anything resembling content.
+
+A finding looks like this:
+
+    tool: chatgpt.com   surface: browser   source: paste_guard
+    severity: warn      evidence: "paste warned: aws_access_key,payment_card"
+
+Two things about that shape matter.
+
+The heartbeat uses the same source. It is `tool: paste-guard`, `severity:
+info`, `evidence: "heartbeat version=1.3.0 mode=warn reason=installed"`, and it
+is how a device proves the guard is working rather than merely installed.
+Counting it as a detection would report every device's daily heartbeat as a
+paste someone tried to make, which is a number wrong in the direction nobody
+checks.
+
+The action is the interesting part. `warned` is the guard working: somebody was
+shown what they were about to paste and stopped. `overridden` is the same
+person deciding to paste it anyway, which is a deliberate act by someone who
+had been told, and the strongest single signal this platform produces.
+`blocked` is the guard in block mode refusing outright.
+"""
+
+import re
+from collections import defaultdict
+
+# Only these are paste events. Anything else on this source is the heartbeat or
+# something that has not been written yet, and is left alone rather than
+# guessed at.
+ACTIONS = ("warned", "blocked", "overridden")
+
+# What a detector id may contain. Every id in guard.js is lowercase, digits and
+# underscores, and constraining it here is not tidiness: evidence is a 2048
+# character operator-adjacent string, and a parser that split on commas and
+# passed the rest through would carry anything appended to an id straight into
+# the output. A test caught exactly that, with the matched secret written into
+# the evidence field.
+_DETECTOR_ID = re.compile(r"^[a-z0-9_]{1,64}$")
+
+# The tool name the heartbeat reports under. It is the guard itself, not a tool
+# anybody uses, and derive.NOT_A_TOOL excludes it from the register for the
+# same reason.
+GUARD_TOOL = "paste-guard"
+
+
+def _parse(evidence):
+    """(action, [detector ids]) from an evidence string, or (None, []).
+
+    Returns None for anything that is not a paste event, which is how the
+    heartbeat is excluded: it shares this source and its evidence starts with
+    "heartbeat", so a parser keyed on the action prefix skips it without
+    needing to know what a heartbeat is.
+    """
+    ev = (evidence or "").strip()
+    if not ev.startswith("paste "):
+        return None, []
+    rest = ev[len("paste "):]
+    action, _, listed = rest.partition(":")
+    action = action.strip().lower()
+    if action not in ACTIONS:
+        return None, []
+    # Anything that is not shaped like an id is discarded rather than cleaned
+    # up. A malformed entry means the evidence is not what this parser expects,
+    # and the safe reading of that is fewer detectors, never more content.
+    detectors = [d.strip() for d in listed.split(",")
+                 if _DETECTOR_ID.match(d.strip())]
+    return action, detectors
+
+
+def paste_guard_from(findings, domain_map=None):
+    """Paste guard activity, as counts and per-tool rows.
+
+    Metadata only. tool, action, detector ids, device, and when. The content
+    that triggered the detector is not in the finding and must never be.
+
+    Rows are per tool rather than per event, because the question a governance
+    reader has is which tools people are pasting secrets into, not a
+    chronological log. The event count and the device count are both kept: five
+    pastes on one machine and five pastes across five machines are different
+    situations and a single number cannot tell them apart.
+    """
+    from app.derive import normalise_tool
+
+    domain_map = domain_map or {}
+    tools = defaultdict(lambda: {
+        "warned": 0, "blocked": 0, "overridden": 0,
+        "detectors": defaultdict(int), "devices": set(),
+        "first_seen": "", "last_seen": "",
+    })
+    detectors_total = defaultdict(int)
+    devices = set()
+    counts = {"warned": 0, "blocked": 0, "overridden": 0}
+
+    for f in findings:
+        if (f.get("source") or "") != "paste_guard":
+            continue
+        action, detectors = _parse(f.get("evidence"))
+        if not action:
+            continue
+
+        tool = f.get("tool") or ""
+        if not tool or tool == GUARD_TOOL:
+            # A paste event should never carry the guard's own name, but if it
+            # did it would be the heartbeat leaking through a future change,
+            # and counting it as a detection is the failure this guards.
+            continue
+        tool = normalise_tool(tool, domain_map)
+
+        t = tools[tool]
+        t[action] += 1
+        counts[action] += 1
+
+        device = (f.get("device") or "").strip()
+        if device:
+            t["devices"].add(device)
+            devices.add(device)
+
+        for d in detectors:
+            t["detectors"][d] += 1
+            detectors_total[d] += 1
+
+        ts = f.get("reported_at") or ""
+        if ts:
+            if not t["first_seen"] or ts < t["first_seen"]:
+                t["first_seen"] = ts
+            if ts > t["last_seen"]:
+                t["last_seen"] = ts
+
+    rows = []
+    for tool, t in tools.items():
+        rows.append({
+            "tool": tool,
+            "warned": t["warned"],
+            "blocked": t["blocked"],
+            "overridden": t["overridden"],
+            "events": t["warned"] + t["blocked"] + t["overridden"],
+            "devices": len(t["devices"]),
+            # Which detectors fired here, commonest first. Identifiers only:
+            # "aws_access_key", never what matched it.
+            "detectors": [d for d, _ in sorted(
+                t["detectors"].items(), key=lambda kv: (-kv[1], kv[0]))],
+            "first_seen": t["first_seen"],
+            "last_seen": t["last_seen"],
+        })
+
+    # Overrides first. Someone shown a warning naming the detector and pasting
+    # anyway is the row worth following up, and sorting by total events would
+    # bury one override under twenty warnings that worked.
+    rows.sort(key=lambda r: (-r["overridden"], -r["events"], r["tool"]))
+
+    return {
+        "rows": rows,
+        "warned": counts["warned"],
+        "blocked": counts["blocked"],
+        "overridden": counts["overridden"],
+        "events": sum(counts.values()),
+        "devices": len(devices),
+        "tools": len(rows),
+        "detectors": [
+            {"detector": d, "count": c}
+            for d, c in sorted(detectors_total.items(),
+                               key=lambda kv: (-kv[1], kv[0]))
+        ],
+    }

--- a/portal/tests/test_paste_guard.py
+++ b/portal/tests/test_paste_guard.py
@@ -1,0 +1,274 @@
+"""Paste guard events, and the two things that would make them wrong.
+
+The heartbeat shares this source. It is the same `source: paste_guard` with
+`tool: paste-guard` and evidence starting "heartbeat", and it is how a device
+proves the guard works rather than merely being installed. Counting it as a
+detection would report every device's daily heartbeat as a paste somebody tried
+to make: a number wrong in the direction nobody checks, because it only ever
+goes up and looks like activity.
+
+And the content must never appear. The guard inspects the clipboard on the
+device and reports detector identifiers only. Nothing here may reintroduce a
+path that carries what matched, which is asserted structurally rather than
+left to review.
+"""
+
+import pytest
+from app.paste_guard import _parse, paste_guard_from
+
+
+def _f(**kw):
+    base = {
+        "tool": "chatgpt.com", "surface": "browser", "source": "paste_guard",
+        "severity": "warn", "evidence": "paste warned: aws_access_key",
+        "device": "D1", "reported_at": "2026-08-12T09:00:00Z",
+    }
+    base.update(kw)
+    return base
+
+
+def _heartbeat(device="D1", version="1.3.0"):
+    return _f(tool="paste-guard", severity="info", device=device,
+              evidence=f"heartbeat version={version} mode=warn reason=installed")
+
+
+# ─────────────────────────────────────────────
+# The heartbeat is not a detection
+# ─────────────────────────────────────────────
+
+def test_a_heartbeat_is_not_counted_as_a_paste():
+    """The regression. Both share source: paste_guard."""
+    out = paste_guard_from([_heartbeat()])
+
+    assert out["events"] == 0
+    assert out["rows"] == []
+
+
+def test_heartbeats_do_not_inflate_the_device_count():
+    """Every device sends one daily. A device count that included them would
+    report the whole fleet as having pasted something."""
+    out = paste_guard_from([_heartbeat("D1"), _heartbeat("D2"), _heartbeat("D3")])
+
+    assert out["devices"] == 0
+
+
+def test_a_real_paste_is_counted_alongside_heartbeats():
+    out = paste_guard_from([_heartbeat("D1"), _f(device="D1"), _heartbeat("D2")])
+
+    assert out["events"] == 1
+    assert out["devices"] == 1
+
+
+def test_a_paste_event_carrying_the_guards_own_name_is_ignored():
+    """Belt and braces. A paste event should never be tool: paste-guard, and if
+    a future change made one it would be the heartbeat leaking through."""
+    out = paste_guard_from([_f(tool="paste-guard")])
+
+    assert out["events"] == 0
+
+
+# ─────────────────────────────────────────────
+# Parsing
+# ─────────────────────────────────────────────
+
+@pytest.mark.parametrize("evidence,action,detectors", [
+    ("paste warned: aws_access_key", "warned", ["aws_access_key"]),
+    # Anything not shaped like a detector id is dropped rather than tidied up.
+    # This is the exact string that broke the content test: a parser that
+    # split on commas and trusted the rest carried the secret through.
+    ("paste warned: aws_access_key (AKIAIOSFODNN7EXAMPLE)", "warned", []),
+    ("paste warned: aws_access_key, Not An Id", "warned", ["aws_access_key"]),
+    ("paste warned: AWS_ACCESS_KEY", "warned", []),
+    ("paste blocked: private_key", "blocked", ["private_key"]),
+    ("paste overridden: aws_access_key,payment_card", "overridden",
+     ["aws_access_key", "payment_card"]),
+    ("paste warned: a, b , c", "warned", ["a", "b", "c"]),
+    ("paste warned:", "warned", []),
+])
+def test_parse_reads_the_action_and_detectors(evidence, action, detectors):
+    assert _parse(evidence) == (action, detectors)
+
+
+@pytest.mark.parametrize("evidence", [
+    "heartbeat version=1.3.0 mode=warn reason=installed",
+    "paste sniffed: something",     # an action nobody defined
+    ".claude.json mcpServers: figma",
+    "",
+    None,
+])
+def test_parse_rejects_anything_that_is_not_a_paste_event(evidence):
+    """An action nobody recognises is not a paste event. Guessing which of
+    three it meant is how a block gets counted as a warning."""
+    assert _parse(evidence) == (None, [])
+
+
+# ─────────────────────────────────────────────
+# Counting
+# ─────────────────────────────────────────────
+
+def test_actions_are_counted_separately():
+    """warned is the guard working. overridden is somebody deciding to paste
+    anyway after being shown what it was. Collapsing them into one total would
+    lose the only distinction that matters here."""
+    out = paste_guard_from([
+        _f(evidence="paste warned: aws_access_key"),
+        _f(evidence="paste warned: aws_access_key"),
+        _f(evidence="paste overridden: aws_access_key"),
+        _f(evidence="paste blocked: private_key"),
+    ])
+
+    assert (out["warned"], out["overridden"], out["blocked"]) == (2, 1, 1)
+    assert out["events"] == 4
+
+
+def test_rows_are_per_tool_and_keep_both_events_and_devices():
+    """Five pastes on one machine and five across five machines are different
+    situations, and one number cannot tell them apart."""
+    out = paste_guard_from([
+        _f(device="D1"), _f(device="D1"), _f(device="D2"),
+    ])
+    row = out["rows"][0]
+
+    assert row["events"] == 3
+    assert row["devices"] == 2
+
+
+def test_overrides_sort_first():
+    """One override matters more than twenty warnings that worked, and sorting
+    by event count would bury it."""
+    out = paste_guard_from(
+        [_f(tool="claude.ai", evidence="paste overridden: private_key")]
+        + [_f(tool="chatgpt.com") for _ in range(20)]
+    )
+
+    assert out["rows"][0]["tool"] == "claude.ai"
+
+
+def test_a_tool_reported_by_domain_and_by_id_is_one_row():
+    """The extension reports the hostname it saw."""
+    from app.derive import load_domain_map_from
+    dm = load_domain_map_from({"tools": [{"id": "chatgpt", "domains": ["chatgpt.com"]}]})
+    out = paste_guard_from([_f(tool="chatgpt.com"), _f(tool="chatgpt")], dm)
+
+    assert len(out["rows"]) == 1
+    assert out["rows"][0]["tool"] == "chatgpt"
+    assert out["rows"][0]["events"] == 2
+
+
+def test_detectors_are_counted_across_the_estate_commonest_first():
+    out = paste_guard_from([
+        _f(evidence="paste warned: aws_access_key"),
+        _f(evidence="paste warned: aws_access_key"),
+        _f(evidence="paste warned: payment_card"),
+    ])
+
+    assert out["detectors"] == [
+        {"detector": "aws_access_key", "count": 2},
+        {"detector": "payment_card", "count": 1},
+    ]
+
+
+def test_first_and_last_seen_span_the_events():
+    out = paste_guard_from([
+        _f(reported_at="2026-08-01T00:00:00Z"),
+        _f(reported_at="2026-08-12T00:00:00Z"),
+        _f(reported_at="2026-08-05T00:00:00Z"),
+    ])
+    row = out["rows"][0]
+
+    assert row["first_seen"] == "2026-08-01T00:00:00Z"
+    assert row["last_seen"] == "2026-08-12T00:00:00Z"
+
+
+def test_findings_from_other_sources_are_ignored():
+    out = paste_guard_from([
+        _f(source="browser_extension", evidence="paste warned: aws_access_key"),
+        _f(source="collector-macos", evidence="paste warned: aws_access_key"),
+    ])
+
+    assert out["events"] == 0
+
+
+def test_no_findings_is_an_empty_result_not_an_error():
+    out = paste_guard_from([])
+
+    assert out["events"] == 0
+    assert out["rows"] == []
+    assert out["detectors"] == []
+
+
+# ─────────────────────────────────────────────
+# The content must not be here
+# ─────────────────────────────────────────────
+
+def test_the_matched_content_never_appears_in_the_output():
+    """Asserted structurally, not by review.
+
+    The guard inspects the clipboard on the device and sends detector
+    identifiers. If a future change ever carried the matched text into a
+    finding, this module must not pass it on, and a test that only checked the
+    fields it expects would not notice a new one appearing.
+    """
+    import json
+
+    secret = "AKIAIOSFODNN7EXAMPLE"
+    out = paste_guard_from([
+        # A finding that wrongly carried the content, in two plausible places.
+        _f(evidence=f"paste warned: aws_access_key ({secret})"),
+        _f(content=secret, matched=secret),
+    ])
+
+    assert secret not in json.dumps(out)
+
+
+def test_only_known_fields_are_carried_from_a_finding():
+    """A finding gaining a field must not silently reach the output.
+
+    The receiver's Finding model is not this module's to control, and a new
+    field there should require a decision here rather than arriving by
+    default.
+    """
+    import json
+
+    out = paste_guard_from([_f(surprise_field="should not appear",
+                               user="someone@example.com")])
+    body = json.dumps(out)
+
+    assert "surprise_field" not in body
+    assert "should not appear" not in body
+    # The user is deliberately absent too: a paste event says a machine tried
+    # to paste something, and attributing it to a person is the identity map's
+    # job rather than a guess made here.
+    assert "someone@example.com" not in body
+
+
+def test_the_endpoint_returns_metadata_and_excludes_heartbeats():
+    """End to end, because the heartbeat exclusion and the domain map both
+    live outside paste_guard_from and a unit test would miss either.
+
+    Calls the endpoint function rather than going over HTTP: TestClient needs
+    httpx, which is not in the portal's lockfile, and a test that breaks for a
+    dependency the thing it tests does not have is a test that breaks for the
+    wrong reason.
+    """
+    import json as _json
+    from unittest.mock import patch
+
+    from app import derive
+    from app import main as pm
+
+    findings = [_heartbeat("D1"), _heartbeat("D2"),
+                _f(device="D1", evidence="paste overridden: aws_access_key"),
+                _f(device="D2", tool="chatgpt")]
+    reg = {"tools": [{"id": "chatgpt", "domains": ["chatgpt.com"]}]}
+
+    with patch.object(pm, "_findings", lambda h: findings), \
+            patch.object(derive, "load_registry", lambda p: reg):
+        pm._cache.clear()
+        body = _json.loads(bytes(pm.paste_guard_events(hours=168).body))
+
+    assert body["events"] == 2
+    assert body["overridden"] == 1
+    # Both findings resolve to one tool through the domain map.
+    assert [r["tool"] for r in body["rows"]] == ["chatgpt"]
+    assert body["devices"] == 2


### PR DESCRIPTION
The paste guard produces the strongest signal this platform has and had no view in the portal at all: one mention in derive.py, none in main.py. Findings sat in Loki with nobody reading them.

The heartbeat shares source: paste_guard. It is tool: paste-guard, severity info, evidence starting 'heartbeat', and it is how a device proves the guard works rather than merely being installed. Counting it as a detection would report every device's daily heartbeat as a paste somebody tried to make: a number wrong in the direction nobody checks, because it only ever rises and looks like activity.

Metadata only, asserted structurally rather than by review. The first parser split detectors on commas and passed the rest through, so a finding whose evidence read 'paste warned: aws_access_key (AKIAIOSFODNN7EXAMPLE)' carried the secret into the output. evidence is a 2048 character operator-adjacent field and treating it as well-formed was the mistake. Detector ids are now constrained to the character set every id in guard.js actually uses, and a test serialises the whole result to assert no content appears rather than checking the fields it expects to find.

Rows sort overrides first. Somebody shown a warning naming the detector and pasting anyway is the row to follow up, and sorting by event count would bury one override under twenty warnings that worked.

Tests: 97 to 125.