### PR TITLE
portal: basic auth for Loki reads, and unblock the compose route

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -39,9 +39,15 @@ LOKI_URL=
 # the path INSIDE the container. You will need to mount it yourself.
 LOKI_TOKEN_FILE=
 
-# Basic auth for the receiver's writes. Grafana Cloud and most hosted Loki
-# need these; a self-hosted one usually does not. Leave both empty to send no
-# credentials, which is not the same as sending empty ones.
+# Basic auth, used by BOTH containers: the receiver to write and the portal to
+# read. Grafana Cloud and most hosted Loki need these; a self-hosted one
+# usually does not. Leave both empty to send no credentials, which is not the
+# same as sending empty ones.
+#
+# On Grafana Cloud the username is a numeric instance id, not an email. Find
+# it and the push URL under your stack's Loki details on grafana.com, and give
+# the access policy BOTH logs:write and logs:read: a read-only token pushes a
+# 401 that the receiver counts and returns 200 to the collector anyway.
 #
 # The password supports the _FILE convention: set LOKI_PASSWORD_FILE to a path
 # instead and mount it, rather than putting the value here.
@@ -115,7 +121,8 @@ DISPLAY_TZ=UTC
 # ----------------------------------------------- only with --profile with-logs
 
 # Ignore these unless you have no log store and are using the bundled Loki and
-# Grafana. If you already run either, do not start the profile.
+# Grafana. If you already run either, do not start the profile, and leave
+# these empty: they are read only by services the profile activates.
 GRAFANA_ADMIN_PASSWORD=
 
 # Grafana refuses to be framed by default, deliberately. Set all three to embed

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -86,6 +86,12 @@ services:
     environment:
       LOKI_URL: ${LOKI_URL:?set LOKI_URL in .env - the portal reads findings from your log store}
       LOKI_TOKEN_FILE: ${LOKI_TOKEN_FILE:-}
+      # The same credentials the receiver writes with. Grafana Cloud wants
+      # basic auth in both directions, and the portal having only a bearer
+      # token meant the receiver stored findings the portal then got a 401
+      # reading back.
+      LOKI_USERNAME: ${LOKI_USERNAME:-}
+      LOKI_PASSWORD: ${LOKI_PASSWORD:-}
       PORTAL_USER: ${PORTAL_USER:-admin}
       PORTAL_PASSWORD_FILE: /run/secrets/portal_password
       REGISTRY_PATH: /etc/ai-guard/registry.json
@@ -147,7 +153,15 @@ services:
     image: grafana/grafana:11.1.0
     restart: unless-stopped
     environment:
-      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?set GRAFANA_ADMIN_PASSWORD in .env}
+      # No :? here, deliberately. Compose interpolates the whole file before
+      # it decides which profiles are active, so a required variable on a
+      # service behind with-logs blocked `docker compose up` for anyone NOT
+      # running the bundled Grafana: the production route could not start
+      # without setting a password for a container it was never going to run.
+      #
+      # Grafana refuses to start with an empty admin password, so an unset
+      # value still fails, and it fails in the one place it means something.
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-}
       GF_USERS_DEFAULT_THEME: "dark"
       # Off by default in Grafana, deliberately: framing a session someone is
       # logged into is how clickjacking works. Both are needed for the portal's

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -67,8 +67,26 @@ COLLECTOR_SOURCES = {"collector-macos", "collector-linux", "collector-windows"}
 COLLECTOR_SURFACES = {"cli", "ide", "mcp", "endpoint"}
 
 
-def fetch_from_loki(base, hours, token=None, limit=5000):
-    """Pull findings from Loki. Returns a list of parsed finding dicts."""
+def fetch_from_loki(base, hours, token=None, limit=5000, username=None,
+                    password=None):
+    """Pull findings from Loki. Returns a list of parsed finding dicts.
+
+    Two authentication shapes, because log stores disagree about which they
+    want. A bearer token covers self-hosted Loki behind a gateway; basic auth
+    is what Grafana Cloud and most hosted offerings use, where the username is
+    a numeric instance id.
+
+    Basic auth was missing here while the receiver already had it, and the
+    asymmetry was invisible until both ran against the same hosted Loki: the
+    receiver wrote successfully and the portal got a 401 reading back the
+    findings it had just stored. A deployment where writes work and reads do
+    not is not a working deployment, and nothing in the config named the gap.
+
+    Both may be set. They are not alternatives to each other in any protocol
+    sense, and a gateway that wants a bearer token in front of a Loki that
+    wants basic auth is a real arrangement.
+    """
+    import base64
     import time
 
     end = int(time.time() * 1e9)
@@ -81,7 +99,15 @@ def fetch_from_loki(base, hours, token=None, limit=5000):
         "direction": "backward",
     })
     req = urllib.request.Request(base.rstrip("/") + "/loki/api/v1/query_range?" + params)
-    if token:
+    if username:
+        # Built by hand rather than with HTTPBasicAuthHandler, which only
+        # sends credentials after a 401 and a realm it recognises. Grafana
+        # Cloud answers 401 without a realm the handler will act on, so the
+        # retry never carries the header and the request fails a second time.
+        creds = base64.b64encode(
+            ("%s:%s" % (username, password or "")).encode()).decode()
+        req.add_header("Authorization", "Basic " + creds)
+    elif token:
         req.add_header("Authorization", "Bearer " + token)
 
     with urllib.request.urlopen(req, timeout=30) as resp:

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -22,7 +22,7 @@ Configuration, all optional except LOKI_URL and the auth pair:
   PORTAL_USER       basic auth username
   PORTAL_PASSWORD   basic auth password
 
-Any of PORTAL_USER, PORTAL_PASSWORD and LOKI_TOKEN can be given as
+Any of PORTAL_USER, PORTAL_PASSWORD, LOKI_TOKEN and LOKI_PASSWORD can be given as
 NAME_FILE pointing at a file instead. Compose has no real secret story: an
 environment variable is visible in docker inspect and in every child process's
 environment, while a file is at least confined to the filesystem. It is not
@@ -33,6 +33,8 @@ encryption.
                     be something nobody noticed
   LOKI_URL          Loki base URL, e.g. http://loki:3100
   LOKI_TOKEN        bearer token, if your Loki needs one
+  LOKI_USERNAME     basic auth user, for Grafana Cloud and most hosted Loki
+  LOKI_PASSWORD     basic auth password, _FILE supported
   LOOKBACK_HOURS    default window, default 168
   REGISTRY_PATH     registry.yaml, for resolving domains to tool ids
   IDENTITY_MAP      CSV of key,identity for attaching people to devices
@@ -156,6 +158,11 @@ def require_auth(creds: HTTPBasicCredentials = Depends(_basic)):
 
 LOKI_URL = os.environ.get("LOKI_URL", "")
 LOKI_TOKEN = _secret("LOKI_TOKEN") or None
+# Basic auth for reads. The receiver has had LOKI_USERNAME/LOKI_PASSWORD for
+# its writes; the portal only had a bearer token, so against Grafana Cloud the
+# receiver stored findings the portal then got a 401 trying to read back.
+LOKI_USERNAME = os.environ.get("LOKI_USERNAME", "") or None
+LOKI_PASSWORD = _secret("LOKI_PASSWORD") or None
 LOOKBACK_HOURS = float(os.environ.get("LOOKBACK_HOURS", "168"))
 REGISTRY_PATH = os.environ.get("REGISTRY_PATH", "/srv/registry/registry.yaml")
 IDENTITY_MAP = os.environ.get("IDENTITY_MAP", "")
@@ -248,7 +255,9 @@ def _findings(hours):
         )
     global _last_loki_ok, _last_loki_error
     try:
-        out = derive.fetch_from_loki(LOKI_URL, hours, LOKI_TOKEN)
+        out = derive.fetch_from_loki(
+            LOKI_URL, hours, LOKI_TOKEN,
+            username=LOKI_USERNAME, password=LOKI_PASSWORD)
         _last_loki_ok = time.time()
         _last_loki_error = ""
         return out

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -518,3 +518,63 @@ def test_the_widget_lists_in_python_and_javascript_agree():
         "only in the browser: %s | only in KNOWN_WIDGETS: %s"
         % (sorted(in_browser - set(KNOWN_WIDGETS)),
            sorted(set(KNOWN_WIDGETS) - in_browser)))
+
+
+class TestLokiReadAuth:
+    """The portal has to authenticate to the log store the receiver writes to.
+
+    The receiver had LOKI_USERNAME/LOKI_PASSWORD for its writes and the portal
+    only had a bearer token. Against Grafana Cloud, which wants basic auth,
+    that meant the receiver stored findings successfully and the portal got a
+    401 reading back the ones it had just stored. Writes working and reads not
+    is not a working deployment, and no piece of configuration named the gap:
+    both variables were present in the environment, and only one container
+    used them.
+    """
+
+    def _header(self, **kw):
+        """The Authorization header fetch_from_loki would send."""
+        from unittest.mock import patch
+
+        from app import derive
+
+        captured = {}
+
+        class _Resp:
+            def __enter__(self): return self
+            def __exit__(self, *a): return False
+            def read(self): return b'{"data":{"result":[]}}'
+
+        def _urlopen(req, timeout=None):
+            captured["auth"] = req.get_header("Authorization")
+            return _Resp()
+
+        with patch.object(derive.urllib.request, "urlopen", _urlopen), \
+                patch.object(derive.json, "load", lambda f: {"data": {"result": []}}):
+            derive.fetch_from_loki("http://loki:3100", 1, **kw)
+        return captured.get("auth")
+
+    def test_basic_auth_is_sent_when_a_username_is_set(self):
+        """The literal header, not a re-derivation of the code under test.
+
+        Grafana Cloud's username is a numeric instance id, which is worth
+        having in the fixture: it looks like a mistake to anyone who has not
+        seen one, and a reader who assumes it should be an email is the reader
+        this test is for.
+        """
+        assert self._header(username="1739257", password="secret") == \
+            "Basic MTczOTI1NzpzZWNyZXQ="
+
+    def test_a_bearer_token_still_works(self):
+        assert self._header(token="abc123") == "Bearer abc123"
+
+    def test_no_credentials_sends_no_header(self):
+        assert self._header() is None
+
+    def test_basic_auth_wins_when_both_are_set(self):
+        """A gateway wanting a bearer token in front of a Loki wanting basic
+        auth is a real arrangement, but only one Authorization header can be
+        sent. Basic is the one the log store itself needs."""
+        h = self._header(username="u", password="p", token="t")
+
+        assert h.startswith("Basic ")


### PR DESCRIPTION
Three fixes, all found by running the compose route on a clean VM against a real Grafana Cloud tenant. None of them was findable in CI, and the reasons are worth recording.

## The portal could not read the log store the receiver writes to

The receiver has had LOKI_USERNAME and LOKI_PASSWORD for its writes. The portal only had LOKI_TOKEN, a bearer token. Grafana Cloud, and most hosted Loki, want basic auth in both directions.

So against a hosted log store the receiver stored findings successfully and the portal got a 401 reading back the ones it had just written. Writes working and reads not is not a working deployment, and nothing named the gap: both variables were present in the environment and only one container used them. aiguard_loki_push_total climbed, the receiver was healthy, and the portal returned an error a deployer would reasonably read as their own misconfiguration.

The header is built by hand rather than with HTTPBasicAuthHandler, which only sends credentials after a 401 carrying a realm it recognises. Grafana Cloud's 401 does not trigger that retry, so the handler would have failed twice and sent the credentials neither time.

Basic auth takes precedence when both are set. A gateway wanting a bearer token in front of a Loki wanting basic auth is a real arrangement, but only one Authorization header can be sent, and the log store is the thing that has to accept it.

## Compose could not start without configuring a container it does not run

GF_SECURITY_ADMIN_PASSWORD used ${GRAFANA_ADMIN_PASSWORD:?...}. Compose interpolates the whole file before it decides which profiles are active, so a required variable on a service behind the with-logs profile blocked `docker compose up` for everyone NOT running the bundled Grafana.

That is the production route being unusable without configuring the thing it exists to avoid, and CI never saw it because the compose job runs with-logs to stand up a Loki it has no external one for. The job's own comment names that difference as the place a green run stops proving anything, which turned out to be exactly right.

Now :- rather than :?. Grafana refuses to start with an empty admin password, so an unset value still fails, in the one place where it means something.

## The portal was not given the credentials in compose

Even with the code above, LOKI_USERNAME and LOKI_PASSWORD reached the receiver service and not the portal one.

## Also

.env.example says the Grafana Cloud username is a numeric instance id rather than an email, and that the access policy needs logs:write as well as logs:read. A read-only token produces a 401 the receiver counts while still returning 200 to the collector, which is a shape worth naming before somebody spends an afternoon on it.

Tests: 191 to 195. Two of the new ones fail without the basic auth path.