### PR TITLE
portal: evidence snapshots

### DIFF
--- a/portal/app/evidence.py
+++ b/portal/app/evidence.py
@@ -1,0 +1,221 @@
+"""Evidence snapshots: a checksummed statement of what the platform observed.
+
+Generated on demand from Loki, the registry and the governance file. Nothing is
+stored. A snapshot is a claim about a moment, and this module's job is to make
+that claim verifiable rather than to keep it.
+
+WHAT MAKES THIS EVIDENCE RATHER THAN A SCREENSHOT
+
+Provenance. The exact query window as timestamps, not "168h", because a
+relative window is unreadable a month later and unverifiable at any distance.
+The app version, so a reader knows which code produced it. Hashes of the
+registry and governance files, so the inputs are identified rather than
+described.
+
+Gaps alongside totals. Every count that could flatter has its denominator
+beside it: sources reporting AND sources known, decisions recorded AND tools
+without one. A snapshot reporting only what it found would let an estate with
+half its collectors silent look complete, which is the failure this project
+exists to catch, committed to a file and handed to an auditor.
+
+A checksum. The manifest is hashed with `snapshot_sha256` omitted, then the
+digest is inserted, and `checksum_scope` says so in the document. A field
+cannot cover itself, and a verification rule that lives only in documentation
+is a rule nobody can apply to a file they were emailed.
+
+WHAT THIS IS NOT
+
+Reproducible. Loki has retention, so regenerating the same window next year may
+legitimately return less. The snapshot is tamper-evident, meaning it can be
+checked against itself, not reproducible, meaning it can be recreated from the
+source. Saying otherwise would be the more useful claim and the false one.
+"""
+
+import hashlib
+import json
+import os
+from datetime import datetime, timedelta, timezone
+
+# How near a review has to be to count as due soon. Hardcoded for now: one
+# threshold does not justify a configuration mechanism, and a number nobody can
+# change is at least a number everybody reads the same way.
+REVIEW_SOON_DAYS = 30
+
+CHECKSUM_SCOPE = "manifest_without_snapshot_sha256"
+
+
+def file_sha256(path):
+    """sha256 of a file, or "" when there is none.
+
+    Identifies the inputs rather than describing them. Two snapshots taken a
+    month apart with the same registry hash used the same registry, which is
+    not something a version number can tell you.
+    """
+    if not path or not os.path.exists(path):
+        return ""
+    h = hashlib.sha256()
+    try:
+        with open(path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(65536), b""):
+                h.update(chunk)
+    except OSError:
+        return ""
+    return "sha256:" + h.hexdigest()
+
+
+def canonical(doc):
+    """The bytes a checksum is taken over.
+
+    Sorted keys and no incidental whitespace, so the same content hashes the
+    same regardless of how it was assembled. Without this, a reordering
+    anywhere upstream would change the digest and every previously issued
+    snapshot would fail verification for no reason anyone could see.
+    """
+    return json.dumps(doc, sort_keys=True, separators=(",", ":"),
+                      ensure_ascii=False).encode("utf-8")
+
+
+def checksum(doc):
+    """The digest of a manifest, with snapshot_sha256 omitted.
+
+    A field cannot cover itself. Verifying means removing that key, hashing
+    what remains, and comparing, which is what checksum_scope names in the
+    document so the rule travels with the file.
+    """
+    return "sha256:" + hashlib.sha256(
+        canonical({k: v for k, v in doc.items() if k != "snapshot_sha256"})
+    ).hexdigest()
+
+
+def _due_soon(rows, days=REVIEW_SOON_DAYS, now=None):
+    """Tools whose review falls inside the next `days`, excluding overdue ones.
+
+    Overdue is counted separately. Rolling the two together would let a review
+    that lapsed six months ago sit in the same number as one due next week, and
+    the first is a finding while the second is a diary entry.
+    """
+    now = now or datetime.now(timezone.utc)
+    horizon = (now + timedelta(days=days)).date().isoformat()
+    today = now.date().isoformat()
+    return sum(1 for r in rows
+               if r.get("review_due")
+               and not r.get("days_overdue")
+               and today <= r["review_due"] <= horizon)
+
+
+def evidence_from(register_rows, status, personal, mcp, paste,
+                  registry_path="", governance_path="",
+                  app_version="", hours=0, now=None):
+    """A snapshot manifest, checksummed.
+
+    Takes derivations already computed rather than findings, so a snapshot and
+    the pages it summarises cannot disagree: the same numbers, from the same
+    read, arranged for export.
+    """
+    now = now or datetime.now(timezone.utc)
+    rows = list(register_rows or [])
+    observed = [r for r in rows if r.get("observed")]
+
+    decided = [r for r in observed if r.get("status_source") == "governance"]
+    by_status = {}
+    for r in decided:
+        by_status[r["status"]] = by_status.get(r["status"], 0) + 1
+
+    st = status or {}
+    doc = {
+        "generated_at": now.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+        # The window as timestamps, not "168h". A relative window is
+        # unreadable a month later and unverifiable at any distance.
+        "window": {
+            "from": (now - timedelta(hours=hours or 0)).replace(
+                microsecond=0).isoformat().replace("+00:00", "Z"),
+            "to": now.replace(microsecond=0).isoformat().replace("+00:00", "Z"),
+            "hours": int(hours) if float(hours or 0).is_integer() else hours,
+        },
+        "app_version": app_version,
+        "registry_sha256": file_sha256(registry_path),
+        "governance_sha256": file_sha256(governance_path),
+
+        # Inventory. Both numbers, always: the registry is a watchlist, and
+        # reporting only what was found would let a quiet estate look small.
+        "tools_observed": len(observed),
+        "tools_watched_for": sum(1 for r in rows if r.get("in_registry")),
+        "tools_not_in_registry": sum(
+            1 for r in observed if not r.get("in_registry")),
+        "tool_device_pairs": sum(r.get("devices", 0) for r in observed),
+
+        # Governance, with the gap stated rather than implied. "8 decisions"
+        # sounds like progress; "8 of 23, and 15 need one" is the finding.
+        "decisions_recorded": len(decided),
+        "tools_without_decision": len(observed) - len(decided),
+        "approved": by_status.get("approved", 0),
+        "not_approved": by_status.get("not_approved", 0),
+        "reviewing": by_status.get("reviewing", 0),
+        "approvals_expired": sum(
+            1 for r in decided if r.get("status_reason") == "approval_expired"),
+        "tools_without_owner": sum(1 for r in decided if not r.get("owner")),
+        "reviews_due_soon": _due_soon(decided, now=now),
+        "reviews_due_soon_days": REVIEW_SOON_DAYS,
+        "active_exceptions": sum(len(r.get("exceptions") or []) for r in rows),
+        "expired_exceptions": sum(
+            len(r.get("expired_exceptions") or []) for r in rows),
+
+        # Coverage. Both, for the same reason as above and more sharply: a
+        # source that has stopped reporting is indistinguishable from a clean
+        # estate, and a snapshot that omitted the denominator would make that
+        # indistinguishable on paper too.
+        "sources_reporting": st.get("reporting", 0),
+        "sources_known": st.get("total", 0),
+        "sources_unexpected": len(st.get("unexpected") or []),
+
+        # Account governance.
+        "personal_accounts": len(personal or []),
+        "personal_account_tools": len({r.get("tool") for r in (personal or [])
+                                       if r.get("tool")}),
+        "personal_account_devices": len({r.get("device") for r in (personal or [])
+                                         if r.get("device")}),
+
+        # Integrations.
+        "mcp_servers": len(mcp or []),
+        "mcp_findings": sum(r.get("findings", 0) for r in (mcp or [])),
+
+        # Data protection. Counts and detector identifiers only. The paste
+        # guard inspects content on the device and reports neither the text nor
+        # anything derived from it, and this manifest must not become the first
+        # place that changes.
+        "paste_events": (paste or {}).get("events", 0),
+        "paste_warned": (paste or {}).get("warned", 0),
+        "paste_blocked": (paste or {}).get("blocked", 0),
+        "paste_overridden": (paste or {}).get("overridden", 0),
+        "paste_detectors": [d["detector"] for d in (paste or {}).get("detectors", [])],
+        "paste_content_retained": False,
+
+        # Providers, from the registry's own vendor field.
+        "providers": len({r.get("vendor") for r in observed if r.get("vendor")}),
+
+        "checksum_scope": CHECKSUM_SCOPE,
+        "reproducible": False,
+        # tool_device_pairs is deliberately not "devices". A register row
+        # carries a per-tool device count, so summing them counts a machine
+        # once per tool it runs. The pair count is a real number; a distinct
+        # device total is not recoverable from this input and is not guessed.
+        "notes": (
+            "Counts are for the stated window. Not reproducible: log retention "
+            "may mean the same window returns less later. Tamper-evident: "
+            "remove snapshot_sha256, hash the remaining document with sorted "
+            "keys and no whitespace, and compare."
+        ),
+    }
+    doc["snapshot_sha256"] = checksum(doc)
+    return doc
+
+
+def verify(doc):
+    """True when a manifest's checksum matches its contents.
+
+    Here so the rule is executable rather than only described. A verification
+    procedure that exists in prose is one every reader implements slightly
+    differently.
+    """
+    claimed = (doc or {}).get("snapshot_sha256")
+    return bool(claimed) and claimed == checksum(doc)

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -59,6 +59,7 @@ encryption.
                     ran, with nothing on screen saying the view was stale.
 """
 
+import json
 import logging
 import os
 import secrets
@@ -70,7 +71,7 @@ from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
-from app import derive, governance, paste_guard
+from app import derive, evidence, governance, paste_guard
 
 log = logging.getLogger("portal")
 
@@ -446,6 +447,50 @@ def status(hours: float = Query(default=None, gt=0, le=24 * 90),
 
     value, at = _cached("status", hours, build)
     return JSONResponse(dict(value, derived_at=at, hours=hours))
+
+
+@app.get("/api/evidence")
+def evidence_snapshot(hours: float = Query(default=None, gt=0, le=24 * 90),
+                      download: bool = Query(default=False),
+                      _=Depends(require_auth)):
+    """A checksummed statement of what the platform observed, for export.
+
+    Generated on demand and not stored. Built from the same derivations the
+    pages use, so a snapshot and the page it summarises cannot disagree: the
+    same numbers from the same read, arranged for export.
+
+    Not cached. A snapshot records a moment, and returning a cached one under a
+    fresh generated_at would be a timestamp that lies about when the numbers
+    were taken.
+    """
+    hours = hours or LOOKBACK_HOURS
+    findings = _findings(hours)
+    reg = derive.load_registry(REGISTRY_PATH)
+    domain_map = derive.load_domain_map_from(reg)
+    gov, exceptions = governance.load_governance(GOVERNANCE_PATH)
+
+    doc = evidence.evidence_from(
+        derive.register_from(findings, reg, domain_map, gov, exceptions),
+        derive.status_from(findings),
+        derive.personal_accounts_from(findings, domain_map),
+        derive.mcp_from(findings),
+        paste_guard.paste_guard_from(findings, domain_map),
+        registry_path=REGISTRY_PATH,
+        governance_path=GOVERNANCE_PATH,
+        app_version=APP_VERSION,
+        hours=hours,
+    )
+
+    if download:
+        stamp = time.strftime("%Y-%m-%dT%H%MZ", time.gmtime())
+        window = ("%dh" % hours) if float(hours).is_integer() else ("%sh" % hours)
+        name = "ai-guard-evidence-%s-%s.json" % (stamp, window)
+        return PlainTextResponse(
+            json.dumps(doc, indent=2),
+            media_type="application/json",
+            headers={"Content-Disposition": 'attachment; filename="%s"' % name},
+        )
+    return JSONResponse(doc)
 
 
 @app.get("/api/paste-guard")

--- a/portal/tests/test_evidence.py
+++ b/portal/tests/test_evidence.py
@@ -1,0 +1,349 @@
+"""Evidence snapshots: provenance, gaps, and a checksum that means something.
+
+Three things separate this from a screenshot, and each has a way of going
+quietly wrong.
+
+Provenance. A window recorded as "168h" is unreadable a month later and
+unverifiable at any distance, so the window is timestamps. The inputs are
+identified by hash rather than described, because two snapshots with the same
+registry hash used the same registry and no version number can tell you that.
+
+Gaps beside totals. Every count that could flatter has its denominator next to
+it. A snapshot reporting sources_reporting without sources_known would let an
+estate with half its collectors silent look complete, which is the failure this
+project exists to catch, committed to a file and handed to an auditor.
+
+A checksum that covers what it claims to. A field cannot hash itself, so the
+digest is taken with snapshot_sha256 removed and the document says so in
+checksum_scope. A verification rule that lives only in documentation is one
+nobody can apply to a file they were emailed.
+"""
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+from app.evidence import (
+    CHECKSUM_SCOPE,
+    REVIEW_SOON_DAYS,
+    canonical,
+    checksum,
+    evidence_from,
+    verify,
+)
+
+NOW = datetime(2026, 8, 12, 9, 0, tzinfo=timezone.utc)
+
+
+def _row(**kw):
+    base = {
+        "observed": True, "in_registry": True, "status_source": "governance",
+        "status": "approved", "stored_status": "approved", "status_reason": "",
+        "owner": "Engineering", "review_due": "2027-01-01", "days_overdue": 0,
+        "devices": 1, "vendor": "Anthropic",
+        "exceptions": [], "expired_exceptions": [],
+    }
+    base.update(kw)
+    return base
+
+
+def _snap(rows=None, status=None, personal=None, mcp=None, paste=None, **kw):
+    kw.setdefault("app_version", "0.9.0")
+    kw.setdefault("hours", 168)
+    kw.setdefault("now", NOW)
+    return evidence_from(rows or [], status or {}, personal or [],
+                         mcp or [], paste or {}, **kw)
+
+
+# ─────────────────────────────────────────────
+# The checksum
+# ─────────────────────────────────────────────
+
+def test_a_snapshot_verifies_against_itself():
+    assert verify(_snap([_row()])) is True
+
+
+def test_tampering_with_any_count_breaks_the_checksum():
+    doc = _snap([_row()])
+    doc["tools_observed"] = 99
+
+    assert verify(doc) is False
+
+
+def test_the_checksum_omits_the_field_that_carries_it():
+    """A field cannot cover itself, and a digest computed over a document
+    containing its own digest could never be recomputed."""
+    doc = _snap([_row()])
+    without = {k: v for k, v in doc.items() if k != "snapshot_sha256"}
+
+    assert doc["snapshot_sha256"] == checksum(without)
+
+
+def test_the_document_states_its_own_verification_rule():
+    """The rule has to travel with the file. Somebody handed this a year from
+    now needs to know what was hashed without finding the repository."""
+    doc = _snap([_row()])
+
+    assert doc["checksum_scope"] == CHECKSUM_SCOPE
+    assert "snapshot_sha256" in doc["notes"]
+
+
+def test_canonical_form_is_order_independent():
+    """Otherwise a reordering anywhere upstream changes the digest and every
+    snapshot already issued fails verification for a reason nobody can see."""
+    a = {"b": 1, "a": {"d": 2, "c": 3}}
+    b = {"a": {"c": 3, "d": 2}, "b": 1}
+
+    assert canonical(a) == canonical(b)
+
+
+def test_a_snapshot_with_no_checksum_does_not_verify():
+    """An absent digest is not a passing one."""
+    doc = _snap([_row()])
+    del doc["snapshot_sha256"]
+
+    assert verify(doc) is False
+
+
+# ─────────────────────────────────────────────
+# Provenance
+# ─────────────────────────────────────────────
+
+def test_the_window_is_timestamps_not_a_duration():
+    """"168h" is unreadable a month later. The dates it covered are not."""
+    doc = _snap([_row()], hours=168)
+
+    assert doc["window"]["to"] == "2026-08-12T09:00:00Z"
+    assert doc["window"]["from"] == "2026-08-05T09:00:00Z"
+    assert doc["window"]["hours"] == 168
+
+
+def test_the_inputs_are_identified_by_hash(tmp_path):
+    """Two snapshots with the same registry hash used the same registry, which
+    a version number cannot tell you."""
+    reg = tmp_path / "registry.json"
+    reg.write_text('{"tools": []}')
+    doc = _snap([_row()], registry_path=str(reg))
+
+    assert doc["registry_sha256"].startswith("sha256:")
+
+
+def test_a_missing_input_hashes_to_empty_rather_than_failing():
+    """A deployment with no governance file is a valid state, and a snapshot
+    that refused to generate would be worse than one saying so."""
+    doc = _snap([_row()], governance_path="/nowhere/governance.yaml")
+
+    assert doc["governance_sha256"] == ""
+
+
+def test_the_snapshot_does_not_claim_to_be_reproducible():
+    """Log retention means the same window may legitimately return less later.
+    Tamper-evident is the true claim; reproducible is the more useful one and
+    the false one."""
+    doc = _snap([_row()])
+
+    assert doc["reproducible"] is False
+    assert "retention" in doc["notes"]
+
+
+# ─────────────────────────────────────────────
+# Gaps beside totals
+# ─────────────────────────────────────────────
+
+def test_coverage_carries_both_reporting_and_known():
+    """The regression. A snapshot with only the numerator would let an estate
+    with half its collectors silent look complete on paper."""
+    doc = _snap([_row()], status={"reporting": 11, "total": 14, "unexpected": []})
+
+    assert doc["sources_reporting"] == 11
+    assert doc["sources_known"] == 14
+
+
+def test_governance_carries_both_decided_and_undecided():
+    """"8 decisions" sounds like progress. "8 of 23, and 15 need one" is the
+    finding."""
+    doc = _snap([_row(), _row(status_source="registry_default"),
+                 _row(status_source="registry_default")])
+
+    assert doc["decisions_recorded"] == 1
+    assert doc["tools_without_decision"] == 2
+
+
+def test_inventory_carries_both_observed_and_watched_for():
+    doc = _snap([_row(), _row(observed=False)])
+
+    assert doc["tools_observed"] == 1
+    assert doc["tools_watched_for"] == 2
+
+
+def test_an_expired_approval_is_counted_separately_from_a_review_due_soon():
+    """One is a finding, the other is a diary entry, and a single number would
+    let a review that lapsed six months ago sit beside one due next week."""
+    doc = _snap([
+        _row(status="reviewing", stored_status="approved",
+             status_reason="approval_expired", days_overdue=193,
+             review_due="2026-01-31"),
+        _row(review_due="2026-08-20"),
+    ])
+
+    assert doc["approvals_expired"] == 1
+    assert doc["reviews_due_soon"] == 1
+
+
+def test_reviews_due_soon_excludes_dates_beyond_the_threshold():
+    doc = _snap([_row(review_due="2027-01-01")])
+
+    assert doc["reviews_due_soon"] == 0
+    assert doc["reviews_due_soon_days"] == REVIEW_SOON_DAYS
+
+
+def test_tools_without_an_owner_are_counted():
+    """An approval nobody owns is one nobody will review."""
+    doc = _snap([_row(owner=""), _row()])
+
+    assert doc["tools_without_owner"] == 1
+
+
+def test_a_tool_observed_and_not_in_the_registry_is_counted():
+    doc = _snap([_row(in_registry=False, status_source="unknown")])
+
+    assert doc["tools_not_in_registry"] == 1
+
+
+def test_exceptions_are_counted_active_and_expired():
+    doc = _snap([_row(exceptions=[{"id": "EX-1"}],
+                      expired_exceptions=[{"id": "EX-2"}, {"id": "EX-3"}])])
+
+    assert doc["active_exceptions"] == 1
+    assert doc["expired_exceptions"] == 2
+
+
+def test_the_device_number_is_named_for_what_it_actually_is():
+    """A register row carries a per-tool device count, so summing them counts a
+    machine once per tool it runs. Calling that "devices" would be a number
+    quietly larger than the fleet.
+    """
+    doc = _snap([_row(devices=2), _row(devices=3)])
+
+    assert doc["tool_device_pairs"] == 5
+    assert "devices" not in doc
+
+
+# ─────────────────────────────────────────────
+# Paste guard stays metadata
+# ─────────────────────────────────────────────
+
+def test_paste_guard_counts_and_detector_ids_only():
+    doc = _snap([_row()], paste={
+        "events": 4, "warned": 3, "overridden": 1, "blocked": 0,
+        "detectors": [{"detector": "aws_access_key", "count": 4}],
+    })
+
+    assert doc["paste_events"] == 4
+    assert doc["paste_overridden"] == 1
+    assert doc["paste_detectors"] == ["aws_access_key"]
+    assert doc["paste_content_retained"] is False
+
+
+def test_the_snapshot_says_that_content_is_not_retained():
+    """Stated in the document rather than only in the docs. An auditor reading
+    the file should not have to take it on trust."""
+    doc = _snap([_row()])
+
+    assert doc["paste_content_retained"] is False
+
+
+def test_no_paste_data_produces_zeroes_not_absence():
+    """A missing key reads as "we did not measure". Zero reads as "we measured
+    and there were none", which is the true statement."""
+    doc = _snap([_row()], paste={})
+
+    assert doc["paste_events"] == 0
+    assert doc["paste_detectors"] == []
+
+
+# ─────────────────────────────────────────────
+# Shape
+# ─────────────────────────────────────────────
+
+def test_an_empty_estate_still_produces_a_valid_snapshot():
+    """A deployment that has just been installed is a legitimate state and
+    should be able to produce evidence saying so."""
+    doc = _snap([])
+
+    assert doc["tools_observed"] == 0
+    assert verify(doc) is True
+
+
+def test_the_snapshot_is_json_serialisable():
+    """It is downloaded as a file, so anything that cannot round-trip through
+    JSON is a runtime error at the moment somebody needs it."""
+    doc = _snap([_row()])
+
+    assert json.loads(json.dumps(doc)) == doc
+
+
+@pytest.mark.parametrize("key", [
+    "generated_at", "window", "app_version", "registry_sha256",
+    "governance_sha256", "tools_observed", "tools_watched_for",
+    "decisions_recorded", "tools_without_decision", "approvals_expired",
+    "active_exceptions", "expired_exceptions", "sources_reporting",
+    "sources_known", "personal_accounts", "mcp_servers", "paste_events",
+    "checksum_scope", "snapshot_sha256",
+])
+def test_the_manifest_carries_every_field_the_spec_asked_for(key):
+    assert key in _snap([_row()])
+
+
+def test_the_endpoint_produces_a_verifiable_snapshot():
+    """End to end, because the endpoint assembles five derivations and a unit
+    test of the aggregator would not catch one of them being wired wrong."""
+    from unittest.mock import patch
+
+    from app import derive
+    from app import evidence as ev
+    from app import main as pm
+
+    findings = [
+        {"tool": "claude", "device": "D1", "surface": "browser",
+         "source": "browser_extension", "severity": "info",
+         "reported_at": "2026-08-12T09:00:00Z"},
+        {"tool": "chatgpt.com", "device": "D2", "surface": "browser",
+         "source": "paste_guard", "severity": "warn",
+         "evidence": "paste overridden: aws_access_key",
+         "reported_at": "2026-08-12T09:00:00Z"},
+    ]
+    reg = {"tools": [{"id": "claude", "name": "Claude", "approved": False},
+                     {"id": "chatgpt", "name": "ChatGPT", "approved": False,
+                      "domains": ["chatgpt.com"]}]}
+
+    with patch.object(pm, "_findings", lambda h: findings), \
+            patch.object(derive, "load_registry", lambda p: reg):
+        pm._cache.clear()
+        body = json.loads(bytes(pm.evidence_snapshot(hours=168).body))
+
+    assert ev.verify(body) is True
+    assert body["tools_observed"] == 2
+    assert body["paste_overridden"] == 1
+    # No governance file in this test, so nothing is decided and the snapshot
+    # should say so rather than leaving the field out.
+    assert body["decisions_recorded"] == 0
+    assert body["tools_without_decision"] == 2
+
+
+def test_the_download_carries_provenance_in_the_filename():
+    """A file emailed onwards keeps when it was taken and over what window,
+    which a header comment inside JSON would not survive."""
+    from unittest.mock import patch
+
+    from app import derive
+    from app import main as pm
+
+    with patch.object(pm, "_findings", lambda h: []), \
+            patch.object(derive, "load_registry", lambda p: {"tools": []}):
+        pm._cache.clear()
+        resp = pm.evidence_snapshot(hours=168, download=True)
+
+    disposition = resp.headers["content-disposition"]
+    assert "ai-guard-evidence-" in disposition
+    assert "-168h.json" in disposition


### PR DESCRIPTION
A checksummed statement of what the platform observed, generated on demand from the same derivations the pages use, so a snapshot and the page it summarises cannot disagree. Nothing is stored.

Provenance rather than description. The window is timestamps, not '168h', because a relative window is unreadable a month later and unverifiable at any distance. The registry and governance files are identified by hash, so two snapshots with the same registry hash used the same registry, which no version number can tell you.

Every count that could flatter has its denominator beside it. sources_reporting with sources_known, decisions_recorded with tools_without_decision, tools_observed with tools_watched_for. A snapshot reporting only what it found would let an estate with half its collectors silent look complete, which is the failure this project exists to catch, committed to a file and handed to an auditor. The demo estate reads 6 of 18 sources reporting and 4 of 8 tools undecided.

snapshot_sha256 hashes the canonical manifest with that field omitted, then is inserted. checksum_scope names the rule in the document, because a verification procedure that lives only in documentation is one nobody can apply to a file they were emailed. verify() is exported so the rule is executable.

reproducible is false, and says why: log retention may mean the same window returns less later. Tamper-evident is the true claim and reproducible is the more useful one.

tool_device_pairs is deliberately not called devices. A register row carries a per-tool device count, so summing them counts a machine once per tool it runs, and a field named devices would have been quietly larger than the fleet. A test asserts the name is absent.

Not cached: a snapshot records a moment, and serving a cached one under a fresh generated_at would be a timestamp that lies.

Tests: 137 to 182.