### PR TITLE
device prefixes: several, and serials shorter than eight

### DIFF
--- a/governance/schema.json
+++ b/governance/schema.json
@@ -32,8 +32,11 @@
             "description": "The decision as recorded. Deliberately three: Restricted, Deprecated and Exception approved are all defensible and none is needed to find out whether this model is useful. Records a governance position and has no effect on finding severity, which depends on the account domain."
           },
           "owner": {
-            "type": "string",
-            "description": "Who owns the decision. A team or a person; the portal does not resolve it against anything."
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Who owns the decision. A team or a person; the portal does not resolve it against anything. null is accepted as well as a string, because `owner:` with nothing after it is null in YAML rather than an empty string, and a key left blank in a template is the commonest way this file gets written. Both mean unset."
           },
           "review_due": {
             "type": "string",
@@ -41,8 +44,11 @@
             "description": "When this decision should be revisited, as YYYY-MM-DD. An approval past this date reports as reviewing, with the reason attached. The stored decision is never rewritten: a clock ticking over is not a decision, and the history has to keep saying what a human decided on a date. Write it unquoted if you like; YAML parses a bare 2026-11-01 as a date object and the validator normalises it back to a string before checking, so both forms work and neither is a trap."
           },
           "reason": {
-            "type": "string",
-            "description": "Why. Free text, shown alongside the decision."
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Why. Free text, shown alongside the decision. null is accepted as well as a string, because `owner:` with nothing after it is null in YAML rather than an empty string, and a key left blank in a template is the commonest way this file gets written. Both mean unset."
           }
         },
         "allOf": [

--- a/scanner/receiver_reporter.py
+++ b/scanner/receiver_reporter.py
@@ -71,12 +71,31 @@ SOURCE_MAP: dict[DetectionSource, tuple[str, str]] = {
 
 # Some fleets name devices <PREFIX>-<serial> while the endpoint collectors
 # report the bare serial, which would make one machine count twice. Set
-# AIGUARD_DEVICE_PREFIX (e.g. "ACME") to strip that prefix here. Unset means
-# no normalisation.
-_DEVICE_PREFIX = os.environ.get("AIGUARD_DEVICE_PREFIX", "")
+# AIGUARD_DEVICE_PREFIX to strip that prefix here. Unset means no
+# normalisation.
+#
+# Comma separated, because a fleet can have more than one: Windows and macOS
+# are often enrolled by different tools under different conventions, and a
+# single prefix silently normalises half an estate. AIGUARD_DEVICE_PREFIX=
+# "ACME,ACM" handles both.
+#
+# The serial must be at least six characters and must contain a digit. Length
+# alone was the original rule at eight, and it was wrong twice over: Dell
+# service tags are seven, so most of a Windows fleet went unnormalised, and a
+# hostname like <PREFIX>-SERVER would have been stripped to SERVER on the way
+# down. A serial essentially always contains a digit and a word essentially
+# never does, which separates them better than counting characters.
+_DEVICE_PREFIXES = [
+    p.strip() for p in os.environ.get("AIGUARD_DEVICE_PREFIX", "").split(",")
+    if p.strip()
+]
 _PREFIX_HOSTNAME = (
-    re.compile(rf"^{re.escape(_DEVICE_PREFIX)}[-_]([A-Z0-9]{{8,}})$", re.IGNORECASE)
-    if _DEVICE_PREFIX
+    re.compile(
+        r"^(?:%s)[-_](?=[A-Z0-9]*\d)([A-Z0-9]{6,})$"
+        % "|".join(re.escape(p) for p in _DEVICE_PREFIXES),
+        re.IGNORECASE,
+    )
+    if _DEVICE_PREFIXES
     else None
 )
 

--- a/scanner/tests/test_normalise_device.py
+++ b/scanner/tests/test_normalise_device.py
@@ -96,3 +96,90 @@ class TestWithPrefix:
         normalise_device = _fresh_import()
         result = normalise_device(None)
         assert result == ("", "")
+
+
+class TestPrefixLengthAndDigits:
+    """The rule that decides whether something is a serial or a hostname.
+
+    It was originally eight characters or more, and that was wrong in both
+    directions. Dell service tags are seven, so most of a Windows fleet went
+    unnormalised and every one of those machines counted twice: once as
+    ACME-XYZ4A21 from the scanner and once as XYZ4A21 from the collector. And
+    length alone would happily strip ACME-SERVER down to SERVER, turning a
+    domain controller's hostname into something that looks like a serial.
+
+    Six or more characters, and at least one digit. A serial essentially
+    always contains a digit; a word essentially never does.
+    """
+
+    def test_a_seven_character_service_tag_is_stripped(self, monkeypatch):
+        """The regression. Dell service tags are seven characters, and the
+        eight-character minimum silently skipped all of them."""
+        monkeypatch.setenv("AIGUARD_DEVICE_PREFIX", "ACME")
+        normalise_device = _fresh_import()
+
+        assert normalise_device("ACME-XYZ4A21") == ("XYZ4A21", "ACME-XYZ4A21")
+
+    def test_a_serial_starting_with_a_digit_is_stripped(self, monkeypatch):
+        monkeypatch.setenv("AIGUARD_DEVICE_PREFIX", "ACME")
+        normalise_device = _fresh_import()
+
+        assert normalise_device("ACME-1ABC234") == ("1ABC234", "ACME-1ABC234")
+
+    def test_a_word_is_not_a_serial(self, monkeypatch):
+        """ACME-SERVER stripped to SERVER would put a hostname in the field
+        every other source fills with a hardware serial, and two machines
+        called SERVER on different fleets would merge into one."""
+        monkeypatch.setenv("AIGUARD_DEVICE_PREFIX", "ACME")
+        normalise_device = _fresh_import()
+
+        assert normalise_device("ACME-SERVER") == ("ACME-SERVER", "ACME-SERVER")
+
+    def test_a_short_asset_number_is_not_a_serial(self, monkeypatch):
+        monkeypatch.setenv("AIGUARD_DEVICE_PREFIX", "ACME")
+        normalise_device = _fresh_import()
+
+        assert normalise_device("ACME-DC01") == ("ACME-DC01", "ACME-DC01")
+
+    def test_the_prefix_without_a_separator_is_left_alone(self, monkeypatch):
+        """ACME015 is a machine named after the fleet, not a prefixed serial."""
+        monkeypatch.setenv("AIGUARD_DEVICE_PREFIX", "ACME")
+        normalise_device = _fresh_import()
+
+        assert normalise_device("ACME015") == ("ACME015", "ACME015")
+
+
+class TestSeveralPrefixes:
+    """A fleet can have more than one convention.
+
+    Windows and macOS are often enrolled by different tools, and a single
+    prefix normalises half an estate while leaving the other half duplicated,
+    which reads as a partial fix and is harder to spot than no fix at all.
+    """
+
+    def test_either_prefix_is_stripped(self, monkeypatch):
+        monkeypatch.setenv("AIGUARD_DEVICE_PREFIX", "ACME,ACM")
+        normalise_device = _fresh_import()
+
+        assert normalise_device("ACME-XYZ4A21") == ("XYZ4A21", "ACME-XYZ4A21")
+        assert normalise_device("ACM-YJXCWNR42G") == ("YJXCWNR42G", "ACM-YJXCWNR42G")
+
+    def test_whitespace_around_a_prefix_is_ignored(self, monkeypatch):
+        monkeypatch.setenv("AIGUARD_DEVICE_PREFIX", "ACME, ACM ")
+        normalise_device = _fresh_import()
+
+        assert normalise_device("ACM-YJXCWNR42G") == ("YJXCWNR42G", "ACM-YJXCWNR42G")
+
+    def test_an_unlisted_prefix_is_left_alone(self, monkeypatch):
+        monkeypatch.setenv("AIGUARD_DEVICE_PREFIX", "ACME")
+        normalise_device = _fresh_import()
+
+        assert normalise_device("OTHER-XYZ4A21") == ("OTHER-XYZ4A21", "OTHER-XYZ4A21")
+
+    def test_an_empty_entry_does_not_match_everything(self, monkeypatch):
+        """"ACME," has a trailing empty element. An empty alternation branch
+        would match any string and strip every hostname in the estate."""
+        monkeypatch.setenv("AIGUARD_DEVICE_PREFIX", "ACME,")
+        normalise_device = _fresh_import()
+
+        assert normalise_device("random-host-99") == ("random-host-99", "random-host-99")


### PR DESCRIPTION
Two fixes found by running this against a real fleet.

## The prefix rule

AIGUARD_DEVICE_PREFIX took one prefix and required eight or more characters after it. Both were wrong on an estate of any size.

One prefix normalises half a fleet. Windows and macOS are usually enrolled by different tools under different conventions, so a single value leaves the other platform duplicated, and a partial fix is harder to notice than no fix: the device count drops, looks better, and is still wrong. It now takes a comma separated list.

Eight characters excluded Dell service tags, which are seven. On the fleet this was found on, that meant most of the Windows estate stayed duplicated even once the prefix was right: the scanner reported PREFIX-XYZ4A21 and the collector reported XYZ4A21, and the portal counted them as two machines. Roughly a third of the uncovered-devices list was one machine listed twice.

Lowering the minimum alone would have introduced the opposite error. PREFIX- SERVER is a hostname, and stripping it to SERVER puts a word in the field every other source fills with a hardware serial, where two machines called SERVER on different fleets would then merge into one. The rule is now six or more characters AND at least one digit: a serial essentially always contains a digit, and a word essentially never does, which separates them better than counting characters.

Verified against a real device list. PREFIX-XYZ4A21, PREFIX-Q3PPK58 and PREFIX-1ABC234 merge with their bare forms; PREFIX-DC01, PREFIX-SERVER, PREFIX015, DESKTOP-A1B2C3D and firstname-Latitude-5540 are left alone.

This only affects findings emitted from now on. Existing data keeps both forms until it ages out of the lookback window.

Tests: 9 to 18. Three of the new ones fail against the old rule.

## The governance schema

owner and reason now accept null as well as a string.

`owner:` with nothing after it is null in YAML, not an empty string, and a key left blank is the commonest way this file gets written: the obvious way to produce one is to generate a skeleton from the registry and fill in the parts that matter. Doing exactly that produced thirty schema errors on a file that was structurally fine.

The loader already coerced with `or ""`, so this was never a runtime problem. The schema was stricter than the code, which is the worse direction: it rejected a file the portal would have read correctly.