### PR TITLE
portal: stop rendering findings into an executable context

### DIFF
--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -197,6 +197,61 @@ APP_VERSION = os.environ.get("APP_VERSION", "dev")
 app = FastAPI(title="ai-guard portal", version=APP_VERSION,
               docs_url=None, redoc_url=None)
 
+
+@app.middleware("http")
+async def security_headers(request, call_next):
+    """Headers that limit what a rendering bug can do.
+
+    The portal renders findings, and a finding is attacker-influenced: anyone
+    holding the reporting token can put arbitrary text in a device name, and
+    that token is on every collector. Escaping is the fix for that and these
+    headers are what stops the next escaping mistake being exploitable.
+
+    Be clear about what this does not do. script-src carries 'unsafe-inline',
+    because the page's whole script is inline in index.html, which is served as
+    a static file. So this policy does NOT stop an injected <script> tag from
+    running. Making it do so means a nonce, which means templating the HTML per
+    request, and that is a real change rather than a header.
+
+    What it does stop is worth having anyway, and connect-src is most of it:
+    the estate data this page can read is
+    the thing worth exfiltrating, and without it a successful injection could
+    read every API and post the result elsewhere. An injection that runs but
+    cannot phone home is a much smaller problem than one that can.
+    frame-ancestors 'none' because nothing should frame a page that names who
+    runs what on which machine, and form-action 'none' because it has no forms.
+
+    So this is a second line rather than the fix. The fix is that findings are
+    escaped and nothing is interpolated into an executable context, which is
+    what the tests in portal/tests hold.
+
+    no-store on everything: the responses name people, devices and accounts,
+    and a shared machine's disk cache is not where that belongs.
+    """
+    response = await call_next(request)
+    response.headers.setdefault(
+        "Content-Security-Policy",
+        "default-src 'self'; "
+        # 'unsafe-inline' because index.html's script is inline and served
+        # static. This is the weak part of the policy and it is deliberate
+        # rather than overlooked: removing it needs a nonce and a templated
+        # page, not a header change.
+        "script-src 'self' 'unsafe-inline'; "
+        "style-src 'self' 'unsafe-inline'; "
+        "img-src 'self' data:; "
+        "connect-src 'self'; "
+        "frame-src " + (GRAFANA_URL or "'none'") + "; "
+        "frame-ancestors 'none'; "
+        "form-action 'none'; "
+        "base-uri 'none'; "
+        "object-src 'none'",
+    )
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("Referrer-Policy", "no-referrer")
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    response.headers.setdefault("Cache-Control", "no-store")
+    return response
+
 # A derived graph, kept briefly. Not state in any meaningful sense: it rebuilds
 # from Loki on the next miss and on every restart. Without it, a 7 day query
 # runs on every page load, which is slow for the reader and unkind to Loki.

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -244,7 +244,17 @@ const fromHash = () => {
 };
 let view = fromHash(), detail = null, filter = '';
 
-const esc = s => String(s ?? '').replace(/[&<>"]/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+// Escapes the five characters that matter in HTML text and in a quoted
+// attribute. The apostrophe was missing, and it mattered: values were
+// interpolated into onclick="open_('device','...')", a single-quoted JS string
+// inside a double-quoted attribute, so a device name containing ' closed the
+// string and ran whatever followed. The inline handlers are gone now and this
+// is still the right set: an attribute quoted either way is covered, and
+// nothing downstream has to remember which.
+//
+// This is not sufficient on its own for a JS or URL context. Nothing should be
+// interpolated into either. Use a data attribute and read it back.
+const esc = s => String(s ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 const ents = o => Object.entries(o || {});
 const label = (k, d) => d.device_name || k;
 const match = s => !filter || String(s).toLowerCase().includes(filter);
@@ -390,7 +400,7 @@ function overview() {
 }
 
 function card(k, d) {
-  return `<div class="card" onclick="open_('device','${esc(k)}')">
+  return `<div class="card" data-open="device" data-key="${esc(k)}">
     <h3>${esc(label(k,d))}</h3>
     <div class="sub">${(d.tools||[]).map(t=>`<span class="pill p-mut">${esc(t)}</span>`).join('')}</div>
     <div class="sub" style="margin-top:6px">
@@ -429,7 +439,7 @@ function tools() {
   return `<h2>Tools</h2><p class="lede">Surfaces are kept apart on purpose: the same
   tool in a browser, a desktop app and a CLI are different exposures.</p>
   <table><tr><th>tool</th><th>devices</th><th>identities</th><th>by surface</th></tr>
-  ${rows.map(([k,t]) => `<tr onclick="open_('tool','${esc(k)}')" style="cursor:pointer">
+  ${rows.map(([k,t]) => `<tr data-open="tool" data-key="${esc(k)}" style="cursor:pointer">
     <td>${esc(k)}</td><td>${(t.devices||[]).length}</td><td>${(t.identities||[]).length}</td>
     <td>${ents(t.devices_by_surface||{}).sort((a,b)=>b[1].length-a[1].length)
       .map(([s,v])=>`<span class="pill p-acc">${esc(s||'none')} ${v.length}</span>`).join('')}</td>
@@ -459,14 +469,14 @@ function coverage() {
 function deviceDetail(k) {
   const d = G.devices[k]; if (!d) return '<p>not found</p>';
   const bridges = ents(G.bridges||{}).filter(([,b]) => (b.devices||[]).includes(k)).map(([n])=>n);
-  return `<button class="back" onclick="open_(null)">back</button>
+  return `<button class="back" data-open="">back</button>
   <h2>${esc(label(k,d))}</h2>
-  <p class="lede">${esc(k)} · ${(d.os||[]).join(', ') || 'os unknown'} · ${d.findings} findings</p>
+  <p class="lede">${esc(k)} · ${esc((d.os||[]).join(', ')) || 'os unknown'} · ${d.findings} findings</p>
   <table>
     <tr><th>person</th><td>${d.person ? esc(d.person) : '<span class="pill p-mut">unattributed</span>'}</td></tr>
-    <tr><th>local users</th><td>${(d.local_users||[]).join(', ') || '—'}</td></tr>
-    <tr><th>surfaces</th><td>${(d.surfaces||[]).filter(Boolean).join(', ')}</td></tr>
-    <tr><th>sources</th><td>${(d.sources||[]).join(', ') || '—'}</td></tr>
+    <tr><th>local users</th><td>${esc((d.local_users||[]).join(', ')) || '—'}</td></tr>
+    <tr><th>surfaces</th><td>${esc((d.surfaces||[]).filter(Boolean).join(', '))}</td></tr>
+    <tr><th>sources</th><td>${esc((d.sources||[]).join(', ')) || '—'}</td></tr>
     <tr><th>accounts</th><td>${(d.accounts||[]).map(a =>
       `<span class="pill ${(d.personal_accounts||[]).includes(a)?'p-warn':'p-ok'}">${esc(a)}</span>`).join('') || '—'}</td></tr>
     <tr><th>tools and accounts</th><td>${ents(d.tool_accounts||{}).length
@@ -482,13 +492,13 @@ function deviceDetail(k) {
 
 function toolDetail(k) {
   const t = G.tools[k]; if (!t) return '<p>not found</p>';
-  return `<button class="back" onclick="open_(null)">back</button>
+  return `<button class="back" data-open="">back</button>
   <h2>${esc(k)}</h2>
   <p class="lede">${(t.devices||[]).length} devices · ${(t.identities||[]).length} identities · ${t.findings} findings</p>
   <table><tr><th>by surface</th><td>${ents(t.devices_by_surface||{})
     .sort((a,b)=>b[1].length-a[1].length)
     .map(([s,v])=>`<span class="pill p-acc">${esc(s||'none')} ${v.length}</span>`).join('')}</td></tr>
-  <tr><th>accounts</th><td>${(t.accounts||[]).join(', ') || '—'}</td></tr></table>
+  <tr><th>accounts</th><td>${esc((t.accounts||[]).join(', ')) || '—'}</td></tr></table>
   <h2 style="margin-top:22px;font-size:16px">Devices</h2>
   ${(t.devices||[]).map(dk => G.devices[dk] ? card(dk, G.devices[dk]) : '').join('')}`;
 }
@@ -514,7 +524,7 @@ function mcp() {
   ${rows.length ? `<table>
   <tr><th>server</th><th>devices</th><th>configured by</th>
   <th>first seen</th><th>last seen</th></tr>
-  ${rows.map(r => `<tr onclick="open_('mcp','${esc(r.server)}')" style="cursor:pointer">
+  ${rows.map(r => `<tr data-open="mcp" data-key="${esc(r.server)}" style="cursor:pointer">
     <td>${esc(r.server)}</td>
     <td>${(r.devices||[]).length}</td>
     <td>${(r.tools||[]).map(t=>`<span class="pill p-mut">${esc(t)}</span>`).join('')}</td>
@@ -536,10 +546,10 @@ function mcpDetail(k) {
   const r = (G.mcp_servers || []).find(x => x.server === k);
   if (!r) return '<p>not found</p>';
   const devs = (r.devices || []);
-  return `<button class="back" onclick="open_(null)">back</button>
+  return `<button class="back" data-open="">back</button>
   <h2>${esc(r.server)}</h2>
   <p class="lede">${devs.length} device${devs.length === 1 ? '' : 's'} ·
-  configured by ${(r.tools||[]).join(', ')} ·
+  configured by ${esc((r.tools||[]).join(', '))} ·
   first seen ${esc((r.first_seen||'').slice(0,10) || 'unknown')} ·
   last seen ${esc((r.last_seen||'').slice(0,10) || 'unknown')}</p>
   <p class="lede">Whatever this server was pointed at is reachable from these
@@ -574,7 +584,7 @@ function personal() {
     <td>${(r.surfaces||[]).map(x=>`<span class="pill p-mut">${esc(x)}</span>`).join('')}</td>
     <td style="color:var(--mut)">${esc((r.first_seen||'').slice(0,10) || '—')}</td>
     <td style="color:var(--mut)">${esc((r.last_seen||'').slice(0,10) || '—')}</td>
-    <td style="color:var(--mut)">${(r.sources||[]).join(', ') || '—'}</td>
+    <td style="color:var(--mut)">${esc((r.sources||[]).join(', ')) || '—'}</td>
   </tr>`).join('')}</table>`
   : `<p class="lede">None seen in the last ${CFG.lookback_hours || '?'} hours.
   That is a result rather than an absence of one, provided the sources on the
@@ -1175,6 +1185,23 @@ async function render() {
                     dashboard, personal, mcp})[view]();
 }
 function open_(kind, key) { detail = kind ? [kind, key] : null; render(); window.scrollTo(0,0); }
+
+// One delegated listener rather than an onclick per row. The handlers used to
+// be inline, which put a finding's own text inside executable script: a device
+// name containing an apostrophe closed the JS string and ran what followed,
+// and the only thing standing between a poisoned finding and code in the
+// portal's origin was an escape function that did not cover the apostrophe.
+//
+// A data attribute cannot become code however it is escaped, which is the
+// point: the value is read back as a string rather than parsed as part of a
+// program. Delegation also means rows rendered after this runs are covered,
+// with no listener to attach per render.
+app.addEventListener('click', e => {
+  const el = e.target.closest('[data-open]');
+  if (!el) return;
+  const kind = el.getAttribute('data-open');
+  open_(kind || null, el.getAttribute('data-key'));
+});
 // Someone editing the fragment, or arriving on a link to a view.
 window.addEventListener('hashchange', () => {
   const h = fromHash();

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -578,3 +578,143 @@ class TestLokiReadAuth:
         h = self._header(username="u", password="p", token="t")
 
         assert h.startswith("Basic ")
+
+
+class TestNoUntrustedValueReachesExecutableContext:
+    """Findings are attacker-influenced, and the portal renders them.
+
+    Anyone holding the reporting token can put arbitrary text in a device name,
+    a username or a tool id, and that token is distributed to every collector
+    and to the browser extension. So a finding is untrusted input that an
+    authenticated operator later views, and the portal's origin has the session
+    that can read the whole estate.
+
+    This started as a stored XSS. esc() escaped & < > and " but not ', and
+    values were interpolated into onclick="open_('device','...')", a
+    single-quoted JS string inside a double-quoted attribute. A device named
+
+        x'),alert(1),open_('a
+
+    closed the string and ran what followed. The inline handlers are gone, but
+    the tests below hold both halves: nothing may put a value in an executable
+    context, and the escape must cover the quote either way.
+
+    Asserted against the file rather than a rendered page, because there is no
+    DOM here. That is a real limit: it catches the shape of the bug and not
+    every instance of it.
+    """
+
+    def _src(self):
+        from pathlib import Path
+        return (Path(__file__).parent.parent / "app" / "static" / "index.html").read_text()
+
+    def test_the_escape_covers_the_single_quote(self):
+        """The specific gap. Everything else was already escaped.
+
+        Asserts on the replacement each character maps to rather than on the
+        character appearing in the source, because quoting a quote inside a
+        regex inside a JS string inside a Python literal is four layers of
+        escaping and the test starts failing for reasons of its own.
+        """
+        import re
+
+        line = re.search(r"const esc = s =>.*", self._src()).group(0)
+
+        for entity in ("&amp;", "&lt;", "&gt;", "&quot;", "&#39;"):
+            assert entity in line, "esc() does not produce %s" % entity
+
+    def test_no_inline_event_handlers(self):
+        """A value in an attribute is data. A value in onclick is code, and the
+        only thing between them is an escape function remembering a character.
+
+        Delegation removes the category rather than escaping around it, so a
+        new row added later cannot reintroduce this by copying a pattern.
+        """
+        import re
+
+        # Comments explaining why they are gone are allowed to name them.
+        code = re.sub(r"^\s*//.*$", "", self._src(), flags=re.M)
+
+        for attr in ("onclick=", "onerror=", "onload=", "onmouseover="):
+            assert attr not in code, "an inline %s handler is back" % attr
+
+    def test_arrays_from_findings_are_joined_through_the_escape(self):
+        """local_users, sources, accounts and tools were joined straight into
+        HTML with no escaping at all. local_users is the sharpest: it is a
+        username read off the device by the collector.
+
+        Checks `.join(` specifically, which is the shape that was broken and
+        the shape a new field would most likely copy. An earlier version tried
+        to match any interpolation mentioning these fields and produced a false
+        positive on a nested template, because a regex cannot find the end of a
+        JavaScript expression. A narrow check that holds is worth more than a
+        broad one that has to be argued with.
+        """
+        import re
+
+        for line in self._src().split("\n"):
+            if line.lstrip().startswith("//"):
+                continue
+            for m in re.finditer(
+                    r"\$\{\(?[a-z]\.(\w+)\s*\|\|\s*\[\]\)[\w.()]*?\.join\(", line):
+                assert "esc(" in m.group(0), (
+                    "%s is joined into HTML unescaped: %s" % (m.group(1), line.strip()))
+
+
+class TestSecurityHeaders:
+    """Headers that limit what a rendering bug can do.
+
+    A second line rather than the fix. The fix is that findings are escaped
+    and nothing reaches an executable context; these limit the damage when
+    that is next got wrong, which on a page rendering attacker-influenced text
+    is a question of when.
+    """
+
+    def _headers(self, path="/healthz"):
+        import asyncio
+
+        from app import main as pm
+
+        async def _call():
+            captured = {}
+
+            class _Req:
+                url = type("U", (), {"path": path})()
+
+            class _Resp:
+                headers = {}
+                def __init__(self): self.headers = {}
+
+            async def _next(req):
+                return _Resp()
+
+            r = await pm.security_headers(_Req(), _next)
+            captured.update(r.headers)
+            return captured
+
+        return asyncio.run(_call())
+
+    def test_connect_src_is_self(self):
+        """The one that matters most here. The estate data this page reads is
+        the thing worth stealing, and an injection that runs but cannot reach
+        another origin is a far smaller problem than one that can."""
+        assert "connect-src 'self'" in self._headers()["Content-Security-Policy"]
+
+    def test_the_page_cannot_be_framed(self):
+        """It names who runs what on which machine."""
+        h = self._headers()
+
+        assert "frame-ancestors 'none'" in h["Content-Security-Policy"]
+        assert h["X-Frame-Options"] == "DENY"
+
+    def test_responses_are_not_cached(self):
+        """They name people, devices and accounts, and a shared machine's disk
+        cache is not where that belongs."""
+        assert self._headers()["Cache-Control"] == "no-store"
+
+    def test_content_type_is_not_sniffed(self):
+        assert self._headers()["X-Content-Type-Options"] == "nosniff"
+
+    def test_no_referrer_is_sent(self):
+        """A portal URL can carry a device or a tool id in its fragment."""
+        assert self._headers()["Referrer-Policy"] == "no-referrer"


### PR DESCRIPTION
A finding is untrusted input. Anyone holding the reporting token can put arbitrary text in a device name, a username or a tool id, and that token is distributed to every collector and to the browser extension. The portal renders those values, and an authenticated operator viewing them has a session that can read the whole estate.

## The bug

esc() escaped & < > and " and not the apostrophe. Values were interpolated into

    onclick="open_('device','${esc(k)}')"

a single-quoted JavaScript string inside a double-quoted HTML attribute. A device named

    x'),alert(1),open_('a

closes the string and runs what follows, in the portal's origin, with the operator's session.

Six arrays were also joined into HTML with no escaping at all: local_users, sources, accounts, tools, os and surfaces. local_users is the sharpest of those, because it is a username read off the machine by the collector.

## The fix

esc() covers the apostrophe now, so a value in an attribute quoted either way is safe and nothing downstream has to remember which.

The six inline handlers are gone. They are data-open and data-key attributes read by one delegated listener on the app element. That removes the category rather than escaping around it: a value in a data attribute cannot become code however badly it is escaped, and a row added later cannot reintroduce this by copying the pattern next to it. Delegation also covers rows rendered after the listener is attached, which every filtered view produces.

The six joins are escaped.

## Security headers, and what they do not do

A CSP, X-Content-Type-Options, Referrer-Policy, X-Frame-Options and no-store on every response.

script-src carries 'unsafe-inline', because the page's whole script is inline in index.html and index.html is served as a static file. So this policy does NOT stop an injected script tag from running. Saying otherwise would be the more comfortable claim and the false one. Removing 'unsafe-inline' means a nonce and templating the page per request, which is a change rather than a header.

What it does stop is worth having. connect-src 'self' means an injection that runs cannot post the estate data to another origin, and exfiltration is the thing that turns a rendering bug into a breach. frame-ancestors 'none' because nothing should frame a page that names who runs what on which machine. Cache-Control: no-store because the responses name people, devices and accounts.

These are a second line. The fix is the escaping.

## Tests

Three, and each was verified by restoring the vulnerability it covers and watching it fail: that esc() produces &#39;, that no inline event handler exists anywhere in the file, and that an array from a finding is never joined into HTML without passing through esc().

They assert against the source text rather than a rendered page, because there is no DOM in this suite. That is a real limit and worth stating: they catch the shape of the bug, not every instance of it. An earlier version of the array test tried to match any interpolation mentioning these fields and produced a false positive on a nested template, because a regular expression cannot find the end of a JavaScript expression. A narrow check that holds is worth more than a broad one that has to be argued with.

Tests: 195 to 203.