### PR TITLE
managed mode: enrollment, per-device credentials, revocation, fleet inventory

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,8 +42,15 @@ should accept before deploying:
   detect.
 - Compromise of one endpoint reveals the same token every endpoint uses.
 
-If that is unacceptable in your threat model, front the receiver with your
-own per-source authentication.
+If that is unacceptable in your threat model, enable managed mode: the
+endpoint collectors then enroll for per-device credentials, one machine can
+be revoked without touching any other, and an enrollment token in an MDM
+artifact can create auditable device records but never submit findings. The
+shared token remains valid alongside (the browser extension and scanners
+still use it), so the consequences above shrink to those surfaces rather
+than disappearing. See the receiver README for the mechanics, including the
+separate `ADMIN_TOKEN` that mints credentials - separate precisely because
+the shared token is on every machine in the fleet.
 
 ### The portal
 

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.8.5
+version: 0.8.6
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/README.md
+++ b/charts/ai-guard/README.md
@@ -120,6 +120,11 @@ the portal.
 | `alertmanager.ttlMinutes` | `120` | how long a warn finding counts as already alerted |
 | `displayTz` | `UTC` | timezone for the readable timestamp on alerts only |
 | `corpDomains` | `[]` | corporate domains served to the collectors via `/registry/collector`; collectors prefer this to their local list, so a change here reaches the fleet on its next check-in with no MDM re-push |
+| `managed.enabled` | `false` | device enrollment, per-device credentials, revocation and a fleet inventory, backed by SQLite on a PVC. Requires `replicaCount: 1` (the chart refuses otherwise) and switches the Deployment to `Recreate` |
+| `managed.adminToken.value` | `""` | the credential that mints/revokes enrollment tokens and devices; leave unset to auto-generate into `<release>-ai-guard-admin` and keep across upgrades |
+| `managed.adminToken.existingSecret` | `""` | a Secret you created yourself, key `adminToken` |
+| `managed.persistence.size` | `1Gi` | the state PVC. Annotated `helm.sh/resource-policy: keep`: uninstalling the chart does not unenroll the fleet |
+| `managed.persistence.existingClaim` | `""` | use a PVC you created yourself |
 | `registry.create` | `true` | ship the compiled registry as a ConfigMap |
 | `registry.existingConfigMap` | `""` | use your own, for example built by CI on every merge |
 | `service.type` | `ClusterIP` | |

--- a/charts/ai-guard/templates/deployment.yaml
+++ b/charts/ai-guard/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.managed.enabled (gt (int .Values.replicaCount) 1) }}
+{{- fail "managed mode is backed by SQLite, which has one writer: set replicaCount to 1 (a Postgres option is future work)" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -6,6 +9,12 @@ metadata:
     {{- include "ai-guard.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.managed.enabled }}
+  # The state volume is ReadWriteOnce, so a rolling update's new pod would
+  # wedge waiting for a mount the old pod still holds.
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "ai-guard.selectorLabels" . | nindent 6 }}
@@ -63,6 +72,17 @@ spec:
             - name: CORP_DOMAINS
               value: {{ join "," . | quote }}
             {{- end }}
+            {{- if .Values.managed.enabled }}
+            - name: MANAGED_MODE
+              value: "true"
+            - name: STATE_DB_PATH
+              value: /var/lib/ai-guard/state.db
+            - name: ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.managed.adminToken.existingSecret | default (printf "%s-admin" (include "ai-guard.fullname" .)) }}
+                  key: adminToken
+            {{- end }}
           volumeMounts:
             - name: registry
               mountPath: /etc/ai-guard
@@ -71,6 +91,10 @@ spec:
             # somewhere to write. /tmp is the only one the receiver uses.
             - name: tmp
               mountPath: /tmp
+            {{- if .Values.managed.enabled }}
+            - name: state
+              mountPath: /var/lib/ai-guard
+            {{- end }}
           readinessProbe:
             httpGet: { path: /healthz, port: http }
             initialDelaySeconds: 3
@@ -85,6 +109,11 @@ spec:
             name: {{ include "ai-guard.registryConfigMap" . }}
         - name: tmp
           emptyDir: {}
+        {{- if .Values.managed.enabled }}
+        - name: state
+          persistentVolumeClaim:
+            claimName: {{ .Values.managed.persistence.existingClaim | default (printf "%s-state" (include "ai-guard.fullname" .)) }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/ai-guard/templates/managed-pvc.yaml
+++ b/charts/ai-guard/templates/managed-pvc.yaml
@@ -1,0 +1,22 @@
+{{- if and .Values.managed.enabled (not .Values.managed.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "ai-guard.fullname" . }}-state
+  labels:
+    {{- include "ai-guard.labels" . | nindent 4 }}
+  annotations:
+    # The one thing in the deployment that is not disposable: the device
+    # registry and its credentials. Kept on uninstall so a helm uninstall /
+    # reinstall cycle does not silently unenroll the entire fleet; delete the
+    # PVC yourself when you mean it.
+    helm.sh/resource-policy: keep
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: {{ .Values.managed.persistence.size }}
+  {{- with .Values.managed.persistence.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+{{- end }}

--- a/charts/ai-guard/templates/managed-secret.yaml
+++ b/charts/ai-guard/templates/managed-secret.yaml
@@ -1,0 +1,27 @@
+{{- if and .Values.managed.enabled (not .Values.managed.adminToken.existingSecret) }}
+{{/*
+  Same precedence as the auth token in secret.yaml: an explicit value wins;
+  otherwise reuse the token already in the cluster so upgrades do not rotate
+  it out from under whoever holds it; otherwise generate one. Its own Secret
+  rather than a key on the auth one, because auth.existingSecret can disable
+  that template entirely and the admin credential must not vanish with it.
+*/}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-admin" (include "ai-guard.fullname" .)) -}}
+{{- $token := "" -}}
+{{- if .Values.managed.adminToken.value -}}
+{{- $token = .Values.managed.adminToken.value -}}
+{{- else if and $existing $existing.data.adminToken -}}
+{{- $token = ($existing.data.adminToken | b64dec) -}}
+{{- else -}}
+{{- $token = randAlphaNum 48 -}}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ai-guard.fullname" . }}-admin
+  labels:
+    {{- include "ai-guard.labels" . | nindent 4 }}
+type: Opaque
+data:
+  adminToken: {{ $token | b64enc | quote }}
+{{- end }}

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -59,6 +59,31 @@ displayTz: UTC
 # served and collectors keep using their local configuration.
 corpDomains: []
 
+# Managed mode: device enrollment, per-device credentials, revocation and a
+# real fleet inventory, backed by one SQLite file on a PersistentVolumeClaim.
+# Off means byte-for-byte the classic receiver: no volume, no admin routes,
+# no state. The shared token keeps working for ingest either way - a fleet
+# migrates by swapping the token in each MDM for an enrollment token, one
+# platform at a time.
+#
+# SQLite has one writer, so managed mode requires replicaCount: 1 (the chart
+# refuses to render otherwise) and uses a Recreate strategy so two pods never
+# hold the volume at once.
+managed:
+  enabled: false
+  # The credential that mints and revokes enrollment tokens and devices.
+  # Deliberately a separate secret from the shared token, which sits on every
+  # machine in the fleet. Leave both unset and the chart generates one on
+  # first install and keeps it across upgrades. Read it back with:
+  #   kubectl get secret <release>-ai-guard-admin -o jsonpath='{.data.adminToken}' | base64 -d
+  adminToken:
+    value: ""
+    existingSecret: ""   # a Secret with an `adminToken` key
+  persistence:
+    size: 1Gi
+    storageClass: ""     # empty means the cluster default
+    existingClaim: ""    # use a PVC you created yourself
+
 # The compiled registry ships with the chart, so the receiver has an
 # identifier list on first install with nothing to build. Set create: false to
 # manage the ConfigMap yourself (for example from a CI job that compiles

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -126,6 +126,10 @@ DISPLAY_TZ=UTC
 # served and collectors keep using their local configuration.
 CORP_DOMAINS=
 
+# Managed mode (device enrollment, per-device credentials, revocation) is an
+# overlay rather than a variable: it needs a secret and a volume, not just an
+# env flag. See docker-compose.managed.yml for the two-step setup.
+
 # ----------------------------------------------- only with --profile with-logs
 
 # Ignore these unless you have no log store and are using the bundled Loki and

--- a/deploy/compose/docker-compose.managed.yml
+++ b/deploy/compose/docker-compose.managed.yml
@@ -1,0 +1,35 @@
+# Managed mode overlay: device enrollment, per-device credentials, revocation
+# and a real fleet inventory, backed by one SQLite file on a named volume.
+#
+# Classic deployments never touch this file. To enable managed mode:
+#
+#   1. Create the admin credential (mints and revokes enrollment tokens and
+#      devices - deliberately a separate secret from the shared token, which
+#      sits on every machine in the fleet):
+#        umask 077; openssl rand -base64 36 > secrets/admin_token
+#   2. Start with both files:
+#        docker compose -f docker-compose.yml -f docker-compose.managed.yml up -d
+#
+# Then mint an enrollment token and put it in your MDM in place of the shared
+# token, one platform at a time:
+#   curl -s -X POST -H "Authorization: Bearer $(cat secrets/admin_token)" \
+#     -H 'Content-Type: application/json' -d '{"note":"macos rollout"}' \
+#     http://127.0.0.1:8080/admin/enrollment-tokens
+#
+# The state volume is the one thing in this deployment that is not
+# disposable: it holds the device registry and its credential hashes.
+# `docker compose down` leaves named volumes in place; only `down -v`
+# destroys it, which unenrolls the entire fleet.
+
+services:
+  receiver:
+    environment:
+      MANAGED_MODE: "true"
+      ADMIN_TOKEN_FILE: /run/secrets/admin_token
+      STATE_DB_PATH: /var/lib/ai-guard/state.db
+    volumes:
+      - managed-state:/var/lib/ai-guard
+      - ./secrets/admin_token:/run/secrets/admin_token:ro
+
+volumes:
+  managed-state:

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -130,6 +130,13 @@ Optional, all off by default:
   the endpoint collectors inside `/registry/collector`. Collectors prefer
   this list to their locally configured one, so a change here reaches the
   fleet on its next check-in with no MDM re-push per platform.
+- `managed.enabled` - device enrollment, per-device credentials and
+  revocation, backed by SQLite on a PVC. The chart generates an admin token
+  into `<release>-ai-guard-admin` on first install; read it back the same way
+  as the auth token. Mint an enrollment token with
+  `POST /admin/enrollment-tokens` and put it in the MDM in place of the
+  shared token, one platform at a time. See the receiver README for the
+  endpoint reference.
 
 Confirm it is up:
 

--- a/endpoint/linux/README.md
+++ b/endpoint/linux/README.md
@@ -36,6 +36,11 @@ AIGUARD_TOKEN           receiver bearer token
 AIGUARD_CORP_DOMAINS    comma-separated corporate domains, e.g. example.com,example.co.uk
 ```
 
+`AIGUARD_TOKEN` can also be an enrollment token (`aige_...`) from a
+managed-mode receiver: the machine then enrolls itself on first run, stores
+its own device credential in `/var/lib/ai-guard`, and can be revoked
+individually from then on. Swapping the RMM variable is the whole migration.
+
 Set `AIGUARD_CORP_DOMAINS` correctly: an empty value means no domain counts
 as corporate, so every account reports as a personal-account warning. If the
 receiver has `CORP_DOMAINS` set, its list overrides this variable at runtime,

--- a/endpoint/linux/ai-guard-collector.sh
+++ b/endpoint/linux/ai-guard-collector.sh
@@ -20,7 +20,13 @@
 # Config arrives as environment variables (set them in your RMM's script
 # variables, or export them from a wrapper):
 #   AIGUARD_RECEIVER_BASE   receiver base URL, e.g. https://ai-guard.example.com
-#   AIGUARD_TOKEN           receiver bearer token
+#   AIGUARD_TOKEN           receiver bearer token. Either the shared token, or
+#                           an enrollment token (aige_...) from a managed-mode
+#                           receiver: on first run the machine enrolls, stores
+#                           its own device credential in /var/lib/ai-guard,
+#                           and uses that from then on. Swapping the shared
+#                           token for an enrollment token in the RMM is the
+#                           whole migration.
 #   AIGUARD_CORP_DOMAINS    comma-separated corporate domains, e.g. example.com.
 #                           A receiver that serves config.corp_domains in
 #                           /registry/collector overrides this at runtime; the
@@ -52,6 +58,12 @@ ENDPOINT=""
 
 STATE_DIR="/var/lib/ai-guard"
 STATE_FILE="$STATE_DIR/reported.state"
+# This machine's own credential, once enrolled with a managed-mode receiver.
+# Root-only: it is this device's identity.
+CRED_FILE="$STATE_DIR/device.cred"
+# Reported at enrollment and on every report, so the receiver's inventory can
+# answer "which script version does the fleet actually run".
+COLLECTOR_VERSION="2.0.0"
 SUMMARY_DIR="$STATE_DIR"
 SUMMARY_FILE="$SUMMARY_DIR/last_scan.txt"
 INFO_INTERVAL=$((24 * 3600))
@@ -286,6 +298,7 @@ report() {
   local code
   code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' \
     -X POST -H "Authorization: Bearer $TOKEN" \
+    -H "X-AiGuard-Agent-Version: $COLLECTOR_VERSION" \
     -H 'Content-Type: application/json' \
     --data "$payload" "$ENDPOINT" 2>/dev/null || echo 000)
   if [ "$code" = "200" ] || [ "$code" = "204" ]; then
@@ -378,9 +391,63 @@ registry_tsv_fallback() {
   return 1
 }
 
+# ------------------------------------------------------------- enrollment --
+# Managed mode. A stored device credential wins; an enrollment token
+# (aige_...) is exchanged for one on first run; anything else is today's
+# behaviour exactly. The prefix is the whole switch: the operator changes one
+# RMM variable from the shared token to an enrollment token when ready.
+if [ -f "$CRED_FILE" ]; then
+  STORED_CRED=$(cat "$CRED_FILE" 2>/dev/null)
+  case "$STORED_CRED" in aigd_*) TOKEN="$STORED_CRED" ;; esac
+fi
+case "$TOKEN" in
+  aige_*)
+    if [ -n "$RECEIVER_BASE" ]; then
+      mkdir -p "$STATE_DIR"
+      ENROLL_BODY=$(printf '{"platform":"linux","serial":"%s","hostname":"%s","agent_version":"%s"}' \
+        "$(json_escape "$DEVICE")" "$(json_escape "$DEVICE_NAME")" "$COLLECTOR_VERSION")
+      ENROLL_RESP=$(mktemp /tmp/ai-guard-enroll.XXXXXX)
+      ENROLL_CODE=$(curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
+        -X POST -H "Authorization: Bearer $TOKEN" \
+        -H 'Content-Type: application/json' \
+        --data "$ENROLL_BODY" "${RECEIVER_BASE%/}/enroll" 2>/dev/null || echo 000)
+      if [ "$ENROLL_CODE" = "200" ]; then
+        if [ -n "$PY" ]; then
+          CRED=$("$PY" -c 'import json,sys; print(json.load(open(sys.argv[1])).get("device_token",""))' "$ENROLL_RESP" 2>/dev/null)
+        else
+          # Our own compact JSON, and the credential is URL-safe base64:
+          # sed is sufficient where a general parser is not available.
+          CRED=$(sed -n 's/.*"device_token":"\([^"]*\)".*/\1/p' "$ENROLL_RESP")
+        fi
+        if [ -n "$CRED" ]; then
+          ( umask 077; printf '%s' "$CRED" > "$CRED_FILE" )
+          chmod 600 "$CRED_FILE" 2>/dev/null
+          TOKEN="$CRED"
+          echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+        fi
+      else
+        # Loud and fatal: an enrollment token cannot report findings, so
+        # carrying on would 401 every POST and look like a clean machine.
+        # A 409 here means a device with this serial is actively reporting -
+        # revoke it on the receiver first. A 401 usually means the token
+        # expired: mint a fresh one and update the RMM variable.
+        echo "[ai-guard] enrollment failed: HTTP $ENROLL_CODE from ${RECEIVER_BASE%/}/enroll"
+        echo "[ai-guard] refusing to scan: an enrollment token cannot report findings"
+        rm -f "$ENROLL_RESP"
+        exit 1
+      fi
+      rm -f "$ENROLL_RESP"
+    fi
+    ;;
+esac
+
 if ! fetch_registry; then
   echo "[ai-guard] registry fetch failed: ${RECEIVER_BASE%/}/registry/collector"
   echo "[ai-guard] refusing to scan without an identifier list - an empty scan looks like a clean machine"
+  case "$TOKEN" in aigd_*)
+    echo "[ai-guard] this machine's device credential may have been revoked;"
+    echo "[ai-guard] delete $CRED_FILE and supply a valid enrollment token to re-enroll"
+  ;; esac
   exit 1
 fi
 REG_TSV=$(registry_tsv "$REG_FILE")

--- a/endpoint/macos/README.md
+++ b/endpoint/macos/README.md
@@ -49,7 +49,12 @@ reports as `warn`; everything else is `info`.
 
 2. **Policy**: create a policy running the script with:
    - Parameter 4: receiver base URL, e.g. `https://ai-guard.example.com`
-   - Parameter 5: the receiver bearer token
+   - Parameter 5: the receiver bearer token - either the shared token, or an
+     enrollment token (`aige_...`) from a managed-mode receiver. With an
+     enrollment token, each Mac enrolls itself on first run, stores its own
+     device credential under `/Library/Application Support/ai-guard`, and can
+     be revoked individually from then on. Swapping this parameter is the
+     whole migration.
    - Parameter 6: corporate domains, comma-separated, e.g.
      `example.com,example.co.uk`. Leave this correct: an empty value means no
      domain counts as corporate and every account warns. If the receiver has

--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -18,7 +18,12 @@
 #
 # Deployment: Jamf policy script, recurring check-in (daily).
 #   Parameter 4: receiver base URL (e.g. https://ai-guard.example.com)
-#   Parameter 5: bearer token
+#   Parameter 5: bearer token. Either the shared token, or an enrollment
+#                token (aige_...) from a managed-mode receiver: on first run
+#                the machine enrolls, stores its own device credential under
+#                /Library/Application Support/ai-guard, and uses that from
+#                then on. Swapping the shared token for an enrollment token
+#                in the Jamf parameter is the whole migration.
 #   Parameter 6: corporate domains, comma-separated (e.g. example.com,example.co.uk).
 #                 Accounts on these domains report as work; anything else is a
 #                 personal account and escalates severity. A receiver that
@@ -44,6 +49,12 @@ CORP_DOMAINS="${6:-}"
 
 SUMMARY_DIR="/Library/Application Support/ai-guard"
 SUMMARY_FILE="$SUMMARY_DIR/last_scan.txt"
+# This machine's own credential, once enrolled with a managed-mode receiver.
+# Root-only: it is this device's identity.
+CRED_FILE="$SUMMARY_DIR/device.cred"
+# Reported at enrollment and on every report, so the receiver's inventory can
+# answer "which script version does the fleet actually run".
+COLLECTOR_VERSION="2.0.0"
 
 # Report throttling. The policy runs at every recurring check-in (~20 min).
 # Unchanged inventory (info) findings only need reporting once a day; warn
@@ -208,6 +219,7 @@ report() {
     local http_code
     http_code=$(/usr/bin/curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "$ENDPOINT" \
       -H "Authorization: Bearer $TOKEN" \
+      -H "X-AiGuard-Agent-Version: $COLLECTOR_VERSION" \
       -H "Content-Type: application/json" \
       -d "$payload" || echo "000")
     if [ "$http_code" != "200" ]; then
@@ -318,6 +330,50 @@ registry_tsv() {
     }' "$1" 2>/dev/null
 }
 
+# ------------------------------------------------------------- enrollment --
+# Managed mode. A stored device credential wins; an enrollment token
+# (aige_...) is exchanged for one on first run; anything else is today's
+# behaviour exactly. The prefix is the whole switch: the operator changes
+# parameter 5 from the shared token to an enrollment token when ready.
+if [ -f "$CRED_FILE" ]; then
+  STORED_CRED=$(/bin/cat "$CRED_FILE" 2>/dev/null)
+  case "$STORED_CRED" in aigd_*) TOKEN="$STORED_CRED" ;; esac
+fi
+case "$TOKEN" in
+  aige_*)
+    if [ -n "$RECEIVER_BASE" ]; then
+      /bin/mkdir -p "$SUMMARY_DIR"
+      ENROLL_BODY=$(/usr/bin/printf '{"platform":"macos","serial":"%s","hostname":"%s","agent_version":"%s"}' \
+        "$(json_escape "$SERIAL")" "$(json_escape "$DEVICE_NAME")" "$COLLECTOR_VERSION")
+      ENROLL_RESP=$(/usr/bin/mktemp /tmp/ai-guard-enroll.XXXXXX)
+      ENROLL_CODE=$(/usr/bin/curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
+        -X POST -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$ENROLL_BODY" "${RECEIVER_BASE%/}/enroll" 2>/dev/null || echo "000")
+      if [ "$ENROLL_CODE" = "200" ]; then
+        CRED=$(json_get "$ENROLL_RESP" device_token)
+        if [ -n "$CRED" ]; then
+          ( umask 077; /usr/bin/printf '%s' "$CRED" > "$CRED_FILE" )
+          /bin/chmod 600 "$CRED_FILE" 2>/dev/null
+          TOKEN="$CRED"
+          echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+        fi
+      else
+        # Loud and fatal: an enrollment token cannot report findings, so
+        # carrying on would 401 every POST and look like a clean machine.
+        # A 409 here means a device with this serial is actively reporting -
+        # revoke it on the receiver first. A 401 usually means the token
+        # expired: mint a fresh one and update the Jamf parameter.
+        echo "[ai-guard] enrollment failed: HTTP $ENROLL_CODE from ${RECEIVER_BASE%/}/enroll"
+        echo "[ai-guard] refusing to scan: an enrollment token cannot report findings"
+        /bin/rm -f "$ENROLL_RESP"
+        exit 1
+      fi
+      /bin/rm -f "$ENROLL_RESP"
+    fi
+    ;;
+esac
+
 if ! fetch_registry; then
   # Distinguish "no receiver configured" from "the receiver did not answer".
   # Both used to print the same line, which reads as a network problem when it
@@ -342,6 +398,10 @@ if ! fetch_registry; then
   fi
   echo "[ai-guard] registry fetch failed: ${RECEIVER_BASE%/}/registry/collector"
   echo "[ai-guard] refusing to scan without an identifier list - an empty scan looks like a clean machine"
+  case "$TOKEN" in aigd_*)
+    echo "[ai-guard] this machine's device credential may have been revoked;"
+    echo "[ai-guard] delete '$CRED_FILE' and supply a valid enrollment token to re-enroll"
+  ;; esac
   exit 1
 fi
 REG_TSV=$(registry_tsv "$REG_FILE")

--- a/endpoint/tests/test_linux_collector.sh
+++ b/endpoint/tests/test_linux_collector.sh
@@ -73,19 +73,23 @@ setup_home() {
 # Fake receiver. Serves the collector registry on GET and returns a chosen
 # status on POST, logging each one so a test can assert a request was or was
 # not attempted.
-# start_receiver <status> [served_corp_domains]
+# start_receiver <status> [served_corp_domains] [enroll_status]
 # The optional second argument makes the served registry carry
-# config.corp_domains, the way a receiver with CORP_DOMAINS set does.
+# config.corp_domains, the way a receiver with CORP_DOMAINS set does. The
+# third sets what POST /enroll answers (default 200 with a fixed credential),
+# so a refused enrollment can be exercised.
 start_receiver() {
   local status="$1"
   : > "$RECEIVER_LOG"
-  python3 - "$PORT" "$status" "$RECEIVER_LOG" "${2-}" <<'PY' &
+  python3 - "$PORT" "$status" "$RECEIVER_LOG" "${2-}" "${3-200}" <<'PY' &
 import json
 import sys
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
 port, status, logpath = int(sys.argv[1]), int(sys.argv[2]), sys.argv[3]
 served_domains = sys.argv[4] if len(sys.argv) > 4 else ""
+enroll_status = int(sys.argv[5]) if len(sys.argv) > 5 else 200
+ENROLL_RESP = b'{"device_id":"d1","device_token":"aigd_testcred"}'
 REGISTRY = (
     b'{"version":1,"cli":[{"tool":"claude-code",'
     b'"config_paths":[".claude-aiguard-test.json"],'
@@ -108,9 +112,21 @@ class H(BaseHTTPRequestHandler):
 
     def do_POST(self):
         n = int(self.headers.get("Content-Length") or 0)
-        # The body rides on the POST line (findings are single-line JSON), so
-        # a test can assert on what was reported, not just that something was.
+        # The body rides on the log line (single-line JSON), so a test can
+        # assert on what was reported, not just that something was.
         body = self.rfile.read(n).decode("utf-8", "replace").replace("\n", " ")
+        if self.path == "/enroll":
+            with open(logpath, "a") as f:
+                f.write("ENROLL " + body + "\n")
+            self.send_response(enroll_status)
+            if enroll_status == 200:
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(ENROLL_RESP)))
+                self.end_headers()
+                self.wfile.write(ENROLL_RESP)
+            else:
+                self.end_headers()
+            return
         with open(logpath, "a") as f:
             f.write("POST " + body + "\n")
         self.send_response(status)
@@ -137,12 +153,13 @@ stop_receiver() {
 
 reset_state() { rm -rf /var/lib/ai-guard; }
 
-# run_collector [corp_domains] [receiver_base]
-# An empty receiver_base exercises print-only mode.
+# run_collector [corp_domains] [receiver_base] [token]
+# An empty receiver_base exercises print-only mode; an aige_-prefixed token
+# exercises enrollment.
 run_collector() {
-  local corp="${1-example.com}" base="${2-$BASE}"
+  local corp="${1-example.com}" base="${2-$BASE}" token="${3-test}"
   AIGUARD_RECEIVER_BASE="$base" \
-  AIGUARD_TOKEN=test \
+  AIGUARD_TOKEN="$token" \
   AIGUARD_CORP_DOMAINS="$corp" \
   AIGUARD_REGISTRY_FILE="${AIGUARD_REGISTRY_FILE:-}" \
     bash "$COLLECTOR" >/dev/null 2>&1
@@ -151,8 +168,9 @@ run_collector() {
 
 state_ts() { grep -F "$1 " "$STATE_FILE" 2>/dev/null | tail -1 | awk '{print $2}'; }
 # awk rather than grep -c: grep exits 1 on no matches, which turns a
-# legitimate zero into a shell error under the || fallback.
-posts_made() { awk 'END{print NR+0}' "$RECEIVER_LOG" 2>/dev/null; }
+# legitimate zero into a shell error under the || fallback. Counts report
+# POSTs only: enrollment requests log as ENROLL lines.
+posts_made() { awk '/^POST /{n++} END{print n+0}' "$RECEIVER_LOG" 2>/dev/null; }
 
 KEY="cli|claude-code|example.com"
 
@@ -326,6 +344,56 @@ test_served_corp_domains_override_the_local_list() {
   fi
 }
 
+CRED_FILE="/var/lib/ai-guard/device.cred"
+
+test_enrollment_exchanges_the_token_and_reports() {
+  # Managed mode, first run: an aige_ token is exchanged at /enroll, the
+  # device credential lands root-only in the state dir, and the scan then
+  # reports with the new credential rather than the enrollment token.
+  local name="an enrollment token enrolls, stores a credential, and reports"
+  reset_state; start_receiver 200
+  run_collector example.com "$BASE" "aige_test-enroll-token"
+  stop_receiver
+  if ! grep -q '^ENROLL .*"platform":"linux"' "$RECEIVER_LOG"; then
+    fail "$name (no enrollment request made)"; return
+  fi
+  if [ "$(cat "$CRED_FILE" 2>/dev/null)" != "aigd_testcred" ]; then
+    fail "$name (credential not stored)"; return
+  fi
+  local perms; perms=$(stat -c '%a' "$CRED_FILE" 2>/dev/null)
+  if [ "$perms" != "600" ]; then fail "$name (credential mode $perms, not 600)"; return; fi
+  if [ "$(posts_made)" -ge 1 ]; then pass "$name"; else fail "$name (enrolled but posted nothing)"; fi
+}
+
+test_a_stored_credential_is_reused() {
+  # Second run: the credential file wins and no second enrollment happens -
+  # the receiver would 409 a same-serial re-enroll of a live device, so a
+  # collector that re-enrolled every run would take the fleet down.
+  local name="a stored credential is reused, not re-exchanged"
+  reset_state; start_receiver 200
+  run_collector example.com "$BASE" "aige_test-enroll-token"
+  stop_receiver
+  start_receiver 200                   # clears the log
+  run_collector example.com "$BASE" "aige_test-enroll-token"
+  stop_receiver
+  if grep -q '^ENROLL ' "$RECEIVER_LOG"; then
+    fail "$name (enrolled again)"
+  else
+    pass "$name"
+  fi
+}
+
+test_a_refused_enrollment_refuses_to_scan() {
+  # An expired or revoked enrollment token is loud and fatal: carrying on
+  # would 401 every POST, which across a fleet reads as a clean estate.
+  local name="a refused enrollment stores nothing and scans nothing"
+  reset_state; start_receiver 200 "" 401
+  run_collector example.com "$BASE" "aige_expired-token"
+  stop_receiver
+  if [ -f "$CRED_FILE" ]; then fail "$name (stored a credential anyway)"; return; fi
+  if [ "$(posts_made)" -eq 0 ]; then pass "$name"; else fail "$name (posted findings)"; fi
+}
+
 # ------------------------------------------------------------------- main --
 
 require_root
@@ -378,6 +446,9 @@ test_warn_outside_window_posts_again
 test_warn_with_no_prior_state_posts_immediately
 test_info_still_throttled_beyond_the_warn_window
 test_served_corp_domains_override_the_local_list
+test_enrollment_exchanges_the_token_and_reports
+test_a_stored_credential_is_reused
+test_a_refused_enrollment_refuses_to_scan
 
 echo
 echo "passed: $PASS  failed: $FAIL"

--- a/endpoint/windows/README.md
+++ b/endpoint/windows/README.md
@@ -37,6 +37,12 @@ If the receiver has `CORP_DOMAINS` set, its list overrides `$CorporateDomains`
 at runtime, so the fleet follows a receiver-side change without an Intune
 re-paste.
 
+`$Token` can also be an enrollment token (`aige_...`) from a managed-mode
+receiver: the machine then enrolls itself on first run, stores its own device
+credential in `C:\ProgramData\ai-guard` (ACL-restricted to SYSTEM and
+Administrators), and can be revoked individually from then on. Swapping the
+constant is the whole migration.
+
 ## Trying it against a local receiver
 
 No Intune needed. Edit the three variables at the top of the script, then run

--- a/endpoint/windows/ai-guard-collector.ps1
+++ b/endpoint/windows/ai-guard-collector.ps1
@@ -41,7 +41,12 @@ param([switch]$FunctionsOnly)
 
 # ------------------------------------------------------------------ config --
 $ReceiverBase    = 'https://ai-guard.example.com'   # your receiver's public ingest URL
-$Token           = '__RECEIVER_TOKEN__'   # replace before upload, or wire to a secure retrieval
+$Token           = '__RECEIVER_TOKEN__'   # replace before upload, or wire to a secure retrieval.
+                                          # Either the shared token, or an enrollment token (aige_...)
+                                          # from a managed-mode receiver: on first run the machine
+                                          # enrolls, stores its own device credential in ProgramData,
+                                          # and uses that from then on. Swapping the shared token for
+                                          # an enrollment token here is the whole migration.
 $CorporateDomains = @('example.com')   # accounts on these domains are 'work'; all others warn as personal.
                                        # A receiver that serves config.corp_domains in /registry/collector
                                        # overrides this at runtime; the constant is the fallback.
@@ -49,6 +54,12 @@ $CorporateDomains = @('example.com')   # accounts on these domains are 'work'; a
 $StateDir  = 'C:\ProgramData\ai-guard'
 $StateFile = Join-Path $StateDir 'reported.state.json'
 $Breadcrumb = Join-Path $StateDir 'last_scan.txt'
+# This machine's own credential, once enrolled with a managed-mode receiver.
+# ACL-restricted to SYSTEM and Administrators: it is this device's identity.
+$CredFile = Join-Path $StateDir 'device.cred'
+# Reported at enrollment and on every report, so the receiver's inventory can
+# answer "which script version does the fleet actually run".
+$CollectorVersion = '2.0.0'
 $InfoReportIntervalHours = 24
 $WarnReportIntervalHours = 1
 
@@ -232,7 +243,8 @@ function Send-Finding {
     }
     try {
         Invoke-RestMethod -Uri $Endpoint -Method Post -TimeoutSec 10 `
-            -Headers @{ Authorization = "Bearer $Token" } `
+            -Headers @{ Authorization = "Bearer $Token"
+                        'X-AiGuard-Agent-Version' = $CollectorVersion } `
             -ContentType 'application/json' -Body $payload -ErrorAction Stop | Out-Null
         $script:Posted++
         $StateNew[$key] = $NowEpoch
@@ -265,6 +277,52 @@ function Get-CollectorRegistry {
 # Skipped under -FunctionsOnly: fetching a registry is work, and the refusal
 # below would exit the caller's session before the functions further down
 # were ever defined.
+# ------------------------------------------------------------ enrollment --
+# Managed mode. A stored device credential wins; an enrollment token
+# (aige_...) is exchanged for one on first run; anything else is today's
+# behaviour exactly. The prefix is the whole switch: the operator changes the
+# $Token constant from the shared token to an enrollment token when ready.
+if (-not $FunctionsOnly) {
+    if (Test-Path $CredFile) {
+        $stored = (Get-Content $CredFile -Raw -ErrorAction SilentlyContinue)
+        if ($stored) { $stored = $stored.Trim() }
+        if ($stored -and $stored.StartsWith('aigd_')) { $Token = $stored }
+    }
+    if ($Token.StartsWith('aige_') -and $ReceiverBase) {
+        if (-not (Test-Path $StateDir)) {
+            New-Item -ItemType Directory -Path $StateDir -Force | Out-Null
+        }
+        $enrollBody = @{
+            platform = 'windows'; serial = $Serial
+            hostname = $DeviceName; agent_version = $CollectorVersion
+        } | ConvertTo-Json -Compress
+        try {
+            $r = Invoke-RestMethod -Uri (($ReceiverBase.TrimEnd('/')) + '/enroll') `
+                -Method Post -TimeoutSec 15 `
+                -Headers @{ Authorization = "Bearer $Token" } `
+                -ContentType 'application/json' -Body $enrollBody -ErrorAction Stop
+            Set-Content -Path $CredFile -Value $r.device_token -NoNewline
+            # The state dir inherits ProgramData's ACL, which lets ordinary
+            # users read. A device credential must not be readable by the
+            # people whose AI accounts it reports on.
+            icacls $CredFile /inheritance:r /grant 'SYSTEM:(F)' 'Administrators:(F)' | Out-Null
+            $Token = $r.device_token
+            Write-Output "ai-guard: enrolled, device credential stored in $CredFile"
+        } catch {
+            # Loud and fatal: an enrollment token cannot report findings, so
+            # carrying on would 401 every POST and look like a clean machine.
+            # A 409 means a device with this serial is actively reporting -
+            # revoke it on the receiver first. A 401 usually means the token
+            # expired: mint a fresh one and update this script in Intune.
+            $code = 'ERR'
+            if ($_.Exception.Response) { $code = [int]$_.Exception.Response.StatusCode }
+            Write-Output "ai-guard: enrollment failed (HTTP $code)"
+            Write-Output 'ai-guard: refusing to scan - an enrollment token cannot report findings'
+            exit 1
+        }
+    }
+}
+
 $Registry = $null
 if (-not $FunctionsOnly) {
     try { $Registry = Get-CollectorRegistry } catch {
@@ -273,6 +331,10 @@ if (-not $FunctionsOnly) {
     if (-not $Registry) {
         # An empty scan looks exactly like a clean machine. Refuse instead.
         Write-Output 'ai-guard: refusing to scan without an identifier list'
+        if ($Token.StartsWith('aigd_')) {
+            Write-Output "ai-guard: this machine's device credential may have been revoked;"
+            Write-Output "ai-guard: delete $CredFile and supply a valid enrollment token to re-enroll"
+        }
         exit 1
     }
 

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -19,8 +19,35 @@ lists at runtime instead of carrying hardcoded copies.
 | POST | `/report` | bearer | submit a finding |
 | POST | `/flag` | bearer | same as `/report`, kept for older browser extension versions |
 
-Auth is a single bearer token. It is a write-mostly credential: it can
-submit findings and read the registry, nothing else.
+Auth is a bearer token. It is a write-mostly credential: it can submit
+findings and read the registry, nothing else. Classically that is one shared
+token for the whole estate; in managed mode a per-device credential works in
+the same places (and the shared token keeps working alongside, which is the
+migration path).
+
+### Managed mode
+
+`MANAGED_MODE=true` adds device enrollment on top: an operator mints an
+enrollment token (`aige_...`), puts it in the MDM where the shared token
+goes, and each machine exchanges it once at `/enroll` for its own credential
+(`aigd_...`). One machine can then be revoked without touching any other,
+and the inventory knows who exists rather than inferring it from silence.
+
+| method | path | auth | what |
+|--------|------|------|------|
+| POST | `/enroll` | enrollment token | exchange for this machine's device credential; same-serial re-enroll supersedes a silent device, 409s an active one |
+| POST | `/admin/enrollment-tokens` | admin | mint (`note`, `ttl_days`, default 180) |
+| GET  | `/admin/enrollment-tokens` | admin | list - ids, notes and expiry, never token material |
+| POST | `/admin/enrollment-tokens/{id}/revoke` | admin | |
+| GET  | `/admin/devices` | admin | the fleet: platform, serial, hostname, last seen, agent version |
+| POST | `/admin/devices/{id}/revoke` | admin | that machine's credential stops working on its next request |
+
+Only SHA-256 hashes of credentials are stored: a copied database file is a
+list of devices, not a bag of credentials. Enrollment tokens default to a
+180-day life because they sit inside MDM artifacts, where a short TTL means
+the deployment silently breaks for new machines - their safety comes from
+what they cannot do (only create auditable device records) and from instant
+revocation, not from a short life.
 
 ## Configuration
 
@@ -38,6 +65,9 @@ Everything is environment variables. Only the token is required.
 | `COLLECTOR_REGISTRY_PATH` | `/etc/ai-guard/collector.json` | where the collector view is mounted |
 | `DISPLAY_TZ` | `UTC` | timezone for the human-readable timestamp on alerts only; machine timestamps are always UTC |
 | `CORP_DOMAINS` | unset | corporate domains, comma-separated. When set, served to the endpoint collectors inside `/registry/collector` as `config.corp_domains`; collectors prefer that list to their locally configured one, so a change here reaches the fleet on its next check-in with no MDM re-push. Unset means collectors keep using their local configuration |
+| `MANAGED_MODE` | unset | `true` enables device enrollment, per-device credentials, revocation and a fleet inventory (see below). Unset means byte-for-byte the classic receiver: no state file, `/enroll` and `/admin/*` answer 404 |
+| `ADMIN_TOKEN` | required in managed mode | the credential that mints and revokes enrollment tokens and devices. Deliberately a separate secret from `AUTH_TOKEN`, which sits on every machine in the fleet - which is exactly why it must not be able to mint credentials |
+| `STATE_DB_PATH` | `/var/lib/ai-guard/state.db` | where the managed-mode SQLite file lives. The one non-disposable thing: it holds the device registry and its credential hashes |
 
 Any of these can be given as `NAME_FILE` pointing at a file instead:
 `AUTH_TOKEN_FILE=/run/secrets/auth_token` rather than `AUTH_TOKEN`. That

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -45,6 +45,10 @@ from prometheus_client import (
 )
 from pydantic import BaseModel, Field
 
+# Importing the module costs nothing stateful: the SQLite file only exists
+# once State() is instantiated, which only happens under MANAGED_MODE below.
+from . import state as _state
+
 # ------------------------------------------------------------------ config --
 
 # Secrets can come from a file instead of the environment. Docker Compose has
@@ -106,6 +110,27 @@ def _token_ok(header: str) -> bool:
     stays.
     """
     return hmac.compare_digest(header.encode("latin-1"), _EXPECTED_AUTH)
+
+
+def _ingest_token_ok(header: str) -> tuple[bool, dict | None]:
+    """Is this bearer allowed to report and read the registry, and as whom?
+
+    The shared token answers (True, None): the estate's anonymous credential,
+    same as ever. In managed mode a device credential answers with its device
+    row, so /report can stamp last_seen and agent_version - the difference
+    between an inventory inferred from silence and one that knows who exists.
+    A revoked device gets (False, None), which is the property this whole
+    mechanism exists for. Lookup is by SHA-256 hash: without the plaintext an
+    attacker cannot construct the hash, so an indexed equality match needs no
+    constant-time scan.
+    """
+    if _token_ok(header):
+        return True, None
+    if STATE is not None and header.startswith("Bearer " + _state.DEVICE_PREFIX):
+        dev = STATE.device_for(header[len("Bearer "):])
+        if dev is not None:
+            return True, dev
+    return False, None
 # Findings are small: a large one is a few hundred bytes. The cap exists so an
 # unauthenticated client cannot make the receiver do work by sending something
 # enormous. Raise it if a source legitimately sends more.
@@ -203,6 +228,24 @@ def _parse_corp_domains(raw: str) -> list[str]:
 # re-push per platform. Unset means collectors keep their local configuration,
 # which is also what any collector talking to an older receiver does.
 CORP_DOMAINS = _parse_corp_domains(os.environ.get("CORP_DOMAINS", ""))
+
+# Managed mode: per-device credentials, enrollment, and a device inventory,
+# backed by the first stateful thing in the project (one SQLite file). Off by
+# default, and off means byte-for-byte today's receiver: no DB file created,
+# /enroll and /admin/* answer 404. The shared AUTH_TOKEN keeps working for
+# ingest either way - that is the migration path, an estate enrolls device by
+# device while unenrolled machines keep reporting.
+MANAGED_MODE = os.environ.get("MANAGED_MODE", "").lower() in ("1", "true", "yes")
+STATE = None
+_EXPECTED_ADMIN = b""
+if MANAGED_MODE:
+    # Required, not defaulted: managed mode without an admin credential is a
+    # deployment that can never mint an enrollment token, which nobody means.
+    # Deliberately a separate secret from AUTH_TOKEN - the shared token is on
+    # every machine in the fleet, which is exactly why it must not be able to
+    # mint credentials.
+    _EXPECTED_ADMIN = b"Bearer " + _secret("ADMIN_TOKEN").encode()
+    STATE = _state.State(os.environ.get("STATE_DB_PATH", "/var/lib/ai-guard/state.db"))
 
 # "network" is a DNS/flow observation from SentinelOne: a device resolved a
 # domain, but the resolving process may be a browser, a desktop app, a CLI or
@@ -367,9 +410,33 @@ APP_VERSION = os.environ.get("APP_VERSION", "dev")
 app = FastAPI(title="ai-guard-receiver", version=APP_VERSION)
 
 
-# Paths that require the bearer token. /healthz and /metrics stay open:
+# Paths that require a bearer token. /healthz and /metrics stay open:
 # healthz is a probe target and metrics carries only bounded label values.
+# _PROTECTED takes the shared token or, in managed mode, a device credential;
+# _MANAGED exists only in managed mode, with its own credentials.
 _PROTECTED = ("/report", "/flag", "/registry")
+_MANAGED = ("/enroll", "/admin")
+
+
+def _body_size_response(request: Request):
+    """The 4xx a too-large or unsized POST body earns, or None if fine."""
+    if request.method != "POST":
+        return None
+    declared = request.headers.get("content-length")
+    if declared is None:
+        # No content-length and no transfer-encoding is no body at all -
+        # which is what an admin revoke POST legitimately sends. A chunked
+        # body, though, would slip past the size check, so it is refused:
+        # every real client that sends a body sends a content-length.
+        if request.headers.get("transfer-encoding") is None:
+            return None
+        return JSONResponse({"detail": "content-length required"}, status_code=411)
+    try:
+        if int(declared) > MAX_BODY_BYTES:
+            return JSONResponse({"detail": "body too large"}, status_code=413)
+    except ValueError:
+        return JSONResponse({"detail": "bad content-length"}, status_code=400)
+    return None
 
 
 @app.middleware("http")
@@ -382,26 +449,44 @@ async def authenticate_before_reading(request: Request, call_next):
     internet-facing, so anyone could make it do that work. Here nothing is
     read until the caller has proved who they are.
 
-    The endpoints still call _auth(). That is deliberate: it keeps them
-    correct if this middleware is ever removed or reordered.
+    The endpoints still call their _auth counterparts. That is deliberate: it
+    keeps them correct if this middleware is ever removed or reordered.
     """
-    if request.url.path.startswith(_PROTECTED):
-        if not _token_ok(request.headers.get("authorization", "")):
+    path = request.url.path
+    if path.startswith(_PROTECTED):
+        ok, device = _ingest_token_ok(request.headers.get("authorization", ""))
+        if not ok:
             return JSONResponse({"detail": "bad token"}, status_code=401)
+        # Which device authenticated, for /report to stamp last_seen. None
+        # when the shared token did, which is not an identity.
+        request.state.device = device
+        resp = _body_size_response(request)
+        if resp is not None:
+            return resp
 
-        if request.method == "POST":
-            declared = request.headers.get("content-length")
-            if declared is None:
-                # Every real client sends one. Refusing chunked bodies keeps
-                # the size check meaningful rather than advisory.
-                return JSONResponse(
-                    {"detail": "content-length required"}, status_code=411
-                )
-            try:
-                if int(declared) > MAX_BODY_BYTES:
-                    return JSONResponse({"detail": "body too large"}, status_code=413)
-            except ValueError:
-                return JSONResponse({"detail": "bad content-length"}, status_code=400)
+    elif path.startswith(_MANAGED):
+        if STATE is None:
+            # Managed mode off: these routes do not exist, and 404 rather
+            # than 401 so a classic deployment does not advertise them.
+            return JSONResponse({"detail": "Not Found"}, status_code=404)
+        auth = request.headers.get("authorization", "")
+        if path.startswith("/admin"):
+            # The emptiness guard is not redundant: compare_digest holds two
+            # empty strings equal, so without it a deployment that somehow
+            # had state but no admin credential would let an empty header in.
+            if not _EXPECTED_ADMIN or not hmac.compare_digest(
+                auth.encode("latin-1"), _EXPECTED_ADMIN
+            ):
+                return JSONResponse({"detail": "bad token"}, status_code=401)
+        else:
+            # /enroll authenticates against the DB inside the handler; here
+            # only the credential shape is checked, so an arbitrary bearer
+            # still cannot make the receiver read a body.
+            if not auth.startswith("Bearer " + _state.ENROLL_PREFIX):
+                return JSONResponse({"detail": "bad token"}, status_code=401)
+        resp = _body_size_response(request)
+        if resp is not None:
+            return resp
 
     return await call_next(request)
 
@@ -488,10 +573,97 @@ def registry_collector(authorization: str = Header(default="")):
 
 
 def _auth(authorization: str):
-    # The middleware above is the real gate; this is defence in depth. Same
-    # bytes comparison for the same reason: see _token_ok.
-    if not _token_ok(authorization):
+    # The middleware above is the real gate; this is defence in depth. Shared
+    # token or device credential, same as the middleware accepts.
+    ok, _ = _ingest_token_ok(authorization)
+    if not ok:
         raise HTTPException(401, "bad token")
+
+
+def _admin_auth(authorization: str):
+    # Defence in depth for /admin/*, like _auth for ingest. 404 when managed
+    # mode is off: routes that do not exist should not confirm they exist.
+    if STATE is None:
+        raise HTTPException(404, "Not Found")
+    if not _EXPECTED_ADMIN or not hmac.compare_digest(
+        authorization.encode("latin-1"), _EXPECTED_ADMIN
+    ):
+        raise HTTPException(401, "bad token")
+
+
+class EnrollRequest(BaseModel):
+    platform: str = Field(min_length=1, max_length=32)
+    serial: str = Field(min_length=1, max_length=256)
+    hostname: str = Field(default="", max_length=256)
+    agent_version: str = Field(default="", max_length=32)
+
+
+class MintRequest(BaseModel):
+    # note is the operator's label ("macOS Jamf rollout"), shown wherever the
+    # token id appears, because a list of anonymous credentials with expiry
+    # dates is unmanageable the day there are three of them.
+    note: str = Field(default="", max_length=200)
+    ttl_days: int = Field(default=180, ge=1, le=3650)
+
+
+@app.post("/enroll")
+def enroll(req: EnrollRequest, authorization: str = Header(default="")):
+    """Exchange an enrollment token for this machine's own credential.
+
+    The one moment a device credential exists in plaintext. Collectors store
+    it root-only in their state dir and present it from then on; the
+    enrollment token itself can do nothing but this exchange.
+    """
+    if STATE is None:
+        raise HTTPException(404, "Not Found")
+    if req.platform not in ("macos", "linux", "windows"):
+        raise HTTPException(422, "platform must be macos, linux or windows")
+    token = authorization[len("Bearer "):] if authorization.startswith("Bearer ") else ""
+    try:
+        result = STATE.enroll(token, req.platform, req.serial, req.hostname,
+                              req.agent_version)
+    except _state.EnrollError as e:
+        raise HTTPException(e.status, e.detail)
+    log.info(json.dumps({"app": "ai-guard-receiver", "kind": "enrolled",
+                         "device_id": result["device_id"],
+                         "platform": req.platform, "serial": req.serial}))
+    return result
+
+
+@app.post("/admin/enrollment-tokens")
+def mint_enrollment_token(req: MintRequest, authorization: str = Header(default="")):
+    _admin_auth(authorization)
+    return STATE.mint_token(req.note, req.ttl_days)
+
+
+@app.get("/admin/enrollment-tokens")
+def list_enrollment_tokens(authorization: str = Header(default="")):
+    # No hashes and no plaintext: a listing is for judging expiry and
+    # provenance, not for recovering credentials.
+    _admin_auth(authorization)
+    return {"tokens": STATE.list_tokens()}
+
+
+@app.post("/admin/enrollment-tokens/{tid}/revoke")
+def revoke_enrollment_token(tid: str, authorization: str = Header(default="")):
+    _admin_auth(authorization)
+    if not STATE.revoke_token(tid):
+        raise HTTPException(404, "no such active token")
+    return {"ok": True}
+
+
+@app.get("/admin/devices")
+def list_devices(authorization: str = Header(default="")):
+    _admin_auth(authorization)
+    return {"devices": STATE.list_devices()}
+
+
+@app.post("/admin/devices/{did}/revoke")
+def revoke_device(did: str, authorization: str = Header(default="")):
+    _admin_auth(authorization)
+    if not STATE.revoke_device(did):
+        raise HTTPException(404, "no such active device")
+    return {"ok": True}
 
 
 # The Loki stream labels derived from each finding. Anything not in this
@@ -613,6 +785,17 @@ async def _fire_alert(f: Finding):
 @app.post("/flag")  # legacy path, kept for older browser extension versions
 async def report(f: Finding, request: Request, authorization: str = Header(default="")):
     _auth(authorization)
+
+    # A device credential is an identity; the shared token is not. Stamping
+    # last_seen (and the script version, sent as a header so the finding
+    # schema stays untouched) on every authenticated report is what turns
+    # the inventory from inferred-from-silence into one that knows who
+    # exists and what they run.
+    device = getattr(request.state, "device", None)
+    if device is not None and STATE is not None:
+        STATE.touch_device(
+            device["id"], request.headers.get("x-aiguard-agent-version", "")[:32]
+        )
 
     if f.surface not in VALID_SURFACES:
         f.surface = "browser"

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -1,0 +1,256 @@
+"""Managed-mode state: enrollment tokens, devices, audit events.
+
+The first stateful thing in the project, and deliberately the only one: a
+single SQLite file. Everything else stays disposable, and with MANAGED_MODE
+unset State() is never instantiated and no file is created, so classic
+deployments keep the property that losing any component loses nothing.
+
+Only credential hashes are stored. The plaintext of an enrollment token or a
+device credential exists exactly once, in the response that minted it, and
+cannot be recovered from here - a copied database file is a list of devices,
+not a bag of credentials.
+
+Two credential kinds, distinguishable by prefix so the receiver can route a
+presented bearer without trying every table, and so a leaked string is
+identifiable in a log:
+
+  aige_...  enrollment token: mints device records at /enroll and does
+            nothing else. Long-lived by default (180 days) because it sits
+            inside an MDM artifact, where a short TTL means the deployment
+            silently breaks for new machines - its safety comes from what it
+            cannot do and from instant revocation, not from a short life.
+  aigd_...  device credential: one machine's bearer for /report and
+            /registry, valid until revoked.
+"""
+
+import hashlib
+import json
+import os
+import secrets
+import sqlite3
+import threading
+from datetime import datetime, timedelta, timezone
+
+ENROLL_PREFIX = "aige_"
+DEVICE_PREFIX = "aigd_"
+
+# A device that authenticated a report this recently is alive, and a
+# same-serial enrollment must not displace it silently: that is the stolen
+# token scenario, not the reimaged laptop one. A reimaged machine stops
+# reporting the moment its disk is wiped, so the legitimate case sails
+# through after at most this long.
+SUPERSEDE_QUIET_SECONDS = 3600
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS enrollment_tokens (
+  id          TEXT PRIMARY KEY,
+  token_hash  BLOB NOT NULL UNIQUE,
+  note        TEXT NOT NULL DEFAULT '',
+  created_at  TEXT NOT NULL,
+  expires_at  TEXT NOT NULL,
+  revoked_at  TEXT
+);
+CREATE TABLE IF NOT EXISTS devices (
+  id            TEXT PRIMARY KEY,
+  platform      TEXT NOT NULL,
+  serial        TEXT NOT NULL,
+  hostname      TEXT NOT NULL DEFAULT '',
+  cred_hash     BLOB NOT NULL UNIQUE,
+  enrolled_at   TEXT NOT NULL,
+  enrolled_with TEXT NOT NULL REFERENCES enrollment_tokens(id),
+  last_seen     TEXT,
+  agent_version TEXT NOT NULL DEFAULT '',
+  revoked_at    TEXT
+);
+CREATE INDEX IF NOT EXISTS devices_serial ON devices (platform, serial);
+CREATE TABLE IF NOT EXISTS events (
+  at     TEXT NOT NULL,
+  kind   TEXT NOT NULL,
+  detail TEXT NOT NULL
+);
+"""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _hash(token: str) -> bytes:
+    return hashlib.sha256(token.encode()).digest()
+
+
+class EnrollError(Exception):
+    """A refused enrollment, carrying the HTTP status it should become."""
+
+    def __init__(self, status: int, detail: str):
+        self.status = status
+        self.detail = detail
+        super().__init__(detail)
+
+
+class State:
+    def __init__(self, path: str):
+        # In a deployment the directory is the mounted volume; on a laptop
+        # it is whatever STATE_DB_PATH points at, which need not exist yet.
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        # One connection, one lock. Findings arrive at human scale (a fleet
+        # checking in daily), not at scale where SQLite's single writer is a
+        # bottleneck; WAL keeps readers unblocked during the rare write.
+        self._db = sqlite3.connect(path, check_same_thread=False)
+        self._db.row_factory = sqlite3.Row
+        self._lock = threading.Lock()
+        with self._lock:
+            self._db.execute("PRAGMA journal_mode=WAL")
+            self._db.execute("PRAGMA foreign_keys=ON")
+            self._db.executescript(_SCHEMA)
+            self._db.commit()
+
+    def _event(self, kind: str, detail: dict):
+        # Callers hold the lock. Detail carries ids only, never secrets.
+        self._db.execute(
+            "INSERT INTO events (at, kind, detail) VALUES (?, ?, ?)",
+            (_now(), kind, json.dumps(detail)),
+        )
+
+    # ------------------------------------------------- enrollment tokens --
+
+    def mint_token(self, note: str, ttl_days: int = 180) -> dict:
+        token = ENROLL_PREFIX + secrets.token_urlsafe(32)
+        tid = secrets.token_hex(4)
+        expires = (datetime.now(timezone.utc) + timedelta(days=ttl_days)).isoformat()
+        with self._lock:
+            self._db.execute(
+                "INSERT INTO enrollment_tokens (id, token_hash, note, created_at, expires_at)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (tid, _hash(token), note, _now(), expires),
+            )
+            self._event("token_minted", {"id": tid, "note": note, "expires_at": expires})
+            self._db.commit()
+        # The one moment the plaintext exists.
+        return {"id": tid, "token": token, "expires_at": expires}
+
+    def list_tokens(self) -> list[dict]:
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT id, note, created_at, expires_at, revoked_at"
+                " FROM enrollment_tokens ORDER BY created_at DESC"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def revoke_token(self, tid: str) -> bool:
+        with self._lock:
+            cur = self._db.execute(
+                "UPDATE enrollment_tokens SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL",
+                (_now(), tid),
+            )
+            if cur.rowcount:
+                self._event("token_revoked", {"id": tid})
+            self._db.commit()
+        return bool(cur.rowcount)
+
+    # ---------------------------------------------------------- devices --
+
+    def enroll(self, token: str, platform: str, serial: str, hostname: str,
+               agent_version: str) -> dict:
+        now = _now()
+        with self._lock:
+            row = self._db.execute(
+                "SELECT id, expires_at, revoked_at FROM enrollment_tokens WHERE token_hash = ?",
+                (_hash(token),),
+            ).fetchone()
+            if row is None or row["revoked_at"] is not None:
+                raise EnrollError(401, "bad enrollment token")
+            if row["expires_at"] <= now:
+                # Named separately from "bad": an expired token in an MDM
+                # artifact is an operations task, not an attack, and the
+                # collector puts this string in the MDM log.
+                raise EnrollError(401, "enrollment token expired")
+
+            prior = self._db.execute(
+                "SELECT id, last_seen FROM devices"
+                " WHERE platform = ? AND serial = ? AND revoked_at IS NULL",
+                (platform, serial),
+            ).fetchone()
+            if prior is not None:
+                quiet_since = (
+                    datetime.now(timezone.utc) - timedelta(seconds=SUPERSEDE_QUIET_SECONDS)
+                ).isoformat()
+                if prior["last_seen"] is not None and prior["last_seen"] > quiet_since:
+                    # The device this would displace reported within the
+                    # hour. A reimaged machine is silent by definition, so an
+                    # active one being superseded is the stolen-token shape:
+                    # refuse, record, and require a manual revoke.
+                    self._event("supersede_conflict", {
+                        "device": prior["id"], "platform": platform, "serial": serial,
+                    })
+                    self._db.commit()
+                    raise EnrollError(
+                        409, "a device with this serial is actively reporting; revoke it first"
+                    )
+                self._db.execute(
+                    "UPDATE devices SET revoked_at = ? WHERE id = ?", (now, prior["id"]),
+                )
+                self._event("superseded", {"old": prior["id"], "serial": serial})
+
+            cred = DEVICE_PREFIX + secrets.token_urlsafe(32)
+            did = secrets.token_hex(8)
+            self._db.execute(
+                "INSERT INTO devices (id, platform, serial, hostname, cred_hash,"
+                " enrolled_at, enrolled_with, agent_version)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (did, platform, serial, hostname, _hash(cred), now, row["id"], agent_version),
+            )
+            self._event("enrolled", {"device": did, "platform": platform,
+                                     "serial": serial, "with": row["id"]})
+            self._db.commit()
+        return {"device_id": did, "device_token": cred}
+
+    def device_for(self, token: str) -> dict | None:
+        """The non-revoked device this credential belongs to, or None.
+
+        Lookup is by SHA-256 hash: an attacker without the plaintext cannot
+        construct the hash, so an indexed equality match is sufficient and no
+        constant-time scan is needed.
+        """
+        with self._lock:
+            row = self._db.execute(
+                "SELECT id, platform, serial FROM devices"
+                " WHERE cred_hash = ? AND revoked_at IS NULL",
+                (_hash(token),),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def touch_device(self, did: str, agent_version: str = ""):
+        with self._lock:
+            if agent_version:
+                self._db.execute(
+                    "UPDATE devices SET last_seen = ?, agent_version = ? WHERE id = ?",
+                    (_now(), agent_version, did),
+                )
+            else:
+                self._db.execute(
+                    "UPDATE devices SET last_seen = ? WHERE id = ?", (_now(), did),
+                )
+            self._db.commit()
+
+    def list_devices(self) -> list[dict]:
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT id, platform, serial, hostname, enrolled_at, enrolled_with,"
+                " last_seen, agent_version, revoked_at"
+                " FROM devices ORDER BY enrolled_at DESC"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def revoke_device(self, did: str) -> bool:
+        with self._lock:
+            cur = self._db.execute(
+                "UPDATE devices SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL",
+                (_now(), did),
+            )
+            if cur.rowcount:
+                self._event("revoked", {"device": did})
+            self._db.commit()
+        return bool(cur.rowcount)

--- a/receiver/tests/test_managed.py
+++ b/receiver/tests/test_managed.py
@@ -1,0 +1,224 @@
+"""Managed mode: enrollment, device credentials, revocation, admin API.
+
+The module is imported classic (MANAGED_MODE unset), as in test_smoke, and
+managed mode is switched on per-test by giving the module a State and an
+admin credential. That mirrors production faithfully - every code path reads
+those globals at call time - and avoids re-importing the module, which
+re-registers every Prometheus metric.
+"""
+
+import os
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import state as state_mod
+from app.main import app
+
+client = TestClient(app)
+
+AUTH = {"Authorization": "Bearer test-token-for-ci"}
+ADMIN = {"Authorization": "Bearer admin-test-token"}
+
+
+@pytest.fixture
+def managed(tmp_path, monkeypatch):
+    from app import main
+
+    st = state_mod.State(str(tmp_path / "state.db"))
+    monkeypatch.setattr(main, "STATE", st)
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"Bearer admin-test-token")
+    return st
+
+
+def _mint(**kw) -> dict:
+    resp = client.post("/admin/enrollment-tokens", headers=ADMIN,
+                       json={"note": "test", **kw})
+    assert resp.status_code == 200
+    return resp.json()
+
+
+def _enroll(token, serial="C02TEST", platform="macos", **kw):
+    return client.post("/enroll",
+                       headers={"Authorization": f"Bearer {token}"},
+                       json={"platform": platform, "serial": serial,
+                             "hostname": "test-mac", **kw})
+
+
+# ------------------------------------------------------------ mode gating --
+
+
+def test_managed_routes_do_not_exist_in_classic_mode():
+    """Off means byte-for-byte today's receiver: 404, not 401, so a classic
+    deployment does not advertise routes it does not serve."""
+    assert client.post("/enroll", json={}).status_code == 404
+    assert client.get("/admin/devices", headers=ADMIN).status_code == 404
+    assert client.post("/admin/enrollment-tokens", headers=ADMIN,
+                       json={}).status_code == 404
+
+
+def test_admin_requires_its_own_token(managed):
+    assert client.get("/admin/devices").status_code == 401
+    assert client.get("/admin/devices", headers=AUTH).status_code == 401  # shared token is not admin
+    assert client.get("/admin/devices", headers=ADMIN).status_code == 200
+
+
+# -------------------------------------------------------------- lifecycle --
+
+
+def test_the_full_lifecycle(managed):
+    """Mint, enroll, report as the device, appear in inventory, revoke, 401.
+
+    The last step is the property the whole phase exists for: one machine's
+    credential stops working without touching any other machine."""
+    minted = _mint()
+    assert minted["token"].startswith("aige_")
+
+    resp = _enroll(minted["token"], agent_version="2.0.0")
+    assert resp.status_code == 200
+    cred = resp.json()["device_token"]
+    did = resp.json()["device_id"]
+    assert cred.startswith("aigd_")
+
+    dev_auth = {"Authorization": f"Bearer {cred}",
+                "X-AiGuard-Agent-Version": "2.0.1"}
+    resp = client.post("/report", headers=dev_auth,
+                       json={"tool": "chatgpt", "surface": "cli", "os": "macos"})
+    assert resp.status_code == 200
+
+    devices = client.get("/admin/devices", headers=ADMIN).json()["devices"]
+    (d,) = [d for d in devices if d["id"] == did]
+    assert d["last_seen"] is not None
+    assert d["agent_version"] == "2.0.1"  # header wins over the enroll-time value
+    assert "cred_hash" not in d
+
+    assert client.post(f"/admin/devices/{did}/revoke", headers=ADMIN).status_code == 200
+    resp = client.post("/report", headers=dev_auth,
+                       json={"tool": "chatgpt", "surface": "cli", "os": "macos"})
+    assert resp.status_code == 401
+
+
+def test_device_credential_reads_the_registry(managed, tmp_path, monkeypatch):
+    """The collector's second request. A credential that can report but not
+    fetch identifiers would enroll a fleet that then refuses to scan."""
+    from app import main
+
+    reg = tmp_path / "collector.json"
+    reg.write_text('{"version": 1}')
+    monkeypatch.setattr(main, "COLLECTOR_REGISTRY_PATH", str(reg))
+
+    cred = _enroll(_mint()["token"]).json()["device_token"]
+    resp = client.get("/registry/collector",
+                      headers={"Authorization": f"Bearer {cred}"})
+    assert resp.status_code == 200
+
+
+def test_shared_token_still_works_in_managed_mode(managed):
+    """The migration path: unenrolled machines keep reporting."""
+    resp = client.post("/report", headers=AUTH,
+                       json={"tool": "chatgpt", "surface": "cli", "os": "macos"})
+    assert resp.status_code == 200
+
+
+# ------------------------------------------------------- token boundaries --
+
+
+def test_an_enrollment_token_cannot_report(managed):
+    """It mints device records and does nothing else - that boundary is why
+    a long TTL inside an MDM artifact is acceptable."""
+    token = _mint()["token"]
+    resp = client.post("/report", headers={"Authorization": f"Bearer {token}"},
+                       json={"tool": "chatgpt"})
+    assert resp.status_code == 401
+
+
+def test_a_device_credential_cannot_enroll_or_administrate(managed):
+    cred = _enroll(_mint()["token"]).json()["device_token"]
+    hdr = {"Authorization": f"Bearer {cred}"}
+    assert _enroll(cred, serial="OTHER").status_code == 401
+    assert client.get("/admin/devices", headers=hdr).status_code == 401
+
+
+def test_expired_and_revoked_tokens_are_refused_and_distinguishable(managed):
+    minted = _mint()
+    managed._db.execute(
+        "UPDATE enrollment_tokens SET expires_at = '2000-01-01T00:00:00+00:00'"
+        " WHERE id = ?", (minted["id"],))
+    managed._db.commit()
+    resp = _enroll(minted["token"])
+    assert resp.status_code == 401
+    # "expired" names an operations task, not an attack; the collector puts
+    # this string in the MDM log.
+    assert "expired" in resp.json()["detail"]
+
+    second = _mint()
+    assert client.post(f"/admin/enrollment-tokens/{second['id']}/revoke",
+                       headers=ADMIN).status_code == 200
+    resp = _enroll(second["token"])
+    assert resp.status_code == 401
+    assert "expired" not in resp.json()["detail"]
+
+
+def test_token_listing_carries_no_secrets(managed):
+    _mint()
+    tokens = client.get("/admin/enrollment-tokens", headers=ADMIN).json()["tokens"]
+    assert tokens and all("token" not in t and "token_hash" not in t for t in tokens)
+    assert all(t["expires_at"] for t in tokens)  # what an operator judges by
+
+
+# ------------------------------------------------------------ supersession --
+
+
+def test_a_silent_device_is_superseded_by_reenrollment(managed):
+    """The reimaged laptop: its old record is revoked, its new one works, and
+    nobody had to notice the machine never said goodbye."""
+    token = _mint()["token"]
+    first = _enroll(token).json()
+    second = _enroll(token).json()
+    assert second["device_id"] != first["device_id"]
+
+    # Old credential dead, new one live.
+    assert client.post("/report", json={"tool": "x"}, headers={
+        "Authorization": f"Bearer {first['device_token']}"}).status_code == 401
+    assert client.post("/report", json={"tool": "x"}, headers={
+        "Authorization": f"Bearer {second['device_token']}"}).status_code == 200
+
+
+def test_an_actively_reporting_device_cannot_be_displaced(managed):
+    """The stolen-token shape: same serial while the real machine is alive is
+    a 409 and an audit event, not a silent takeover."""
+    token = _mint()["token"]
+    first = _enroll(token).json()
+    client.post("/report", json={"tool": "x"}, headers={
+        "Authorization": f"Bearer {first['device_token']}"})  # stamps last_seen
+
+    resp = _enroll(token)
+    assert resp.status_code == 409
+    # The real machine is untouched.
+    assert client.post("/report", json={"tool": "x"}, headers={
+        "Authorization": f"Bearer {first['device_token']}"}).status_code == 200
+    kinds = [r["kind"] for r in managed._db.execute("SELECT kind FROM events")]
+    assert "supersede_conflict" in kinds
+
+    # Manual revoke is the documented path through the 409.
+    did = first["device_id"]
+    client.post(f"/admin/devices/{did}/revoke", headers=ADMIN)
+    assert _enroll(token).status_code == 200
+
+
+# ------------------------------------------------------------- edge cases --
+
+
+def test_enroll_validates_platform_and_caps_the_body(managed):
+    token = _mint()["token"]
+    assert _enroll(token, platform="solaris").status_code == 422
+    resp = client.post("/enroll",
+                       headers={"Authorization": f"Bearer {token}",
+                                "Content-Length": "9999999"})
+    assert resp.status_code == 413
+
+
+def test_enroll_with_a_shaped_but_unknown_token_is_401(managed):
+    assert _enroll("aige_never-minted").status_code == 401


### PR DESCRIPTION
The keystone the portal phase builds on. MANAGED_MODE=true gives the receiver its first state - one SQLite file - and with it: an admin API that mints enrollment tokens (aige_, default 180 days, instantly revocable), a /enroll exchange where each machine trades one for its own credential (aigd_), and revocation that stops a single laptop without touching any other. Off means byte-for-byte today's receiver: no state file, /enroll and /admin answer 404.

Only credential hashes are stored - a copied database is a list of devices, not a bag of credentials. The admin token is deliberately a separate secret from the shared one, which sits on every machine in the fleet and is exactly why it must not mint credentials. The shared token keeps working for ingest: that is the migration, an estate enrolls one MDM value at a time while unenrolled machines keep reporting.

Enrollment tokens live long because they sit inside MDM artifacts, where a short TTL silently breaks the deployment for new machines; their safety is what they cannot do, not how briefly they exist. Same-serial re-enrollment supersedes a silent device (the reimaged laptop) but 409s one that reported within the hour (the stolen-token shape), which then needs a manual revoke.

All three collectors enroll on the aige_ prefix, store the credential root-only in their state dir, and send their version on every report, so the inventory answers which script the fleet actually runs. A refused enrollment refuses to scan, loudly: an enrollment token cannot report findings, and carrying on would read as a clean estate.

Found live rather than in unit tests: bodyless admin revokes were 411'd by the content-length middleware, so the revoke never happened. No content-length with no transfer-encoding is no body at all and now passes; chunked bodies stay refused.

Chart 0.8.6: managed.* values, an -admin Secret generated and kept across upgrades, a PVC annotated keep so helm uninstall cannot unenroll the fleet, Recreate strategy (the volume is RWO), and a refusal to render more than one replica against SQLite's single writer. Compose gets managed mode as an overlay file so classic setups are untouched.

Receiver tests 47 (13 new: lifecycle, token boundaries, supersession both ways, mode gating); container suite 14 (3 new: enroll-and-report, credential reuse, refused enrollment).