### PR TITLE
docs: the portal is in the chart, mcp is a surface, and the pins are current

### DIFF
--- a/charts/ai-guard/README.md
+++ b/charts/ai-guard/README.md
@@ -114,6 +114,8 @@ the portal.
 | `auth.value` | `""` | set the token explicitly; ends up in your helm values |
 | `auth.existingSecret` | `""` | use a Secret you created yourself, key `authToken` |
 | `loki.pushUrl` | `""` | unset means stdout only, for pipelines that scrape logs |
+| `loki.username` | `""` | basic auth, used by BOTH containers: the receiver writes, the portal reads |
+| `loki.existingSecret` | `""` | a Secret with a `lokiPassword` key. Not a value: `helm get values` would show it |
 | `alertmanager.url` | `""` | unset means findings are logged and dashboarded but nothing pages |
 | `alertmanager.ttlMinutes` | `120` | how long a warn finding counts as already alerted |
 | `displayTz` | `UTC` | timezone for the readable timestamp on alerts only |
@@ -173,6 +175,33 @@ helm upgrade ai-guard charts/ai-guard --set registry.existingConfigMap=ai-guard-
 
 The receiver reads the registry per request and the kubelet syncs ConfigMap
 changes into the mount, so later updates need no restart.
+
+## A log store that needs credentials
+
+Grafana Cloud and most hosted Loki want basic auth, and both containers need
+it: the receiver to write and the portal to read.
+
+```bash
+kubectl create secret generic my-loki-creds \
+  --from-literal=lokiPassword='<token>'
+
+helm upgrade --install ai-guard charts/ai-guard \
+  --set loki.username=123456 \
+  --set loki.existingSecret=my-loki-creds
+```
+
+Setting them for one and not the other gives you a deployment where findings
+are stored and cannot be read back, and neither container reports an error you
+would attribute to the right cause: the receiver is healthy, its push counter
+climbs, and the portal returns something a deployer reads as their own
+misconfiguration.
+
+On Grafana Cloud the username is a numeric instance id rather than an email,
+and the access policy needs `logs:write` AND `logs:read`. A read-only token
+produces a 401 on every push that the receiver counts and logs while still
+answering 200 to the collector, so findings look accepted and are not stored.
+`aiguard_loki_push_total` staying at zero while findings arrive is that
+failure.
 
 ## Not in the chart
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -151,7 +151,7 @@ enforcement, and it rides the same pipeline.
 ```
 
 - **tool**, which AI tool, from the registry.
-- **surface**, one of browser, cli, ide, desktop, network, cloud.
+- **surface**, one of browser, cli, ide, desktop, mcp, network, cloud.
 - **os**, macos, windows, linux, or unknown (cloud and network findings
   have no single device OS).
 - **account_domain**, the domain of the signed-in account, never the

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -1,8 +1,8 @@
 # Deploying on Kubernetes
 
-Deploys the receiver: the one service every source reports to. The portal is
-not in the chart yet and is available on the [Docker Compose
-route](../../deploy/compose/README.md).
+Deploys the receiver, which every source reports to, and the portal, which
+reads the findings back. Both are in the chart and the portal is enabled by
+default; set `portal.enabled=false` if you want the receiver alone.
 
 If you have no cluster, you do not need one: see [the routes](README.md).
 
@@ -52,14 +52,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.2
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.4
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.2
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.4
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod
@@ -139,6 +139,67 @@ And that it serves the registry:
 curl -s -H "Authorization: Bearer $TOKEN" \
   https://your-receiver-host/registry/collector | head
 ```
+
+## The portal
+
+Enabled by default and deployed alongside the receiver. It reads findings back
+out of the log store, so it needs to be told where that is:
+
+    --set portal.lokiUrl=http://loki.monitoring.svc.cluster.local:3100
+
+That is the BASE url, not the push endpoint: the portal appends its own query
+path, while `loki.pushUrl` is POSTed to verbatim by the receiver. Two values,
+same host, and getting them crossed produces a receiver that stores findings
+and a portal that finds none.
+
+### A log store that needs credentials
+
+Grafana Cloud and most hosted Loki want basic auth, and **both containers need
+it**: the receiver to write, the portal to read.
+
+    kubectl create secret generic my-loki-creds \
+      --from-literal=lokiPassword='<token>'
+
+    --set loki.username=123456 \
+    --set loki.existingSecret=my-loki-creds
+
+The username is a value; the password comes from a Secret, because a password
+passed as a value ends up in `helm get values` and in whatever holds your
+values file.
+
+Setting them for one container and not the other produces a deployment where
+findings are stored and cannot be read back, and neither container reports an
+error you would attribute to the right cause. On Grafana Cloud the username is
+a numeric instance id rather than an email, and the access policy needs both
+`logs:write` and `logs:read`: a read-only token produces a 401 the receiver
+counts while still answering 200 to the collector, so findings look accepted
+and are not stored. `aiguard_loki_push_total` staying at zero while findings
+arrive is that failure.
+
+### Authentication
+
+The portal names who runs what on which machine, so it refuses to start without
+credentials. The chart generates a password on first install and keeps it
+across upgrades:
+
+    kubectl -n "$NS" get secret ai-guard-portal \
+      -o jsonpath='{.data.password}' | base64 -d; echo
+
+If your ingress can do OIDC or mTLS, do it there and set
+`portal.auth.mode=none` behind it. That is the better arrangement: basic auth
+is one shared credential with no per-user trail.
+
+### Governance and identity
+
+Both optional, both ConfigMaps:
+
+    --set portal.governance.existingConfigMap=ai-guard-governance
+    --set portal.identityMap.existingConfigMap=ai-guard-identity
+
+The first records approvals, owners and review dates
+([governance](../governance.md)). The second maps device keys to people, so
+reports carry a name rather than a serial. Without either, the register falls
+back to the registry's own `approved` flag and devices show as serials.
 
 ## When findings stop arriving
 

--- a/docs/evidence.md
+++ b/docs/evidence.md
@@ -13,7 +13,7 @@ demand from Loki, the registry and the governance file.
 {
   "generated_at": "2026-08-12T19:08:55Z",
   "window": { "from": "2026-08-05T19:08:55Z", "to": "2026-08-12T19:08:55Z", "hours": 168 },
-  "app_version": "0.9.0",
+  "app_version": "0.9.4",
   "registry_sha256": "sha256:e982bf...",
   "governance_sha256": "sha256:21a696...",
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -128,7 +128,7 @@ On the compose route it is already there, on port 8091. Otherwise:
 docker run --rm -p 8091:8091 \
   -e LOKI_URL=http://your-loki:3100 \
   -e PORTAL_USER=admin -e PORTAL_PASSWORD=... \
-  ghcr.io/amansk5/shadow-ai-guard/portal:0.4.0
+  ghcr.io/amansk5/shadow-ai-guard/portal:0.9.4
 ```
 
 It refuses to start without authentication, because it names who runs what on

--- a/docs/writing-a-scanner.md
+++ b/docs/writing-a-scanner.md
@@ -18,6 +18,7 @@ interface:
   "os": "unknown",
   "account_domain": "gmail.com",
   "device": "",
+  "device_name": "",
   "user": "",
   "evidence": "entra-signin",
   "severity": "warn",
@@ -31,11 +32,22 @@ Field rules:
 - **tool** should match a registry entry where possible, so it lines up with
   other sources on the dashboard. If your source discovers something not yet
   in the registry, add it to the registry too.
-- **surface** is one of browser, cli, ide, desktop, network, cloud. Pick the
-  one that describes how you observed it.
+- **surface** is one of browser, cli, ide, desktop, mcp, network, cloud. Pick
+  the one that describes how you observed it. `mcp` is for a Model Context
+  Protocol server wired into a tool: the tool is the finding's `tool`, and the
+  server names go in `evidence` rather than into the tool id, because folding
+  them in made every distinct combination look like a separate tool.
 - **os** is the device OS if you know it, else `unknown`. Cloud and network
   findings usually have no single device, so `unknown` and an empty
   `device` is correct.
+- **device** is a stable machine identifier, and a hardware serial where you
+  have one. It is what other sources key on, so a scanner sending a hostname
+  where the rest send serials splits that machine into two on every view.
+- **device_name** is what a human recognises: the hostname, or the name your
+  platform shows. The portal prefers it and falls back to `device`, so a
+  scanner that sends only the serial shows a serial where the others show a
+  name. Send both when you have both, and leave both empty for cloud findings
+  that belong to a person rather than a machine.
 - **account_domain** is the domain only. If your source gives you a full
   address, strip the local part before putting it here. The `account_domain`
   field must never contain a local part or full email.

--- a/portal/README.md
+++ b/portal/README.md
@@ -69,6 +69,8 @@ about the estate.
 | `PORTAL_AUTH` | yes* | `none` to run without auth, deliberately |
 | `LOKI_URL` | yes | Loki base URL, the same one the receiver writes to |
 | `LOKI_TOKEN` | no | bearer token, if your Loki needs one |
+| `LOKI_USERNAME` | no | basic auth user. Grafana Cloud and most hosted Loki want this rather than a token, and the receiver needs the same pair to write |
+| `LOKI_PASSWORD` | no | basic auth password, `_FILE` supported |
 | `LOOKBACK_HOURS` | no | default window, default 168 |
 | `REGISTRY_PATH` | no | registry.yaml, for resolving domains to tool ids |
 | `IDENTITY_MAP` | no | CSV of `key,identity` attaching people to devices |
@@ -81,6 +83,25 @@ about the estate.
 | `DEPLOY_CHART_VERSION` | no | shown on the settings page, clearly unverified |
 | `DEPLOY_RELEASE` | no | as above |
 | `DEPLOY_NAMESPACE` | no | as above |
+
+### Reading from a hosted log store
+
+`LOKI_USERNAME` and `LOKI_PASSWORD` are the same credentials the receiver
+writes with, and both containers need them. Setting them on one and not the
+other produces a deployment where findings are stored and cannot be read back,
+and nothing reports an error you would attribute to the right cause: the
+receiver is healthy, its push counter climbs, and this portal returns something
+a deployer reads as their own misconfiguration.
+
+Basic auth takes precedence over `LOKI_TOKEN` when both are set, because only
+one `Authorization` header can be sent and the log store is the thing that has
+to accept it.
+
+On Grafana Cloud the username is a numeric instance id rather than an email,
+and `LOKI_URL` is the base URL without the query path, while the receiver's
+`LOKI_PUSH_URL` ends `/loki/api/v1/push`. Same host, two values, and crossing
+them is the commonest way to get a receiver that stores findings and a portal
+that finds none.
 
 ## Identity
 
@@ -317,7 +338,7 @@ reported". It stays useful afterwards as an is-it-still-working view.
 
 ## Embedding Grafana
 
-The Dashboard tab embeds Grafana panels, so the portal can be the one place
+The Grafana tab embeds Grafana panels, so the portal can be the one place
 someone looks. It is optional, and everything else works without it.
 
 Grafana refuses to be framed by default, deliberately: framing a session

--- a/receiver/tests/test_smoke.py
+++ b/receiver/tests/test_smoke.py
@@ -330,3 +330,37 @@ def test_a_non_http_loki_push_url_is_refused():
 
     assert require_http_url("LOKI_PUSH_URL", "http://loki:3100/push")
     assert require_http_url("LOKI_PUSH_URL", "") == ""
+
+
+def test_the_docs_do_not_pin_a_stale_image():
+    """Documentation carries copy-paste commands with image tags in them.
+
+    getting-started.md had portal:0.4.0 in a docker run, five releases behind,
+    on the page somebody follows first. kubernetes.md named a receiver two
+    releases back. Every one of these goes stale on every release, and the
+    person who notices is a new user pulling an image with bugs that were
+    fixed months ago.
+
+    Same reasoning as the manifest test above: a number maintained by
+    remembering drifts, so this is the thing that remembers.
+    """
+    import re
+    from pathlib import Path
+
+    root = Path(__file__).parent.parent.parent
+    chart = (root / "charts" / "ai-guard" / "Chart.yaml").read_text()
+    app_version = re.search(r'^appVersion:\s*"?([^"\s]+)"?', chart, re.MULTILINE).group(1)
+
+    stale = []
+    for doc in sorted(root.glob("docs/**/*.md")) + sorted(root.glob("*.md")):
+        for i, line in enumerate(doc.read_text().split("\n"), start=1):
+            for m in re.finditer(
+                    r"shadow-ai-guard/(receiver|portal|scanner|discovery):"
+                    r"(\d+\.\d+\.\d+)", line):
+                if m.group(2) != app_version:
+                    stale.append("%s:%d pins %s" % (doc.name, i, m.group(0)))
+
+    assert not stale, (
+        "these pin an image that is not the released version (%s):\n  %s"
+        % (app_version, "\n  ".join(stale))
+    )


### PR DESCRIPTION
Four corrections from an outside review, plus two gaps of my own.

kubernetes.md said the portal "is not in the chart yet" and pointed at the Compose route for it. The chart has shipped the portal since 0.4.0 and enables it by default, so anyone following that page deployed a receiver and no portal, and the page documented no portal values at all. It now has a portal section: lokiUrl against pushUrl, the basic auth both containers need, where the generated password lives, and the governance and identity ConfigMaps.

The surface enum was missing mcp in two places. The receiver accepts seven and both docs listed six. writing-a-scanner.md is the contract page, so a scanner author reading it would not have known the surface existed, while the portal has an MCP servers page and there is an MCP scanner.

writing-a-scanner.md also omitted device_name from the finding example, and neither device nor device_name had an entry in the field list. A scanner written from that example sends a serial where the portal expects a name it can show a human, which is the difference between a row saying C02XK1AB and one saying someone's laptop.

Three version pins were stale: portal:0.4.0 in a copy-paste docker run on the getting-started page, five releases behind, and receiver:0.9.2 twice in kubernetes.md. All now 0.9.4, and a test keeps them there: it scans the docs for image pins and fails naming the file, the line and the pin. Same reasoning as the manifest test beside it, because a number maintained by remembering drifts.

Two of mine, both from 0.9.1. The chart README documented no loki.username or loki.existingSecret, and portal/README.md did not mention LOKI_USERNAME at all, which is the difference between a Helm or Compose deployment reading a hosted log store and silently finding nothing in it. Both now say that the credentials are used by both containers, and what a read-only Grafana Cloud token does.

And the portal's Grafana tab was still called Dashboard, renamed in 0.9.0.