### PR TITLE
extension: persist personal-account dedupe in storage.session so it survives worker restarts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,23 @@ jobs:
       - name: shellcheck macOS collector
         run: shellcheck -S warning endpoint/macos/*.sh endpoint/linux/*.sh
 
+  extension-tests:
+    # The extension has no build step and no package.json, and its tests are
+    # plain node scripts that exit non-zero on failure. They existed without a
+    # job for a while, which meant the paste guard's card detector and the
+    # account dedupe were tested once by hand and then never again. No
+    # setup-node: the runner's preinstalled node is enough for scripts with no
+    # dependencies, and one fewer action is one fewer thing to pin.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: extension tests
+        run: |
+          for t in extension/tests/test_*.js; do
+            echo "== $t"
+            node "$t" || exit 1
+          done
+
   collector-delivery-state:
     # The throttle timestamp must advance only after confirmed delivery. If it
     # advances on failure, a finding that never reached the receiver is never

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -16,29 +16,74 @@ const FALLBACK_ENDPOINT = ""; // leave blank; set via managed config in producti
 const FALLBACK_DEVICE = "";   // optional: set a label for LOCAL testing only
 const FALLBACK_AUTH_TOKEN = ""; // optional: set for LOCAL testing only
 const DEDUPE_WINDOW_MS = 6 * 60 * 60 * 1000; // one flag per tool+domain per 6h
-const seen = new Map();
+
+// Dedupe state for personal-account flags. This was a module-level Map, which
+// lives exactly as long as the service worker does: Chrome stops an MV3
+// worker after roughly thirty seconds idle and content.js checks every five
+// minutes, so the six-hour window was in practice one flag per check. The
+// receiver's alert TTL hid it from Slack, which is why nobody noticed, but
+// every repeat was a Loki line, a skewed occurrence count and a slice of the
+// portal's read budget.
+//
+// storage.session survives worker restarts, is cleared when the browser
+// exits and is never written to disk, which is the right lifetime for "we
+// already said this today". storage.local is the fallback for a browser
+// without it: the same fix the heartbeat already uses for lastHeartbeat.
+const SEEN_KEY = "personalAccountSeen";
+
+function seenStore() {
+  return api.storage.session || api.storage.local;
+}
+
+// True if this tool+domain was reported inside the window. Otherwise records
+// it and returns false. Entries past the window are dropped on the way
+// through so the object cannot grow without bound.
+async function alreadyReported(key, now) {
+  const store = seenStore();
+  let seen = {};
+  try {
+    const state = await store.get(SEEN_KEY);
+    seen = (state && state[SEEN_KEY]) || {};
+  } catch (e) { /* unreadable state is an empty state: report rather than lose */ }
+
+  if (seen[key] && now - seen[key] < DEDUPE_WINDOW_MS) return true;
+
+  for (const k of Object.keys(seen)) {
+    if (now - seen[k] >= DEDUPE_WINDOW_MS) delete seen[k];
+  }
+  seen[key] = now;
+  try {
+    await store.set({ [SEEN_KEY]: seen });
+  } catch (e) { /* a write that fails costs one duplicate, not a finding */ }
+  return false;
+}
+
+async function onPersonalAccount(msg) {
+  const key = msg.tool + ":" + msg.domain;
+  if (await alreadyReported(key, Date.now())) return;
+  await report({
+    tool: msg.tool,
+    // Absent until 1.2.0. The receiver defaults surface to "browser" and
+    // severity to "warn", so these findings looked right while carrying no
+    // source at all: on one fleet that was thousands a week that could not
+    // be traced to a detector. Defaults that happen to be correct are not
+    // the same as fields that are set.
+    surface: "browser",
+    source: "browser_extension",
+    severity: "warn",
+    account_domain: msg.domain,
+    reported_at: msg.ts,
+  });
+}
 
 api.runtime.onMessage.addListener((msg) => {
   if (!msg) return;
 
   if (msg.type === "personal-account") {
-    const key = msg.tool + ":" + msg.domain;
-    const now = Date.now();
-    if (seen.has(key) && now - seen.get(key) < DEDUPE_WINDOW_MS) return;
-    seen.set(key, now);
-    report({
-      tool: msg.tool,
-      // Absent until 1.2.0. The receiver defaults surface to "browser" and
-      // severity to "warn", so these findings looked right while carrying no
-      // source at all: on one fleet that was thousands a week that could not
-      // be traced to a detector. Defaults that happen to be correct are not
-      // the same as fields that are set.
-      surface: "browser",
-      source: "browser_extension",
-      severity: "warn",
-      account_domain: msg.domain,
-      reported_at: msg.ts,
-    }).catch((e) => console.warn("[ai-account-guard] report failed", e));
+    // Not returned. A listener that returns a promise tells Firefox a reply is
+    // coming, and content.js is not waiting for one.
+    onPersonalAccount(msg)
+      .catch((e) => console.warn("[ai-account-guard] report failed", e));
     return;
   }
 

--- a/extension/src/content.js
+++ b/extension/src/content.js
@@ -143,10 +143,10 @@ async function check() {
   // Firefox returns a promise here and rejects it when the background page is
   // not yet awake to receive. Chrome MV3 does the same. Nothing is waiting on
   // the result, so an uncaught rejection would surface in the page console of
-  // a user's browser for no reason. The dedupe map has already recorded this
-  // one, so a dropped message is a lost finding rather than a repeated one,
-  // which is the right way round: the guard has already acted on screen and
-  // the report is the record of it.
+  // a user's browser for no reason. Dedupe lives in background.js, keyed on
+  // tool+domain in storage.session, so a message dropped here is retried at
+  // the next check rather than lost: this check runs every five minutes and
+  // the window is six hours.
   api.runtime.sendMessage({
     type: "personal-account",
     tool: host,

--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Guard",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Flags AI tools signed in with a non-corporate account and stops secrets being pasted into them. Reports detector ids and account domains only, never content.",
   "permissions": [
     "storage",

--- a/extension/tests/test_account_dedupe.js
+++ b/extension/tests/test_account_dedupe.js
@@ -1,0 +1,116 @@
+// Personal-account dedupe must survive a service worker restart.
+//
+// The dedupe state was a module-level Map. Chrome stops an MV3 worker after
+// roughly thirty seconds idle and content.js checks every five minutes, so the
+// advertised six-hour window was in practice one flag per check. This test
+// evaluates background.js, sends the same flag, throws the module away and
+// evaluates it again against the same storage, the way the browser does, and
+// counts what reached the receiver.
+//
+// No test framework, same as test_payment_card.js. Run it with:
+//     node extension/tests/test_account_dedupe.js
+
+const fs = require("fs");
+const path = require("path");
+
+const src = fs.readFileSync(path.join(__dirname, "..", "src", "background.js"), "utf8");
+
+// One storage backing shared across "restarts": that is the property under
+// test. Everything else is rebuilt per boot, as it would be.
+function makeStorage(backing) {
+  return {
+    get: (key) => Promise.resolve(key in backing ? { [key]: backing[key] } : {}),
+    set: (obj) => { Object.assign(backing, obj); return Promise.resolve(); },
+  };
+}
+
+// Boot the worker once. Returns the captured onMessage listener and the list
+// of payloads POSTed to the receiver.
+function boot(sessionBacking, localBacking, now) {
+  const posted = [];
+  let listener = null;
+  const api = {
+    storage: {
+      session: sessionBacking && makeStorage(sessionBacking),
+      local: makeStorage(localBacking),
+      managed: { get: () => Promise.resolve({ reportEndpoint: "https://r.example/report",
+                                               deviceIdentifier: "DEV1" }) },
+    },
+    runtime: {
+      onMessage: { addListener: (fn) => { listener = fn; } },
+      onStartup: { addListener: () => {} },
+      onInstalled: { addListener: () => {} },
+      getManifest: () => ({ version: "test" }),
+      getPlatformInfo: () => Promise.resolve({ os: "mac" }),
+    },
+    alarms: { create: () => {}, onAlarm: { addListener: () => {} } },
+  };
+  const ctx = {};
+  new Function("globalThis", "fetch", "Date", "console",
+    src
+  ).call(ctx,
+    { browser: api },
+    (url, opts) => { posted.push(JSON.parse(opts.body)); return Promise.resolve({ ok: true }); },
+    { now: () => now() },
+    { warn: () => {}, log: () => {} });
+  return { send: (msg) => listener(msg), posted };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+async function settle() { for (let i = 0; i < 10; i++) await tick(); }
+
+let pass = 0, fail = 0;
+function check(name, got, want) {
+  if (got === want) { pass++; console.log("  ok:   " + name); }
+  else { fail++; console.log("  FAIL: " + name + " (got " + got + ", want " + want + ")"); }
+}
+
+const flag = { type: "personal-account", tool: "chatgpt.com", domain: "gmail.com", ts: "t" };
+
+(async () => {
+  console.log("personal-account dedupe");
+
+  // Same boot, same flag twice: one report.
+  let clock = 1_000_000;
+  let session = {}, local = {};
+  let w = boot(session, local, () => clock);
+  w.send(flag); await settle();
+  w.send(flag); await settle();
+  check("second flag in one worker lifetime is dropped", w.posted.length, 1);
+
+  // Worker restarted five minutes later, same storage: still dropped.
+  clock += 5 * 60 * 1000;
+  w = boot(session, local, () => clock);
+  w.send(flag); await settle();
+  check("flag after a worker restart is dropped", w.posted.length, 0);
+
+  // A different account on the same tool is a different finding.
+  w.send({ ...flag, domain: "outlook.com" }); await settle();
+  check("different domain on the same tool is reported", w.posted.length, 1);
+
+  // Past the window: reported again, and the expired entry is pruned.
+  clock += 6 * 60 * 60 * 1000 + 1;
+  w = boot(session, local, () => clock);
+  w.send(flag); await settle();
+  check("flag past the six-hour window is reported", w.posted.length, 1);
+  check("expired entries are pruned from storage",
+    Object.keys(session.personalAccountSeen).join(","), "chatgpt.com:gmail.com");
+
+  // No storage.session at all: storage.local carries it instead.
+  clock = 2_000_000; session = null; local = {};
+  w = boot(null, local, () => clock);
+  w.send(flag); await settle();
+  w = boot(null, local, () => clock + 60_000);
+  w.send(flag); await settle();
+  check("falls back to storage.local when session is absent",
+    "personalAccountSeen" in local, true);
+  check("local fallback still dedupes across a restart", w.posted.length, 0);
+
+  // The state was never persisted under the old code. This is the regression
+  // guard: a Map would pass every in-lifetime check above and fail this one.
+  check("dedupe state is in storage, not module scope",
+    typeof session === "object" || "personalAccountSeen" in local, true);
+
+  console.log(pass + " passed, " + fail + " failed");
+  process.exit(fail ? 1 : 0);
+})();


### PR DESCRIPTION
Adds a CI job running the extension's node tests, which had no job before.

Closes #105