### PR TITLE
docs: evidence, exceptions, and the ISO 42001 index

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ lives under `docs/` and the component folders.
 | Understand the architecture | [Architecture](docs/architecture.md) |
 | Configure the receiver | [Receiver](receiver/README.md) |
 | Configure the portal | [Portal](portal/README.md) |
+| Record approvals, owners and review dates | [Governance decisions](docs/governance.md) |
+| Produce evidence for an AI management system | [Evidence](docs/evidence.md) |
 | Deploy macOS collection | [macOS collector](endpoint/macos/README.md) |
 | Deploy Windows collection | [Windows collector](endpoint/windows/README.md) |
 | Deploy Linux collection | [Linux collector](endpoint/linux/README.md) |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -253,6 +253,16 @@ rule the platform applies to a source that has stopped reporting, turned on the
 decision instead: an approval nobody has revisited is not evidence a tool is
 safe, it is evidence that nobody looked.
 
+Evidence is that same idea pointed outwards. A snapshot states what was observed
+for a stated window, identifies the registry and governance files by hash rather
+than by version, and carries a digest of itself with that field omitted so it
+can be checked against itself later. It is tamper-evident rather than
+reproducible: log retention means the same window may return less next year, and
+claiming otherwise would be the more useful statement and the false one. Every
+count that could flatter has its denominator beside it, because a snapshot
+reporting sources_reporting without sources_known would let a half-blind estate
+look complete on paper. See [evidence.md](evidence.md).
+
 Its entry points differ because the sources do. Endpoint findings carry a
 device and a local username, and the username is a hint rather than a key: it
 is firstname.lastname on one enrolment, a local account on another, whatever

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -125,6 +125,64 @@ organisation believes it has decided something it has not.
 Treat tool ids as stable keys for this reason. Display names and metadata can
 change; an id is what a decision is attached to.
 
+## Exceptions
+
+A temporary departure from the general decision, for a stated scope and period.
+
+```yaml
+exceptions:
+  EX-001:
+    tool: chatgpt
+    scope:
+      team: Marketing
+    reason: Client campaign work, no personal data
+    owner: Security
+    expires: 2026-12-01
+```
+
+Keyed on its own id, not on the tool. A tool can have more than one, for
+different teams or different reasons, and keying on the tool would allow exactly
+one and would discard the previous the moment a second was written. An exception
+is also a record with its own life: raised, applying, expired, and still visible
+afterwards.
+
+### It sits beside the decision, not in place of it
+
+The register shows both. `ollama` reads as **not approved** with the Research
+exception underneath, because the general position has not been withdrawn.
+Showing the exception as the status would make a note about one team read as a
+decision about everybody.
+
+### expires is required
+
+Unlike `review_due` on a decision, which is required only on an approval. A
+departure from the general position with no end is not an exception, it is an
+undocumented change of policy.
+
+When it expires it simply stops applying. The underlying status is already what
+it was, so **nothing becomes `reviewing`**: that is the expired-approval rule,
+and applying it here would put a tool under review because a campaign finished.
+
+Expired exceptions stay visible, quieter. One that has run its course is a
+record of something an organisation decided and then let lapse, which is worth
+seeing rather than losing.
+
+### scope
+
+Free-form keys such as `team` or `project`. The portal displays it and does not
+resolve it against anything: enforcing scope would need identity the platform
+does not have. It is a note for the reader about who the exception covers.
+
+### Fields
+
+| field | required | notes |
+|---|---|---|
+| `tool` | yes | An id the registry does not know validates and is reported, same as a decision |
+| `expires` | yes | `YYYY-MM-DD` |
+| `scope` | no | Free-form keys, displayed not enforced |
+| `reason` | no | Free text |
+| `owner` | no | A team or a person |
+
 ## Validating
 
 ```bash

--- a/portal/README.md
+++ b/portal/README.md
@@ -163,9 +163,11 @@ effect within `CACHE_TTL_SECONDS` (default 30) without a restart.
 | Personal accounts | every personal account seen, with first and last seen |
 | MCP servers | which MCP servers are configured, on which machines, by which tool |
 | AI register | the tools actually in use, joined to what has been decided about each |
+| Paste guard | what the guard stopped, on which tool, and how often |
+| ISO 42001 evidence | an index of what the platform can say and where each record lives |
 | Setup | which detection sources are reporting and which are silent |
 | Uncovered devices | machines a scanner knows about that no collector reports from |
-| Dashboard | Grafana, embedded |
+| Grafana | Grafana, embedded, with a link to the real thing |
 | Settings | what the portal can say about itself, for a support conversation |
 
 ## AI register
@@ -192,6 +194,35 @@ ticking over is not a decision.
 `GET /api/register?fmt=csv` exports the same rows the page shows, with the
 timestamp and lookback window in the filename. It is a convenience export
 rather than an evidence artifact: no manifest, no checksum.
+
+## Paste guard
+
+What the guard stopped, on which tool, and how often. Metadata only: it inspects
+clipboard content on the device and reports detector identifiers, so what was
+nearly pasted is not here and is not stored anywhere.
+
+Overrides sort first. Somebody shown the detector by name who pasted anyway is
+the row to follow up, and sorting by event count would bury one override under
+twenty warnings that worked.
+
+The page also reports how many devices the guard checked in from, and which
+versions and modes they are running. Without that, "0 pastes stopped" means both
+an estate where nobody pasted a secret and one where the extension was never
+deployed. More than one version is a rollout that stalled; a device in warn mode
+where policy says block is a policy not in force.
+
+Heartbeats are excluded from the event counts. They share the same source, and
+counting them would report every device's daily check-in as a paste somebody
+tried to make.
+
+## ISO 42001 evidence
+
+An index of what the platform can currently say and where each record lives, with
+review inputs below it. No compliance score, no clause numbers, no assessment.
+See [docs/evidence.md](../docs/evidence.md).
+
+The evidence snapshot is generated from the same derivations these pages use, so
+a snapshot and the page it summarises cannot disagree.
 
 ## Overview widgets
 


### PR DESCRIPTION
docs/evidence.md is new: what the snapshot contains, why the window is timestamps rather than 168h, how to verify one by hand, and why it is tamper-evident rather than reproducible. Also the ISO index and the paste guard view, including why the heartbeat is counted separately from the events.

docs/governance.md gains exceptions, which shipped in this release with no documentation at all: keyed on their own id rather than the tool, sitting beside the decision rather than replacing it, mandatory expiry, and why an expired exception does not make a tool reviewing.

governance.md was also missing from the root README's index, so it has been undiscoverable from the front page since 0.8.0. Both it and evidence.md are listed now.