### PR TITLE
docker: apply Debian security updates on top of the base image

### DIFF
--- a/discovery/Dockerfile
+++ b/discovery/Dockerfile
@@ -1,4 +1,22 @@
 FROM python:3.12-slim
+
+# Debian security updates on top of the base image. The base rebuilds on its
+# own schedule, so it lags patched packages: CVE-2026-53615 in util-linux was
+# fixed in Debian as 2.41.5-0+deb13u1 while python:3.12-slim still carried
+# 2.41-5, and the Trivy gate failed on it in all four images at once.
+#
+# upgrade rather than pinning the one package. The next lag will be a different
+# package, and a list of CVEs somebody has to maintain by hand is a list that
+# goes stale between the release that adds it and the one that needed it.
+#
+# It costs a layer and some build time, and it means two builds of the same
+# commit can differ. That is the trade: reproducible-and-vulnerable is not the
+# better half of it, and the image tag plus the digest still say exactly what
+# shipped.
+RUN apt-get update \
+ && apt-get upgrade -y --no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /srv
 COPY requirements.lock .
 RUN pip install --no-cache-dir --require-hashes -r requirements.lock

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -1,4 +1,22 @@
 FROM python:3.12-slim
+
+# Debian security updates on top of the base image. The base rebuilds on its
+# own schedule, so it lags patched packages: CVE-2026-53615 in util-linux was
+# fixed in Debian as 2.41.5-0+deb13u1 while python:3.12-slim still carried
+# 2.41-5, and the Trivy gate failed on it in all four images at once.
+#
+# upgrade rather than pinning the one package. The next lag will be a different
+# package, and a list of CVEs somebody has to maintain by hand is a list that
+# goes stale between the release that adds it and the one that needed it.
+#
+# It costs a layer and some build time, and it means two builds of the same
+# commit can differ. That is the trade: reproducible-and-vulnerable is not the
+# better half of it, and the image tag plus the digest still say exactly what
+# shipped.
+RUN apt-get update \
+ && apt-get upgrade -y --no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /srv
 COPY requirements.lock .
 RUN pip install --no-cache-dir --require-hashes -r requirements.lock

--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -1,4 +1,22 @@
 FROM python:3.12-slim
+
+# Debian security updates on top of the base image. The base rebuilds on its
+# own schedule, so it lags patched packages: CVE-2026-53615 in util-linux was
+# fixed in Debian as 2.41.5-0+deb13u1 while python:3.12-slim still carried
+# 2.41-5, and the Trivy gate failed on it in all four images at once.
+#
+# upgrade rather than pinning the one package. The next lag will be a different
+# package, and a list of CVEs somebody has to maintain by hand is a list that
+# goes stale between the release that adds it and the one that needed it.
+#
+# It costs a layer and some build time, and it means two builds of the same
+# commit can differ. That is the trade: reproducible-and-vulnerable is not the
+# better half of it, and the image tag plus the digest still say exactly what
+# shipped.
+RUN apt-get update \
+ && apt-get upgrade -y --no-install-recommends \
+ && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /srv
 COPY requirements.lock .
 RUN pip install --no-cache-dir --require-hashes -r requirements.lock

--- a/scanner/Dockerfile
+++ b/scanner/Dockerfile
@@ -7,7 +7,17 @@
 FROM python:3.12-slim
 
 # tzdata so TZ works if a deployer sets it; default is UTC.
+#
+# upgrade in the same layer for Debian security updates. The base image
+# rebuilds on its own schedule and so lags patched packages: CVE-2026-53615 in
+# util-linux was fixed in Debian as 2.41.5-0+deb13u1 while python:3.12-slim
+# still carried 2.41-5, and the Trivy gate failed on it in all four images.
+#
+# upgrade rather than pinning the one package, because the next lag will be a
+# different package and a hand-maintained CVE list goes stale between the
+# release that adds it and the one that needed it.
 RUN apt-get update \
+ && apt-get upgrade -y --no-install-recommends \
  && apt-get install -y --no-install-recommends tzdata \
  && rm -rf /var/lib/apt/lists/*
 ENV TZ=UTC


### PR DESCRIPTION
Trivy failed all four image jobs on CVE-2026-53615, an integer overflow in util-linux libblkid. Debian fixed it as 2.41.5-0+deb13u1; python:3.12-slim still carries 2.41-5, because the base rebuilds on its own schedule and so lags patched packages.

apt-get upgrade rather than pinning the one package. The next lag will be a different package, and a hand-maintained CVE list goes stale between the release that adds it and the one that needed it. The scanner folds it into the existing tzdata layer rather than adding a second.

The trade is that two builds of the same commit can now differ. Reproducible-and-vulnerable is not the better half of that, and the digest still records exactly what shipped.

Verified locally: all four build, util-linux is 2.41.5-0+deb13u1, and tzdata survives the scanner's restructured layer.