### PR TITLE
governance: exceptions

### DIFF
--- a/governance/governance.yaml.example
+++ b/governance/governance.yaml.example
@@ -75,3 +75,42 @@ tools:
     owner: Security
     review_due: 2026-09-30
     reason: Found on two machines, no vendor assessment yet
+
+# ─────────────────────────────────────────────
+# Exceptions
+# ─────────────────────────────────────────────
+#
+# A temporary departure from the general decision, for a stated scope and a
+# stated period. Keyed on its own id rather than on the tool, because a tool
+# can have more than one and because an exception is a record with its own
+# life: raised, applying, expired, and still visible afterwards.
+#
+# An exception does NOT replace the tool's status. The general position has not
+# been withdrawn, and showing the exception instead would make a note about one
+# team read as a decision about everybody. The register shows both.
+#
+# expires is required, unlike review_due on a decision. A departure from the
+# general position with no end is not an exception, it is an undocumented
+# change of policy. When it expires it simply stops applying: the underlying
+# status is already what it was, and nothing becomes "reviewing" because a
+# campaign finished.
+
+exceptions:
+
+  EX-001:
+    tool: chatgpt
+    scope:
+      team: Marketing
+    reason: Client campaign work, no personal data, agreed with the client
+    owner: Security
+    expires: 2026-12-01
+
+  # Expired, and kept. It is a record of something the organisation decided and
+  # then let lapse, which is worth seeing rather than losing.
+  EX-002:
+    tool: deepseek
+    scope:
+      project: Vendor evaluation
+    reason: Time-boxed evaluation against a public dataset only
+    owner: Engineering
+    expires: 2026-03-31

--- a/governance/schema.json
+++ b/governance/schema.json
@@ -66,6 +66,39 @@
           }
         ]
       }
+    },
+    "exceptions": {
+      "type": "object",
+      "description": "Temporary departures from the general decision, for a stated scope and period. Keyed on an exception id rather than on the tool, because a tool can have more than one and because an exception is a record with its own life: raised, applying, expired, and still visible afterwards. An exception does not replace the tool's status; the general position has not been withdrawn, and when the exception expires it simply stops applying.",
+      "additionalProperties": {
+        "type": "object",
+        "required": [
+          "tool",
+          "expires"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "tool": {
+            "type": "string",
+            "description": "The tool this applies to. An id the registry does not know validates and is reported by the portal, same as a decision: the tool most in need of an exception is often one nobody has registered yet, and that is also what a typo looks like."
+          },
+          "expires": {
+            "type": "string",
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+            "description": "Required, unlike review_due on a decision. A departure from the general position with no end is not an exception, it is an undocumented change of policy."
+          },
+          "scope": {
+            "type": "object",
+            "description": "Who or what this covers, as free-form keys such as team or project. Not resolved against anything: the portal displays it, and enforcing scope would require identity the platform does not have."
+          },
+          "reason": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }

--- a/governance/validate.py
+++ b/governance/validate.py
@@ -35,6 +35,9 @@ def normalise(doc):
     for rec in (doc.get("tools") or {}).values():
         if isinstance(rec, dict) and isinstance(rec.get("review_due"), date):
             rec["review_due"] = rec["review_due"].isoformat()
+    for rec in (doc.get("exceptions") or {}).values():
+        if isinstance(rec, dict) and isinstance(rec.get("expires"), date):
+            rec["expires"] = rec["expires"].isoformat()
     return doc
 
 
@@ -62,10 +65,17 @@ def main(path):
         return 1
 
     tools = doc.get("tools") or {}
-    print("%s valid: %d decision%s" % (path, len(tools), "" if len(tools) == 1 else "s"))
+    exceptions = doc.get("exceptions") or {}
+    print("%s valid: %d decision%s, %d exception%s"
+          % (path, len(tools), "" if len(tools) == 1 else "s",
+             len(exceptions), "" if len(exceptions) == 1 else "s"))
 
     known = known_tool_ids()
     if known is not None:
+        for ex_id, rec in sorted(exceptions.items()):
+            if rec.get("tool") not in known:
+                print("warning: exception %s names tool %s, which is not in the "
+                      "registry" % (ex_id, rec.get("tool")), file=sys.stderr)
         unknown = sorted(set(tools) - known)
         for tid in unknown:
             print("warning: %s is not a tool id in the registry. That is fine "

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -797,7 +797,8 @@ def _base_tool(tool):
     return base or tool
 
 
-def register_from(findings, reg=None, domain_map=None, gov=None):
+def register_from(findings, reg=None, domain_map=None, gov=None,
+                  exceptions=None):
     """One row per tool: what the registry knows, joined to what was observed.
 
     Returns the full join, observed and not. Callers decide what to show: the
@@ -889,7 +890,8 @@ def register_from(findings, reg=None, domain_map=None, gov=None):
         # the two distinguishable, because every tool ships not approved and a
         # register that presented that as a position would be asserting a
         # refusal nobody made.
-        g = governance.decide(tid, gov, meta.get("approved"))
+        g = governance.decide(tid, gov, meta.get("approved"),
+                              exceptions=exceptions)
         rows.append({
             "id": tid,
             "name": meta.get("name") or tid,
@@ -906,6 +908,8 @@ def register_from(findings, reg=None, domain_map=None, gov=None):
             "owner": g["owner"],
             "review_due": g["review_due"],
             "days_overdue": g["days_overdue"],
+            "exceptions": g["exceptions"],
+            "expired_exceptions": g["expired_exceptions"],
             "in_registry": tid in known,
             "observed": o is not None,
             "devices": len(o["devices"]) if o else 0,

--- a/portal/app/governance.py
+++ b/portal/app/governance.py
@@ -48,10 +48,11 @@ VALID_STATUSES = {APPROVED, NOT_APPROVED, REVIEWING}
 
 # Why an effective status differs from the stored one. Empty when it does not.
 EXPIRED = "approval_expired"
+EXCEPTED = "exception"
 
 
 def load_governance(path):
-    """Governance decisions keyed on tool id, or {} when none are configured.
+    """(decisions, exceptions) from one file, or ({}, {}) when none configured.
 
     Returns {} rather than raising on a missing file, because governance is
     optional and its absence is a valid state. A file that exists and cannot be
@@ -59,11 +60,11 @@ def load_governance(path):
     is not, so it complains to stderr rather than passing silently.
     """
     if not path:
-        return {}
+        return {}, {}
     if not os.path.exists(path):
         print("governance file not found at %s: decisions will fall back to "
               "the registry's approved flag" % path, file=sys.stderr)
-        return {}
+        return {}, {}
 
     try:
         with open(path) as fh:
@@ -72,13 +73,13 @@ def load_governance(path):
     except ImportError:
         print("pyyaml not installed: governance decisions will not be loaded",
               file=sys.stderr)
-        return {}
+        return {}, {}
     except Exception as e:
         print("could not read governance file (%s): decisions will fall back "
               "to the registry's approved flag" % e, file=sys.stderr)
-        return {}
+        return {}, {}
 
-    return load_governance_from(doc)
+    return load_governance_from(doc), load_exceptions_from(doc)
 
 
 def load_governance_from(doc):
@@ -102,6 +103,65 @@ def load_governance_from(doc):
             "reason": str(rec.get("reason") or "").strip(),
         }
     return out
+
+
+def load_exceptions_from(doc):
+    """Exceptions, keyed on their own id rather than on the tool.
+
+    Keyed on an id because a tool can have more than one, for different teams
+    or different reasons, and because an exception is a record with its own
+    life: it is raised, it applies, it expires, and it stays visible
+    afterwards. Keying on the tool would allow exactly one and would lose the
+    previous one the moment a second was written.
+
+    Expiry is mandatory here in a way it is not for a decision. An exception is
+    a deliberate departure from the general position for a stated scope and
+    period, and one without an end is not an exception, it is an undocumented
+    change of policy.
+    """
+    out = {}
+    for ex_id, rec in ((doc or {}).get("exceptions") or {}).items():
+        if not isinstance(rec, dict):
+            continue
+        tool = str(rec.get("tool") or "").strip()
+        expires = _parse_date(rec.get("expires"))
+        if not tool:
+            print("governance: exception %s names no tool, ignoring it" % ex_id,
+                  file=sys.stderr)
+            continue
+        if not expires:
+            # Caught by the schema, so reaching here means a file that got in
+            # another way. An exception with no end applying forever is the
+            # thing this must not do.
+            print("governance: exception %s has no usable expiry, ignoring it"
+                  % ex_id, file=sys.stderr)
+            continue
+        out[str(ex_id)] = {
+            "id": str(ex_id),
+            "tool": tool,
+            "scope": rec.get("scope") or {},
+            "reason": str(rec.get("reason") or "").strip(),
+            "owner": str(rec.get("owner") or "").strip(),
+            "expires": expires,
+        }
+    return out
+
+
+def exceptions_for(tool_id, exceptions, today=None):
+    """(active, expired) exceptions for one tool.
+
+    Expired ones are returned rather than filtered out. An exception that has
+    run its course is a record of something an organisation decided and then
+    let lapse, and dropping it from the view loses the history at the moment it
+    becomes most worth seeing.
+    """
+    today = today or date.today()
+    mine = [e for e in (exceptions or {}).values() if e["tool"] == tool_id]
+    active = sorted((e for e in mine if e["expires"] >= today),
+                    key=lambda e: e["expires"])
+    expired = sorted((e for e in mine if e["expires"] < today),
+                     key=lambda e: e["expires"], reverse=True)
+    return active, expired
 
 
 def _parse_date(value):
@@ -156,7 +216,7 @@ def days_overdue(record, today=None):
     return max(0, (today - due).days)
 
 
-def decide(tool_id, governance, registry_approved, today=None):
+def decide(tool_id, governance, registry_approved, today=None, exceptions=None):
     """The whole governance position for one tool, ready to render.
 
     Falls back to the registry's own flag when no decision has been recorded,
@@ -165,11 +225,26 @@ def decide(tool_id, governance, registry_approved, today=None):
     decision: `source` says whether a human recorded this or whether it is the
     shipped default, and nobody should read "not approved by default" as
     "somebody decided against it".
+
+    An active exception is reported alongside the decision, not in place of it.
+    An exception is a departure from the general position for a stated scope,
+    and the general position has not been withdrawn: replacing the status would
+    lose what the organisation actually decided, and would make an exception
+    for one team read as a decision about everybody. When it expires it simply
+    stops applying, and the underlying status is already what it was. An
+    expired exception does not make a tool reviewing: nothing about the
+    decision changed, only the departure from it ended.
     """
+    active, expired = exceptions_for(tool_id, exceptions, today)
+    ex = {
+        "exceptions": [_jsonable_exception(e) for e in active],
+        "expired_exceptions": [_jsonable_exception(e) for e in expired],
+    }
+
     rec = (governance or {}).get(tool_id)
     if rec:
         status, reason = effective(rec, today)
-        return {
+        return dict(ex, **{
             "status": status,
             "stored_status": rec["status"],
             "reason": reason,
@@ -177,18 +252,37 @@ def decide(tool_id, governance, registry_approved, today=None):
             "review_due": rec["review_due"].isoformat() if rec.get("review_due") else "",
             "days_overdue": days_overdue(rec, today),
             "source": "governance",
-        }
+        })
 
     if registry_approved is None:
         # Not in the registry either. Unknown, which is not the same as
         # not approved: nobody has decided anything about this tool.
-        return {"status": "", "stored_status": "", "reason": "", "owner": "",
-                "review_due": "", "days_overdue": 0, "source": "unknown"}
+        return dict(ex, **{"status": "", "stored_status": "", "reason": "",
+                           "owner": "", "review_due": "", "days_overdue": 0,
+                           "source": "unknown"})
 
     status = APPROVED if registry_approved else NOT_APPROVED
-    return {"status": status, "stored_status": status, "reason": "",
-            "owner": "", "review_due": "", "days_overdue": 0,
-            "source": "registry_default"}
+    return dict(ex, **{"status": status, "stored_status": status, "reason": "",
+                       "owner": "", "review_due": "", "days_overdue": 0,
+                       "source": "registry_default"})
+
+
+def _jsonable_exception(e):
+    """An exception as plain data, with the date as a string."""
+    return {"id": e["id"], "tool": e["tool"], "scope": e["scope"],
+            "reason": e["reason"], "owner": e["owner"],
+            "expires": e["expires"].isoformat()}
+
+
+def unmatched_exceptions(exceptions, known_ids):
+    """Exceptions naming a tool the registry does not know.
+
+    Same treatment as an unmatched decision and for the same reason: usually a
+    typo, occasionally a rename, and either way the exception is not applying
+    to anything. Reported rather than dropped.
+    """
+    return sorted({e["tool"] for e in (exceptions or {}).values()
+                   if e["tool"] not in set(known_ids or ())})
 
 
 def unmatched(governance, known_ids):

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -510,9 +510,10 @@ def register(hours: float = Query(default=None, gt=0, le=24 * 90),
     def build():
         findings = _findings(hours)
         reg = derive.load_registry(REGISTRY_PATH)
-        gov = governance.load_governance(GOVERNANCE_PATH)
+        gov, exceptions = governance.load_governance(GOVERNANCE_PATH)
         return derive.register_from(findings, reg,
-                                    derive.load_domain_map_from(reg), gov)
+                                    derive.load_domain_map_from(reg), gov,
+                                    exceptions)
 
     all_rows, at = _cached("register", hours, build)
     # The register is what is in use. The rest of the join is the watchlist,
@@ -528,7 +529,9 @@ def register(hours: float = Query(default=None, gt=0, le=24 * 90),
             headers={"Content-Disposition": 'attachment; filename="%s"' % name},
         )
 
-    gov = governance.load_governance(GOVERNANCE_PATH)
+    gov, exceptions = governance.load_governance(GOVERNANCE_PATH)
+    known = [t.get("id") for t in (
+        derive.load_registry(REGISTRY_PATH).get("tools") or [])]
     return JSONResponse({
         "rows": rows,
         "derived_at": at,
@@ -538,9 +541,16 @@ def register(hours: float = Query(default=None, gt=0, le=24 * 90),
         # than dropped: the likely cause is a typo, and a decision that
         # silently matches nothing is how an organisation believes it has
         # decided something it has not.
-        "governance_unmatched": governance.unmatched(
-            gov, [t.get("id") for t in (
-                derive.load_registry(REGISTRY_PATH).get("tools") or [])]),
+        "governance_unmatched": governance.unmatched(gov, known),
+        # Exceptions naming a tool the registry does not know, same treatment
+        # and for the same reason: usually a typo, and either way the exception
+        # is applying to nothing.
+        "exceptions_unmatched": governance.unmatched_exceptions(
+            exceptions, known),
+        "exceptions_active": sum(
+            len(r.get("exceptions") or []) for r in rows),
+        "exceptions_expired": sum(
+            len(r.get("expired_exceptions") or []) for r in rows),
         # Both counts, deliberately. A register that reported only what it
         # found would let an estate with a silent source look complete.
         "tools_observed": len(rows),

--- a/portal/tests/test_governance.py
+++ b/portal/tests/test_governance.py
@@ -21,7 +21,6 @@ decision: the organisation believes it has decided something it has not.
 from datetime import date
 
 import pytest
-
 from app.governance import (
     APPROVED,
     EXPIRED,
@@ -269,3 +268,157 @@ def test_governance_carries_no_severity():
 
     assert "severity" not in d
     assert "severity" not in gov["claude"]
+
+
+# ─────────────────────────────────────────────
+# Exceptions
+# ─────────────────────────────────────────────
+
+from app.governance import (
+    EXCEPTED,
+    exceptions_for,
+    load_exceptions_from,
+    unmatched_exceptions,
+)
+
+
+def _ex(**exceptions):
+    return {"exceptions": exceptions}
+
+
+def test_an_exception_is_keyed_on_its_own_id_not_the_tool():
+    """A tool can have more than one, for different teams or reasons.
+
+    Keying on the tool would allow exactly one and would silently discard the
+    previous the moment a second was written.
+    """
+    ex = load_exceptions_from(_ex(
+        **{"EX-001": {"tool": "chatgpt", "expires": "2027-01-01",
+                      "scope": {"team": "Marketing"}},
+           "EX-002": {"tool": "chatgpt", "expires": "2027-06-01",
+                      "scope": {"team": "Sales"}}}))
+
+    assert set(ex) == {"EX-001", "EX-002"}
+    active, _ = exceptions_for("chatgpt", ex, TODAY)
+    assert len(active) == 2
+
+
+def test_an_exception_with_no_expiry_is_not_an_exception():
+    """A departure from the general position with no end is not an exception,
+    it is an undocumented change of policy."""
+    ex = load_exceptions_from(_ex(**{"EX-001": {"tool": "chatgpt"}}))
+
+    assert ex == {}
+
+
+def test_an_exception_naming_no_tool_is_ignored():
+    ex = load_exceptions_from(_ex(**{"EX-001": {"expires": "2027-01-01"}}))
+
+    assert ex == {}
+
+
+def test_an_active_exception_does_not_replace_the_decision():
+    """The regression, and the whole design of this.
+
+    An exception is a departure from the general position for a stated scope.
+    The general position has not been withdrawn, so replacing the status would
+    lose what the organisation actually decided and would make an exception for
+    one team read as a decision about everybody.
+    """
+    gov = load_governance_from(_doc(
+        chatgpt={"status": "not_approved", "owner": "Security"}))
+    ex = load_exceptions_from(_ex(
+        **{"EX-001": {"tool": "chatgpt", "expires": "2027-01-01",
+                      "scope": {"team": "Marketing"}}}))
+
+    d = decide("chatgpt", gov, None, TODAY, exceptions=ex)
+
+    assert d["status"] == NOT_APPROVED
+    assert len(d["exceptions"]) == 1
+    assert d["exceptions"][0]["scope"] == {"team": "Marketing"}
+
+
+def test_an_expired_exception_stops_applying():
+    gov = load_governance_from(_doc(chatgpt={"status": "not_approved"}))
+    ex = load_exceptions_from(_ex(
+        **{"EX-001": {"tool": "chatgpt", "expires": "2026-01-01"}}))
+
+    d = decide("chatgpt", gov, None, TODAY, exceptions=ex)
+
+    assert d["exceptions"] == []
+    assert len(d["expired_exceptions"]) == 1
+
+
+def test_an_expired_exception_does_not_make_a_tool_reviewing():
+    """Nothing about the decision changed. Only the departure from it ended.
+
+    Expiring into reviewing would be the expired-approval rule applied where it
+    does not belong, and would put a tool under review because a marketing
+    campaign finished.
+    """
+    gov = load_governance_from(_doc(
+        chatgpt={"status": "approved", "review_due": "2027-01-01"}))
+    ex = load_exceptions_from(_ex(
+        **{"EX-001": {"tool": "chatgpt", "expires": "2026-01-01"}}))
+
+    d = decide("chatgpt", gov, None, TODAY, exceptions=ex)
+
+    assert d["status"] == APPROVED
+    assert d["reason"] != EXCEPTED
+
+
+def test_an_expired_exception_stays_visible():
+    """It is a record of something an organisation decided and then let lapse,
+    and dropping it loses the history at the moment it is most worth seeing."""
+    ex = load_exceptions_from(_ex(
+        **{"EX-001": {"tool": "chatgpt", "expires": "2026-01-01",
+                      "reason": "Client campaign"}}))
+    active, expired = exceptions_for("chatgpt", ex, TODAY)
+
+    assert active == []
+    assert expired[0]["reason"] == "Client campaign"
+
+
+def test_an_exception_expiring_today_is_still_active():
+    ex = load_exceptions_from(_ex(
+        **{"EX-001": {"tool": "chatgpt", "expires": "2026-08-12"}}))
+    active, expired = exceptions_for("chatgpt", ex, TODAY)
+
+    assert len(active) == 1
+    assert expired == []
+
+
+def test_exceptions_reach_a_tool_with_no_decision_at_all():
+    """An exception can be the only record about a tool, and often is: the one
+    most in need of a note is the one nobody has decided about yet."""
+    ex = load_exceptions_from(_ex(
+        **{"EX-001": {"tool": "notion-ai", "expires": "2027-01-01"}}))
+
+    d = decide("notion-ai", {}, None, TODAY, exceptions=ex)
+
+    assert d["source"] == "unknown"
+    assert len(d["exceptions"]) == 1
+
+
+def test_an_exception_naming_an_unknown_tool_is_surfaced():
+    ex = load_exceptions_from(_ex(
+        **{"EX-001": {"tool": "github_copilot", "expires": "2027-01-01"}}))
+
+    assert unmatched_exceptions(ex, ["github-copilot"]) == ["github_copilot"]
+
+
+def test_no_exceptions_is_not_an_error():
+    assert load_exceptions_from({}) == {}
+    assert exceptions_for("claude", {}, TODAY) == ([], [])
+    assert unmatched_exceptions(None, None) == []
+
+
+def test_exceptions_carry_no_severity_either():
+    """Same boundary as decisions. An exception is a governance record and must
+    not become a way to quieten a finding."""
+    ex = load_exceptions_from(_ex(
+        **{"EX-001": {"tool": "chatgpt", "expires": "2027-01-01"}}))
+    d = decide("chatgpt", {}, False, TODAY, exceptions=ex)
+
+    assert "severity" not in d
+    assert all("severity" not in e for e in d["exceptions"])


### PR DESCRIPTION
A temporary departure from the general decision, for a stated scope and period. Keyed on its own id rather than on the tool, because a tool can have more than one and because an exception is a record with its own life: raised, applying, expired, and still visible afterwards. Keying on the tool would allow exactly one and would discard the previous the moment a second was written.

An active exception is reported alongside the decision, never in place of it. The general position has not been withdrawn, so replacing the status would lose what the organisation actually decided and would make a note about one team read as a decision about everybody. Verified by implementing the wrong version: overriding the status to approved when an exception is active fails the test that asserts this.

expires is mandatory, unlike review_due on a decision. A departure from the general position with no end is not an exception, it is an undocumented change of policy. When it expires it stops applying and stays visible, and the tool does not become reviewing: nothing about the decision changed, only the departure from it ended. Applying the expired-approval rule here would put a tool under review because a campaign finished.

An exception naming a tool the registry does not know validates and is surfaced, same as a decision and for the same reason.

load_governance now returns (decisions, exceptions) from one read. Both callers updated.

Tests: 125 to 137.