### PR TITLE
portal: the identity map is CSV, so read and write it as CSV

### DIFF
--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -30,6 +30,7 @@ import csv
 import io
 import json
 import os
+import re
 import sys
 import time
 import urllib.parse
@@ -87,7 +88,6 @@ def fetch_from_loki(base, hours, token=None, limit=5000, username=None,
     wants basic auth is a real arrangement.
     """
     import base64
-    import time
 
     end = int(time.time() * 1e9)
     start = end - int(hours * 3600 * 1e9)
@@ -196,10 +196,19 @@ def load_identity_map(path):
             # of the identity: feeding the tool's own suggested file straight
             # back in, which is what the docs tell you to do, put
             # "jo.bloggs  # via local user Jo.Bloggs" on every report.
+            #
+            # A hash cannot appear in a generated key or identity, so this
+            # cannot truncate one. A hand-written file that puts a hash inside
+            # a value loses the rest of it, which is the trade for a format
+            # where a comment can follow a row.
             line = line.split("#", 1)[0].strip()
             if not line:
                 continue
-            parts = [c.strip() for c in line.split(",", 1)]
+            # csv.reader rather than split(","). The exporter quotes with
+            # csv.writer, and a parser that splits on the first comma reads a
+            # quoted value as two fields and gets both wrong.
+            row = next(csv.reader([line]), [])
+            parts = [c.strip() for c in row[:2]]
             if len(parts) == 2 and parts[0] and parts[1]:
                 if parts[0].lower() in ("key", "device", "local_user"):
                     continue  # header
@@ -275,24 +284,81 @@ def csv_safe(value):
                        or s.lstrip("\t\r\n ").startswith(_FORMULA_LEAD)) else s
 
 
+# Characters that cannot appear in a key or an identity in this file.
+#
+# A newline is the one that matters: this file is line oriented, so a device
+# key containing one plants a second row. Someone able to report a finding
+# could propose an identity mapping nobody wrote, and if a deployer accepted
+# the file, later reports would name the wrong person. That is a quiet failure
+# in the only direction this platform must not fail quietly.
+#
+# A comma or a quote is handled by csv.writer, but a key containing either is
+# not a device serial and a file that needs quoting is harder to hand-edit,
+# which is what this format is for. A hash would collide with the inline
+# comments below.
+#
+# Rejected rather than escaped, because every one of these means the value is
+# already wrong. A rejected row is visible in the output; a quoted one looks
+# deliberate.
+_UNSAFE_IN_KEY = re.compile(r"[\x00-\x1f\x7f,\"'#]")
+
+
 def suggest_identity_csv(matched, unmatched):
-    """The same proposals as a CSV a deployer can save, edit and feed back."""
+    """The same proposals as a CSV a deployer can save, edit and feed back.
+
+    Rows are written with csv.writer and read back with csv.reader. The first
+    version built and parsed both ends by hand, and a device key containing a
+    newline therefore wrote an extra row: the guard added for spreadsheet
+    formulas did nothing about it, because a formula and an injected record are
+    different problems that happen to share a file.
+    """
+    buf = io.StringIO()
+    w = csv.writer(buf, lineterminator="\n")
+
     out = [
         "# key,identity",
         "# Proposed from local usernames. REVIEW BEFORE USE: these are string",
         "# matches, not authoritative. Anything wrong here puts the wrong name",
         "# on a report.",
     ]
+    skipped = []
     for m in matched:
-        out.append("%s,%s  # via local user %s"
-                   % (csv_safe(m["key"]), csv_safe(m["identity"]), m["via"]))
+        key, identity = str(m["key"]), str(m["identity"])
+        if _UNSAFE_IN_KEY.search(key) or _UNSAFE_IN_KEY.search(identity):
+            skipped.append(key)
+            continue
+        buf.seek(0), buf.truncate(0)
+        w.writerow([csv_safe(key), csv_safe(identity)])
+        out.append("%s  # via local user %s"
+                   % (buf.getvalue().rstrip("\n"), _comment_safe(m["via"])))
+
+    if skipped:
+        out.append("#")
+        out.append("# %d device%s left out: the key or the proposed identity "
+                   % (len(skipped), "" if len(skipped) == 1 else "s")
+                   + "contained a character that cannot appear in this file.")
+        out.append("# Said out loud rather than dropped: a row missing without "
+                   "explanation")
+        out.append("# looks the same as a device nobody could name.")
+
     if unmatched:
         out.append("#")
         out.append("# No candidate identity. Fill these in from your MDM, RMM or CMDB:")
         for u in unmatched:
             out.append("# %s,   # local users: %s"
-                       % (u["key"], ", ".join(u["local_users"]) or "(none)"))
+                       % (_comment_safe(u["key"]),
+                          _comment_safe(", ".join(u["local_users"])) or "(none)"))
     return "\n".join(out) + "\n"
+
+
+def _comment_safe(value):
+    """A value safe to put in a comment: no newline, so it stays a comment.
+
+    A commented-out row is still a row if the value inside it can end the line.
+    The unmatched block had no guard at all, which the formula fix missed
+    because it was only looking at the rows that were not commented.
+    """
+    return re.sub(r"[\x00-\x1f\x7f]", " ", str(value or ""))
 
 
 def suggest_identities(devices, identities, path):
@@ -557,8 +623,7 @@ def personal_accounts_from(findings, domain_map=None):
         if ts:
             if not r["first_seen"] or ts < r["first_seen"]:
                 r["first_seen"] = ts
-            if ts > r["last_seen"]:
-                r["last_seen"] = ts
+            r["last_seen"] = max(r["last_seen"], ts)
 
     out = [dict(r, surfaces=sorted(r["surfaces"]), sources=sorted(r["sources"]))
            for r in rows.values()]
@@ -630,8 +695,7 @@ def mcp_from(findings):
             if ts:
                 if not r["first_seen"] or ts < r["first_seen"]:
                     r["first_seen"] = ts
-                if ts > r["last_seen"]:
-                    r["last_seen"] = ts
+                r["last_seen"] = max(r["last_seen"], ts)
 
     out = [dict(r, tools=sorted(r["tools"]), devices=sorted(r["devices"]),
                 device_names=sorted(r["device_names"]))
@@ -694,8 +758,7 @@ def status_from(findings):
         e = by_source[src]
         e["findings"] += 1
         ts = f.get("reported_at") or ""
-        if ts > e["last_seen"]:
-            e["last_seen"] = ts
+        e["last_seen"] = max(e["last_seen"], ts)
         dev = (f.get("device") or "").strip()
         if dev:
             e["devices"].add(dev)
@@ -858,8 +921,7 @@ def _base_tool(tool):
     resolved, because nobody would add claude-code-mcp to a registry of tools.
     """
     base = tool.split("-mcp:", 1)[0] if "-mcp:" in tool else tool
-    if base.endswith("-mcp"):
-        base = base[:-4]
+    base = base.removesuffix("-mcp")
     return base or tool
 
 
@@ -938,8 +1000,7 @@ def register_from(findings, reg=None, domain_map=None, gov=None,
         if ts:
             if not o["first_seen"] or ts < o["first_seen"]:
                 o["first_seen"] = ts
-            if ts > o["last_seen"]:
-                o["last_seen"] = ts
+            o["last_seen"] = max(o["last_seen"], ts)
 
     known = {}
     for t in reg.get("tools", []) or []:

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -156,7 +156,27 @@ def require_auth(creds: HTTPBasicCredentials = Depends(_basic)):
         )
 
 
-LOKI_URL = os.environ.get("LOKI_URL", "")
+def require_http_url(name, url):
+    """The URL back, or exit if it is not http or https.
+
+    derive.fetch_from_loki reaches this through urllib.request.urlopen, which
+    honours file:, ftp: and anything else with a handler registered, so a
+    mistyped LOKI_URL of file:///etc/passwd would be read and parsed as a Loki
+    response rather than refused. Operator-supplied rather than
+    attacker-supplied, so less an attack path than a way for a typo to do
+    something surprising quietly.
+
+    Refuses at startup rather than warning. A portal that starts against a log
+    store it cannot query shows an empty estate, and an empty estate is the
+    answer this platform exists to distinguish from a quiet one.
+    """
+    if url and not url.startswith(("http://", "https://")):
+        raise SystemExit("%s must be http:// or https://, got %r"
+                         % (name, url[:40]))
+    return url
+
+
+LOKI_URL = require_http_url("LOKI_URL", os.environ.get("LOKI_URL", ""))
 LOKI_TOKEN = _secret("LOKI_TOKEN") or None
 # Basic auth for reads. The receiver has had LOKI_USERNAME/LOKI_PASSWORD for
 # its writes; the portal only had a bearer token, so against Grafana Cloud the

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -10,15 +10,13 @@ Every case here corresponds to something that was actually wrong at some point
 during the build, or to a property the design depends on.
 """
 
-import json
 import os
 
 # PORTAL_AUTH must be set before the app module is imported: main.py refuses to
 # start without authentication, and that refusal happens at module level.
 os.environ.setdefault("PORTAL_AUTH", "none")
 
-from app import derive  # noqa: E402
-
+from app import derive
 
 # Sources set by something other than a scanner: the three endpoint collectors,
 # and the browser extension's two. Kept beside the test that uses it so adding
@@ -276,6 +274,7 @@ def test_the_expected_sources_match_what_the_scanners_emit():
     """
     import ast
     import pathlib
+
     import pytest
 
     base = (pathlib.Path(__file__).resolve().parents[2]
@@ -413,7 +412,7 @@ def _widgets_for(spec):
     import os
     os.environ["PORTAL_AUTH"] = "none"
     os.environ["OVERVIEW_WIDGETS"] = spec
-    import app.main as main
+    from app import main
     importlib.reload(main)
     return main._widgets()
 
@@ -506,9 +505,9 @@ def test_the_widget_lists_in_python_and_javascript_agree():
     from app.main import KNOWN_WIDGETS
 
     src = (Path(__file__).parent.parent / "app" / "static" / "index.html").read_text()
-    block = re.search(r"const WIDGETS = \{(.*?)\n\};", src, re.S).group(1)
+    block = re.search(r"const WIDGETS = \{(.*?)\n\};", src, re.DOTALL).group(1)
     # Top-level keys only: two-space indent, then a name and a colon.
-    in_browser = set(re.findall(r"^  ([a-z_]+): ", block, re.M))
+    in_browser = set(re.findall(r"^  ([a-z_]+): ", block, re.MULTILINE))
 
     # grafana and error are dispatch targets rather than things an operator
     # names in OVERVIEW_WIDGETS, so they are not expected in KNOWN_WIDGETS.
@@ -560,10 +559,10 @@ class TestLokiReadAuth:
         Grafana Cloud's username is a numeric instance id, which is worth
         having in the fixture: it looks like a mistake to anyone who has not
         seen one, and a reader who assumes it should be an email is the reader
-        this test is for.
+        this test is for. Invented, not a real one.
         """
-        assert self._header(username="1739257", password="secret") == \
-            "Basic MTczOTI1NzpzZWNyZXQ="
+        assert self._header(username="1234567", password="secret") == \
+            "Basic MTIzNDU2NzpzZWNyZXQ="
 
     def test_a_bearer_token_still_works(self):
         assert self._header(token="abc123") == "Bearer abc123"
@@ -633,7 +632,7 @@ class TestNoUntrustedValueReachesExecutableContext:
         import re
 
         # Comments explaining why they are gone are allowed to name them.
-        code = re.sub(r"^\s*//.*$", "", self._src(), flags=re.M)
+        code = re.sub(r"^\s*//.*$", "", self._src(), flags=re.MULTILINE)
 
         for attr in ("onclick=", "onerror=", "onload=", "onmouseover="):
             assert attr not in code, "an inline %s handler is back" % attr
@@ -770,3 +769,136 @@ class TestIdentityMapRoundTrip:
             [{"key": "=cmd", "identity": "=calc", "via": "x"}], [])
 
         assert "'=cmd,'=calc" in text
+
+    def test_a_newline_in_a_key_cannot_plant_a_row(self):
+        """The injection this format invited.
+
+        The file is line oriented and was built by joining strings, so a device
+        key containing a newline wrote a second record. Anyone able to report a
+        finding could propose an identity mapping nobody wrote, and a deployer
+        who accepted the file would then see later findings attributed to
+        whoever the attacker named. Wrong attribution is the one failure this
+        platform must not have: the whole point of an identity map is putting a
+        person's name on a report.
+
+        The formula guard added earlier did nothing about it. A spreadsheet
+        formula and an injected record are different problems that happen to
+        share a file, and fixing the one that was reported is not the same as
+        fixing the file.
+        """
+        out = self._round_trip([{
+            "key": "device-a\nVICTIM,attacker",
+            "identity": "x", "via": "alice",
+        }])
+
+        assert "VICTIM" not in out
+        assert out == {}
+
+    def test_a_rejected_row_says_so(self):
+        """A row missing without explanation looks the same as a device nobody
+        could name, and the operator reviewing this file is the control the
+        whole format relies on."""
+        from app.derive import suggest_identity_csv
+
+        text = suggest_identity_csv(
+            [{"key": "a\nb", "identity": "x", "via": "v"}], [])
+
+        assert "1 device left out" in text
+
+    def test_a_newline_in_an_unmatched_key_stays_in_its_comment(self):
+        """The unmatched block is commented out, which made it look safe. A
+        comment is only a comment until a value inside it ends the line."""
+        out = self._round_trip(
+            [], [{"key": "d\nEVIL,attacker", "local_users": ["x"]}])
+
+        assert out == {}
+
+    def test_a_comma_in_an_identity_does_not_split_the_row(self):
+        """csv.writer would quote it and csv.reader would read it back, but a
+        key with a comma is not a device serial, and a file needing quotes is
+        harder to hand-edit, which is what this format is for."""
+        from app.derive import suggest_identity_csv
+
+        text = suggest_identity_csv(
+            [{"key": "a,b", "identity": "x", "via": "v"}], [])
+
+        assert "left out" in text
+
+    def test_a_file_written_by_hand_still_loads(self):
+        """The parser moved from splitting on the first comma to csv.reader,
+        and deployments already have files written the old way. A format change
+        that silently drops half an identity map would attribute reports to
+        nobody and look like a data problem.
+        """
+        import os
+        import tempfile
+
+        from app.derive import load_identity_map
+
+        with tempfile.NamedTemporaryFile("w", suffix=".csv", delete=False) as fh:
+            fh.write("# key,identity\n"
+                     "ABC123,jo.bloggs\n"
+                     "DEF456,  ann.smith\n"
+                     "  GHI789,bob.jones\n"
+                     "# a comment line\n"
+                     "JKL012,carol.white  # a hand-written note\n"
+                     "\n"
+                     "MNO345,dave.brown\n")
+            path = fh.name
+        try:
+            out = load_identity_map(path)
+        finally:
+            os.unlink(path)
+
+        assert out == {
+            "ABC123": "jo.bloggs", "DEF456": "ann.smith",
+            "GHI789": "bob.jones", "JKL012": "carol.white",
+            "MNO345": "dave.brown",
+        }
+
+
+class TestLokiUrlScheme:
+    """urlopen honours more schemes than anyone configuring a log store means.
+
+    file:, ftp: and anything else with a handler registered are all accepted,
+    so a mistyped LOKI_URL could read a local file and have it parsed as a Loki
+    response. Operator-supplied rather than attacker-supplied, so this is less
+    an attack path than a way for a typo to do something surprising quietly.
+    """
+
+    def test_a_file_url_is_refused(self):
+        import pytest
+        from app.main import require_http_url
+
+        with pytest.raises(SystemExit, match="must be http"):
+            require_http_url("LOKI_URL", "file:///etc/passwd")
+
+    def test_an_ftp_url_is_refused(self):
+        import pytest
+        from app.main import require_http_url
+
+        with pytest.raises(SystemExit):
+            require_http_url("LOKI_URL", "ftp://example.com/x")
+
+    def test_http_and_https_pass_through(self):
+        """The check has to let through what it exists to carry."""
+        from app.main import require_http_url
+
+        assert require_http_url("LOKI_URL", "http://loki:3100") == "http://loki:3100"
+        assert require_http_url("LOKI_URL", "https://x.example") == "https://x.example"
+
+    def test_unset_is_allowed(self):
+        """Loki is optional: the portal starts and says it has no data rather
+        than refusing to run."""
+        from app.main import require_http_url
+
+        assert require_http_url("LOKI_URL", "") == ""
+
+    def test_the_message_names_the_variable(self):
+        """Somebody reading a crashed container's last line needs to know which
+        of several URLs was wrong."""
+        import pytest
+        from app.main import require_http_url
+
+        with pytest.raises(SystemExit, match="LOKI_URL"):
+            require_http_url("LOKI_URL", "file:///x")

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -23,14 +23,14 @@ New in v0.1.3:
   - GET /metrics: Prometheus metrics (scraped via ServiceMonitor)
 """
 
+import hmac
 import json
 import logging
-import hmac
 import os
-import urllib.parse
 import sys
 import threading
 import time
+import urllib.parse
 from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
@@ -95,7 +95,24 @@ MAX_BODY_BYTES = int(os.environ.get("MAX_BODY_BYTES", "65536"))
 ALERTMANAGER_URL = os.environ.get("ALERTMANAGER_URL", "")
 # If set, findings are POSTed straight to Loki (matches receiver v0.1.1
 # behaviour); stdout JSON logging happens regardless.
-LOKI_PUSH_URL = os.environ.get("LOKI_PUSH_URL", "")
+def require_http_url(name, url):
+    """The URL back, or exit if it is not http or https.
+
+    Refuses rather than warns. A log store URL that is not http is a typo or
+    the wrong value pasted, and carrying on means findings accepted and never
+    stored, which is the failure this project exists to notice.
+
+    A separate function rather than an inline check so it can be tested without
+    re-importing the module, which re-registers every Prometheus metric.
+    """
+    if url and not url.startswith(("http://", "https://")):
+        raise SystemExit("%s must be http:// or https://, got %r"
+                         % (name, url[:40]))
+    return url
+
+
+LOKI_PUSH_URL = require_http_url("LOKI_PUSH_URL",
+                                 os.environ.get("LOKI_PUSH_URL", ""))
 
 
 def _redact_url(url):
@@ -607,7 +624,10 @@ async def report(f: Finding, request: Request, authorization: str = Header(defau
                 await _fire_alert(f)
                 alert_fired = True
         except httpx.HTTPError as e:
-            log.info(json.dumps({"app": "ai-guard-receiver", "kind": "error",
-                                 "error": f"alertmanager: {e}"}))
+            log.error(json.dumps({
+                "app": "ai-guard-receiver", "kind": "error",
+                "error": "alertmanager: %s" % type(e).__name__,
+                "url": _redact_url(ALERTMANAGER_URL),
+            }))
 
     return {"ok": True, "severity": f.severity, "alerted": alert_fired}

--- a/receiver/tests/test_smoke.py
+++ b/receiver/tests/test_smoke.py
@@ -6,10 +6,8 @@ import os
 # main.py reads it at module level.
 os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
 
+from app.main import app
 from fastapi.testclient import TestClient
-
-from app.main import app  # noqa: E402
-
 
 client = TestClient(app)
 
@@ -167,10 +165,10 @@ def test_a_rejected_push_is_counted_and_says_why():
     collector saw a 200.
     """
     import asyncio
-    import httpx
-    from prometheus_client import generate_latest
 
+    import httpx
     from app import main
+    from prometheus_client import generate_latest
 
     class FakeResponse:
         status_code = 404
@@ -283,10 +281,52 @@ def test_the_standalone_manifest_matches_the_released_version():
     chart = (root / "charts" / "ai-guard" / "Chart.yaml").read_text()
     manifest = (root / "receiver" / "deploy" / "receiver.yaml").read_text()
 
-    app_version = re.search(r'^appVersion:\s*"?([^"\s]+)"?', chart, re.M).group(1)
+    app_version = re.search(r'^appVersion:\s*"?([^"\s]+)"?', chart, re.MULTILINE).group(1)
     pinned = re.search(r"receiver:([^\s]+)", manifest).group(1)
 
     assert pinned == app_version, (
         "receiver/deploy/receiver.yaml pins %s while the chart ships %s. "
         "Bump the manifest with the release." % (pinned, app_version)
     )
+
+
+class TestAlertmanagerErrorsAreRedacted:
+    """Same treatment as the Loki push URL, and for the same reason.
+
+    ALERTMANAGER_URL is operator-supplied and can carry userinfo or a
+    query-string token. str(e) on an httpx error includes the request URL, so
+    logging the exception put the whole thing in stdout. This was fixed for
+    Loki and not for Alertmanager, which is what happens when a fix is applied
+    to the line that was reported rather than to the pattern.
+    """
+
+    def test_the_url_is_redacted_the_same_way(self):
+        from app.main import _redact_url
+
+        assert _redact_url("https://u:p@alerts.example.com/api/v2/alerts") == \
+            "https://alerts.example.com/api/v2/alerts"
+
+    def test_the_error_line_carries_the_type_not_the_message(self):
+        """httpx puts the request URL in the message, which would carry
+        userinfo straight past the redaction beside it."""
+        import inspect
+
+        from app import main as pm
+
+        src = inspect.getsource(pm)
+
+        assert '"error": "alertmanager: %s" % type(e).__name__' in src
+        assert 'f"alertmanager: {e}"' not in src
+
+
+def test_a_non_http_loki_push_url_is_refused():
+    """A log store URL that is not http is a typo or the wrong value pasted,
+    and carrying on means findings accepted and never stored."""
+    import pytest
+    from app.main import require_http_url
+
+    with pytest.raises(SystemExit, match="must be http"):
+        require_http_url("LOKI_PUSH_URL", "file:///tmp/x")
+
+    assert require_http_url("LOKI_PUSH_URL", "http://loki:3100/push")
+    assert require_http_url("LOKI_PUSH_URL", "") == ""


### PR DESCRIPTION
A second review of v0.9.2 found one medium remaining, and it is in a file I changed the day before.

## The bug

suggest_identity_csv built rows by joining strings and load_identity_map read them by splitting on the first comma. The file is line oriented, so a device key containing a newline wrote a second record:

    key: "device-a\nVICTIM,attacker"

    # device-a
    VICTIM,attacker,   # local users: alice

Loaded, that is {"VICTIM": "attacker,"}. Anyone able to report a finding could propose an identity mapping nobody wrote, and a deployer who accepted the file would see later findings attributed to whoever the attacker named.

Wrong attribution is the failure this component must not have. The entire point of an identity map is putting a person's name on a report about what they were doing.

## Why the previous fix missed it

I added a spreadsheet formula guard to this function yesterday, in response to the same reviewer naming formula injection. It did nothing about this, because a formula and an injected record are different problems that happen to share a file. I fixed the line that was reported rather than the shape underneath it.

The unmatched block had no guard at all, not even the formula one. It is written commented out, and a commented row looks safe until you notice that a value inside it can end the line.

## The fix

Rows are written with csv.writer and read with csv.reader.

Keys and identities containing control characters, commas, quotes or a hash are rejected rather than escaped. Every one of those means the value is already wrong: a device serial does not contain a newline, and a file that needs quoting is harder to hand-edit, which is what this format is for. A hash would collide with the inline comments the format uses.

Rejected rows are counted and explained in the file. A row missing without explanation looks the same as a device nobody could name, and the operator reviewing this file is the control the whole format depends on.

Values interpolated into comments have their control characters replaced, so a comment stays a comment.

## Existing files still load

The parser moved from splitting on the first comma to csv.reader, and deployments already have identity maps written the old way. A format change that silently dropped half of one would attribute reports to nobody and look like a data problem.

Checked rather than assumed, with a test: leading whitespace, blank lines, comment lines and inline notes all load exactly as before.

## Two hardening items with it

Alertmanager errors get the URL redaction the Loki push already had, and log at error rather than info. Same fix, same reason, second call site: yesterday I applied it where it was reported and not where the same pattern was.

require_http_url on both components closes the urlopen scheme warning. A mistyped LOKI_URL of file:///etc/passwd would otherwise be read and parsed as a log store response. Extracted as a function rather than an inline check so it can be tested without re-importing the module, which re-registers every Prometheus metric.

## Also

A test added for 0.9.1 used a real Grafana Cloud instance id as a fixture. It is public, already merged, and does nothing without a token, but it was mine to put there and it is an invented number now.

Tests: portal 214 to 224, receiver 26 to 29. Three of the new ones fail against the code as it was.