### PR TITLE
chart 0.8.1, appVersion 0.9.1, and Loki credentials for both containers

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.8.0
+version: 0.8.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.9.0"
+appVersion: "0.9.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/templates/deployment.yaml
+++ b/charts/ai-guard/templates/deployment.yaml
@@ -40,6 +40,17 @@ spec:
             - name: LOKI_PUSH_URL
               value: {{ . | quote }}
             {{- end }}
+            {{- with .Values.loki.username }}
+            - name: LOKI_USERNAME
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.loki.existingSecret }}
+            - name: LOKI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: lokiPassword
+            {{- end }}
             {{- with .Values.alertmanager.url }}
             - name: ALERTMANAGER_URL
               value: {{ . | quote }}

--- a/charts/ai-guard/templates/portal-deployment.yaml
+++ b/charts/ai-guard/templates/portal-deployment.yaml
@@ -52,6 +52,23 @@ spec:
             # version of the same message, delivered before anyone can see it.
             - name: LOKI_URL
               value: {{ .Values.portal.lokiUrl | quote }}
+            {{- with .Values.loki.username }}
+            # The same credentials the receiver writes with. The portal had no
+            # Loki auth of any kind, so a chart install pointed at an
+            # authenticated log store stored findings the portal then got a 401
+            # reading back: the receiver healthy, the counters climbing, and
+            # the portal reporting an error a deployer would read as their own
+            # misconfiguration.
+            - name: LOKI_USERNAME
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.loki.existingSecret }}
+            - name: LOKI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: lokiPassword
+            {{- end }}
             {{- if eq .Values.portal.auth.mode "none" }}
             # Deliberate, and it logs a warning on every start. Correct behind
             # something that authenticates for it; wrong on anything reachable.

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -29,6 +29,20 @@ auth:
 loki:
   pushUrl: ""        # e.g. http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
 
+  # Basic auth, used by BOTH containers: the receiver to write and the portal
+  # to read. Grafana Cloud and most hosted Loki need these; a Loki inside the
+  # cluster usually does not.
+  #
+  # On Grafana Cloud the username is a numeric instance id, not an email, and
+  # the access policy needs logs:write AND logs:read. A read-only token
+  # produces a 401 the receiver counts while still returning 200 to the
+  # collector, so findings look accepted and are not stored.
+  #
+  # The password comes from a Secret rather than a value, because a value here
+  # ends up in `helm get values` and in whatever holds this file.
+  username: ""
+  existingSecret: ""       # a Secret with a `lokiPassword` key
+
 # Optional. Unset means findings are logged and dashboarded but nothing pages.
 alertmanager:
   url: ""


### PR DESCRIPTION
Neither chart container had Loki credentials. The receiver got pushUrl and nothing else; the portal got no Loki auth of any kind, not even the bearer token the code has supported for months. So the Helm route could not use an authenticated log store at all, which is the same failure just fixed in compose, in the deployment path that is meant to be the mature one.

loki.username as a value, loki.existingSecret for the password with a lokiPassword key. A password as a plain value ends up in helm get values and in whatever holds the file, which is the reasoning the chart already applies to the receiver's auth token.

Both containers, gated on the same values, so unset keeps the current behaviour.