### PR TITLE
portal: ISO 42001 evidence index, paste guard view, guard heartbeat

### DIFF
--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -168,7 +168,7 @@ services:
       # by panel id. Prefer the id where a title contains a comma, because this
       # list is comma separated and the title would split into two entries that
       # match nothing. GRAFANA_PANELS uses semicolons for that same reason.
-      OVERVIEW_WIDGETS: ${OVERVIEW_WIDGETS:-stat_row,top_tools,recent_personal_accounts,detection_coverage,source_health,grafana:31}
+      OVERVIEW_WIDGETS: ${OVERVIEW_WIDGETS:-stat_row,top_tools,recent_personal_accounts,detection_coverage,source_health,paste_guard}
       # The browser loads these frames, so this is the URL you reach Grafana
       # on, not the one the portal container would use.
       GRAFANA_URL: "http://localhost:3000"

--- a/portal/README.md
+++ b/portal/README.md
@@ -208,7 +208,14 @@ OVERVIEW_WIDGETS=stat_row,top_tools,recent_personal_accounts,detection_coverage
 | `recent_personal_accounts` | most recently seen personal accounts |
 | `detection_coverage` | how much of each surface is reporting |
 | `source_health` | sources listed as silent |
+| `paste_guard` | pastes warned, overridden and blocked |
 | `grafana:<panel title>` | a panel named in `GRAFANA_PANELS` |
+
+Prefer a native widget to a `grafana:` one where both exist. An embedded panel
+renders cross-origin, so it arrives in Grafana's typography with a title the
+portal cannot restyle, and it sits visibly apart from the cards beside it.
+`paste_guard` used to be a panel for this reason and no longer needs to be: the
+portal derives those counts itself.
 
 Unset gives a sensible default rather than an empty page. An unknown name
 renders an error card naming what is valid, because a widget that silently does

--- a/portal/app/evidence.py
+++ b/portal/app/evidence.py
@@ -189,6 +189,11 @@ def evidence_from(register_rows, status, personal, mcp, paste,
         "paste_overridden": (paste or {}).get("overridden", 0),
         "paste_detectors": [d["detector"] for d in (paste or {}).get("detectors", [])],
         "paste_content_retained": False,
+        # Without this, "paste_events: 0" in a snapshot reads as an estate
+        # where nobody pasted a secret and an estate where the guard was never
+        # deployed, and those are the same number. Same reason sources_known
+        # sits beside sources_reporting.
+        "paste_guard_devices": (paste or {}).get("guard_devices", 0),
 
         # Providers, from the registry's own vendor field.
         "providers": len({r.get("vendor") for r in observed if r.get("vendor")}),

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -326,6 +326,7 @@ KNOWN_WIDGETS = {
     "recent_personal_accounts": "Most recently seen personal accounts",
     "detection_coverage": "How much of each surface is reporting",
     "source_health": "Sources reporting versus silent",
+    "paste_guard": "Pastes warned, overridden and blocked",
 }
 
 DEFAULT_WIDGETS = ["stat_row", "top_tools", "recent_personal_accounts",

--- a/portal/app/paste_guard.py
+++ b/portal/app/paste_guard.py
@@ -50,6 +50,31 @@ _DETECTOR_ID = re.compile(r"^[a-z0-9_]{1,64}$")
 GUARD_TOOL = "paste-guard"
 
 
+def _parse_heartbeat(evidence):
+    """(version, mode) from a heartbeat, or (None, None).
+
+    The heartbeat is deliberately not a detection, and it is not noise either.
+    It is the only thing that distinguishes an estate where nobody pasted a
+    secret from one where the guard was never deployed, and those look
+    identical in an event count of zero. The extension writes lastHeartbeat
+    only on confirmed delivery, so a device appearing here has a working chain
+    end to end rather than merely having the extension installed.
+
+    version and mode come free in the same string, and both matter: a fleet
+    split across versions is a rollout that stalled, and a device in warn mode
+    where policy says block is a policy that is not in force.
+    """
+    ev = (evidence or "").strip()
+    if not ev.startswith("heartbeat"):
+        return None, None
+    fields = {}
+    for part in ev.split():
+        if "=" in part:
+            k, _, v = part.partition("=")
+            fields[k] = v
+    return fields.get("version") or "", fields.get("mode") or ""
+
+
 def _parse(evidence):
     """(action, [detector ids]) from an evidence string, or (None, []).
 
@@ -97,10 +122,28 @@ def paste_guard_from(findings, domain_map=None):
     detectors_total = defaultdict(int)
     devices = set()
     counts = {"warned": 0, "blocked": 0, "overridden": 0}
+    # Devices whose guard checked in, and what they are running. Kept apart
+    # from the event counts on purpose: a heartbeat is not something somebody
+    # tried to paste.
+    guard_devices = set()
+    guard_versions = defaultdict(set)
+    guard_modes = defaultdict(set)
 
     for f in findings:
         if (f.get("source") or "") != "paste_guard":
             continue
+        device = (f.get("device") or "").strip()
+
+        version, mode = _parse_heartbeat(f.get("evidence"))
+        if version is not None:
+            if device:
+                guard_devices.add(device)
+                if version:
+                    guard_versions[version].add(device)
+                if mode:
+                    guard_modes[mode].add(device)
+            continue
+
         action, detectors = _parse(f.get("evidence"))
         if not action:
             continue
@@ -117,7 +160,6 @@ def paste_guard_from(findings, domain_map=None):
         t[action] += 1
         counts[action] += 1
 
-        device = (f.get("device") or "").strip()
         if device:
             t["devices"].add(device)
             devices.add(device)
@@ -167,5 +209,18 @@ def paste_guard_from(findings, domain_map=None):
             {"detector": d, "count": c}
             for d, c in sorted(detectors_total.items(),
                                key=lambda kv: (-kv[1], kv[0]))
+        ],
+        # Devices whose guard checked in during the window. Without this,
+        # "0 pastes stopped" reads as an estate where nobody pasted a secret
+        # and an estate where the extension was never deployed, and those are
+        # the same number.
+        "guard_devices": len(guard_devices),
+        "guard_versions": [
+            {"version": v, "devices": len(d)}
+            for v, d in sorted(guard_versions.items(), reverse=True)
+        ],
+        "guard_modes": [
+            {"mode": m, "devices": len(d)}
+            for m, d in sorted(guard_modes.items())
         ],
     }

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -121,6 +121,8 @@ td{padding:7px 10px 7px 0;border-bottom:1px solid color-mix(in oklch,var(--bd) 4
 .gov-owner{white-space:nowrap}
 /* No border, no fill. Absence of governance, not a state with equal weight to
    approved or reviewing. */
+.inputs{margin:0 0 18px;padding-left:20px;font-size:13px;line-height:1.9}
+.inputs a{color:var(--warn)}
 .none{color:color-mix(in oklch,var(--mut) 70%,transparent);font-family:ui-monospace,monospace;
       font-size:11px;white-space:nowrap}
 /* A zero is the absence of something and should not compete with a real
@@ -166,6 +168,8 @@ let G = {devices:{},identities:{},tools:{},bridges:{},unattributed:[],counts:{}}
 // refresh.
 let DIAG = null;
 let REG = null;
+let EV = null;
+let PG = null;
 let S = null, CFG = {}, loadError = '';
 
 async function load(force) {
@@ -173,7 +177,7 @@ async function load(force) {
   const q = force ? '?refresh=true' : '';
   // Refresh must clear the views that read a second endpoint too, or the
   // button refreshes some of the page and silently not the rest.
-  if (force) { DIAG = null; REG = null; }
+  if (force) { DIAG = null; REG = null; EV = null; PG = null; }
   try {
     CFG = await (await fetch('/api/config')).json();
     const gr = await fetch('/api/graph' + q);
@@ -181,6 +185,10 @@ async function load(force) {
     G = await gr.json();
     const sr = await fetch('/api/status' + q);
     if (sr.ok) S = await sr.json();
+    // Fetched here rather than lazily, because the overview may draw a paste
+    // guard widget and a widget that fetches on render would flash empty.
+    const pr = await fetch('/api/paste-guard' + q);
+    if (pr.ok) PG = await pr.json();
     loadError = '';
   } catch (e) {
     loadError = String(e.message || e);
@@ -219,8 +227,9 @@ const NAV = [
                            ['devices','Devices'],['personal','Personal accounts'],
                            ['mcp','MCP servers']]},
   {grp:'Coverage',  items:[['setup','Setup'],['coverage','Uncovered devices']]},
-  {grp:'Governance',items:[['register','AI register']]},
-  {grp:'Analytics', items:[['dashboard','Dashboard']]},
+  {grp:'Governance',items:[['register','AI register'],['paste','Paste guard'],
+                           ['iso','ISO 42001 evidence']]},
+  {grp:'Analytics', items:[['dashboard','Grafana']]},
   {grp:'System',    items:[['settings','Settings']]},
 ];
 
@@ -239,6 +248,12 @@ const esc = s => String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;
 const ents = o => Object.entries(o || {});
 const label = (k, d) => d.device_name || k;
 const match = s => !filter || String(s).toLowerCase().includes(filter);
+// Shared by any view rendering counts or dates. Declared here rather than
+// inside a view: they began as locals of register(), which made them invisible
+// to every other function, and the second view to use them rendered nothing at
+// all because the ReferenceError fired while building the HTML.
+const num = n => n ? String(n) : '<span class="z">0</span>';
+const when = t => t ? `<span class="nw">${esc(String(t).slice(0, 10))}</span>` : '—';
 
 const WIDGETS = {
 
@@ -302,6 +317,34 @@ const WIDGETS = {
     ${silent.length ? silent.slice(0,8).map(r=>
       `<div style="font-size:12px;margin:4px 0"><span class="pill p-mut">${esc(r.source)}</span></div>`
     ).join('') : '<p class="lede">Every listed source is reporting.</p>'}</div>`;
+  },
+
+  paste_guard: () => {
+    // Native rather than an embedded Grafana panel. This number is derived by
+    // the portal now, so embedding an iframe to show it meant a card in
+    // Grafana's typography sitting beside cards in the portal's, with a title
+    // we could not restyle because it renders cross-origin.
+    //
+    // Two numbers, not four. The overview is a glance: is the guard running,
+    // and did somebody ignore it. Warned and blocked are the detail behind
+    // that, and they have a page. Four stat cells also clipped in a
+    // third-width card on a narrower content area, which is the same lesson
+    // the register learned the long way.
+    if (!PG) return '<div class="wcard w4"><h3>Paste guard</h3>'
+      + '<p class="lede">No paste guard data.</p></div>';
+    const over = PG.overridden || 0, live = PG.guard_devices || 0;
+    const versions = (PG.guard_versions || []).length;
+    return `<div class="wcard w4"><h3>Paste guard</h3>
+      <dl class="stats" style="margin:0;grid-template-columns:repeat(2,1fr)">
+        <div><dt${live ? '' : ' style="color:var(--dstr)"'}>${live}</dt><dd>devices</dd></div>
+        <div><dt${over ? ' style="color:var(--dstr)"' : ''}>${over}</dt><dd>overridden</dd></div>
+      </dl>
+      <p class="src-note">${live
+        ? `Checked in from ${live} device${live === 1 ? '' : 's'}${
+             versions > 1 ? ` across ${versions} versions` : ''}, so a low
+           count of stopped pastes means what it says.`
+        : `No device checked in, so nothing here can be read as an estate that
+           pasted nothing.`}</p></div>`;
   },
 
   grafana: (w) => {
@@ -561,8 +604,6 @@ async function register() {
   const RISK = {high:'p-warn', medium:'p-acc', low:'p-mut'};
   const risk = t => t
     ? `<span class="pill ${RISK[t]||'p-mut'}">${esc(t)}</span>` : '—';
-  const num = n => n ? String(n) : '<span class="z">0</span>';
-  const when = t => t ? `<span class="nw">${esc(String(t).slice(0, 10))}</span>` : '—';
 
   // Effective status, with the stored decision alongside when they differ.
   // An approval past its review date reads as reviewing and says why: a green
@@ -728,6 +769,172 @@ async function register() {
   one.</p>`}`;
 }
 
+async function paste() {
+  if (!PG) {
+    try { PG = await (await fetch('/api/paste-guard')).json(); }
+    catch (e) { return `<h2>Paste guard</h2><div class="note">Could not read
+      paste guard activity: ${esc(String(e.message || e))}</div>`; }
+  }
+  const rows = (PG.rows || []).filter(r => match(r.tool));
+
+  return `<h2>Paste guard</h2>
+  <p class="lede">What the paste guard stopped, on which tool, and how often.
+  Metadata only: the guard inspects clipboard content on the device and reports
+  detector identifiers, so what was nearly pasted is not here and is not stored
+  anywhere. A warning heeded is the guard working; an override is somebody who
+  was shown the detector by name and pasted anyway, which is the row worth
+  following up.</p>
+
+  <dl class="stats">
+    <div><dt${(PG.guard_devices || 0) ? '' : ' style="color:var(--dstr)"'}>${PG.guard_devices || 0}</dt>
+      <dd>devices running the guard</dd></div>
+    <div><dt>${PG.warned || 0}</dt><dd>warned</dd></div>
+    <div><dt style="color:var(--dstr)">${PG.overridden || 0}</dt><dd>overridden</dd></div>
+    <div><dt>${PG.blocked || 0}</dt><dd>blocked</dd></div>
+    <div><dt>${PG.devices || 0}</dt><dd>devices with an event</dd></div>
+  </dl>
+
+  ${(PG.guard_versions || []).length ? `<p class="lede">Running
+    ${PG.guard_versions.map(v => `<span class="pill p-mut">${esc(v.version)} on ${v.devices}</span>`).join('')}
+    in ${PG.guard_modes.map(m => `<span class="pill ${m.mode === 'block' ? 'p-ok' : 'p-acc'}">${esc(m.mode)} on ${m.devices}</span>`).join('')}.
+    A fleet split across versions is a rollout that stalled, and a device in
+    warn mode where policy says block is a policy that is not in force. Neither
+    is visible in a count of what was stopped.</p>` : ''}
+
+  ${rows.length ? `<table>
+  <tr><th>tool</th><th class="n">warned</th><th class="n">overridden</th>
+  <th class="n">blocked</th><th class="n">devices</th><th>detectors</th>
+  <th>last seen</th></tr>
+  ${rows.map(r => `<tr>
+    <td>${esc(r.tool)}</td>
+    <td class="n">${num(r.warned)}</td>
+    <td class="n">${r.overridden
+      ? `<span class="pill p-warn">${r.overridden}</span>` : num(0)}</td>
+    <td class="n">${num(r.blocked)}</td>
+    <td class="n">${num(r.devices)}</td>
+    <td>${r.detectors.map(d => `<span class="pill p-mut">${esc(d)}</span>`).join('')}</td>
+    <td class="nowrap">${when(r.last_seen)}</td>
+  </tr>`).join('')}
+  </table>` : `<p class="lede">No paste events in this window. That is a real
+  answer, and it is also what an estate with the extension not deployed looks
+  like: check Setup before reading it as nobody having tried.</p>`}`;
+}
+
+async function iso() {
+  if (!EV) {
+    try { EV = await (await fetch('/api/evidence')).json(); }
+    catch (e) { return `<h2>ISO/IEC 42001 evidence</h2><div class="note">Could
+      not build the evidence index: ${esc(String(e.message || e))}</div>`; }
+  }
+  const e = EV;
+  const n = v => `<b>${v}</b>`;
+
+  // An index, not a report. Each row says what area of an AI management system
+  // this supports, what the platform can currently say about it, and where the
+  // underlying evidence lives. Deliberately not a card per theme: that would
+  // re-render every source view and turn this into a second Overview, when the
+  // value here is knowing where to look.
+  //
+  // No clause numbers. A mapping asserted without validation implies an
+  // authority this project does not have, and reproducing the standard's own
+  // wording is not ours to do.
+  const rows = [
+    ['Inventory and usage',
+     `${n(e.tools_observed)} tools in use, ${n(e.tools_watched_for)} watched for`
+     + (e.tools_not_in_registry
+        ? `, ${n(e.tools_not_in_registry)} not in the registry` : ''),
+     'register', 'AI register'],
+
+    ['Governance',
+     `${n(e.decisions_recorded)} decisions recorded, `
+     + `${n(e.tools_without_decision)} tools without one`
+     + (e.approvals_expired ? `, ${n(e.approvals_expired)} approval expired` : '')
+     + (e.active_exceptions ? `, ${n(e.active_exceptions)} active exception` : ''),
+     'register', 'AI register'],
+
+    ['Monitoring coverage',
+     `${n(e.sources_reporting)} of ${n(e.sources_known)} expected sources reporting`,
+     'setup', 'Setup'],
+
+    ['Account governance',
+     `${n(e.personal_accounts)} personal accounts across `
+     + `${n(e.personal_account_tools)} tools`,
+     'personal', 'Personal accounts'],
+
+    ['Data protection',
+     `${n(e.paste_events)} paste events, ${n(e.paste_overridden)} overridden. `
+     + `Inspected content is not retained`,
+     'paste', 'Paste guard'],
+
+    ['Integrations',
+     `${n(e.mcp_servers)} MCP servers observed`,
+     'mcp', 'MCP servers'],
+
+    ['Third parties',
+     `${n(e.providers)} providers observed across the tools in use`,
+     'register', 'AI register'],
+
+    ['Evidence',
+     `Snapshot for the window ${esc((e.window||{}).from||'').slice(0,10)} to `
+     + `${esc((e.window||{}).to||'').slice(0,10)}, checksummed`,
+     null, 'This page'],
+  ];
+
+  // Review inputs are the only separate block, because they are things
+  // somebody may need to act on rather than a category of evidence. Framed as
+  // inputs to a human review, not as conclusions: the platform can say a tool
+  // has no decision, and cannot say whether that matters.
+  const inputs = [
+    [e.approvals_expired, `${e.approvals_expired} approval${e.approvals_expired === 1 ? '' : 's'} expired`, 'register'],
+    [e.tools_without_decision, `${e.tools_without_decision} observed tool${e.tools_without_decision === 1 ? '' : 's'} with no governance decision`, 'register'],
+    [e.tools_not_in_registry, `${e.tools_not_in_registry} tool${e.tools_not_in_registry === 1 ? '' : 's'} in use and not in the registry`, 'register'],
+    [e.tools_without_owner, `${e.tools_without_owner} decision${e.tools_without_owner === 1 ? '' : 's'} with no owner`, 'register'],
+    [e.reviews_due_soon, `${e.reviews_due_soon} review${e.reviews_due_soon === 1 ? '' : 's'} due within ${e.reviews_due_soon_days} days`, 'register'],
+    [e.personal_accounts, `${e.personal_accounts} personal account${e.personal_accounts === 1 ? '' : 's'} observed`, 'personal'],
+    [Math.max(0, (e.sources_known||0) - (e.sources_reporting||0)),
+     `${Math.max(0, (e.sources_known||0) - (e.sources_reporting||0))} expected source${(e.sources_known - e.sources_reporting) === 1 ? '' : 's'} not reporting`, 'setup'],
+    [e.paste_overridden, `${e.paste_overridden} paste warning${e.paste_overridden === 1 ? '' : 's'} overridden`, 'paste'],
+    [e.mcp_findings, `${e.mcp_findings} MCP finding${e.mcp_findings === 1 ? '' : 's'}`, 'mcp'],
+  ].filter(([count]) => count > 0);
+
+  return `<h2>ISO/IEC 42001 evidence</h2>
+  <p class="lede">Evidence Shadow AI Guard can provide to support an AI
+  management system. An index of what the platform can currently say and where
+  each record lives, not an assessment: nothing here is a compliance score, a
+  clause mapping, or a claim that a control is satisfied. The gaps are shown
+  beside the totals because a gap is the more useful finding.</p>
+
+  <table>
+  <tr><th>Theme</th><th>What Shadow AI Guard can say</th><th>Evidence source</th></tr>
+  ${rows.map(([theme, says, target, label]) => `<tr>
+    <td>${esc(theme)}</td>
+    <td style="font-family:inherit">${says}</td>
+    <td>${target ? `<a href="#${target}" style="color:var(--pri)">${esc(label)}</a>`
+                 : esc(label)}</td>
+  </tr>`).join('')}
+  </table>
+
+  <h3 style="margin-top:26px;font-size:14px">Review inputs</h3>
+  <p class="lede">Things a person may need to look at. These are inputs to a
+  review rather than conclusions: the platform can say a tool has no recorded
+  decision, and cannot say whether that is a problem.</p>
+  ${inputs.length ? `<ul class="inputs">
+    ${inputs.map(([, text, target]) =>
+      `<li><a href="#${target}">${esc(text)}</a></li>`).join('')}
+  </ul>` : `<p class="lede">Nothing outstanding in this window. That is a real
+  answer for a small estate, and it is also what an estate with no collectors
+  reporting looks like: ${e.sources_reporting} of ${e.sources_known} expected
+  sources are reporting.</p>`}
+
+  <h3 style="margin-top:26px;font-size:14px">Evidence snapshot</h3>
+  <p class="lede">A checksummed statement of the counts above, for the stated
+  window, with the registry and governance files identified by hash. Generated
+  on demand and not stored. Not reproducible, because log retention may mean
+  the same window returns less later; tamper-evident, because the manifest
+  carries a digest of itself with that field omitted.
+  <a href="/api/evidence?download=true" style="color:var(--pri)">Download JSON</a></p>`;
+}
+
 async function settings() {
   if (!DIAG) {
     try { DIAG = await (await fetch('/api/diagnostics')).json(); }
@@ -871,8 +1078,17 @@ function setup() {
     `<tr><td>${esc(u)}</td></tr>`).join('')}</table>` : ''}`;
 }
 
+// A way out to the real Grafana. The embedded frames are kiosk mode with a
+// fixed window, which is right for a glance and wrong the moment somebody
+// wants to change the range or drill into a series. The URL has to be
+// configured for the embed to work at all, so linking to it costs nothing.
+const openIn = base => `<p class="lede">Embedded below in kiosk mode with a
+  fixed window. To change the range, drill in, or edit anything, open
+  <a href="${esc(base)}" target="_blank" rel="noopener noreferrer"
+     style="color:var(--pri)">${esc(base)}</a> directly.</p>`;
+
 function dashboard() {
-  if (!CFG.grafana_url) return `<h2>Dashboard</h2>
+  if (!CFG.grafana_url) return `<h2>Grafana</h2>
     <div class="note">No Grafana configured. Set <code>GRAFANA_URL</code> to a
     Grafana that permits embedding, then either <code>GRAFANA_PANELS</code> as
     <code>dashboardUid:panelId:Title</code> entries separated by commas, or
@@ -892,7 +1108,8 @@ function dashboard() {
   const q = 'orgId=1&theme=dark&from=now-7d&to=now&kiosk';
 
   if (!panels.length && CFG.grafana_dashboard_uid) {
-    return `<h2>Dashboard</h2>
+    return `<h2>Grafana</h2>
+      ${openIn(base)}
       <p class="lede">Embedded from ${esc(base)}. Set
       <code>GRAFANA_PANELS</code> to pick individual panels instead of the
       whole dashboard.</p>
@@ -906,7 +1123,8 @@ function dashboard() {
     Set <code>GRAFANA_PANELS</code> or <code>GRAFANA_DASHBOARD_UID</code>.</div>`;
 
   const bad = panels.filter(p => p.error);
-  return `<h2>Dashboard</h2>
+  return `<h2>Grafana</h2>
+  ${openIn(base)}
   <p class="lede">Panels embedded from ${esc(base)}. If a frame stays blank,
   Grafana is refusing to be framed rather than the panel being wrong — check
   <code>allow_embedding</code> and the cookie <code>SameSite</code> setting.</p>
@@ -951,6 +1169,8 @@ async function render() {
   // settings and register each read a second endpoint, so they are async.
   if (view === 'settings') { app.innerHTML = await settings(); return; }
   if (view === 'register') { app.innerHTML = await register(); return; }
+  if (view === 'paste') { app.innerHTML = await paste(); return; }
+  if (view === 'iso') { app.innerHTML = await iso(); return; }
   app.innerHTML = ({setup, overview, devices, people, tools, coverage,
                     dashboard, personal, mcp})[view]();
 }

--- a/portal/tests/test_evidence.py
+++ b/portal/tests/test_evidence.py
@@ -347,3 +347,12 @@ def test_the_download_carries_provenance_in_the_filename():
     disposition = resp.headers["content-disposition"]
     assert "ai-guard-evidence-" in disposition
     assert "-168h.json" in disposition
+
+
+def test_the_snapshot_says_how_many_devices_ran_the_guard():
+    """paste_events: 0 with no denominator is the same failure as reporting
+    sources without knowing how many were expected."""
+    doc = _snap([_row()], paste={"events": 0, "guard_devices": 12})
+
+    assert doc["paste_events"] == 0
+    assert doc["paste_guard_devices"] == 12

--- a/portal/tests/test_paste_guard.py
+++ b/portal/tests/test_paste_guard.py
@@ -272,3 +272,85 @@ def test_the_endpoint_returns_metadata_and_excludes_heartbeats():
     # Both findings resolve to one tool through the domain map.
     assert [r["tool"] for r in body["rows"]] == ["chatgpt"]
     assert body["devices"] == 2
+
+
+# ─────────────────────────────────────────────
+# The heartbeat as its own signal
+# ─────────────────────────────────────────────
+
+def test_devices_running_the_guard_are_counted_from_heartbeats():
+    """Zero events means nothing on its own.
+
+    An estate where nobody pasted a secret and an estate where the extension
+    was never deployed produce the same event count. The heartbeat is the only
+    thing that separates them, and the extension writes lastHeartbeat only on
+    confirmed delivery, so a device here has a working chain end to end rather
+    than merely the extension installed.
+    """
+    out = paste_guard_from([_heartbeat("D1"), _heartbeat("D2")])
+
+    assert out["events"] == 0
+    assert out["guard_devices"] == 2
+
+
+def test_heartbeats_still_do_not_count_as_events():
+    """Both facts at once: counted as devices, never as detections."""
+    out = paste_guard_from([_heartbeat("D1"), _heartbeat("D2"), _f(device="D1")])
+
+    assert out["events"] == 1
+    assert out["devices"] == 1
+    assert out["guard_devices"] == 2
+
+
+def test_versions_are_reported_per_device():
+    """A fleet split across versions is a rollout that stalled, which is worth
+    seeing before somebody wonders why a fix did not take."""
+    out = paste_guard_from([
+        _heartbeat("D1", "1.3.0"), _heartbeat("D2", "1.3.0"),
+        _heartbeat("D3", "1.2.1"),
+    ])
+
+    assert out["guard_versions"] == [
+        {"version": "1.3.0", "devices": 2},
+        {"version": "1.2.1", "devices": 1},
+    ]
+
+
+def test_modes_are_reported_per_device():
+    """A device in warn mode where policy says block is a policy not in
+    force, and it is invisible in any count of what was stopped."""
+    out = paste_guard_from([
+        _f(tool="paste-guard", severity="info", device="D1",
+           evidence="heartbeat version=1.3.0 mode=block reason=alarm"),
+        _f(tool="paste-guard", severity="info", device="D2",
+           evidence="heartbeat version=1.3.0 mode=warn reason=alarm"),
+    ])
+
+    assert out["guard_modes"] == [
+        {"mode": "block", "devices": 1},
+        {"mode": "warn", "devices": 1},
+    ]
+
+
+def test_a_device_reporting_several_heartbeats_is_counted_once():
+    """They fire on a schedule, so a window contains many per device."""
+    out = paste_guard_from([_heartbeat("D1") for _ in range(20)])
+
+    assert out["guard_devices"] == 1
+
+
+def test_a_malformed_heartbeat_still_counts_the_device():
+    """The device checked in, which is the fact that matters. An unparseable
+    version is a reason to report fewer details, not to lose the device."""
+    out = paste_guard_from([_f(tool="paste-guard", severity="info", device="D1",
+                               evidence="heartbeat")])
+
+    assert out["guard_devices"] == 1
+    assert out["guard_versions"] == []
+
+
+def test_no_heartbeats_reports_zero_devices_not_absence():
+    out = paste_guard_from([_f()])
+
+    assert out["guard_devices"] == 0
+    assert out["guard_versions"] == []

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -485,3 +485,36 @@ def test_mcp_finding_with_no_server_list_is_still_counted():
     ])["mcp_servers"]
     assert len(rows) == 1
     assert rows[0]["server"] == "(unnamed)"
+
+
+def test_the_widget_lists_in_python_and_javascript_agree():
+    """KNOWN_WIDGETS and the browser's WIDGETS object must name the same set.
+
+    They are two lists that have to agree with nothing enforcing it, and the
+    failure is asymmetric and confusing in both directions. A widget in the
+    browser but not in KNOWN_WIDGETS renders an error card telling the operator
+    their config is wrong when it is not. One in KNOWN_WIDGETS but not in the
+    browser passes validation and then draws nothing, which looks like a data
+    problem rather than a missing renderer.
+
+    This happened: paste_guard was added to the browser and not to the server,
+    and the error card blamed the deployment for naming a widget that existed.
+    """
+    import re
+    from pathlib import Path
+
+    from app.main import KNOWN_WIDGETS
+
+    src = (Path(__file__).parent.parent / "app" / "static" / "index.html").read_text()
+    block = re.search(r"const WIDGETS = \{(.*?)\n\};", src, re.S).group(1)
+    # Top-level keys only: two-space indent, then a name and a colon.
+    in_browser = set(re.findall(r"^  ([a-z_]+): ", block, re.M))
+
+    # grafana and error are dispatch targets rather than things an operator
+    # names in OVERVIEW_WIDGETS, so they are not expected in KNOWN_WIDGETS.
+    in_browser -= {"grafana", "error"}
+
+    assert in_browser == set(KNOWN_WIDGETS), (
+        "only in the browser: %s | only in KNOWN_WIDGETS: %s"
+        % (sorted(in_browser - set(KNOWN_WIDGETS)),
+           sorted(set(KNOWN_WIDGETS) - in_browser)))


### PR DESCRIPTION
Two pages and a widget over the derivations added earlier in 0.9.0.

## ISO 42001 evidence

An index rather than a report. Each row says what area of an AI management system it supports, what the platform can currently say about it, and where the underlying record lives, with the evidence source as a link.

Deliberately not a card per theme. That would re-render every source view and turn this into a second Overview, when the value here is knowing where to look rather than seeing the same numbers twice.

No clause numbers and no score. A mapping asserted without validation implies an authority this project does not have, and reproducing the standard's own wording is not ours to do. The page says what it is: evidence Shadow AI Guard can provide to support an AI management system.

Gaps sit beside totals throughout, because a gap is the more useful finding. The demo estate reads "4 decisions recorded, 4 tools without one" and "6 of 18 expected sources reporting", which is the honest shape of both numbers.

Review inputs is the only separate block, because it is things somebody may need to act on rather than a category of evidence. Framed as inputs to a human review: the platform can say a tool has no recorded decision, and cannot say whether that matters. Zero-count entries are omitted rather than shown as ticks.

## Paste guard

The view implied by paste_guard_from and never built. The ISO page links to it, so the alternative was a dead link.

Per tool: warned, overridden, blocked, devices, which detectors fired, last seen. Overrides sort first, because somebody shown the detector by name who pasted anyway is the row to follow up and sorting by event count would bury one override under twenty warnings that worked.

## The heartbeat, as its own signal

paste_guard_from excluded heartbeats from the event counts, correctly, and threw the rest away. That left "0 pastes stopped" meaning both an estate where nobody pasted a secret and one where the extension was never deployed, which are the same number.

It now reports guard_devices, guard_versions and guard_modes. The version and mode came free in the same string and both say something a stopped-paste count cannot: more than one version is a rollout that stalled, and a device in warn mode where policy says block is a policy not in force. The evidence manifest carries paste_guard_devices for the same reason sources_known sits beside sources_reporting.

## Overview widget

Native, not an embedded Grafana panel. The portal derives these counts now, so embedding an iframe meant a card in Grafana's typography beside cards in the portal's, with a title that could not be restyled because it renders cross-origin. Noted in the README so nobody tries.

Two numbers, devices and overridden: is the guard running, and did somebody ignore it. Warned and blocked are the detail behind those and have a page. Four cells also clipped in a third-width card at a real content width, which is the same lesson the register learned the long way. The version split appears in the caption only when there is more than one, because a single version is not worth saying.

## Also

KNOWN_WIDGETS and the browser's WIDGETS object are now asserted to match. They are two lists that must agree with nothing enforcing it, and paste_guard was added to one and not the other: the error card then told the operator their configuration named a widget that did not exist, when it did. The failure is confusing in both directions, so the test covers both.

The dashboard view is renamed Grafana, and every branch of it now leads with a link to the real thing. The embeds are kiosk mode with a fixed window, which is right for a glance and wrong the moment somebody wants a different range, and the URL has to be configured for the embed to work at all.

Tests: 137 to 191.