### PR TITLE
central config: corp domains served to the fleet via /registry/collector

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.8.4
+version: 0.8.5
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/README.md
+++ b/charts/ai-guard/README.md
@@ -119,6 +119,7 @@ the portal.
 | `alertmanager.url` | `""` | unset means findings are logged and dashboarded but nothing pages |
 | `alertmanager.ttlMinutes` | `120` | how long a warn finding counts as already alerted |
 | `displayTz` | `UTC` | timezone for the readable timestamp on alerts only |
+| `corpDomains` | `[]` | corporate domains served to the collectors via `/registry/collector`; collectors prefer this to their local list, so a change here reaches the fleet on its next check-in with no MDM re-push |
 | `registry.create` | `true` | ship the compiled registry as a ConfigMap |
 | `registry.existingConfigMap` | `""` | use your own, for example built by CI on every merge |
 | `service.type` | `ClusterIP` | |

--- a/charts/ai-guard/templates/deployment.yaml
+++ b/charts/ai-guard/templates/deployment.yaml
@@ -59,6 +59,10 @@ spec:
             {{- end }}
             - name: DISPLAY_TZ
               value: {{ .Values.displayTz | quote }}
+            {{- with .Values.corpDomains }}
+            - name: CORP_DOMAINS
+              value: {{ join "," . | quote }}
+            {{- end }}
           volumeMounts:
             - name: registry
               mountPath: /etc/ai-guard

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -52,6 +52,13 @@ alertmanager:
 # always UTC.
 displayTz: UTC
 
+# Corporate domains, served to the endpoint collectors inside
+# /registry/collector as config.corp_domains. Collectors prefer this list to
+# their locally configured one, so a change here reaches the fleet on its
+# next check-in with no MDM re-push per platform. Empty means nothing is
+# served and collectors keep using their local configuration.
+corpDomains: []
+
 # The compiled registry ships with the chart, so the receiver has an
 # identifier list on first install with nothing to build. Set create: false to
 # manage the ConfigMap yourself (for example from a CI job that compiles

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -118,6 +118,14 @@ PORTAL_PORT=8091
 # Timezone for human-readable timestamps in alerts.
 DISPLAY_TZ=UTC
 
+# Corporate domains, comma-separated (example.com,example.co.uk). When set,
+# the receiver serves them to the endpoint collectors inside
+# /registry/collector as config.corp_domains, and collectors prefer that list
+# to their locally configured one - so a change here reaches the fleet on its
+# next check-in with no MDM re-push per platform. Empty means nothing is
+# served and collectors keep using their local configuration.
+CORP_DOMAINS=
+
 # ----------------------------------------------- only with --profile with-logs
 
 # Ignore these unless you have no log store and are using the bundled Loki and

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -61,6 +61,7 @@ services:
       REGISTRY_PATH: /etc/ai-guard/registry.json
       COLLECTOR_REGISTRY_PATH: /etc/ai-guard/collector.json
       DISPLAY_TZ: ${DISPLAY_TZ:-UTC}
+      CORP_DOMAINS: ${CORP_DOMAINS:-}
     volumes:
       - registry-dist:/etc/ai-guard:ro
       - ./secrets/auth_token:/run/secrets/auth_token:ro

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -126,6 +126,10 @@ Optional, all off by default:
 - `ALERTMANAGER_URL` - unset means findings are logged and dashboarded but
   nothing pages.
 - `DISPLAY_TZ` - timezone for the human-readable timestamp on alerts.
+- `CORP_DOMAINS` (chart value `corpDomains`) - corporate domains, served to
+  the endpoint collectors inside `/registry/collector`. Collectors prefer
+  this list to their locally configured one, so a change here reaches the
+  fleet on its next check-in with no MDM re-push per platform.
 
 Confirm it is up:
 

--- a/endpoint/linux/README.md
+++ b/endpoint/linux/README.md
@@ -37,7 +37,9 @@ AIGUARD_CORP_DOMAINS    comma-separated corporate domains, e.g. example.com,exam
 ```
 
 Set `AIGUARD_CORP_DOMAINS` correctly: an empty value means no domain counts
-as corporate, so every account reports as a personal-account warning.
+as corporate, so every account reports as a personal-account warning. If the
+receiver has `CORP_DOMAINS` set, its list overrides this variable at runtime,
+so the fleet follows a receiver-side change without an RMM re-edit.
 
 If `AIGUARD_RECEIVER_BASE` is unset the script prints findings to stdout
 instead of POSTing, which is the local-test mode.

--- a/endpoint/linux/ai-guard-collector.sh
+++ b/endpoint/linux/ai-guard-collector.sh
@@ -21,7 +21,10 @@
 # variables, or export them from a wrapper):
 #   AIGUARD_RECEIVER_BASE   receiver base URL, e.g. https://ai-guard.example.com
 #   AIGUARD_TOKEN           receiver bearer token
-#   AIGUARD_CORP_DOMAINS    comma-separated corporate domains, e.g. example.com
+#   AIGUARD_CORP_DOMAINS    comma-separated corporate domains, e.g. example.com.
+#                           A receiver that serves config.corp_domains in
+#                           /registry/collector overrides this at runtime; the
+#                           variable is the fallback.
 # If AIGUARD_RECEIVER_BASE is unset, findings print to stdout instead of
 # POSTing, which is the local-test mode.
 #
@@ -384,6 +387,29 @@ REG_TSV=$(registry_tsv "$REG_FILE")
 if [ -z "$REG_TSV" ]; then
   echo "[ai-guard] registry parse failed: $REG_FILE"
   exit 1
+fi
+
+# Corporate domains can arrive with the registry: the receiver serves
+# config.corp_domains in the payload just fetched when it has CORP_DOMAINS
+# set. The served list wins over AIGUARD_CORP_DOMAINS, because a list changed
+# once on the receiver reaches the fleet on its next run rather than waiting
+# on an RMM variable edit per platform; the variable stays as the fallback,
+# so a receiver serving nothing changes nothing. Guarded on $PY, though a
+# registry parse without python3 already refused above.
+if [ -n "$PY" ]; then
+  CENTRAL_DOMAINS=$("$PY" - "$REG_FILE" <<'PYEOF' 2>/dev/null
+import json, sys
+try:
+    r = json.load(open(sys.argv[1]))
+    print(",".join((r.get("config") or {}).get("corp_domains") or []))
+except Exception:
+    pass
+PYEOF
+)
+  if [ -n "$CENTRAL_DOMAINS" ]; then
+    echo "[ai-guard] corporate domains from receiver: $CENTRAL_DOMAINS"
+    CORP_DOMAINS="$CENTRAL_DOMAINS"
+  fi
 fi
 
 STATE_NEW=$(mktemp /tmp/ai-guard-state.XXXXXX)

--- a/endpoint/macos/README.md
+++ b/endpoint/macos/README.md
@@ -52,7 +52,9 @@ reports as `warn`; everything else is `info`.
    - Parameter 5: the receiver bearer token
    - Parameter 6: corporate domains, comma-separated, e.g.
      `example.com,example.co.uk`. Leave this correct: an empty value means no
-     domain counts as corporate and every account warns.
+     domain counts as corporate and every account warns. If the receiver has
+     `CORP_DOMAINS` set, its list overrides this parameter at runtime, so the
+     fleet follows a receiver-side change without a Jamf re-edit.
    - Trigger: Recurring Check-in, plus a custom trigger (e.g. `aiguard`) so
      you can run it on demand with `sudo jamf policy -event aiguard`.
    - Frequency: Ongoing. The 24 hour throttle above keeps the volume sane.

--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -21,7 +21,9 @@
 #   Parameter 5: bearer token
 #   Parameter 6: corporate domains, comma-separated (e.g. example.com,example.co.uk).
 #                 Accounts on these domains report as work; anything else is a
-#                 personal account and escalates severity.
+#                 personal account and escalates severity. A receiver that
+#                 serves config.corp_domains in /registry/collector overrides
+#                 this at runtime; the parameter is the fallback.
 #
 # Local test: AIGUARD_REGISTRY_FILE=registry/dist/collector.json ./ai-guard-collector.sh
 # with no args - findings are printed instead of POSTed.
@@ -346,6 +348,21 @@ REG_TSV=$(registry_tsv "$REG_FILE")
 if [ -z "$REG_TSV" ]; then
   echo "[ai-guard] registry parse failed: $REG_FILE"
   exit 1
+fi
+
+# Corporate domains can arrive with the registry: the receiver serves
+# config.corp_domains in the payload just fetched when it has CORP_DOMAINS
+# set. The served list wins over parameter 6, because a list changed once on
+# the receiver reaches the fleet on its next check-in rather than waiting on
+# an MDM re-paste per platform; the parameter stays as the fallback, so a
+# receiver serving nothing changes nothing. json_get stringifies the array
+# comma-joined, which is the exact shape the severity check in report()
+# matches against - the receiver serves it trimmed and lowercased for the
+# same reason.
+CENTRAL_DOMAINS=$(json_get "$REG_FILE" config corp_domains)
+if [ -n "$CENTRAL_DOMAINS" ]; then
+  echo "[ai-guard] corporate domains from receiver: $CENTRAL_DOMAINS"
+  CORP_DOMAINS="$CENTRAL_DOMAINS"
 fi
 
 # report_once <surface> <tool> <account> <evidence>

--- a/endpoint/tests/test_linux_collector.sh
+++ b/endpoint/tests/test_linux_collector.sh
@@ -73,14 +73,19 @@ setup_home() {
 # Fake receiver. Serves the collector registry on GET and returns a chosen
 # status on POST, logging each one so a test can assert a request was or was
 # not attempted.
+# start_receiver <status> [served_corp_domains]
+# The optional second argument makes the served registry carry
+# config.corp_domains, the way a receiver with CORP_DOMAINS set does.
 start_receiver() {
   local status="$1"
   : > "$RECEIVER_LOG"
-  python3 - "$PORT" "$status" "$RECEIVER_LOG" <<'PY' &
+  python3 - "$PORT" "$status" "$RECEIVER_LOG" "${2-}" <<'PY' &
+import json
 import sys
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 port, status, logpath = int(sys.argv[1]), int(sys.argv[2]), sys.argv[3]
+served_domains = sys.argv[4] if len(sys.argv) > 4 else ""
 REGISTRY = (
     b'{"version":1,"cli":[{"tool":"claude-code",'
     b'"config_paths":[".claude-aiguard-test.json"],'
@@ -88,6 +93,10 @@ REGISTRY = (
     b'"account_json_keys":["oauthAccount"],"binaries":["claude"]}],'
     b'"ide":[],"desktop":[],"mcp":[]}'
 )
+if served_domains:
+    reg = json.loads(REGISTRY)
+    reg["config"] = {"corp_domains": served_domains.split(",")}
+    REGISTRY = json.dumps(reg).encode()
 
 class H(BaseHTTPRequestHandler):
     def do_GET(self):
@@ -99,9 +108,11 @@ class H(BaseHTTPRequestHandler):
 
     def do_POST(self):
         n = int(self.headers.get("Content-Length") or 0)
-        self.rfile.read(n)
+        # The body rides on the POST line (findings are single-line JSON), so
+        # a test can assert on what was reported, not just that something was.
+        body = self.rfile.read(n).decode("utf-8", "replace").replace("\n", " ")
         with open(logpath, "a") as f:
-            f.write("POST\n")
+            f.write("POST " + body + "\n")
         self.send_response(status)
         self.end_headers()
 
@@ -297,6 +308,24 @@ test_info_still_throttled_beyond_the_warn_window() {
   if [ "$n" -eq 0 ]; then pass "$name"; else fail "$name (made $n request(s))"; fi
 }
 
+test_served_corp_domains_override_the_local_list() {
+  # Central config: a receiver with CORP_DOMAINS set serves the list inside
+  # /registry/collector, and the served list wins over AIGUARD_CORP_DOMAINS.
+  # Here the local list calls example.com personal while the receiver says it
+  # is corporate, so the fixture account must land as info; a warn means the
+  # override was lost and the fleet is still following per-machine config.
+  local name="receiver-served corp domains override the local list"
+  reset_state; start_receiver 200 example.com
+  run_collector other-company.example
+  stop_receiver
+  if grep -q '"severity":"info"' "$RECEIVER_LOG" \
+      && ! grep -q '"severity":"warn"' "$RECEIVER_LOG"; then
+    pass "$name"
+  else
+    fail "$name (severities: $(grep -o '"severity":"[a-z]*"' "$RECEIVER_LOG" | sort -u | tr '\n' ' '))"
+  fi
+}
+
 # ------------------------------------------------------------------- main --
 
 require_root
@@ -348,6 +377,7 @@ test_warn_inside_window_suppresses
 test_warn_outside_window_posts_again
 test_warn_with_no_prior_state_posts_immediately
 test_info_still_throttled_beyond_the_warn_window
+test_served_corp_domains_override_the_local_list
 
 echo
 echo "passed: $PASS  failed: $FAIL"

--- a/endpoint/windows/README.md
+++ b/endpoint/windows/README.md
@@ -33,6 +33,10 @@ token cannot expand). Commit only the placeholder version; the tokenised copy
 exists only inside Intune. CI fails the build if the placeholder is missing, 
 so a tokenised copy cannot reach main by accident.
 
+If the receiver has `CORP_DOMAINS` set, its list overrides `$CorporateDomains`
+at runtime, so the fleet follows a receiver-side change without an Intune
+re-paste.
+
 ## Trying it against a local receiver
 
 No Intune needed. Edit the three variables at the top of the script, then run

--- a/endpoint/windows/ai-guard-collector.ps1
+++ b/endpoint/windows/ai-guard-collector.ps1
@@ -42,7 +42,9 @@ param([switch]$FunctionsOnly)
 # ------------------------------------------------------------------ config --
 $ReceiverBase    = 'https://ai-guard.example.com'   # your receiver's public ingest URL
 $Token           = '__RECEIVER_TOKEN__'   # replace before upload, or wire to a secure retrieval
-$CorporateDomains = @('example.com')   # accounts on these domains are 'work'; all others warn as personal
+$CorporateDomains = @('example.com')   # accounts on these domains are 'work'; all others warn as personal.
+                                       # A receiver that serves config.corp_domains in /registry/collector
+                                       # overrides this at runtime; the constant is the fallback.
 
 $StateDir  = 'C:\ProgramData\ai-guard'
 $StateFile = Join-Path $StateDir 'reported.state.json'
@@ -272,6 +274,18 @@ if (-not $FunctionsOnly) {
         # An empty scan looks exactly like a clean machine. Refuse instead.
         Write-Output 'ai-guard: refusing to scan without an identifier list'
         exit 1
+    }
+
+    # Corporate domains can arrive with the registry: the receiver serves
+    # config.corp_domains in the payload just fetched when it has CORP_DOMAINS
+    # set. The served list wins over the constant above, because a list
+    # changed once on the receiver reaches the fleet on its next run rather
+    # than waiting on an Intune re-paste; the constant stays as the fallback,
+    # so a receiver serving nothing changes nothing. Lowercased to match the
+    # severity check, which lowercases the account side.
+    if ($Registry.PSObject.Properties['config'] -and $Registry.config.corp_domains) {
+        $CorporateDomains = @($Registry.config.corp_domains | ForEach-Object { "$_".ToLower() })
+        Write-Output "ai-guard: corporate domains from receiver: $($CorporateDomains -join ',')"
     }
 }
 

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -37,6 +37,7 @@ Everything is environment variables. Only the token is required.
 | `REGISTRY_PATH` | `/etc/ai-guard/registry.json` | where the compiled registry is mounted |
 | `COLLECTOR_REGISTRY_PATH` | `/etc/ai-guard/collector.json` | where the collector view is mounted |
 | `DISPLAY_TZ` | `UTC` | timezone for the human-readable timestamp on alerts only; machine timestamps are always UTC |
+| `CORP_DOMAINS` | unset | corporate domains, comma-separated. When set, served to the endpoint collectors inside `/registry/collector` as `config.corp_domains`; collectors prefer that list to their locally configured one, so a change here reaches the fleet on its next check-in with no MDM re-push. Unset means collectors keep using their local configuration |
 
 Any of these can be given as `NAME_FILE` pointing at a file instead:
 `AUTH_TOKEN_FILE=/run/secrets/auth_token` rather than `AUTH_TOKEN`. That

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -181,6 +181,29 @@ COLLECTOR_REGISTRY_PATH = os.environ.get(
 # alerts. Machine timestamps are always UTC.
 DISPLAY_TZ = ZoneInfo(os.environ.get("DISPLAY_TZ", "UTC"))
 
+
+def _parse_corp_domains(raw: str) -> list[str]:
+    """The comma-separated list as collectors need it: trimmed, lowercased,
+    empties dropped, duplicates removed, order preserved. The macOS collector
+    matches with a comma-anchored case pattern, so a stray space or an upper
+    case letter served here would silently turn a work account into a warn.
+    """
+    out: list[str] = []
+    for part in raw.split(","):
+        d = part.strip().lower()
+        if d and d not in out:
+            out.append(d)
+    return out
+
+
+# Corporate domains, comma-separated (example.com,example.co.uk). When set,
+# they ride inside /registry/collector as config.corp_domains and the
+# collectors use them in place of their locally configured list, so one value
+# changed here reaches the whole fleet on its next check-in instead of an MDM
+# re-push per platform. Unset means collectors keep their local configuration,
+# which is also what any collector talking to an older receiver does.
+CORP_DOMAINS = _parse_corp_domains(os.environ.get("CORP_DOMAINS", ""))
+
 # "network" is a DNS/flow observation from SentinelOne: a device resolved a
 # domain, but the resolving process may be a browser, a desktop app, a CLI or
 # a system daemon. It is deliberately distinct from "browser", which means the
@@ -447,13 +470,21 @@ def registry_collector(authorization: str = Header(default="")):
 
     Served so a new AI tool is a registry merge request rather than an edit
     to every collector script plus an MDM re-paste on each platform.
+
+    Deployment config rides in the same response under "config" when the
+    receiver has any to serve. The collectors already fetch this payload on
+    every run, so central config costs no extra request, and a collector that
+    pre-dates the key ignores it.
     """
     _auth(authorization)
     try:
         with open(COLLECTOR_REGISTRY_PATH) as f:
-            return json.load(f)
+            reg = json.load(f)
     except (OSError, json.JSONDecodeError):
         raise HTTPException(503, "collector registry not available")
+    if CORP_DOMAINS and isinstance(reg, dict):
+        reg.setdefault("config", {})["corp_domains"] = CORP_DOMAINS
+    return reg
 
 
 def _auth(authorization: str):

--- a/receiver/tests/test_smoke.py
+++ b/receiver/tests/test_smoke.py
@@ -197,6 +197,49 @@ def test_domain_map_survives_a_missing_registry():
     assert _build_domain_map(None) == {}
     assert _build_domain_map({}) == {}
 
+def test_corp_domains_are_normalised_for_the_strictest_matcher():
+    """The macOS collector matches with a comma-anchored case pattern: no
+    trimming, no case folding. A list served with a stray space or capital
+    would silently turn a work account into a personal-account warn."""
+    from app.main import _parse_corp_domains
+
+    raw = " Example.COM , example.co.uk ,, example.com "
+    assert _parse_corp_domains(raw) == ["example.com", "example.co.uk"]
+    assert _parse_corp_domains("") == []
+
+
+def test_collector_registry_carries_corp_domains_when_configured(tmp_path, monkeypatch):
+    """One value changed on the receiver reaches the fleet on its next
+    check-in, riding in the payload collectors already fetch."""
+    from app import main
+
+    reg = tmp_path / "collector.json"
+    reg.write_text('{"version": 1, "cli": []}')
+    monkeypatch.setattr(main, "COLLECTOR_REGISTRY_PATH", str(reg))
+    monkeypatch.setattr(main, "CORP_DOMAINS", ["example.com", "example.co.uk"])
+
+    resp = client.get("/registry/collector", headers=AUTH)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["config"]["corp_domains"] == ["example.com", "example.co.uk"]
+    assert body["version"] == 1  # the registry content is untouched
+
+
+def test_collector_registry_is_untouched_when_no_corp_domains(tmp_path, monkeypatch):
+    """No CORP_DOMAINS means no config key at all: a collector must fall back
+    to its local list, and an empty served list must not clobber it."""
+    from app import main
+
+    reg = tmp_path / "collector.json"
+    reg.write_text('{"version": 1}')
+    monkeypatch.setattr(main, "COLLECTOR_REGISTRY_PATH", str(reg))
+    monkeypatch.setattr(main, "CORP_DOMAINS", [])
+
+    resp = client.get("/registry/collector", headers=AUTH)
+    assert resp.status_code == 200
+    assert "config" not in resp.json()
+
+
 def test_a_rejected_push_is_counted_and_says_why():
     """A push that fails is a finding that exists only in this container's
     stdout. The receiver still answers 200, which is right - a log store being


### PR DESCRIPTION
Set CORP_DOMAINS on the receiver (chart value corpDomains, compose env) and it rides inside the payload the collectors already fetch on every run, as config.corp_domains. All three collectors prefer the served list to their locally configured one, so a domain change reaches the fleet on its next check-in with no MDM re-push per platform. The local settings stay as the bootstrap fallback: a receiver serving nothing changes nothing, and older collectors ignore the key.

The receiver normalises the list (trimmed, lowercased, deduped) because the macOS matcher is comma-anchored and exact: a stray space served centrally would silently turn a work account into a personal-account warn. An empty list serves no config key at all, so unset means off rather than no-domain-is-corporate.

Chart 0.8.4 -> 0.8.5. New receiver tests for parsing and both endpoint shapes; new delivery-state test proving the served list wins over AIGUARD_CORP_DOMAINS, with the fake receiver now logging POST bodies so tests can assert on what was reported, not just that something was.