### PR TITLE
portal: the write path - fleet, enrollment tokens, artifact downloads

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.8.6
+version: 0.8.7
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/README.md
+++ b/charts/ai-guard/README.md
@@ -125,6 +125,8 @@ the portal.
 | `managed.adminToken.existingSecret` | `""` | a Secret you created yourself, key `adminToken` |
 | `managed.persistence.size` | `1Gi` | the state PVC. Annotated `helm.sh/resource-policy: keep`: uninstalling the chart does not unenroll the fleet |
 | `managed.persistence.existingClaim` | `""` | use a PVC you created yourself |
+| `portal.receiverUrl` | receiver service | managed mode: where the portal proxies admin actions; defaults to the chart's own receiver service |
+| `portal.receiverPublicUrl` | ingress host | managed mode: the ingest URL baked into downloaded deployment artifacts; defaults to the receiver ingress host when one is enabled |
 | `registry.create` | `true` | ship the compiled registry as a ConfigMap |
 | `registry.existingConfigMap` | `""` | use your own, for example built by CI on every merge |
 | `service.type` | `ClusterIP` | |

--- a/charts/ai-guard/templates/portal-deployment.yaml
+++ b/charts/ai-guard/templates/portal-deployment.yaml
@@ -83,6 +83,20 @@ spec:
                   name: {{ include "ai-guard.portal.secretName" . }}
                   key: password
             {{- end }}
+            {{- if .Values.managed.enabled }}
+            # Managed mode: where admin actions proxy to (the receiver's
+            # in-cluster service) and, separately, the ingest URL agents can
+            # actually reach - that one gets baked into downloaded artifacts,
+            # and a cluster-internal name baked into a Jamf script would
+            # enroll nothing. Defaults: the chart's own service, and the
+            # receiver ingress host when one is enabled.
+            - name: RECEIVER_URL
+              value: {{ .Values.portal.receiverUrl | default (printf "http://%s:%v" (include "ai-guard.fullname" .) .Values.service.port) | quote }}
+            {{- with .Values.portal.receiverPublicUrl | default (ternary (printf "https://%s" .Values.ingress.host) "" .Values.ingress.enabled) }}
+            - name: RECEIVER_PUBLIC_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- end }}
             - name: REGISTRY_PATH
               value: /etc/ai-guard/registry.json
             - name: LOOKBACK_HOURS

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -123,6 +123,16 @@ ingress:
 portal:
   enabled: true
 
+  # Managed mode only (managed.enabled above): where the portal proxies
+  # admin actions, and the ingest URL that gets baked into downloaded
+  # deployment artifacts. Both default sensibly - the chart's own receiver
+  # service, and the receiver ingress host when one is enabled. Set
+  # receiverPublicUrl explicitly when agents reach the receiver some other
+  # way: it must be reachable from the machines being enrolled, which a
+  # cluster-internal service name is not.
+  receiverUrl: ""
+  receiverPublicUrl: ""
+
   image:
     repository: ghcr.io/amansk5/shadow-ai-guard/portal
     tag: ""          # defaults to the chart's appVersion

--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -130,6 +130,12 @@ CORP_DOMAINS=
 # overlay rather than a variable: it needs a secret and a volume, not just an
 # env flag. See docker-compose.managed.yml for the two-step setup.
 
+# Managed overlay only: the receiver URL agents reach from outside - your
+# reverse proxy's public HTTPS address, not a compose service name. The
+# portal bakes it into downloaded deployment artifacts; leave it empty and
+# artifact downloads say what is missing while everything else works.
+RECEIVER_PUBLIC_URL=
+
 # ----------------------------------------------- only with --profile with-logs
 
 # Ignore these unless you have no log store and are using the bundled Loki and

--- a/deploy/compose/docker-compose.managed.yml
+++ b/deploy/compose/docker-compose.managed.yml
@@ -31,5 +31,14 @@ services:
       - managed-state:/var/lib/ai-guard
       - ./secrets/admin_token:/run/secrets/admin_token:ro
 
+  portal:
+    environment:
+      # Where admin actions proxy to (the compose-internal service), and the
+      # ingest URL agents can actually reach - the second is what gets baked
+      # into downloaded deployment artifacts, so it is your public receiver
+      # URL, not a compose service name. Set it in .env.
+      RECEIVER_URL: http://receiver:8080
+      RECEIVER_PUBLIC_URL: ${RECEIVER_PUBLIC_URL:-}
+
 volumes:
   managed-state:

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -133,10 +133,12 @@ Optional, all off by default:
 - `managed.enabled` - device enrollment, per-device credentials and
   revocation, backed by SQLite on a PVC. The chart generates an admin token
   into `<release>-ai-guard-admin` on first install; read it back the same way
-  as the auth token. Mint an enrollment token with
-  `POST /admin/enrollment-tokens` and put it in the MDM in place of the
-  shared token, one platform at a time. See the receiver README for the
-  endpoint reference.
+  as the auth token. The portal gains a Managed section for this: enter that
+  admin token there to see the fleet, mint and revoke enrollment tokens, and
+  download pre-configured collector scripts from the Setup view - or drive
+  the same `/admin` API with curl. Enrollment tokens go in the MDM in place
+  of the shared token, one platform at a time. See the receiver and portal
+  READMEs for the details.
 
 Confirm it is up:
 

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -21,6 +21,11 @@ WORKDIR /srv
 COPY requirements.lock .
 RUN pip install --no-cache-dir --require-hashes -r requirements.lock
 COPY app/ app/
+# Verified copies of the endpoint collector scripts, for artifact downloads.
+# The build context is portal/, so the endpoint/ tree is out of reach; a test
+# asserts these are byte-identical to the sources, the same pattern as the
+# chart's bundled registry.
+COPY collector-scripts/ collector-scripts/
 
 # Passed by CI from the release tag, or the commit for a build off main. A
 # local build leaves it as "dev", which is honest: a hardcoded version drifts,

--- a/portal/README.md
+++ b/portal/README.md
@@ -83,6 +83,29 @@ about the estate.
 | `DEPLOY_CHART_VERSION` | no | shown on the settings page, clearly unverified |
 | `DEPLOY_RELEASE` | no | as above |
 | `DEPLOY_NAMESPACE` | no | as above |
+| `RECEIVER_URL` | no | the receiver's admin API, reachable from the portal. Unset means the Managed views say so and nothing else changes |
+| `RECEIVER_PUBLIC_URL` | no | the ingest URL agents can reach, baked into downloaded deployment artifacts. Different from `RECEIVER_URL` on purpose: a cluster-internal service name baked into a Jamf script would enroll nothing |
+| `COLLECTOR_SCRIPTS_DIR` | no | verified copies of the endpoint collector scripts, shipped in the image; override for development |
+
+## Managed mode: the one write path
+
+With `RECEIVER_URL` set (and `MANAGED_MODE=true` on the receiver), the
+portal gains a Managed section: a fleet view of enrolled devices, an
+enrollment-token view that mints and revokes, and per-source Download
+buttons on the Setup view that generate a pre-configured collector script
+with a fresh enrollment token baked in as the script's own fallback default
+(MDM-supplied values still win; corporate domains are never baked - the
+receiver serves those at runtime).
+
+Every one of those actions is authorized by the **receiver**, not the
+portal: the operator enters the receiver's admin token in the UI, it is
+held in the tab's memory only, forwarded per request in an `X-Admin-Token`
+header, and never stored anywhere in the portal. The portal still holds no
+database and no credentials - a compromised portal yields readable
+findings, which it always did, and nothing that can mint or revoke.
+Governance decisions remain in the file ([docs/governance.md](../docs/governance.md));
+these routes manage operational credentials, which is a different kind of
+thing.
 
 ### Reading from a hosted log store
 

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -841,6 +841,11 @@ def status_from(findings):
          "a collector is reporting and this is not, nobody has wired up an MCP "
          "server yet."),
     ]
+    # Sources the portal can generate a pre-configured deployment artifact
+    # for, when managed mode is on. The value doubles as the API path
+    # segment (/api/artifacts/<kind>); only the endpoint collectors today.
+    artifact_sources = {"collector-macos", "collector-linux", "collector-windows"}
+
     rows = []
     for group, src, label, doc, needs in expected:
         e = by_source.get(src)
@@ -850,6 +855,7 @@ def status_from(findings):
             "label": label,
             "doc": doc,
             "needs": needs,
+            "artifact": src if src in artifact_sources else "",
             "reporting": bool(e),
             "findings": e["findings"] if e else 0,
             "devices": len(e["devices"]) if e else 0,

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -64,16 +64,18 @@ encryption.
 import json
 import logging
 import os
+import re
 import secrets
 import time
 import urllib.parse
 from pathlib import Path
 
-from fastapi import Depends, FastAPI, HTTPException, Query
+from fastapi import Depends, FastAPI, Header, HTTPException, Query
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from pydantic import BaseModel, Field
 
-from app import derive, evidence, governance, paste_guard
+from app import derive, evidence, governance, managed, paste_guard
 
 log = logging.getLogger("portal")
 
@@ -207,6 +209,24 @@ OVERVIEW_WIDGETS = os.environ.get("OVERVIEW_WIDGETS", "")
 DEPLOY_CHART = os.environ.get("DEPLOY_CHART_VERSION", "")
 DEPLOY_RELEASE = os.environ.get("DEPLOY_RELEASE", "")
 DEPLOY_NAMESPACE = os.environ.get("DEPLOY_NAMESPACE", "")
+
+# Managed mode. RECEIVER_URL is where admin actions are proxied - the
+# receiver's internal address, because the browser's CSP keeps it on 'self'
+# and something has to make the call. Unset means the managed views say so
+# and everything else is exactly the classic portal. RECEIVER_PUBLIC_URL is
+# different on purpose: it is the ingest URL agents can actually reach, and
+# it is what gets baked into downloaded deployment artifacts - a
+# cluster-internal service name baked into a Jamf script would enroll
+# nothing. The portal holds no admin credential for any of this: the
+# operator's token arrives per request and is forwarded, never stored.
+RECEIVER_URL = require_http_url("RECEIVER_URL", os.environ.get("RECEIVER_URL", ""))
+RECEIVER_PUBLIC_URL = require_http_url(
+    "RECEIVER_PUBLIC_URL", os.environ.get("RECEIVER_PUBLIC_URL", ""))
+# Verified copies of the endpoint collector scripts, shipped in the image
+# because the build cannot see the endpoint/ tree (same pattern as the
+# chart's bundled registry; a test asserts byte equality with the sources).
+COLLECTOR_SCRIPTS_DIR = os.environ.get(
+    "COLLECTOR_SCRIPTS_DIR", str(Path(__file__).parent.parent / "collector-scripts"))
 
 STATIC = Path(__file__).parent / "static"
 
@@ -396,6 +416,14 @@ def config(_=Depends(require_auth)):
         "cache_ttl_seconds": CACHE_TTL,
         "version": APP_VERSION,
         "overview_widgets": _widgets(),
+        # enabled says the portal can reach an admin API; artifacts_ready
+        # says downloads can bake a URL agents can reach. Separate flags,
+        # because a deployment can sensibly have the first without the
+        # second and the UI should name which one is missing.
+        "managed": {
+            "enabled": bool(RECEIVER_URL),
+            "artifacts_ready": bool(RECEIVER_URL and RECEIVER_PUBLIC_URL),
+        },
     }
 
 
@@ -719,6 +747,123 @@ def suggest_identities(hours: float = Query(default=None, gt=0, le=24 * 90),
         "matched": matched,
         "unmatched": unmatched,
         "identity_map_path": IDENTITY_MAP or None,
+    })
+
+
+# ----------------------------------------------------------- managed mode --
+# The portal's first write path, and it is deliberately a thin one: every
+# route below forwards the operator's admin token to the receiver, which is
+# the component that actually authorizes and records. The portal checks
+# nothing but shape, stores nothing, and a portal database still does not
+# exist. Governance decisions remain in the file (docs/governance.md); these
+# routes manage operational credentials, which is a different kind of thing.
+
+# Receiver-assigned ids are hex, but the exact alphabet is the receiver's
+# business; this guard only ensures a path segment cannot smuggle separators
+# or dots into the URL built below.
+_ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+
+
+def _admin_forward(x_admin_token: str = Header(default="")) -> str:
+    """The operator's admin token, from the header, or the refusal that
+    explains the model: forwarded per request, never stored here."""
+    if not RECEIVER_URL:
+        raise HTTPException(
+            503, "RECEIVER_URL is not set. Managed mode needs the portal to "
+                 "reach the receiver's admin API; see the portal README.")
+    if not x_admin_token:
+        raise HTTPException(
+            401, "X-Admin-Token required: the receiver's admin token. The "
+                 "portal forwards it per request and never stores it.")
+    return x_admin_token
+
+
+def _receiver(method: str, path: str, token: str, body: dict | None = None):
+    try:
+        return managed.receiver_request(RECEIVER_URL, method, path, token, body)
+    except managed.ReceiverError as e:
+        if e.status == 502:
+            log.warning("receiver call failed for %s: %s",
+                        _redact_url(RECEIVER_URL), e.detail)
+        raise HTTPException(e.status, e.detail)
+
+
+@app.get("/api/fleet")
+def fleet(_=Depends(require_auth), token: str = Depends(_admin_forward)):
+    """The enrolled devices, from the receiver's registry - who exists,
+    rather than who has spoken lately, which is what /api/graph derives."""
+    return _receiver("GET", "/admin/devices", token)
+
+
+@app.get("/api/enrollment-tokens")
+def enrollment_tokens(_=Depends(require_auth), token: str = Depends(_admin_forward)):
+    return _receiver("GET", "/admin/enrollment-tokens", token)
+
+
+class MintRequest(BaseModel):
+    note: str = Field(default="", max_length=200)
+    ttl_days: int = Field(default=180, ge=1, le=3650)
+
+
+@app.post("/api/enrollment-tokens")
+def mint_enrollment_token(req: MintRequest, _=Depends(require_auth),
+                          token: str = Depends(_admin_forward)):
+    """Mint via the receiver. The response carries the plaintext exactly
+    once, which is the receiver's contract; the UI shows it once and the
+    portal remembers nothing."""
+    return _receiver("POST", "/admin/enrollment-tokens", token,
+                     {"note": req.note, "ttl_days": req.ttl_days})
+
+
+@app.post("/api/enrollment-tokens/{tid}/revoke")
+def revoke_enrollment_token(tid: str, _=Depends(require_auth),
+                            token: str = Depends(_admin_forward)):
+    if not _ID_RE.match(tid):
+        raise HTTPException(422, "malformed token id")
+    return _receiver("POST", "/admin/enrollment-tokens/%s/revoke" % tid, token)
+
+
+@app.post("/api/devices/{did}/revoke")
+def revoke_device(did: str, _=Depends(require_auth),
+                  token: str = Depends(_admin_forward)):
+    if not _ID_RE.match(did):
+        raise HTTPException(422, "malformed device id")
+    return _receiver("POST", "/admin/devices/%s/revoke" % did, token)
+
+
+@app.post("/api/artifacts/{kind}")
+def artifact(kind: str, _=Depends(require_auth),
+             token: str = Depends(_admin_forward)):
+    """A pre-configured collector script, with a fresh enrollment token.
+
+    POST, not GET, because generating one mints: each download gets its own
+    token, noted with the artifact kind, so the tokens list shows where
+    every credential went and any single artifact can be revoked without
+    touching the others. Values are baked as the scripts' own fallback
+    defaults, so MDM-supplied parameters still win; corporate domains are
+    not baked at all - the receiver serves those at runtime.
+    """
+    if kind not in managed.ARTIFACTS:
+        raise HTTPException(404, "no such artifact")
+    if not RECEIVER_PUBLIC_URL:
+        raise HTTPException(
+            503, "RECEIVER_PUBLIC_URL is not set. Artifacts bake the ingest "
+                 "URL agents reach from outside, which is not the portal's "
+                 "internal RECEIVER_URL; see the portal README.")
+    minted = _receiver("POST", "/admin/enrollment-tokens", token,
+                       {"note": "portal artifact: %s" % kind})
+    try:
+        filename, content = managed.generate(
+            kind, COLLECTOR_SCRIPTS_DIR, RECEIVER_PUBLIC_URL, minted["token"])
+    except managed.ArtifactError as e:
+        # The token is already minted; say which one so it can be revoked
+        # rather than left dangling behind a failed download.
+        raise HTTPException(500, "%s (enrollment token %s was minted for "
+                                 "this artifact and can be revoked)"
+                                 % (e, minted.get("id", "?")))
+    return PlainTextResponse(content, headers={
+        "Content-Disposition": 'attachment; filename="%s"' % filename,
+        "X-Enrollment-Token-Id": minted.get("id", ""),
     })
 
 

--- a/portal/app/managed.py
+++ b/portal/app/managed.py
@@ -1,0 +1,146 @@
+"""Managed-mode proxy and deployment-artifact generation.
+
+The portal's CSP keeps the browser on 'self', so every admin action goes
+through here to the receiver. The portal holds no write credential: the
+operator's admin token arrives per request in the X-Admin-Token header, is
+forwarded verbatim, and the receiver authorizes. A compromised portal
+therefore yields readable findings - which it always did - and nothing that
+can mint or revoke.
+
+Artifacts are the collector scripts with the receiver URL and a freshly
+minted enrollment token substituted in as *defaults*, not hardcodes: every
+substitution targets the script's existing fallback syntax, so a value the
+MDM supplies still wins. Corporate domains are deliberately not baked - the
+receiver serves those to every collector at runtime via /registry/collector.
+
+The scripts themselves are verified copies of endpoint/* (a test asserts
+byte equality, the same pattern as the chart's bundled registry), because
+the portal image cannot see the endpoint/ tree at build time.
+"""
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+TIMEOUT_SECONDS = 10
+
+
+class ReceiverError(Exception):
+    """A failed receiver call, carrying the HTTP status it should become."""
+
+    def __init__(self, status: int, detail: str):
+        self.status = status
+        self.detail = detail
+        super().__init__(detail)
+
+
+def receiver_request(base: str, method: str, path: str, admin_token: str,
+                     body: dict | None = None) -> dict:
+    """One call to the receiver's admin API, the operator's token forwarded.
+
+    stdlib urllib, matching derive.fetch_from_loki, so the portal gains no
+    HTTP dependency. Receiver 4xx passes through with its own detail when
+    that detail is a plain string (the receiver's are fixed messages, and a
+    401 must reach the operator as "bad token", not as a portal error);
+    anything unreachable is a 502 naming only the exception class, because
+    the URL and the error text are for the log, not the browser.
+    """
+    data = json.dumps(body).encode() if body is not None else b""
+    req = urllib.request.Request(
+        base.rstrip("/") + path,
+        method=method,
+        data=data if method == "POST" else None,
+        headers={
+            "Authorization": "Bearer " + admin_token,
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
+            return json.loads(resp.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        detail = "receiver refused with HTTP %d" % e.code
+        try:
+            parsed = json.loads(e.read() or b"{}").get("detail")
+            if isinstance(parsed, str) and parsed:
+                detail = parsed
+        except (ValueError, OSError):
+            pass
+        raise ReceiverError(e.code, detail)
+    except Exception as e:
+        raise ReceiverError(502, "could not reach the receiver (%s)"
+                            % type(e).__name__)
+
+
+# Each artifact names the exact fallback syntax it substitutes. An anchor
+# that stops matching means the collector script changed shape; the fix is
+# updating the anchor, and the loud failure below is what makes that a
+# build-time task instead of a fleet quietly deployed with no configuration.
+ARTIFACTS = {
+    "collector-macos": {
+        "file": "collector-macos.sh",
+        "download": "ai-guard-collector.sh",
+        "anchors": [
+            ('RECEIVER_BASE="${4:-}"', 'RECEIVER_BASE="${4:-%(url)s}"'),
+            ('TOKEN="${5:-}"', 'TOKEN="${5:-%(token)s}"'),
+        ],
+    },
+    "collector-linux": {
+        "file": "collector-linux.sh",
+        "download": "ai-guard-collector.sh",
+        "anchors": [
+            ('RECEIVER_BASE="${AIGUARD_RECEIVER_BASE:-}"',
+             'RECEIVER_BASE="${AIGUARD_RECEIVER_BASE:-%(url)s}"'),
+            ('TOKEN="${AIGUARD_TOKEN:-}"',
+             'TOKEN="${AIGUARD_TOKEN:-%(token)s}"'),
+        ],
+    },
+    "collector-windows": {
+        "file": "collector-windows.ps1",
+        "download": "ai-guard-collector.ps1",
+        "anchors": [
+            ("$ReceiverBase    = 'https://ai-guard.example.com'",
+             "$ReceiverBase    = '%(url)s'"),
+            ("$Token           = '__RECEIVER_TOKEN__'",
+             "$Token           = '%(token)s'"),
+        ],
+    },
+}
+
+
+class ArtifactError(Exception):
+    pass
+
+
+def generate(kind: str, scripts_dir: str, url: str, token: str) -> tuple[str, str]:
+    """(download filename, content) for one pre-configured collector.
+
+    Values are embedded inside shell and PowerShell quoting, so anything that
+    could escape it is refused outright rather than escaped: the URL is
+    operator-supplied configuration and the token alphabet is URL-safe
+    base64, so a rejection here is a misconfiguration being named, not a
+    case to handle gracefully.
+    """
+    spec = ARTIFACTS.get(kind)
+    if spec is None:
+        raise ArtifactError("no such artifact: %s" % kind)
+    for value, name in ((url, "receiver URL"), (token, "token")):
+        if any(c in value for c in "'\"\\$`\n\r\t ") or not value:
+            raise ArtifactError("the %s cannot be embedded in a script" % name)
+
+    path = Path(scripts_dir) / spec["file"]
+    try:
+        content = path.read_text()
+    except OSError as e:
+        raise ArtifactError("collector script not readable: %s (%s)"
+                            % (path.name, type(e).__name__))
+
+    for anchor, template in spec["anchors"]:
+        if content.count(anchor) != 1:
+            raise ArtifactError(
+                "substitution anchor not found exactly once in %s: %r - the "
+                "collector script changed shape; update ARTIFACTS to match"
+                % (spec["file"], anchor))
+        content = content.replace(anchor, template % {"url": url, "token": token})
+    return spec["download"], content

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -140,6 +140,14 @@ h2{font-size:19px;margin:0 0 4px}
    constraint on the prose only makes it stop short of the table it
    introduces, which reads as a broken line rather than a measure. */
 input{background:var(--sf2);border:1px solid var(--bd);color:var(--fg);border-radius:6px;padding:6px 10px;font:inherit;min-width:220px}
+/* Managed views: small action buttons, the admin-token field, and the
+   one-time pane a minted token appears in. */
+button.mini{font:inherit;font-size:12px;padding:3px 10px;border:1px solid var(--line,#8884);border-radius:6px;background:transparent;color:var(--pri);cursor:pointer}
+button.mini:hover{border-color:var(--pri)}
+.mfield{font:inherit;font-size:13px;padding:5px 8px;border:1px solid var(--line,#8884);border-radius:6px;background:transparent;color:inherit;min-width:260px}
+.tokpane{border:1px solid var(--pri);border-radius:8px;padding:12px 14px;margin:14px 0}
+.tokpane code{word-break:break-all}
+.adminbar{margin:10px 0 14px;font-size:12px;color:var(--mut)}
 </style>
 <div class="shell">
   <aside>
@@ -170,14 +178,25 @@ let DIAG = null;
 let REG = null;
 let EV = null;
 let PG = null;
+let FLEET = null;
+let TOKENS = null;
 let S = null, CFG = {}, loadError = '';
+// The receiver admin token, held in this tab's memory for the session and
+// sent per request as a header. Never written to storage of any kind: the
+// portal's whole security story for the write path is that it stores no
+// credential, and localStorage would quietly undo that.
+let ADMIN = '';
+// The one moment a minted token is visible. Kept until dismissed or the
+// admin token is forgotten, because a pane that vanishes on the next click
+// loses a credential that cannot be recovered.
+let MINTED = null;
 
 async function load(force) {
   app.innerHTML = '<p class="lede">Reading findings…</p>';
   const q = force ? '?refresh=true' : '';
   // Refresh must clear the views that read a second endpoint too, or the
   // button refreshes some of the page and silently not the rest.
-  if (force) { DIAG = null; REG = null; EV = null; PG = null; }
+  if (force) { DIAG = null; REG = null; EV = null; PG = null; FLEET = null; TOKENS = null; }
   try {
     CFG = await (await fetch('/api/config')).json();
     const gr = await fetch('/api/graph' + q);
@@ -230,6 +249,7 @@ const NAV = [
   {grp:'Governance',items:[['register','AI register'],['paste','Paste guard'],
                            ['iso','ISO 42001 evidence']]},
   {grp:'Analytics', items:[['dashboard','Grafana']]},
+  {grp:'Managed',   items:[['fleet','Fleet'],['tokens','Enrollment tokens']]},
   {grp:'System',    items:[['settings','Settings']]},
 ];
 
@@ -1043,7 +1063,9 @@ function setup() {
       <td>${esc(r.label)}<br><span class="mono" style="font-size:11px;color:var(--mut)">${esc(r.source)}</span>
         ${r.reporting ? '' : `<div style="margin-top:6px;font-family:inherit;font-size:12px;color:var(--mut);max-width:52ch;line-height:1.5">
           ${esc(r.needs || '')}
-          <br><span class="mono" style="font-size:11px">${esc(r.doc)}</span></div>`}</td>
+          <br><span class="mono" style="font-size:11px">${esc(r.doc)}</span></div>`}
+        ${r.artifact && CFG.managed && CFG.managed.artifacts_ready ? `<div style="margin-top:6px">
+          <button class="mini" data-act="artifact" data-key="${esc(r.artifact)}">Download pre-configured script</button></div>` : ''}</td>
       <td>${r.reporting ? '<span class="pill p-ok">reporting</span>'
                         : '<span class="pill p-mut">not reporting</span>'}</td>
       <td>${r.findings || '—'}</td><td>${r.devices || '—'}</td>
@@ -1147,6 +1169,187 @@ function dashboard() {
   </div>`;
 }
 
+// ------------------------------------------------------------- managed --
+// These two views call the receiver's admin API through the portal. The
+// admin token is entered once per session, held in the ADMIN variable, and
+// forwarded per request; forgetting it (or a 401) drops back to the gate.
+
+function managedGate(title) {
+  if (!CFG.managed || !CFG.managed.enabled) return `<h2>${esc(title)}</h2>
+  <p class="lede">Managed mode is not configured. Set <code>RECEIVER_URL</code>
+  on the portal (and <code>MANAGED_MODE=true</code> on the receiver) to manage
+  enrollment tokens and devices from here. The classic file-and-token flow
+  keeps working without it.</p>`;
+  if (!ADMIN) return `<h2>${esc(title)}</h2>
+  <p class="lede">This view calls the receiver's admin API. Enter the
+  receiver's admin token: it is held in this tab's memory only, sent with
+  each request, and never stored — the portal keeps holding no credentials.</p>
+  <input type="password" id="admin-token-input" class="mfield"
+    placeholder="receiver admin token">
+  <button class="mini" data-act="admin-save">Unlock</button>`;
+  return '';
+}
+
+const adminBar = () => `<div class="adminbar">admin token held in memory —
+  <button class="mini" data-act="admin-forget">forget it</button></div>`;
+
+async function mfetch(path, opts) {
+  return fetch(path, {...(opts || {}), headers: {
+    'X-Admin-Token': ADMIN, 'Content-Type': 'application/json',
+    ...((opts || {}).headers || {})}});
+}
+
+async function managedError(r, title) {
+  let d = r.statusText;
+  try { d = (await r.json()).detail || d; } catch (e) { /* keep statusText */ }
+  if (r.status === 401) ADMIN = '';
+  return `<h2>${esc(title)}</h2><div class="note">${esc(String(d))}</div>`
+    + (r.status === 401 ? `<p class="lede">The admin token was refused; enter
+      it again from the view menu.</p>` : '');
+}
+
+async function fleet() {
+  const gate = managedGate('Fleet'); if (gate) return gate;
+  if (!FLEET) {
+    const r = await mfetch('/api/fleet');
+    if (!r.ok) return managedError(r, 'Fleet');
+    FLEET = await r.json();
+  }
+  const ds = FLEET.devices || [];
+  return `<h2>Fleet</h2>
+  <p class="lede">Enrolled devices, from the receiver's registry — who holds a
+  credential, rather than who has reported lately (the Devices view derives
+  that from findings). Revoking stops that one machine's credential on its
+  next request and touches nothing else.</p>
+  ${adminBar()}
+  ${ds.length ? `<table><tr><th>device</th><th>platform</th><th>serial</th>
+    <th>enrolled</th><th>last seen</th><th>agent</th><th>status</th><th></th></tr>
+  ${ds.map(d => `<tr>
+    <td>${esc(d.hostname || d.serial)}<br><span class="mono" style="font-size:11px;color:var(--mut)">${esc(d.id)}</span></td>
+    <td>${esc(d.platform)}</td><td class="mono">${esc(d.serial)}</td>
+    <td>${when(d.enrolled_at)}</td><td>${when(d.last_seen)}</td>
+    <td>${esc(d.agent_version || '—')}</td>
+    <td>${d.revoked_at ? '<span class="pill p-mut">revoked</span>'
+                       : '<span class="pill p-ok">active</span>'}</td>
+    <td>${d.revoked_at ? '' : `<button class="mini" data-act="revoke-device" data-key="${esc(d.id)}">revoke</button>`}</td>
+  </tr>`).join('')}</table>`
+  : `<div class="note">No devices enrolled yet. Mint an enrollment token in
+    the Enrollment tokens view, or download a pre-configured collector from
+    Setup, and machines appear here as they enroll.</div>`}`;
+}
+
+async function tokens() {
+  const gate = managedGate('Enrollment tokens'); if (gate) return gate;
+  if (!TOKENS) {
+    const r = await mfetch('/api/enrollment-tokens');
+    if (!r.ok) return managedError(r, 'Enrollment tokens');
+    TOKENS = await r.json();
+  }
+  const ts = TOKENS.tokens || [];
+  const nowIso = new Date().toISOString();
+  const state = t => t.revoked_at ? ['revoked', 'p-mut']
+    : t.expires_at <= nowIso ? ['expired', 'p-mut'] : ['active', 'p-ok'];
+  return `<h2>Enrollment tokens</h2>
+  <p class="lede">An enrollment token goes where the shared token goes today —
+  a Jamf parameter, the Intune script, an RMM variable — and machines exchange
+  it once for their own credential. It can create auditable device records and
+  nothing else, which is why a long life inside an MDM artifact is
+  acceptable; revoke it here the moment it is not.</p>
+  ${adminBar()}
+  ${MINTED ? (MINTED.error
+    ? `<div class="note">${esc(MINTED.error)}
+       <button class="mini" data-act="dismiss-minted">dismiss</button></div>`
+    : `<div class="tokpane"><strong>Token ${esc(MINTED.id)} minted.</strong>
+       This is the only time it is shown — the receiver stores a hash.
+       <br><code>${esc(MINTED.token)}</code><br>
+       <button class="mini" data-act="copy" data-copy="${esc(MINTED.token)}">copy</button>
+       <button class="mini" data-act="dismiss-minted">done, it is saved</button>
+       </div>`) : ''}
+  <div style="margin:10px 0 16px">
+    <input id="mint-note" class="mfield" placeholder="note, e.g. macOS Jamf rollout">
+    <input id="mint-ttl" class="mfield" style="min-width:90px" value="180" title="days until expiry">
+    <button class="mini" data-act="mint">Mint token</button>
+  </div>
+  ${ts.length ? `<table><tr><th>id</th><th>note</th><th>created</th><th>expires</th><th>status</th><th></th></tr>
+  ${ts.map(t => { const [lbl, cls] = state(t); return `<tr>
+    <td class="mono">${esc(t.id)}</td><td>${esc(t.note || '—')}</td>
+    <td>${when(t.created_at)}</td><td>${when(t.expires_at)}</td>
+    <td><span class="pill ${cls}">${lbl}</span></td>
+    <td>${lbl === 'active' ? `<button class="mini" data-act="revoke-token" data-key="${esc(t.id)}">revoke</button>` : ''}</td>
+  </tr>`; }).join('')}</table>` : '<div class="note">No enrollment tokens yet.</div>'}`;
+}
+
+async function managedAction(act, el) {
+  if (act === 'admin-save') {
+    const v = document.getElementById('admin-token-input');
+    ADMIN = ((v && v.value) || '').trim();
+    FLEET = null; TOKENS = null; render(); return;
+  }
+  if (act === 'admin-forget') {
+    ADMIN = ''; FLEET = null; TOKENS = null; MINTED = null; render(); return;
+  }
+  if (act === 'dismiss-minted') { MINTED = null; render(); return; }
+  if (act === 'copy') {
+    try { await navigator.clipboard.writeText(el.getAttribute('data-copy') || '');
+          el.textContent = 'copied'; } catch (e) { /* clipboard denied */ }
+    return;
+  }
+  if (!ADMIN) {
+    alert('Enter the receiver admin token first — Managed section, either view.');
+    return;
+  }
+  if (act === 'mint') {
+    const note = (document.getElementById('mint-note')?.value || '').trim();
+    const ttl = parseInt(document.getElementById('mint-ttl')?.value || '180', 10) || 180;
+    const r = await mfetch('/api/enrollment-tokens',
+      {method: 'POST', body: JSON.stringify({note, ttl_days: ttl})});
+    if (r.ok) { MINTED = await r.json(); TOKENS = null; }
+    else {
+      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+      if (r.status === 401) ADMIN = '';
+      MINTED = {error: String(d)};
+    }
+    render(); return;
+  }
+  if (act === 'revoke-token' || act === 'revoke-device') {
+    const id = el.getAttribute('data-key');
+    const what = act === 'revoke-token' ? 'enrollment token' : 'device credential';
+    if (!confirm('Revoke ' + what + ' ' + id + '? This cannot be undone; a '
+                 + 'revoked device re-enrolls with a valid enrollment token.')) return;
+    const path = act === 'revoke-token'
+      ? '/api/enrollment-tokens/' + encodeURIComponent(id) + '/revoke'
+      : '/api/devices/' + encodeURIComponent(id) + '/revoke';
+    const r = await mfetch(path, {method: 'POST'});
+    if (!r.ok) {
+      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+      if (r.status === 401) ADMIN = '';
+      alert('Revoke failed: ' + d);
+    }
+    FLEET = null; TOKENS = null; render(); return;
+  }
+  if (act === 'artifact') {
+    const kind = el.getAttribute('data-key');
+    const r = await mfetch('/api/artifacts/' + encodeURIComponent(kind), {method: 'POST'});
+    if (!r.ok) {
+      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+      if (r.status === 401) ADMIN = '';
+      alert('Could not generate the artifact: ' + d);
+      return;
+    }
+    // Each artifact mints its own enrollment token, so the tokens list is
+    // stale the moment this succeeds.
+    TOKENS = null;
+    const blob = await r.blob();
+    const m = (r.headers.get('Content-Disposition') || '').match(/filename="([^"]+)"/);
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = (m && m[1]) || 'ai-guard-collector';
+    a.click();
+    URL.revokeObjectURL(a.href);
+    return;
+  }
+}
+
 function drawNav() {
   const n = document.getElementById('nav');
   n.innerHTML = NAV.map(sec =>
@@ -1181,6 +1384,8 @@ async function render() {
   if (view === 'register') { app.innerHTML = await register(); return; }
   if (view === 'paste') { app.innerHTML = await paste(); return; }
   if (view === 'iso') { app.innerHTML = await iso(); return; }
+  if (view === 'fleet') { app.innerHTML = await fleet(); return; }
+  if (view === 'tokens') { app.innerHTML = await tokens(); return; }
   app.innerHTML = ({setup, overview, devices, people, tools, coverage,
                     dashboard, personal, mcp})[view]();
 }
@@ -1201,6 +1406,13 @@ app.addEventListener('click', e => {
   if (!el) return;
   const kind = el.getAttribute('data-open');
   open_(kind || null, el.getAttribute('data-key'));
+});
+// Managed actions, same delegation for the same reason. A separate listener
+// rather than branches in the one above, because data-open is navigation and
+// data-act is a side effect, and a row carrying both should do both.
+app.addEventListener('click', e => {
+  const el = e.target.closest('[data-act]');
+  if (el) managedAction(el.getAttribute('data-act'), el);
 });
 // Someone editing the fragment, or arriving on a link to a view.
 window.addEventListener('hashchange', () => {

--- a/portal/collector-scripts/collector-linux.sh
+++ b/portal/collector-scripts/collector-linux.sh
@@ -1,0 +1,723 @@
+#!/usr/bin/env bash
+#
+# ai-guard endpoint collector (Linux)
+# -----------------------------------
+# Scans a developer workstation for AI tooling across four surfaces:
+#   cli      - tools that store an account identity in a config file
+#   ide      - AI extensions in VS Code / Cursor
+#   desktop  - AI desktop apps, local runtimes and their binaries
+#   mcp      - MCP server definitions in AI tool configs
+#
+# The identifiers for all four come from the receiver's /registry/collector
+# at runtime. Nothing tool-specific is hardcoded: adding a new AI tool is a
+# registry merge request, not a script edit plus a re-push through the RMM.
+#
+# Delivery: any mechanism that can run this as root on a schedule - an RMM
+# (Level, NinjaOne, Action1...), an Ansible cron/systemd-timer role, or plain
+# cron. It is the Linux sibling of the macOS (Jamf) and Windows (Intune)
+# collectors: same finding schema, same receiver, same design rules.
+#
+# Config arrives as environment variables (set them in your RMM's script
+# variables, or export them from a wrapper):
+#   AIGUARD_RECEIVER_BASE   receiver base URL, e.g. https://ai-guard.example.com
+#   AIGUARD_TOKEN           receiver bearer token. Either the shared token, or
+#                           an enrollment token (aige_...) from a managed-mode
+#                           receiver: on first run the machine enrolls, stores
+#                           its own device credential in /var/lib/ai-guard,
+#                           and uses that from then on. Swapping the shared
+#                           token for an enrollment token in the RMM is the
+#                           whole migration.
+#   AIGUARD_CORP_DOMAINS    comma-separated corporate domains, e.g. example.com.
+#                           A receiver that serves config.corp_domains in
+#                           /registry/collector overrides this at runtime; the
+#                           variable is the fallback.
+# If AIGUARD_RECEIVER_BASE is unset, findings print to stdout instead of
+# POSTing, which is the local-test mode.
+#
+# Local test:
+#   AIGUARD_REGISTRY_FILE=registry/dist/collector.json ./ai-guard-collector.sh
+#
+# Design rules learned on the macOS and Windows collectors and kept here:
+#   * Resolve the real user's home. RMM agents run as root, whose HOME is
+#     /root and contains nothing - the Linux form of the /var/root and
+#     SYSTEM-profile traps that silently produced empty pilots elsewhere.
+#   * Fail loudly. A collector that reports nothing looks identical to a
+#     clean machine; across a fleet that is false confidence.
+#   * The account_domain field carries the domain only. The console username
+#     is sent in the user field (already known to IT).
+
+set -u
+
+# ------------------------------------------------------------------ config --
+RECEIVER_BASE="${AIGUARD_RECEIVER_BASE:-}"
+TOKEN="${AIGUARD_TOKEN:-}"
+CORP_DOMAINS="${AIGUARD_CORP_DOMAINS:-}"
+
+ENDPOINT=""
+[ -n "$RECEIVER_BASE" ] && ENDPOINT="${RECEIVER_BASE%/}/report"
+
+STATE_DIR="/var/lib/ai-guard"
+STATE_FILE="$STATE_DIR/reported.state"
+# This machine's own credential, once enrolled with a managed-mode receiver.
+# Root-only: it is this device's identity.
+CRED_FILE="$STATE_DIR/device.cred"
+# Reported at enrollment and on every report, so the receiver's inventory can
+# answer "which script version does the fleet actually run".
+COLLECTOR_VERSION="2.0.0"
+SUMMARY_DIR="$STATE_DIR"
+SUMMARY_FILE="$SUMMARY_DIR/last_scan.txt"
+INFO_INTERVAL=$((24 * 3600))
+# warn findings (personal accounts) are a persistent state, not an event, so
+# repeating them at every run adds volume without adding information. The
+# first report already said it. New keys bypass the throttle entirely, so an
+# account switch still surfaces on the next run.
+WARN_INTERVAL=$((3600))
+
+PY=$(command -v python3 || true)
+
+NOW=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+NOW_EPOCH=$(date -u +%s)
+
+# ------------------------------------------------- resolve the real user --
+# RMM agents run as root ($HOME=/root). The AI tool configs live in the
+# developer's home under /home. Resolve the human account: an entry in /home
+# that is a directory, not owned by root, and not a package cache like
+# linuxbrew. On a single-user workstation there is exactly one.
+resolve_user() {
+  local d owner
+  for d in /home/*/; do
+    [ -d "$d" ] || continue
+    owner=$(stat -c '%U' "$d" 2>/dev/null)
+    [ -z "$owner" ] && continue
+    [ "$owner" = "root" ] && continue
+    case "$(basename "$d")" in linuxbrew|lost+found) continue ;; esac
+    CONSOLE_USER="$owner"
+    HOME_DIR="${d%/}"
+    return 0
+  done
+  return 1
+}
+
+if ! resolve_user; then
+  echo "[ai-guard] no human user home found under /home, skipping"
+  exit 0
+fi
+
+# The home directory with every symlink already resolved, so the containment
+# check below compares like with like. Doing it once here rather than per path
+# keeps it to one subshell for the whole run.
+HOME_REAL=$(cd "$HOME_DIR" 2>/dev/null && pwd -P) || HOME_REAL="$HOME_DIR"
+
+# device carries the most stable identifier available: the DMI product serial
+# (root can read it), then machine-id, then hostname. That is what Jamf,
+# Intune, SentinelOne and most RMMs key on. device_name carries the hostname,
+# which is what a human recognises and what platforms with no serial can join
+# on. The dashboard prefers device_name and falls back to device, so a
+# collector sending only the serial shows a serial where scanners show a name.
+DEVICE_NAME=$(hostname 2>/dev/null || echo "")
+
+DEVICE=""
+if [ -r /sys/class/dmi/id/product_serial ]; then
+  DEVICE=$(tr -d ' \n' < /sys/class/dmi/id/product_serial 2>/dev/null)
+fi
+[ -z "$DEVICE" ] && [ -r /etc/machine-id ] && DEVICE=$(cat /etc/machine-id 2>/dev/null)
+# Said out loud. Falling back to the hostname changes what every finding from
+# this machine is keyed on, and a hostname is mutable where a serial is not.
+# Silence would make it indistinguishable from a machine that reported a real
+# serial, which is how one device becomes two on a dashboard that groups by it.
+if [ -z "$DEVICE" ]; then
+  echo "[ai-guard] no DMI serial or machine-id readable, using hostname for device"
+  DEVICE="$DEVICE_NAME"
+fi
+
+# --------------------------------------------------------------- helpers ---
+# domain_of <email> - strip local-part, lowercase. Never reports local-part.
+domain_of() {
+  case "$1" in
+    *@*) printf '%s' "${1##*@}" | tr '[:upper:]' '[:lower:]' ;;
+    *) : ;;
+  esac
+}
+
+# is_corp <domain> - is this one of the configured corporate domains?
+is_corp() {
+  local d="$1" c old
+  [ -n "$d" ] || return 1
+  old="$IFS"; IFS=','
+  for c in $CORP_DOMAINS; do
+    c=$(printf '%s' "$c" | tr -d '[:space:]' | tr '[:upper:]' '[:lower:]')
+    [ -n "$c" ] && [ "$c" = "$d" ] && { IFS="$old"; return 0; }
+  done
+  IFS="$old"; return 1
+}
+
+# ------------------------------------------------------------- json tools --
+# python3 is present on developer machines. These mirror the macOS collector's
+# json_get / json_keys (which use JXA there) with the same contract, so the
+# scan bodies below are identical to the macOS ones.
+
+# json_get <file> <key...> - walk a JSON path, print string value or "".
+# Tolerant of the .claude.json duplicate-key problem (json.load keeps last).
+json_get() {
+  local f="$1"; shift
+  [ -n "$PY" ] || { json_get_fallback "$f" "$@"; return; }
+  "$PY" - "$f" "$@" <<'PYEOF' 2>/dev/null
+import json, sys
+f, keys = sys.argv[1], sys.argv[2:]
+try:
+    with open(f) as fh:
+        cur = json.load(fh)
+    for k in keys:
+        cur = cur[k]
+    print(cur if isinstance(cur, str) else "")
+except Exception:
+    print("")
+PYEOF
+}
+
+# json_keys <file> <key> - comma-separated sorted keys of the object at <key>.
+json_keys() {
+  local f="$1" key="$2"
+  [ -n "$PY" ] || { json_keys_fallback "$f" "$key"; return; }
+  "$PY" - "$f" "$key" <<'PYEOF' 2>/dev/null
+import json, sys
+f, key = sys.argv[1], sys.argv[2]
+try:
+    with open(f) as fh:
+        obj = json.load(fh).get(key) or {}
+    print(",".join(sorted(obj.keys())) if isinstance(obj, dict) else "")
+except Exception:
+    print("")
+PYEOF
+}
+
+# Fallbacks for the (unexpected) no-python3 case: line-wise extraction, the
+# same approach the Windows collector uses. Handles only the leaf field, which
+# is all the cli scan needs.
+json_get_fallback() {
+  local f="$1"; shift
+  local leaf="" k
+  for k in "$@"; do leaf="$k"; done
+  grep -oE "\"$leaf\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$f" 2>/dev/null \
+    | head -1 | sed -E "s/.*:[[:space:]]*\"([^\"]*)\"/\1/"
+}
+json_keys_fallback() {
+  local f="$1" key="$2"
+  awk -v key="\"$key\"" '
+    index($0,key){cap=1; next}
+    cap && /}/{cap=0}
+    cap && match($0,/"[^"]+"[[:space:]]*:/){
+      s=substr($0,RSTART+1); sub(/".*/,"",s); print s
+    }' "$f" 2>/dev/null | sort | paste -sd, -
+}
+
+# decode a JWT claim (codex-cli stores identity in an id_token)
+jwt_claim() {
+  local jwt="$1" claim="$2" payload
+  payload=$(printf '%s' "$jwt" | cut -d. -f2)
+  case $(( ${#payload} % 4 )) in 2) payload="${payload}==";; 3) payload="${payload}=";; esac
+  printf '%s' "$payload" | tr '_-' '/+' | base64 -d 2>/dev/null \
+    | grep -oE "\"$claim\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | head -1 \
+    | sed -E "s/.*:[[:space:]]*\"([^\"]*)\"/\1/"
+}
+
+# ------------------------------------------------------------- reporting ---
+# Evidence labels use a literal ~ so a username never lands in a finding.
+# A quoted "~" does not expand (SC2088); that is intended here - it is a label.
+HOME_LABEL='~'
+POSTED=0; SUPPRESSED=0; POST_FAILURES=0; WARN_COUNT=0; PARSE_FAILURES=0
+SUMMARY=""
+SEEN=""
+
+# throttle state: key "surface|tool|domain" -> last-reported epoch
+declare_state() { :; }
+state_get() {
+  [ -f "$STATE_FILE" ] || return 1
+  grep -F "$1 " "$STATE_FILE" 2>/dev/null | tail -1 | awk '{print $2}'
+}
+
+# json_escape <string> - escape a value for use inside a JSON string.
+# Findings carry values the script does not control: device names, usernames,
+# and evidence built from registry data. A quote or a backslash in any of them
+# turns the payload into invalid JSON, the receiver rejects it, and the finding
+# is lost with nothing to say so. Order matters: backslash first, or the
+# escapes added afterwards get escaped again. Remaining control characters are
+# dropped rather than emitted raw, since raw ones are invalid JSON and these
+# values are labels, not data anyone parses.
+json_escape() {
+  local s="$1"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  s=${s//[[:cntrl:]]/}
+  printf '%s' "$s"
+}
+
+# report <surface> <tool> <account> <evidence>
+report() {
+  local surface="$1" tool="$2" acct="$3" evidence="$4"
+  local severity="info" key prev interval
+
+  if [ -n "$acct" ] && ! is_corp "$acct"; then
+    severity="warn"; WARN_COUNT=$((WARN_COUNT + 1))
+  fi
+
+  if [ -n "$acct" ]; then SUMMARY="$SUMMARY $tool($acct);"; else SUMMARY="$SUMMARY $tool;"; fi
+
+  # Throttle by severity: info daily, warn hourly. A key with no previous
+  # timestamp falls through regardless, so new findings are never delayed.
+  key="$surface|$tool|$acct"
+  interval="$INFO_INTERVAL"
+  [ "$severity" = "warn" ] && interval="$WARN_INTERVAL"
+
+  prev=$(state_get "$key")
+  if [ -n "$prev" ] && [ $((NOW_EPOCH - prev)) -lt "$interval" ]; then
+    printf '%s %s\n' "$key" "$prev" >> "$STATE_NEW"
+    SUPPRESSED=$((SUPPRESSED + 1))
+    return
+  fi
+
+  # severity and reported_at are generated here, so they need no escaping.
+  # Everything else came from the registry, the machine or a config file.
+  local payload
+  payload=$(printf '{"tool":"%s","surface":"%s","os":"linux","account_domain":"%s","device":"%s","device_name":"%s","user":"%s","evidence":"%s","severity":"%s","reported_at":"%s","source":"collector-linux"}' \
+    "$(json_escape "$tool")" "$(json_escape "$surface")" "$(json_escape "$acct")" \
+    "$(json_escape "$DEVICE")" "$(json_escape "$DEVICE_NAME")" \
+    "$(json_escape "$CONSOLE_USER")" "$(json_escape "$evidence")" \
+    "$severity" "$NOW")
+  if [ -z "$ENDPOINT" ]; then
+    echo "[ai-guard] FLAG (no endpoint set): $payload"
+    # Print-only: preserve old timestamp if one exists, but don't advance it.
+    local old_ts
+    old_ts=$(state_get "$key")
+    [ -n "$old_ts" ] && printf '%s %s\n' "$key" "$old_ts" >> "$STATE_NEW"
+    return
+  fi
+  local code
+  code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' \
+    -X POST -H "Authorization: Bearer $TOKEN" \
+    -H "X-AiGuard-Agent-Version: $COLLECTOR_VERSION" \
+    -H 'Content-Type: application/json' \
+    --data "$payload" "$ENDPOINT" 2>/dev/null || echo 000)
+  if [ "$code" = "200" ] || [ "$code" = "204" ]; then
+    POSTED=$((POSTED + 1))
+    printf '%s %s\n' "$key" "$NOW_EPOCH" >> "$STATE_NEW"
+  else
+    echo "[ai-guard] POST failed: HTTP $code for $tool -> $ENDPOINT"
+    POST_FAILURES=$((POST_FAILURES + 1))
+    # Keep the old timestamp so the finding retries next run.
+    local old_ts
+    old_ts=$(state_get "$key")
+    [ -n "$old_ts" ] && printf '%s %s\n' "$key" "$old_ts" >> "$STATE_NEW"
+  fi
+}
+
+# report_once <surface> <tool> <account> <evidence> - one finding per
+# surface+tool per run (a tool can match several identifiers).
+report_once() {
+  local k="$1|$2"
+  case "$SEEN" in *"[$k]"*) return 0 ;; esac
+  SEEN="${SEEN}[$k]"
+  report "$@"
+}
+
+# ---------------------------------------------------------------- registry --
+SEP=$(printf '\x1f')
+REG_FILE=""; REG_TMP=""
+cleanup() { [ -n "$REG_TMP" ] && rm -f "$REG_TMP"; }
+trap cleanup EXIT
+
+fetch_registry() {
+  if [ -n "${AIGUARD_REGISTRY_FILE:-}" ]; then
+    REG_FILE="$AIGUARD_REGISTRY_FILE"; [ -f "$REG_FILE" ]; return $?
+  fi
+  [ -n "$RECEIVER_BASE" ] || return 1
+  REG_TMP=$(mktemp /tmp/ai-guard-reg.XXXXXX) || return 1
+  REG_FILE="$REG_TMP"
+  local code
+  code=$(curl -s -m 15 -o "$REG_FILE" -w '%{http_code}' \
+    -H "Authorization: Bearer $TOKEN" \
+    "${RECEIVER_BASE%/}/registry/collector" 2>/dev/null || echo 000)
+  [ "$code" = "200" ]
+}
+
+# registry_tsv <file> - flatten collector registry to \x1f-separated rows.
+# Same shape as the macOS collector's JXA version, built with python3.
+registry_tsv() {
+  [ -n "$PY" ] || { registry_tsv_fallback "$1"; return; }
+  "$PY" - "$1" <<'PYEOF' 2>/dev/null
+import json, sys
+U = "\x1f"
+try:
+    r = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+out = []
+for t in r.get("ide", []):
+    e = t.get("extension_ids") or {}
+    # linux VS Code / Cursor use the same extension IDs as elsewhere.
+    # chrome/edge IDs are browser extensions: matched against installed
+    # extension folders in Chrome-family browser profiles below.
+    for x in e.get("vscode", []):
+        out.append(U.join(["ide", x, t["tool"]]))
+    for x in e.get("chrome", []):
+        out.append(U.join(["bext", "chrome", x, t["tool"]]))
+    for x in e.get("edge", []):
+        out.append(U.join(["bext", "edge", x, t["tool"]]))
+for t in r.get("desktop", []):
+    for a in (t.get("app_names") or []):
+        out.append(U.join(["app", a, t["tool"]]))
+for t in r.get("cli", []):
+    out.append(U.join(["cli", t["tool"], t.get("account_json_path",""),
+                        ",".join(t.get("account_json_keys") or []),
+                        ",".join(t.get("account_jwt_path") or []),
+                        t.get("account_jwt_claim",""),
+                        ",".join(t.get("config_paths") or []),
+                        ",".join(t.get("binaries") or [])]))
+for m in r.get("mcp", []):
+    out.append(U.join(["mcp", m["tool"], m["path"], m.get("os","any")]))
+print("\n".join(out))
+PYEOF
+}
+
+# No-python fallback: minimal grep-based extraction of the fields the scans use.
+registry_tsv_fallback() {
+  # Without a JSON parser we cannot reliably flatten nested arrays; emit the
+  # cli rows only (the highest-value account findings) via python-free jq-less
+  # parsing is not attempted. Better to fail loud than half-scan.
+  echo "[ai-guard] python3 unavailable and no fallback registry parse; refusing" >&2
+  return 1
+}
+
+# ------------------------------------------------------------- enrollment --
+# Managed mode. A stored device credential wins; an enrollment token
+# (aige_...) is exchanged for one on first run; anything else is today's
+# behaviour exactly. The prefix is the whole switch: the operator changes one
+# RMM variable from the shared token to an enrollment token when ready.
+if [ -f "$CRED_FILE" ]; then
+  STORED_CRED=$(cat "$CRED_FILE" 2>/dev/null)
+  case "$STORED_CRED" in aigd_*) TOKEN="$STORED_CRED" ;; esac
+fi
+case "$TOKEN" in
+  aige_*)
+    if [ -n "$RECEIVER_BASE" ]; then
+      mkdir -p "$STATE_DIR"
+      ENROLL_BODY=$(printf '{"platform":"linux","serial":"%s","hostname":"%s","agent_version":"%s"}' \
+        "$(json_escape "$DEVICE")" "$(json_escape "$DEVICE_NAME")" "$COLLECTOR_VERSION")
+      ENROLL_RESP=$(mktemp /tmp/ai-guard-enroll.XXXXXX)
+      ENROLL_CODE=$(curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
+        -X POST -H "Authorization: Bearer $TOKEN" \
+        -H 'Content-Type: application/json' \
+        --data "$ENROLL_BODY" "${RECEIVER_BASE%/}/enroll" 2>/dev/null || echo 000)
+      if [ "$ENROLL_CODE" = "200" ]; then
+        if [ -n "$PY" ]; then
+          CRED=$("$PY" -c 'import json,sys; print(json.load(open(sys.argv[1])).get("device_token",""))' "$ENROLL_RESP" 2>/dev/null)
+        else
+          # Our own compact JSON, and the credential is URL-safe base64:
+          # sed is sufficient where a general parser is not available.
+          CRED=$(sed -n 's/.*"device_token":"\([^"]*\)".*/\1/p' "$ENROLL_RESP")
+        fi
+        if [ -n "$CRED" ]; then
+          ( umask 077; printf '%s' "$CRED" > "$CRED_FILE" )
+          chmod 600 "$CRED_FILE" 2>/dev/null
+          TOKEN="$CRED"
+          echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+        fi
+      else
+        # Loud and fatal: an enrollment token cannot report findings, so
+        # carrying on would 401 every POST and look like a clean machine.
+        # A 409 here means a device with this serial is actively reporting -
+        # revoke it on the receiver first. A 401 usually means the token
+        # expired: mint a fresh one and update the RMM variable.
+        echo "[ai-guard] enrollment failed: HTTP $ENROLL_CODE from ${RECEIVER_BASE%/}/enroll"
+        echo "[ai-guard] refusing to scan: an enrollment token cannot report findings"
+        rm -f "$ENROLL_RESP"
+        exit 1
+      fi
+      rm -f "$ENROLL_RESP"
+    fi
+    ;;
+esac
+
+if ! fetch_registry; then
+  echo "[ai-guard] registry fetch failed: ${RECEIVER_BASE%/}/registry/collector"
+  echo "[ai-guard] refusing to scan without an identifier list - an empty scan looks like a clean machine"
+  case "$TOKEN" in aigd_*)
+    echo "[ai-guard] this machine's device credential may have been revoked;"
+    echo "[ai-guard] delete $CRED_FILE and supply a valid enrollment token to re-enroll"
+  ;; esac
+  exit 1
+fi
+REG_TSV=$(registry_tsv "$REG_FILE")
+if [ -z "$REG_TSV" ]; then
+  echo "[ai-guard] registry parse failed: $REG_FILE"
+  exit 1
+fi
+
+# Corporate domains can arrive with the registry: the receiver serves
+# config.corp_domains in the payload just fetched when it has CORP_DOMAINS
+# set. The served list wins over AIGUARD_CORP_DOMAINS, because a list changed
+# once on the receiver reaches the fleet on its next run rather than waiting
+# on an RMM variable edit per platform; the variable stays as the fallback,
+# so a receiver serving nothing changes nothing. Guarded on $PY, though a
+# registry parse without python3 already refused above.
+if [ -n "$PY" ]; then
+  CENTRAL_DOMAINS=$("$PY" - "$REG_FILE" <<'PYEOF' 2>/dev/null
+import json, sys
+try:
+    r = json.load(open(sys.argv[1]))
+    print(",".join((r.get("config") or {}).get("corp_domains") or []))
+except Exception:
+    pass
+PYEOF
+)
+  if [ -n "$CENTRAL_DOMAINS" ]; then
+    echo "[ai-guard] corporate domains from receiver: $CENTRAL_DOMAINS"
+    CORP_DOMAINS="$CENTRAL_DOMAINS"
+  fi
+fi
+
+STATE_NEW=$(mktemp /tmp/ai-guard-state.XXXXXX)
+trap 'cleanup; rm -f "$STATE_NEW"' EXIT
+
+# json_get_csv <file> <comma-separated-key-path>
+json_get_csv() {
+  local f="$1" keys="$2" old="$IFS"
+  IFS=','; set -- $keys; IFS="$old"
+  json_get "$f" "$@"
+}
+
+# safe_rel_path <path> - true if a registry-supplied path is safe to join to
+# a home directory. The collector runs as root and the registry arrives over
+# the network, so the value is treated as input rather than configuration:
+# absolute paths, drive letters, parent traversal and control characters are
+# refused. Symlinks are not resolved. The threat here is a tampered registry,
+# and a symlink the user made inside their own home is not that.
+#
+# A bad entry is skipped rather than fatal. Aborting the scan would mean one
+# poisoned path could switch off detection everywhere, which is a better
+# outcome for an attacker than being ignored.
+safe_rel_path() {
+  case "$1" in
+    "" ) return 1 ;;
+    /* | \\* ) return 1 ;;
+    [A-Za-z]:* ) return 1 ;;
+    *..* ) return 1 ;;
+  esac
+  [ "${#1}" -le 256 ] || return 1
+  case "$1" in *[[:cntrl:]]* ) return 1 ;; esac
+  return 0
+}
+
+# resolve_under_home <absolute-path> - print the real path if it stays inside
+# the home directory, fail if it does not.
+#
+# safe_rel_path above rejects a registry value that tries to escape. This
+# catches the other half: a path that looks fine but resolves somewhere else,
+# because a symlink on the machine points out of the home directory. The
+# collector runs as root, so following one reads a file the user could not.
+#
+# Symlinks are resolved rather than rejected. Dotfiles are commonly managed
+# by symlinking them into a checkout, and those are exactly the machines that
+# have AI CLIs on them; refusing to follow any link would drop real findings
+# to prevent an unlikely one.
+#
+# No realpath or readlink -f: neither is dependable on macOS. The loop walks
+# links one at a time, and pwd -P canonicalises the directory chain.
+resolve_under_home() {
+  local p="$1" hops=0 target dir base
+  [ -e "$p" ] || return 1
+  while [ -L "$p" ]; do
+    hops=$((hops + 1))
+    [ "$hops" -le 16 ] || return 1        # a symlink loop, or someone being clever
+    target=$(readlink "$p") || return 1
+    case "$target" in
+      /*) p="$target" ;;
+      *)  p="$(dirname "$p")/$target" ;;
+    esac
+    [ -e "$p" ] || return 1
+  done
+  dir=$(dirname "$p")
+  base=$(basename "$p")
+  dir=$(cd "$dir" 2>/dev/null && pwd -P) || return 1
+  case "$dir/$base" in
+    "$HOME_REAL"/*) printf '%s' "$dir/$base"; return 0 ;;
+  esac
+  return 1
+}
+
+# first_existing <base> <comma-paths> - print first path that exists
+first_existing() {
+  local base="$1" list="$2" old="$IFS" c
+  IFS=','; set -- $list; IFS="$old"
+  for c in "$@"; do
+    [ -n "$c" ] || continue
+    safe_rel_path "$c" || continue
+    resolve_under_home "$base/$c" >/dev/null 2>&1 || continue
+    [ -e "$base/$c" ] && { printf '%s' "$c"; return 0; }
+  done
+  return 1
+}
+
+# first_binary <comma-names> - print first found on PATH or common bins
+first_binary() {
+  local list="$1" old="$IFS" b
+  IFS=','; set -- $list; IFS="$old"
+  for b in "$@"; do
+    [ -n "$b" ] || continue
+    if command -v "$b" >/dev/null 2>&1 \
+       || [ -x "/usr/local/bin/$b" ] \
+       || [ -x "$HOME_DIR/.local/bin/$b" ] \
+       || [ -x "/home/linuxbrew/.linuxbrew/bin/$b" ]; then
+      printf '%s' "$b"; return 0
+    fi
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------- cli -------
+# Tools that store an account identity in a config file. The registry says
+# where the file is and how to read it.
+while IFS="$SEP" read -r _kind tool acct_path keys jwt_path jwt_claim cfg_paths _bins; do
+  [ -n "$acct_path" ] || continue
+  if ! safe_rel_path "$acct_path"; then
+    echo "[ai-guard] refusing registry path for $tool: not relative to home" >&2
+    continue
+  fi
+  f=$(resolve_under_home "$HOME_DIR/$acct_path") || f=""
+  if [ -f "$f" ]; then
+    email=""
+    if [ -n "$keys" ]; then
+      email=$(json_get_csv "$f" "$keys")
+    elif [ -n "$jwt_path" ]; then
+      idt=$(json_get_csv "$f" "$jwt_path")
+      [ -n "$idt" ] && email=$(jwt_claim "$idt" "$jwt_claim")
+    fi
+    report_once "cli" "$tool" "$(domain_of "$email")" "$HOME_LABEL/$acct_path"
+  else
+    hit=$(first_existing "$HOME_DIR" "$cfg_paths") \
+      && report_once "cli" "$tool" "" "$HOME_LABEL/$hit"
+  fi
+done <<EOF
+$(printf '%s\n' "$REG_TSV" | grep "^cli${SEP}")
+EOF
+
+# ---------------------------------------------------------------- ide -------
+# VS Code / Cursor extensions live in ~/.vscode/extensions and
+# ~/.cursor/extensions on Linux, same as macOS.
+scan_ext_dir() {
+  local dir="$1" label="$2" d base
+  [ -d "$dir" ] || return 0
+  for d in "$dir"/*/; do
+    [ -d "$d" ] || continue
+    base=$(basename "$d")
+    while IFS="$SEP" read -r _k ext tool; do
+      case "$base" in "$ext"-*) report_once "ide" "$tool" "" "$label/$base" ;; esac
+    done <<EOF
+$(printf '%s\n' "$REG_TSV" | grep "^ide${SEP}")
+EOF
+  done
+}
+scan_ext_dir "$HOME_DIR/.vscode/extensions" ".vscode/extensions"
+scan_ext_dir "$HOME_DIR/.vscode-server/extensions" ".vscode-server/extensions"
+scan_ext_dir "$HOME_DIR/.cursor/extensions" ".cursor/extensions"
+
+# ------------------------------------------------- browser extensions -------
+# Installed browser extensions, matched by extension id against the registry.
+# Presence is the finding: an AI extension reads pages without anything being
+# pasted. Chrome, Chromium and Brave install from the Chrome store, so all
+# match chrome ids; Edge installs from both stores, so it matches both sets.
+# Snap Chromium keeps profiles under ~/snap and is not covered.
+scan_browser_extensions() {
+  local root="$1" label="$2" idkinds="$3" pdir profile extdir ext
+  [ -d "$root" ] || return 0
+  for pdir in "$root/Default" "$root"/Profile\ *; do
+    [ -d "$pdir/Extensions" ] || continue
+    profile=$(basename "$pdir")
+    for extdir in "$pdir/Extensions"/*/; do
+      [ -d "$extdir" ] || continue
+      ext=$(basename "$extdir")
+      while IFS="$SEP" read -r _k bkind id tool; do
+        case ",$idkinds," in *",$bkind,"*) ;; *) continue ;; esac
+        [ "$ext" = "$id" ] && report_once "browser" "$tool" "" "$label/$profile extension $id"
+      done <<EOF
+$(printf '%s\n' "$REG_TSV" | grep "^bext${SEP}")
+EOF
+    done
+  done
+}
+scan_browser_extensions "$HOME_DIR/.config/google-chrome"               "Chrome"   "chrome"
+scan_browser_extensions "$HOME_DIR/.config/chromium"                    "Chromium" "chrome"
+scan_browser_extensions "$HOME_DIR/.config/BraveSoftware/Brave-Browser" "Brave"    "chrome"
+scan_browser_extensions "$HOME_DIR/.config/microsoft-edge"              "Edge"     "chrome,edge"
+# Flatpak installs keep browser profiles under ~/.var/app/<app-id>/config.
+scan_browser_extensions "$HOME_DIR/.var/app/com.google.Chrome/config/google-chrome" "Chrome (flatpak)" "chrome"
+scan_browser_extensions "$HOME_DIR/.var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser" "Brave (flatpak)" "chrome"
+
+# ---------------------------------------------------------------- desktop ---
+# Linux desktop apps: registry app_names may carry a macOS ".app" suffix, so
+# match on the basename without it against .desktop files and binaries.
+while IFS="$SEP" read -r _kind app tool; do
+  name="${app%.app}"
+  # .desktop entries (system + per-user), and a same-named binary
+  if ls "$HOME_DIR/.local/share/applications/"*"$name"* >/dev/null 2>&1 \
+     || ls "/usr/share/applications/"*"$name"* >/dev/null 2>&1 \
+     || command -v "$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')" >/dev/null 2>&1; then
+    report_once "desktop" "$tool" "" "$name"
+  fi
+done <<EOF
+$(printf '%s\n' "$REG_TSV" | grep "^app${SEP}")
+EOF
+
+# Local runtimes / editors with no account file: presence via config dir or
+# binary. Tools WITH an account file are handled by the cli scan above.
+while IFS="$SEP" read -r _kind tool acct_path _keys _jwt _claim cfg_paths bins; do
+  [ -n "$acct_path" ] && continue
+  hit=$(first_existing "$HOME_DIR" "$cfg_paths") \
+    && { report_once "desktop" "$tool" "" "$HOME_LABEL/$hit"; continue; }
+  bin=$(first_binary "$bins") \
+    && report_once "desktop" "$tool" "" "$bin binary"
+done <<EOF
+$(printf '%s\n' "$REG_TSV" | grep "^cli${SEP}")
+EOF
+
+# ---------------------------------------------------------------- mcp -------
+while IFS="$SEP" read -r _kind tool path os; do
+  # skip rows scoped to another OS; Linux uses the "any" rows (and Claude
+  # Desktop on Linux uses the same ~/.config path as the "any" default).
+  case "$os" in any|linux) ;; *) continue ;; esac
+  if ! safe_rel_path "$path"; then
+    echo "[ai-guard] refusing registry path for $tool: not relative to home" >&2
+    continue
+  fi
+  f=$(resolve_under_home "$HOME_DIR/$path") || continue
+  [ -f "$f" ] || continue
+  servers=$(json_keys "$f" mcpServers)
+  # The tool is the tool. The server list is evidence, not identity: folding it
+  # into the name made every distinct combination of servers a separate tool,
+  # so a machine with figma and context7 looked unrelated to a machine with
+  # figma alone. About twenty two near-identical rows where there should have
+  # been three.
+  [ -n "$servers" ] && report_once "mcp" "${tool}-mcp" "" "$path mcpServers: $servers"
+done <<EOF
+$(printf '%s\n' "$REG_TSV" | grep "^mcp${SEP}")
+EOF
+
+# ---------------------------------------------------------------- summary ---
+mkdir -p "$STATE_DIR" 2>/dev/null
+sort -u "$STATE_NEW" > "$STATE_FILE" 2>/dev/null || cp "$STATE_NEW" "$STATE_FILE"
+
+post_status="posted=$POSTED suppressed=$SUPPRESSED"
+[ "$POST_FAILURES" -gt 0 ] && post_status="POST-FAILED=$POST_FAILURES $post_status"
+[ "$PARSE_FAILURES" -gt 0 ] && post_status="PARSE-FAILED=$PARSE_FAILURES $post_status"
+[ -z "$ENDPOINT" ] && post_status="print-only"
+[ -z "$SUMMARY" ] && SUMMARY=" none"
+echo "${SUMMARY# } [$post_status] ($NOW)" > "$SUMMARY_FILE" 2>/dev/null
+echo "[ai-guard]${SUMMARY} [$post_status]"
+
+if [ "$POST_FAILURES" -gt 0 ] || [ "$WARN_COUNT" -gt 0 ] || [ "$PARSE_FAILURES" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/portal/collector-scripts/collector-macos.sh
+++ b/portal/collector-scripts/collector-macos.sh
@@ -1,0 +1,693 @@
+#!/bin/bash
+#
+# ai-guard endpoint collector (macOS)
+# -----------------------------------
+# Scans the console user's machine for AI tooling across four surfaces:
+#   cli      - tools that store an account identity in a config file
+#   ide      - AI extensions in VS Code / Cursor / JetBrains
+#   desktop  - AI desktop apps, local runtimes and their binaries
+#   mcp      - MCP server definitions in AI tool configs
+#
+# The identifiers for all four come from the receiver's /registry/collector
+# at runtime. Nothing tool-specific is hardcoded in this script: adding a new
+# AI tool is a registry merge request, not a script edit plus an MDM re-paste.
+#
+# Privacy: the account_domain field is the domain only. The console username
+# is sent in the user field (already known to IT via MDM).
+# Same flag schema as the companion browser extension, plus "surface", "os", "severity".
+#
+# Deployment: Jamf policy script, recurring check-in (daily).
+#   Parameter 4: receiver base URL (e.g. https://ai-guard.example.com)
+#   Parameter 5: bearer token. Either the shared token, or an enrollment
+#                token (aige_...) from a managed-mode receiver: on first run
+#                the machine enrolls, stores its own device credential under
+#                /Library/Application Support/ai-guard, and uses that from
+#                then on. Swapping the shared token for an enrollment token
+#                in the Jamf parameter is the whole migration.
+#   Parameter 6: corporate domains, comma-separated (e.g. example.com,example.co.uk).
+#                 Accounts on these domains report as work; anything else is a
+#                 personal account and escalates severity. A receiver that
+#                 serves config.corp_domains in /registry/collector overrides
+#                 this at runtime; the parameter is the fallback.
+#
+# Local test: AIGUARD_REGISTRY_FILE=registry/dist/collector.json ./ai-guard-collector.sh
+# with no args - findings are printed instead of POSTed.
+#
+# Also writes a one-line summary to /Library/Application Support/ai-guard/last_scan.txt
+# which the companion Jamf Extension Attribute reads into inventory.
+
+set -u
+
+# Parameter 4 is the receiver base URL (https://host). The report path is
+# appended here so a trailing slash in the Jamf parameter can never produce
+# //report. An empty parameter leaves ENDPOINT empty: print-only mode.
+RECEIVER_BASE="${4:-}"
+ENDPOINT=""
+[ -n "$RECEIVER_BASE" ] && ENDPOINT="${RECEIVER_BASE%/}/report"
+TOKEN="${5:-}"
+CORP_DOMAINS="${6:-}"
+
+SUMMARY_DIR="/Library/Application Support/ai-guard"
+SUMMARY_FILE="$SUMMARY_DIR/last_scan.txt"
+# This machine's own credential, once enrolled with a managed-mode receiver.
+# Root-only: it is this device's identity.
+CRED_FILE="$SUMMARY_DIR/device.cred"
+# Reported at enrollment and on every report, so the receiver's inventory can
+# answer "which script version does the fleet actually run".
+COLLECTOR_VERSION="2.0.0"
+
+# Report throttling. The policy runs at every recurring check-in (~20 min).
+# Unchanged inventory (info) findings only need reporting once a day; warn
+# findings (personal accounts) report hourly, since a personal account is a
+# persistent state rather than an event and the first report already said it.
+# STATE_FILE holds one line per already-reported finding: "<key> <epoch>".
+# A finding not yet in the state file (new tool, new account) reports
+# immediately at any severity, so a fresh install or an account switch
+# surfaces within one check-in.
+STATE_FILE="$SUMMARY_DIR/reported.state"
+INFO_REPORT_INTERVAL=$(( 24 * 3600 ))
+WARN_REPORT_INTERVAL=$(( 3600 ))
+NOW_EPOCH=$(/bin/date +%s)
+STATE_OLD=""
+[ -f "$STATE_FILE" ] && STATE_OLD=$(/bin/cat "$STATE_FILE" 2>/dev/null)
+STATE_NEW=""
+SUPPRESSED=0
+
+state_lookup() {  # state_lookup <key> -> prints epoch or nothing
+  printf '%s\n' "$STATE_OLD" | /usr/bin/awk -v k="$1" '$1 == k {print $2; exit}'
+}
+
+# ---------------------------------------------------------------- context ---
+
+CONSOLE_USER=$(/usr/bin/stat -f%Su /dev/console)
+if [ -z "$CONSOLE_USER" ] || [ "$CONSOLE_USER" = "root" ]; then
+  # No one logged in; fall back to the most recently modified real user home
+  CONSOLE_USER=$(/bin/ls -t /Users | /usr/bin/grep -v -e '^Shared$' -e '^\.' | /usr/bin/head -1)
+fi
+HOME_DIR=$(/usr/bin/dscl . -read "/Users/$CONSOLE_USER" NFSHomeDirectory 2>/dev/null | /usr/bin/awk '{print $2}')
+[ -z "${HOME_DIR:-}" ] && HOME_DIR="/Users/$CONSOLE_USER"
+
+# The home directory with every symlink already resolved, so the containment
+# check below compares like with like. Doing it once here rather than per path
+# keeps it to one subshell for the whole run.
+HOME_REAL=$(cd "$HOME_DIR" 2>/dev/null && pwd -P) || HOME_REAL="$HOME_DIR"
+
+SERIAL=$(/usr/sbin/ioreg -rd1 -c IOPlatformExpertDevice | /usr/bin/awk -F'"' '/IOPlatformSerialNumber/{print $4}')
+
+# device carries the serial: immutable, and what Jamf, Intune, SentinelOne and
+# most RMMs key on. device_name carries the hostname, which is what a human
+# recognises and what platforms that have no serial can still join on. The
+# dashboard prefers device_name and falls back to device, so a collector that
+# sends only the serial shows a serial where the scanners show a name.
+DEVICE_NAME=$(/usr/sbin/scutil --get ComputerName 2>/dev/null || /bin/hostname -s 2>/dev/null || echo "")
+
+# Said out loud, because an empty serial changes what every finding from this
+# machine is keyed on. Silence here would look identical to a machine with no
+# AI tools on it.
+if [ -z "$SERIAL" ]; then
+  echo "[ai-guard] serial lookup failed via ioreg, falling back to hostname for device"
+  SERIAL="$DEVICE_NAME"
+fi
+
+NOW=$(/bin/date -u +%Y-%m-%dT%H:%M:%SZ)
+
+# ---------------------------------------------------------------- helpers ---
+
+# json_get <file> <key> [key...]  - walk a JSON path, print string value or ""
+# Uses JXA so there is no dependency on jq or python3.
+json_get() {
+  /usr/bin/osascript -l JavaScript -e '
+    function run(argv) {
+      try {
+        var s = $.NSString.stringWithContentsOfFileEncodingError(argv[0], $.NSUTF8StringEncoding, null).js;
+        var o = JSON.parse(s);
+        for (var i = 1; i < argv.length; i++) {
+          o = o[argv[i]];
+          if (o === undefined || o === null) return "";
+        }
+        return String(o);
+      } catch (e) { return ""; }
+    }' "$@" 2>/dev/null
+}
+
+# json_keys <file> <key> - print comma-separated keys of an object at <key>
+json_keys() {
+  /usr/bin/osascript -l JavaScript -e '
+    function run(argv) {
+      try {
+        var s = $.NSString.stringWithContentsOfFileEncodingError(argv[0], $.NSUTF8StringEncoding, null).js;
+        var o = JSON.parse(s)[argv[1]];
+        if (!o || typeof o !== "object") return "";
+        return Object.keys(o).join(",");
+      } catch (e) { return ""; }
+    }' "$@" 2>/dev/null
+}
+
+# domain_of <email> - strip local-part, lowercase. Never reports the local-part.
+domain_of() {
+  local e="$1"
+  case "$e" in
+    *@*) printf '%s' "${e##*@}" | /usr/bin/tr '[:upper:]' '[:lower:]' ;;
+    *)   printf '' ;;
+  esac
+}
+
+SUMMARY_PARTS=()
+POST_OK=0
+POST_FAILURES=0
+
+# json_escape <string> - escape a value for use inside a JSON string.
+# Findings carry values the script does not control: device names, usernames,
+# and evidence built from registry data. A quote or a backslash in any of them
+# turns the payload into invalid JSON, the receiver rejects it, and the finding
+# is lost with nothing to say so. Order matters: backslash first, or the
+# escapes added afterwards get escaped again. Remaining control characters are
+# dropped rather than emitted raw, since raw ones are invalid JSON and these
+# values are labels, not data anyone parses.
+json_escape() {
+  local s="$1"
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  s=${s//[[:cntrl:]]/}
+  printf '%s' "$s"
+}
+
+# report <surface> <tool> <account_domain> <evidence>
+report() {
+  local surface="$1" tool="$2" acct="$3" evidence="$4" severity="info"
+  if [ -n "$acct" ]; then
+    case ",${CORP_DOMAINS}," in
+      *",${acct},"*) ;;          # corporate (any alias) -> info
+      *) severity="warn" ;;      # anything else -> personal account
+    esac
+  fi
+
+  # Report throttling. The policy runs at every recurring check-in (~20 min).
+  # Unchanged inventory (info) findings only need reporting once a day; warn
+  # findings (personal accounts) report hourly, since a personal account is a
+  # persistent state rather than an event and the first report already told us.
+  # Throttle by severity: info daily, warn hourly. A key with no previous
+  # timestamp falls through regardless, so new findings are never delayed.
+  local key="${surface}|${tool}|${acct}"
+  local interval="$INFO_REPORT_INTERVAL"
+  [ "$severity" = "warn" ] && interval="$WARN_REPORT_INTERVAL"
+
+  local last
+  last=$(state_lookup "$key")
+  if [ -n "$last" ] && [ $(( NOW_EPOCH - last )) -lt "$interval" ]; then
+    STATE_NEW="${STATE_NEW}${key} ${last}
+"
+    SUPPRESSED=$((SUPPRESSED + 1))
+    if [ -n "$acct" ]; then SUMMARY_PARTS+=("$tool($acct)"); else SUMMARY_PARTS+=("$tool"); fi
+    return 0
+  fi
+
+  # severity and reported_at are generated here, so they need no escaping.
+  # Everything else came from the registry, the machine or a config file.
+  local payload
+  payload=$(/usr/bin/printf '{"tool":"%s","surface":"%s","os":"macos","account_domain":"%s","device":"%s","device_name":"%s","user":"%s","evidence":"%s","severity":"%s","reported_at":"%s","source":"collector-macos"}' \
+    "$(json_escape "$tool")" "$(json_escape "$surface")" "$(json_escape "$acct")" \
+    "$(json_escape "$SERIAL")" "$(json_escape "$DEVICE_NAME")" \
+    "$(json_escape "$CONSOLE_USER")" "$(json_escape "$evidence")" \
+    "$severity" "$NOW")
+
+  local delivered=false
+  if [ -n "$ENDPOINT" ]; then
+    local http_code
+    http_code=$(/usr/bin/curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "$ENDPOINT" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "X-AiGuard-Agent-Version: $COLLECTOR_VERSION" \
+      -H "Content-Type: application/json" \
+      -d "$payload" || echo "000")
+    if [ "$http_code" != "200" ]; then
+      # A collector that fails silently across a fleet produces a clean
+      # dashboard and false confidence. Fail loudly: Jamf shows this line
+      # in the policy log and the script exits non-zero at the end.
+      echo "[ai-guard] POST failed: HTTP $http_code for $tool -> $ENDPOINT"
+      POST_FAILURES=$((POST_FAILURES + 1))
+    else
+      POST_OK=$((POST_OK + 1))
+      delivered=true
+    fi
+  else
+    echo "[ai-guard] FLAG (no endpoint set): $payload"
+  fi
+
+  # Advance the throttle timestamp only after confirmed delivery.
+  # On failure, keep the old timestamp (if any) so the finding retries
+  # on the next run rather than being suppressed for 24h.
+  if [ "$delivered" = true ]; then
+    STATE_NEW="${STATE_NEW}${key} ${NOW_EPOCH}
+"
+  else
+    local old_ts
+    old_ts=$(state_lookup "$key")
+    if [ -n "$old_ts" ]; then
+      STATE_NEW="${STATE_NEW}${key} ${old_ts}
+"
+    fi
+  fi
+
+  if [ -n "$acct" ]; then
+    SUMMARY_PARTS+=("$tool($acct)")
+  else
+    SUMMARY_PARTS+=("$tool")
+  fi
+}
+
+# ---------------------------------------------------------------- registry --
+
+# Which extension IDs, app names, config paths and MCP files belong to which
+# tool now comes from the receiver at runtime. It used to be hardcoded here,
+# which meant a new AI tool needed a script edit and an MDM re-paste on every
+# machine, while the registry that should have owned that list was already
+# being maintained by merge request. A new tool is now a registry MR only.
+#
+# Fields are separated by \x1f (unit separator), not tab: tab is IFS
+# whitespace, so `IFS=$'\t' read` silently collapses consecutive empty
+# fields and the CLI rows below have several.
+SEP=$(printf '\x1f')
+
+REG_FILE=""
+REG_TMP=""
+cleanup() { [ -n "$REG_TMP" ] && /bin/rm -f "$REG_TMP"; }
+trap cleanup EXIT
+
+fetch_registry() {
+  # AIGUARD_REGISTRY_FILE points at a checked-out registry/dist/collector.json
+  # so the script can be run locally with no receiver.
+  if [ -n "${AIGUARD_REGISTRY_FILE:-}" ]; then
+    REG_FILE="$AIGUARD_REGISTRY_FILE"
+    [ -f "$REG_FILE" ]
+    return $?
+  fi
+  [ -n "$RECEIVER_BASE" ] || return 1
+  REG_TMP=$(/usr/bin/mktemp /tmp/ai-guard-reg.XXXXXX) || return 1
+  REG_FILE="$REG_TMP"
+  local code
+  code=$(/usr/bin/curl -s -m 15 -o "$REG_FILE" -w '%{http_code}' \
+    -H "Authorization: Bearer $TOKEN" \
+    "${RECEIVER_BASE%/}/registry/collector" 2>/dev/null || echo "000")
+  [ "$code" = "200" ]
+}
+
+# registry_tsv <file> - flatten the collector registry into lookup rows.
+registry_tsv() {
+  /usr/bin/osascript -l JavaScript -e '
+    function run(argv) {
+      try {
+        var s = $.NSString.stringWithContentsOfFileEncodingError(argv[0], $.NSUTF8StringEncoding, null).js;
+        var r = JSON.parse(s);
+        var U = String.fromCharCode(31);
+        var out = [];
+        (r.ide || []).forEach(function (t) {
+          var e = t.extension_ids || {};
+          // Cursor is a VS Code fork and uses the same extension IDs.
+          (e.vscode || []).forEach(function (x) { out.push(["ide", x, t.tool].join(U)); });
+          (e.jetbrains || []).forEach(function (x) { out.push(["jb", x, t.tool].join(U)); });
+          // chrome/edge IDs are browser extensions: matched against installed
+          // extension folders in Chrome-family browser profiles below.
+          (e.chrome || []).forEach(function (x) { out.push(["bext", "chrome", x, t.tool].join(U)); });
+          (e.edge || []).forEach(function (x) { out.push(["bext", "edge", x, t.tool].join(U)); });
+        });
+        (r.desktop || []).forEach(function (t) {
+          (t.app_names || []).forEach(function (a) { out.push(["app", a, t.tool].join(U)); });
+        });
+        (r.cli || []).forEach(function (t) {
+          out.push(["cli", t.tool, t.account_json_path || "",
+                    (t.account_json_keys || []).join(","),
+                    (t.account_jwt_path || []).join(","),
+                    t.account_jwt_claim || "",
+                    (t.config_paths || []).join(","),
+                    (t.binaries || []).join(",")].join(U));
+        });
+        (r.mcp || []).forEach(function (m) { out.push(["mcp", m.tool, m.path, m.os || "any"].join(U)); });
+        return out.join("\n");
+      } catch (e) { return ""; }
+    }' "$1" 2>/dev/null
+}
+
+# ------------------------------------------------------------- enrollment --
+# Managed mode. A stored device credential wins; an enrollment token
+# (aige_...) is exchanged for one on first run; anything else is today's
+# behaviour exactly. The prefix is the whole switch: the operator changes
+# parameter 5 from the shared token to an enrollment token when ready.
+if [ -f "$CRED_FILE" ]; then
+  STORED_CRED=$(/bin/cat "$CRED_FILE" 2>/dev/null)
+  case "$STORED_CRED" in aigd_*) TOKEN="$STORED_CRED" ;; esac
+fi
+case "$TOKEN" in
+  aige_*)
+    if [ -n "$RECEIVER_BASE" ]; then
+      /bin/mkdir -p "$SUMMARY_DIR"
+      ENROLL_BODY=$(/usr/bin/printf '{"platform":"macos","serial":"%s","hostname":"%s","agent_version":"%s"}' \
+        "$(json_escape "$SERIAL")" "$(json_escape "$DEVICE_NAME")" "$COLLECTOR_VERSION")
+      ENROLL_RESP=$(/usr/bin/mktemp /tmp/ai-guard-enroll.XXXXXX)
+      ENROLL_CODE=$(/usr/bin/curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
+        -X POST -H "Authorization: Bearer $TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$ENROLL_BODY" "${RECEIVER_BASE%/}/enroll" 2>/dev/null || echo "000")
+      if [ "$ENROLL_CODE" = "200" ]; then
+        CRED=$(json_get "$ENROLL_RESP" device_token)
+        if [ -n "$CRED" ]; then
+          ( umask 077; /usr/bin/printf '%s' "$CRED" > "$CRED_FILE" )
+          /bin/chmod 600 "$CRED_FILE" 2>/dev/null
+          TOKEN="$CRED"
+          echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+        fi
+      else
+        # Loud and fatal: an enrollment token cannot report findings, so
+        # carrying on would 401 every POST and look like a clean machine.
+        # A 409 here means a device with this serial is actively reporting -
+        # revoke it on the receiver first. A 401 usually means the token
+        # expired: mint a fresh one and update the Jamf parameter.
+        echo "[ai-guard] enrollment failed: HTTP $ENROLL_CODE from ${RECEIVER_BASE%/}/enroll"
+        echo "[ai-guard] refusing to scan: an enrollment token cannot report findings"
+        /bin/rm -f "$ENROLL_RESP"
+        exit 1
+      fi
+      /bin/rm -f "$ENROLL_RESP"
+    fi
+    ;;
+esac
+
+if ! fetch_registry; then
+  # Distinguish "no receiver configured" from "the receiver did not answer".
+  # Both used to print the same line, which reads as a network problem when it
+  # is a missing parameter - and prints a URL with no host in front of it,
+  # which is the giveaway nobody notices. This script takes its configuration
+  # as positional parameters because Jamf passes script parameters, not
+  # environment variables; running it by hand needs the same shape.
+  if [ -z "$RECEIVER_BASE" ]; then
+    echo "[ai-guard] no receiver configured. This script reads its settings as"
+    echo "[ai-guard] positional parameters, because that is how Jamf passes"
+    echo "[ai-guard] them. Environment variables are ignored."
+    echo "[ai-guard]"
+    echo "[ai-guard]   Jamf: set parameters 4, 5 and 6 on the policy."
+    echo "[ai-guard]   By hand: \$1-\$3 are Jamf's own, so pass three empty"
+    echo "[ai-guard]   strings first:"
+    echo "[ai-guard]"
+    echo "[ai-guard]     sudo ./ai-guard-collector.sh \"\" \"\" \"\" \\"
+    echo "[ai-guard]       https://receiver.example.com <token> example.com"
+    echo "[ai-guard]"
+    echo "[ai-guard] Refusing to scan: an empty scan looks like a clean machine."
+    exit 1
+  fi
+  echo "[ai-guard] registry fetch failed: ${RECEIVER_BASE%/}/registry/collector"
+  echo "[ai-guard] refusing to scan without an identifier list - an empty scan looks like a clean machine"
+  case "$TOKEN" in aigd_*)
+    echo "[ai-guard] this machine's device credential may have been revoked;"
+    echo "[ai-guard] delete '$CRED_FILE' and supply a valid enrollment token to re-enroll"
+  ;; esac
+  exit 1
+fi
+REG_TSV=$(registry_tsv "$REG_FILE")
+if [ -z "$REG_TSV" ]; then
+  echo "[ai-guard] registry parse failed: $REG_FILE"
+  exit 1
+fi
+
+# Corporate domains can arrive with the registry: the receiver serves
+# config.corp_domains in the payload just fetched when it has CORP_DOMAINS
+# set. The served list wins over parameter 6, because a list changed once on
+# the receiver reaches the fleet on its next check-in rather than waiting on
+# an MDM re-paste per platform; the parameter stays as the fallback, so a
+# receiver serving nothing changes nothing. json_get stringifies the array
+# comma-joined, which is the exact shape the severity check in report()
+# matches against - the receiver serves it trimmed and lowercased for the
+# same reason.
+CENTRAL_DOMAINS=$(json_get "$REG_FILE" config corp_domains)
+if [ -n "$CENTRAL_DOMAINS" ]; then
+  echo "[ai-guard] corporate domains from receiver: $CENTRAL_DOMAINS"
+  CORP_DOMAINS="$CENTRAL_DOMAINS"
+fi
+
+# report_once <surface> <tool> <account> <evidence>
+# One finding per surface+tool per run. A tool can match several identifiers
+# (both Copilot extension IDs, an app name AND a binary) and is still one
+# finding on this device.
+# Evidence labels stand in for the console user's home with a literal ~ so a
+# username never appears in a finding. Kept in a variable because a quoted
+# "~/..." is a shellcheck warning (SC2088): a tilde does not expand inside
+# quotes, which here is intended.
+HOME_LABEL='~'
+
+SEEN=""
+report_once() {
+  local key="$1|$2"
+  case "$SEEN" in *"[$key]"*) return 0 ;; esac
+  SEEN="${SEEN}[$key]"
+  report "$@"
+}
+
+# json_get_csv <file> <comma-separated-key-path>
+# json_get with the key path supplied as registry data. `set --` inside a
+# function only rebinds that function's positional parameters.
+json_get_csv() {
+  local f="$1" keys="$2" old="$IFS"
+  IFS=','
+  set -- $keys
+  IFS="$old"
+  json_get "$f" "$@"
+}
+
+# safe_rel_path <path> - true if a registry-supplied path is safe to join to
+# a home directory. The collector runs as root and the registry arrives over
+# the network, so the value is treated as input rather than configuration:
+# absolute paths, drive letters, parent traversal and control characters are
+# refused. Symlinks are not resolved. The threat here is a tampered registry,
+# and a symlink the user made inside their own home is not that.
+#
+# A bad entry is skipped rather than fatal. Aborting the scan would mean one
+# poisoned path could switch off detection everywhere, which is a better
+# outcome for an attacker than being ignored.
+safe_rel_path() {
+  case "$1" in
+    "" ) return 1 ;;
+    /* | \\* ) return 1 ;;
+    [A-Za-z]:* ) return 1 ;;
+    *..* ) return 1 ;;
+  esac
+  [ "${#1}" -le 256 ] || return 1
+  case "$1" in *[[:cntrl:]]* ) return 1 ;; esac
+  return 0
+}
+
+# resolve_under_home <absolute-path> - print the real path if it stays inside
+# the home directory, fail if it does not.
+#
+# safe_rel_path above rejects a registry value that tries to escape. This
+# catches the other half: a path that looks fine but resolves somewhere else,
+# because a symlink on the machine points out of the home directory. The
+# collector runs as root, so following one reads a file the user could not.
+#
+# Symlinks are resolved rather than rejected. Dotfiles are commonly managed
+# by symlinking them into a checkout, and those are exactly the machines that
+# have AI CLIs on them; refusing to follow any link would drop real findings
+# to prevent an unlikely one.
+#
+# No realpath or readlink -f: neither is dependable on macOS. The loop walks
+# links one at a time, and pwd -P canonicalises the directory chain.
+resolve_under_home() {
+  local p="$1" hops=0 target dir base
+  [ -e "$p" ] || return 1
+  while [ -L "$p" ]; do
+    hops=$((hops + 1))
+    [ "$hops" -le 16 ] || return 1        # a symlink loop, or someone being clever
+    target=$(readlink "$p") || return 1
+    case "$target" in
+      /*) p="$target" ;;
+      *)  p="$(dirname "$p")/$target" ;;
+    esac
+    [ -e "$p" ] || return 1
+  done
+  dir=$(dirname "$p")
+  base=$(basename "$p")
+  dir=$(cd "$dir" 2>/dev/null && pwd -P) || return 1
+  case "$dir/$base" in
+    "$HOME_REAL"/*) printf '%s' "$dir/$base"; return 0 ;;
+  esac
+  return 1
+}
+
+# first_existing <base> <comma-separated-paths> - print the first that exists
+first_existing() {
+  local base="$1" list="$2" old="$IFS" c
+  IFS=','
+  set -- $list
+  IFS="$old"
+  for c in "$@"; do
+    [ -n "$c" ] || continue
+    safe_rel_path "$c" || continue
+    resolve_under_home "$base/$c" >/dev/null 2>&1 || continue
+    if [ -e "$base/$c" ]; then printf '%s' "$c"; return 0; fi
+  done
+  return 1
+}
+
+# first_binary <comma-separated-names> - print the first found in brew paths
+first_binary() {
+  local list="$1" old="$IFS" b
+  IFS=','
+  set -- $list
+  IFS="$old"
+  for b in "$@"; do
+    [ -n "$b" ] || continue
+    if [ -x "/usr/local/bin/$b" ] || [ -x "/opt/homebrew/bin/$b" ]; then
+      printf '%s' "$b"; return 0
+    fi
+  done
+  return 1
+}
+
+# ---------------------------------------------------------------- cli -------
+
+# Tools that store an account identity in a config file. The registry says
+# where the file is and how to read it: account_json_keys for a plain field,
+# account_jwt_path + account_jwt_claim when the identity is inside a token.
+while IFS="$SEP" read -r _kind tool acct_path keys jwt_path jwt_claim cfg_paths _bins; do
+  [ -n "$acct_path" ] || continue   # presence-only tools are handled by the desktop scan
+  if ! safe_rel_path "$acct_path"; then
+    echo "[ai-guard] refusing registry path for $tool: not relative to home" >&2
+    continue
+  fi
+  f=$(resolve_under_home "$HOME_DIR/$acct_path") || f=""
+  if [ -n "$f" ] && [ -f "$f" ]; then
+    email=""
+    if [ -n "$keys" ]; then
+      email=$(json_get_csv "$f" "$keys")
+    elif [ -n "$jwt_path" ]; then
+      idt=$(json_get_csv "$f" "$jwt_path")
+      if [ -n "$idt" ]; then
+        p=$(printf '%s' "$idt" | /usr/bin/cut -d. -f2 | /usr/bin/tr '_-' '/+')
+        while [ $(( ${#p} % 4 )) -ne 0 ]; do p="${p}="; done
+        email=$(printf '%s' "$p" | /usr/bin/base64 -D 2>/dev/null \
+          | /usr/bin/grep -oE "\"${jwt_claim}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+          | /usr/bin/head -1 | /usr/bin/cut -d'"' -f4)
+      fi
+    fi
+    report_once "cli" "$tool" "$(domain_of "$email")" "$HOME_LABEL/$acct_path"
+  else
+    # Installed but never authenticated: still report presence so the tool
+    # appears in the inventory, with no account.
+    hit=$(first_existing "$HOME_DIR" "$cfg_paths") \
+      && report_once "cli" "$tool" "" "$HOME_LABEL/$hit"
+  fi
+done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^cli${SEP}")
+
+# ---------------------------------------------------------------- ide -------
+
+scan_extensions_dir() {
+  local dir="$1" label="$2" d base _kind ext tool
+  [ -d "$dir" ] || return 0
+  for d in "$dir"/*/; do
+    [ -d "$d" ] || continue
+    base=$(/usr/bin/basename "$d")
+    while IFS="$SEP" read -r _kind ext tool; do
+      case "$base" in
+        "$ext"-*) report_once "ide" "$tool" "" "$label/$base" ;;
+      esac
+    done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^ide${SEP}")
+  done
+}
+
+scan_extensions_dir "$HOME_DIR/.vscode/extensions" "$HOME_LABEL/.vscode/extensions"
+scan_extensions_dir "$HOME_DIR/.cursor/extensions" "$HOME_LABEL/.cursor/extensions"
+
+# JetBrains plugin directories are named after the plugin itself.
+while IFS="$SEP" read -r _kind ext tool; do
+  if /bin/ls -d "$HOME_DIR/Library/Application Support/JetBrains"/*/plugins/"$ext"* >/dev/null 2>&1; then
+    report_once "ide" "$tool" "" "JetBrains plugins dir ($ext)"
+  fi
+done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^jb${SEP}")
+
+# ------------------------------------------------------- browser extensions --
+
+# Installed browser extensions, matched by extension id against the
+# registry. Presence is the finding: an AI extension reads pages without
+# anything being pasted. Chrome and Brave install from the Chrome store, so
+# both match chrome ids; Edge installs from both stores, so it matches both
+# sets. Folder presence in a profile's Extensions dir is the signal;
+# evidence names the browser and profile, never the user's home path.
+scan_browser_extensions() {
+  local root="$1" label="$2" idkinds="$3" profile pdir extdir bkind ext tool
+  [ -d "$root" ] || return 0
+  for pdir in "$root/Default" "$root"/Profile\ *; do
+    [ -d "$pdir/Extensions" ] || continue
+    profile=$(/usr/bin/basename "$pdir")
+    for extdir in "$pdir/Extensions"/*/; do
+      [ -d "$extdir" ] || continue
+      ext=$(/usr/bin/basename "$extdir")
+      while IFS="$SEP" read -r _kind bkind id tool; do
+        case ",$idkinds," in *",$bkind,"*) ;; *) continue ;; esac
+        [ "$ext" = "$id" ] && report_once "browser" "$tool" "" "$label/$profile extension $id"
+      done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^bext${SEP}")
+    done
+  done
+}
+
+APPSUP="$HOME_DIR/Library/Application Support"
+scan_browser_extensions "$APPSUP/Google/Chrome"                "Chrome" "chrome"
+scan_browser_extensions "$APPSUP/BraveSoftware/Brave-Browser"  "Brave"  "chrome"
+scan_browser_extensions "$APPSUP/Microsoft Edge"               "Edge"   "chrome,edge"
+
+# ---------------------------------------------------------------- desktop ---
+
+# Installed applications.
+while IFS="$SEP" read -r _kind app tool; do
+  if [ -d "/Applications/$app" ] || [ -d "$HOME_DIR/Applications/$app" ]; then
+    report_once "desktop" "$tool" "" "$app"
+  fi
+done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^app${SEP}")
+
+# Local runtimes and editors with no account file: presence via their config
+# directory or their binary. Tools WITH an account file are cli-scanned above.
+while IFS="$SEP" read -r _kind tool acct_path _keys _jwt _claim cfg_paths bins; do
+  [ -n "$acct_path" ] && continue
+  hit=$(first_existing "$HOME_DIR" "$cfg_paths") \
+    && { report_once "desktop" "$tool" "" "$HOME_LABEL/$hit"; continue; }
+  bin=$(first_binary "$bins") \
+    && report_once "desktop" "$tool" "" "$bin binary"
+done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^cli${SEP}")
+
+# ---------------------------------------------------------------- mcp -------
+
+while IFS="$SEP" read -r _kind tool path os; do
+  # Claude Desktop's config path differs per platform; skip the Windows rows.
+  case "$os" in any|macos) ;; *) continue ;; esac
+  if ! safe_rel_path "$path"; then
+    echo "[ai-guard] refusing registry path for $tool: not relative to home" >&2
+    continue
+  fi
+  f=$(resolve_under_home "$HOME_DIR/$path") || continue
+  [ -f "$f" ] || continue
+  servers=$(json_keys "$f" mcpServers)
+  # The tool is the tool. The server list is evidence, not identity: folding it
+  # into the name made every distinct combination of servers a separate tool,
+  # so a machine with figma and context7 looked unrelated to a machine with
+  # figma alone. About twenty two near-identical rows where there should have
+  # been three.
+  [ -n "$servers" ] && report_once "mcp" "${tool}-mcp" "" "$path mcpServers: $servers"
+done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^mcp${SEP}")
+
+# ---------------------------------------------------------------- summary ---
+
+/bin/mkdir -p "$SUMMARY_DIR"
+printf '%s' "$STATE_NEW" > "$STATE_FILE"
+POST_STATUS="posted=$POST_OK suppressed=$SUPPRESSED"
+[ "$POST_FAILURES" -gt 0 ] && POST_STATUS="POST-FAILED=$POST_FAILURES posted=$POST_OK"
+[ -z "$ENDPOINT" ] && POST_STATUS="print-only"
+if [ ${#SUMMARY_PARTS[@]} -eq 0 ]; then
+  echo "none [$POST_STATUS] ($NOW)" > "$SUMMARY_FILE"
+else
+  (IFS='; '; echo "${SUMMARY_PARTS[*]} [$POST_STATUS] ($NOW)") > "$SUMMARY_FILE"
+fi
+
+if [ "$POST_FAILURES" -gt 0 ]; then
+  echo "[ai-guard] $POST_FAILURES finding(s) failed to POST to $ENDPOINT"
+  exit 1
+fi
+exit 0

--- a/portal/collector-scripts/collector-windows.ps1
+++ b/portal/collector-scripts/collector-windows.ps1
@@ -1,0 +1,688 @@
+<#
+.SYNOPSIS
+  AI Guard endpoint collector for Windows.
+
+  Reads AI tool configuration files from the logged-on user's profile and
+  reports which account domain each tool is signed into, plus installed IDE
+  extensions and MCP server configurations. Which identifiers to look for
+  come from the receiver's /registry/collector at runtime, so a new AI tool
+  is a registry merge request rather than a script edit plus an Intune
+  re-paste. The Windows sibling of
+  endpoint/macos/ai-guard-collector.sh - same finding schema, same receiver,
+  same design rules learned there:
+
+    * Resolve the LOGGED-ON user's profile. Intune remediations run as
+      SYSTEM, whose own profile contains nothing - the Windows version of
+      the Jamf /var/root bug that silently produced an empty pilot.
+    * Fail loudly. A collector that swallows POST errors across a fleet
+      produces a healthy-looking dashboard and false confidence.
+    * Throttle info findings to one report per day and warn findings
+      (personal accounts) to one per hour. A personal account is a
+      persistent state, not an event, so repeating it at every check-in
+      adds volume without adding information. Never-seen findings report
+      immediately at any severity, so an account switch still surfaces on
+      the next run.
+    * Report the account domain in account_domain; the console username is
+      sent in the user field. Both are already known to IT through the MDM.
+
+.NOTES
+  Deployed via Intune Proactive Remediation (detection script). Exits 1 when
+  anything warn-severity was found or a POST failed, so remediation status
+  in the Intune console doubles as a fleet health/attention view.
+
+  Configuration is baked in below rather than parameterised: remediation
+  scripts take no arguments. The one switch it does take is not
+  configuration: -FunctionsOnly loads the functions and stops before the
+  scans, so the path containment logic can be tested without running a
+  collection. Intune never passes it.
+#>
+
+param([switch]$FunctionsOnly)
+
+# ------------------------------------------------------------------ config --
+$ReceiverBase    = 'https://ai-guard.example.com'   # your receiver's public ingest URL
+$Token           = '__RECEIVER_TOKEN__'   # replace before upload, or wire to a secure retrieval.
+                                          # Either the shared token, or an enrollment token (aige_...)
+                                          # from a managed-mode receiver: on first run the machine
+                                          # enrolls, stores its own device credential in ProgramData,
+                                          # and uses that from then on. Swapping the shared token for
+                                          # an enrollment token here is the whole migration.
+$CorporateDomains = @('example.com')   # accounts on these domains are 'work'; all others warn as personal.
+                                       # A receiver that serves config.corp_domains in /registry/collector
+                                       # overrides this at runtime; the constant is the fallback.
+
+$StateDir  = 'C:\ProgramData\ai-guard'
+$StateFile = Join-Path $StateDir 'reported.state.json'
+$Breadcrumb = Join-Path $StateDir 'last_scan.txt'
+# This machine's own credential, once enrolled with a managed-mode receiver.
+# ACL-restricted to SYSTEM and Administrators: it is this device's identity.
+$CredFile = Join-Path $StateDir 'device.cred'
+# Reported at enrollment and on every report, so the receiver's inventory can
+# answer "which script version does the fleet actually run".
+$CollectorVersion = '2.0.0'
+$InfoReportIntervalHours = 24
+$WarnReportIntervalHours = 1
+
+$Endpoint = ''
+if ($ReceiverBase) { $Endpoint = ($ReceiverBase.TrimEnd('/')) + '/report' }
+
+# ------------------------------------------------- resolve the real user --
+# Remediations run as SYSTEM. The signed-in user's profile is where the AI
+# tool configs live. Owner of the explorer.exe process is the reliable
+# answer; fall back to the most recently written real profile.
+function Get-ConsoleUserProfile {
+    try {
+        $owner = (Get-CimInstance Win32_Process -Filter "Name='explorer.exe'" |
+                  Select-Object -First 1 |
+                  Invoke-CimMethod -MethodName GetOwner -ErrorAction Stop)
+        if ($owner.User) {
+            $prof = Join-Path 'C:\Users' $owner.User
+            if (Test-Path $prof) { return @{ User = $owner.User; Home = $prof } }
+        }
+    } catch {
+        # Ordinary: no interactive session, or explorer.exe is not running.
+        # The profile below is a real answer, not a guess of last resort, so
+        # this is noted rather than reported.
+        Write-Verbose "console user lookup failed: $($_.Exception.Message)"
+    }
+    $candidate = Get-ChildItem 'C:\Users' -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -notin @('Public','Default','Default User','All Users','defaultuser0') } |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($candidate) { return @{ User = $candidate.Name; Home = $candidate.FullName } }
+    return $null
+}
+
+$Console = Get-ConsoleUserProfile
+if (-not $Console) {
+    # No user profile: loginwindow-equivalent state. Nothing to scan; exit
+    # clean so an unattended machine is not a red remediation.
+    Write-Output 'ai-guard: no logged-on user profile found, skipping'
+    exit 0
+}
+$UserHome = $Console.Home
+$ConsoleUser = $Console.User
+
+# device carries the serial: immutable, and what Jamf, Intune, SentinelOne and
+# most RMMs key on. device_name carries the hostname, which is what a human
+# recognises and what platforms with no serial can still join on. The dashboard
+# prefers device_name and falls back to device, so a collector that sends only
+# the serial shows a serial where the scanners show a name.
+$DeviceName = $env:COMPUTERNAME
+
+$Serial = ''
+try {
+    $Serial = (Get-CimInstance Win32_BIOS -ErrorAction Stop).SerialNumber.Trim()
+} catch {
+    # Said out loud, because the fallback below changes what every finding
+    # from this machine is keyed on. One device reporting a hostname where
+    # the rest report serials reads as a deliberate difference rather than a
+    # failed WMI query, and it splits that device into two on any dashboard
+    # that groups by device.
+    Write-Output "ai-guard: serial lookup failed ($($_.Exception.Message)), using COMPUTERNAME"
+}
+if (-not $Serial) { $Serial = $DeviceName }
+
+$Now = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')
+$NowEpoch = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds()
+
+# --------------------------------------------------------------- throttle --
+$StateOld = @{}
+if (Test-Path $StateFile) {
+    try {
+        (Get-Content $StateFile -Raw | ConvertFrom-Json).psobject.Properties |
+            ForEach-Object { $StateOld[$_.Name] = [int64]$_.Value }
+    } catch { $StateOld = @{} }
+}
+$StateNew = @{}
+$script:Posted = 0
+$script:Suppressed = 0
+$script:PostFailures = 0
+$script:WarnCount = 0
+$script:ParseFailures = 0
+$SummaryParts = New-Object System.Collections.Generic.List[string]
+
+function Get-Domain([string]$email) {
+    if ($email -and $email.Contains('@')) { return $email.Split('@')[-1].ToLower() }
+    return ''
+}
+
+# Extract a single string field value without parsing the whole file. Used
+# for configs that are not safely whole-file parseable (see .claude.json).
+# Returns the first match's value, or ''.
+function Get-JsonStringField {
+    param([string]$Path, [string]$Field)
+    $m = Select-String -Path $Path -Pattern ('"' + [regex]::Escape($Field) + '"\s*:\s*"([^"]*)"') -List
+    if ($m -and $m.Matches.Count -gt 0) { return $m.Matches[0].Groups[1].Value }
+    return ''
+}
+
+# Collect the KEYS under an "mcpServers" object without whole-file parsing
+# (see Get-JsonStringField for why). Walks the object character by character
+# tracking brace depth and string state, so it works whether the config is
+# pretty-printed or written on a single line. Returns a sorted comma-joined
+# string, or ''.
+# The plural is correct: this returns every server named in the config, not
+# one. Renaming it to satisfy the rule would make the name less true than the
+# warning it silences, so the rule is suppressed instead. The attribute
+# belongs inside the function, above param: PowerShell rejects it in front of
+# the declaration.
+function Get-McpServerNames {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseSingularNouns', '',
+        Justification = 'Returns every server named in the config, not one.')]
+    param([string]$Path)
+    $text = Get-Content $Path -Raw
+    $m = [regex]::Match($text, '"mcpServers"\s*:\s*\{')
+    if (-not $m.Success) { return '' }
+    $i = $m.Index + $m.Length
+    $depth = 1; $inStr = $false; $esc = $false; $capturing = $false
+    $cur = ''; $names = @()
+    while ($i -lt $text.Length -and $depth -gt 0) {
+        $c = $text[$i]
+        if ($inStr) {
+            if ($esc) { $esc = $false }
+            elseif ($c -eq '`\') { $esc = $true }
+            elseif ($c -eq '"') {
+                $inStr = $false
+                if ($capturing) {
+                    # Only a key if the next non-space character is a colon.
+                    $j = $i + 1
+                    while ($j -lt $text.Length -and [char]::IsWhiteSpace($text[$j])) { $j++ }
+                    if ($j -lt $text.Length -and $text[$j] -eq ':') { $names += $cur }
+                    $capturing = $false
+                }
+            }
+            elseif ($capturing) { $cur += $c }
+        }
+        else {
+            if ($c -eq '"') { $inStr = $true; if ($depth -eq 1) { $capturing = $true; $cur = '' } }
+            elseif ($c -eq '{') { $depth++ }
+            elseif ($c -eq '}') { $depth-- }
+        }
+        $i++
+    }
+    if ($names.Count -gt 0) { return (($names | Sort-Object) -join ',') }
+    return ''
+}
+
+function Send-Finding {
+    param([string]$Surface, [string]$Tool, [string]$Account, [string]$Evidence)
+
+    $severity = 'info'
+    if ($Account -and ($CorporateDomains -notcontains $Account.ToLower())) {
+        $severity = 'warn'
+        $script:WarnCount++
+    }
+
+    if ($Account) { $SummaryParts.Add("$Tool($Account)") } else { $SummaryParts.Add($Tool) }
+
+    # Throttle by severity: info daily, warn hourly. A key with no previous
+    # timestamp falls through regardless, so new findings are never delayed.
+    $key = "$Surface|$Tool|$Account"
+    $intervalHours = if ($severity -eq 'warn') { $WarnReportIntervalHours } else { $InfoReportIntervalHours }
+    if ($StateOld.ContainsKey($key)) {
+        if (($NowEpoch - $StateOld[$key]) -lt ($intervalHours * 3600)) {
+            $StateNew[$key] = $StateOld[$key]
+            $script:Suppressed++
+            return
+        }
+    }
+
+    $payload = @{
+        tool = $Tool; surface = $Surface; os = 'windows'
+        account_domain = $Account; device = $Serial; device_name = $DeviceName
+        user = $ConsoleUser
+        evidence = $Evidence; severity = $severity; reported_at = $Now
+        source = 'collector-windows'
+    } | ConvertTo-Json -Compress
+
+    if (-not $Endpoint) {
+        Write-Output "ai-guard FLAG (no endpoint set): $payload"
+        # Print-only: preserve old timestamp if one exists, but don't advance it.
+        if ($StateOld.ContainsKey($key)) { $StateNew[$key] = $StateOld[$key] }
+        return
+    }
+    try {
+        Invoke-RestMethod -Uri $Endpoint -Method Post -TimeoutSec 10 `
+            -Headers @{ Authorization = "Bearer $Token"
+                        'X-AiGuard-Agent-Version' = $CollectorVersion } `
+            -ContentType 'application/json' -Body $payload -ErrorAction Stop | Out-Null
+        $script:Posted++
+        $StateNew[$key] = $NowEpoch
+    } catch {
+        $code = 'ERR'
+        if ($_.Exception.Response) { $code = [int]$_.Exception.Response.StatusCode }
+        Write-Output "ai-guard POST failed: HTTP $code for $Tool -> $Endpoint"
+        $script:PostFailures++
+        # Keep the old timestamp so the finding retries next run.
+        if ($StateOld.ContainsKey($key)) { $StateNew[$key] = $StateOld[$key] }
+    }
+}
+
+# --------------------------------------------------------------- registry --
+
+# Which extension IDs, config paths and MCP files belong to which tool comes
+# from the receiver at runtime. It used to be hardcoded here, which meant a
+# new AI tool needed a script edit and an Intune re-paste on every machine,
+# while the registry that should have owned that list was already maintained
+# by merge request. A new tool is now a registry MR only.
+function Get-CollectorRegistry {
+    if ($env:AIGUARD_REGISTRY_FILE) {
+        return (Get-Content $env:AIGUARD_REGISTRY_FILE -Raw | ConvertFrom-Json)
+    }
+    if (-not $ReceiverBase) { return $null }
+    return Invoke-RestMethod -Uri (($ReceiverBase.TrimEnd('/')) + '/registry/collector') `
+        -Headers @{ Authorization = "Bearer $Token" } -TimeoutSec 15 -ErrorAction Stop
+}
+
+# Skipped under -FunctionsOnly: fetching a registry is work, and the refusal
+# below would exit the caller's session before the functions further down
+# were ever defined.
+# ------------------------------------------------------------ enrollment --
+# Managed mode. A stored device credential wins; an enrollment token
+# (aige_...) is exchanged for one on first run; anything else is today's
+# behaviour exactly. The prefix is the whole switch: the operator changes the
+# $Token constant from the shared token to an enrollment token when ready.
+if (-not $FunctionsOnly) {
+    if (Test-Path $CredFile) {
+        $stored = (Get-Content $CredFile -Raw -ErrorAction SilentlyContinue)
+        if ($stored) { $stored = $stored.Trim() }
+        if ($stored -and $stored.StartsWith('aigd_')) { $Token = $stored }
+    }
+    if ($Token.StartsWith('aige_') -and $ReceiverBase) {
+        if (-not (Test-Path $StateDir)) {
+            New-Item -ItemType Directory -Path $StateDir -Force | Out-Null
+        }
+        $enrollBody = @{
+            platform = 'windows'; serial = $Serial
+            hostname = $DeviceName; agent_version = $CollectorVersion
+        } | ConvertTo-Json -Compress
+        try {
+            $r = Invoke-RestMethod -Uri (($ReceiverBase.TrimEnd('/')) + '/enroll') `
+                -Method Post -TimeoutSec 15 `
+                -Headers @{ Authorization = "Bearer $Token" } `
+                -ContentType 'application/json' -Body $enrollBody -ErrorAction Stop
+            Set-Content -Path $CredFile -Value $r.device_token -NoNewline
+            # The state dir inherits ProgramData's ACL, which lets ordinary
+            # users read. A device credential must not be readable by the
+            # people whose AI accounts it reports on.
+            icacls $CredFile /inheritance:r /grant 'SYSTEM:(F)' 'Administrators:(F)' | Out-Null
+            $Token = $r.device_token
+            Write-Output "ai-guard: enrolled, device credential stored in $CredFile"
+        } catch {
+            # Loud and fatal: an enrollment token cannot report findings, so
+            # carrying on would 401 every POST and look like a clean machine.
+            # A 409 means a device with this serial is actively reporting -
+            # revoke it on the receiver first. A 401 usually means the token
+            # expired: mint a fresh one and update this script in Intune.
+            $code = 'ERR'
+            if ($_.Exception.Response) { $code = [int]$_.Exception.Response.StatusCode }
+            Write-Output "ai-guard: enrollment failed (HTTP $code)"
+            Write-Output 'ai-guard: refusing to scan - an enrollment token cannot report findings'
+            exit 1
+        }
+    }
+}
+
+$Registry = $null
+if (-not $FunctionsOnly) {
+    try { $Registry = Get-CollectorRegistry } catch {
+        Write-Output "ai-guard: registry fetch failed ($($_.Exception.Message))"
+    }
+    if (-not $Registry) {
+        # An empty scan looks exactly like a clean machine. Refuse instead.
+        Write-Output 'ai-guard: refusing to scan without an identifier list'
+        if ($Token.StartsWith('aigd_')) {
+            Write-Output "ai-guard: this machine's device credential may have been revoked;"
+            Write-Output "ai-guard: delete $CredFile and supply a valid enrollment token to re-enroll"
+        }
+        exit 1
+    }
+
+    # Corporate domains can arrive with the registry: the receiver serves
+    # config.corp_domains in the payload just fetched when it has CORP_DOMAINS
+    # set. The served list wins over the constant above, because a list
+    # changed once on the receiver reaches the fleet on its next run rather
+    # than waiting on an Intune re-paste; the constant stays as the fallback,
+    # so a receiver serving nothing changes nothing. Lowercased to match the
+    # severity check, which lowercases the account side.
+    if ($Registry.PSObject.Properties['config'] -and $Registry.config.corp_domains) {
+        $CorporateDomains = @($Registry.config.corp_domains | ForEach-Object { "$_".ToLower() })
+        Write-Output "ai-guard: corporate domains from receiver: $($CorporateDomains -join ',')"
+    }
+}
+
+# One finding per surface+tool per run: a tool can match several identifiers
+# (both Copilot extension IDs, a config path AND an install directory).
+$script:Seen = @{}
+function Send-FindingOnce {
+    param([string]$Surface, [string]$Tool, [string]$Account, [string]$Evidence)
+    $key = "$Surface|$Tool"
+    if ($script:Seen.ContainsKey($key)) { return }
+    $script:Seen[$key] = $true
+    Send-Finding -Surface $Surface -Tool $Tool -Account $Account -Evidence $Evidence
+}
+
+# Registry-supplied paths are documented as relative to the user's profile,
+# but the collector runs as SYSTEM and the registry arrives over the network,
+# so the value is treated as input rather than configuration. Absolute paths,
+# drive letters, parent traversal and control characters return $null and the
+# caller skips that entry.
+#
+# Skipped rather than fatal: aborting would let one poisoned path switch off
+# detection everywhere, which suits an attacker better than being ignored.
+function Test-SafeRelativePath {
+    param([string]$Rel)
+    if ([string]::IsNullOrWhiteSpace($Rel)) { return $false }
+    if ($Rel.Length -gt 256) { return $false }
+    if ($Rel -match '^[\\/]' -or $Rel -match '^[A-Za-z]:') { return $false }
+    if ($Rel -match '\.\.') { return $false }
+    if ($Rel -match '[\x00-\x1f]') { return $false }
+    return $true
+}
+
+
+# Get-LinkTarget <item> - where a reparse point points, or $null.
+#
+# Hard links are deliberately not followed. A hard link is not a redirect:
+# both names are equally the file, and resolving one to the other would move
+# an ordinary file to some unrelated path, possibly outside the profile, for
+# no reason. Windows PowerShell exposes LinkType; PowerShell 6 and later
+# expose LinkTarget, which is already null for a hard link.
+function Get-LinkTarget {
+    param($Item)
+    if (-not $Item) { return $null }
+    $type = $null
+    if ($Item.PSObject.Properties['LinkType']) { $type = $Item.LinkType }
+    if ($type -and $type -ne 'SymbolicLink' -and $type -ne 'Junction') { return $null }
+    if ($Item.PSObject.Properties['LinkTarget'] -and $Item.LinkTarget) {
+        return $Item.LinkTarget
+    }
+    if ($Item.PSObject.Properties['Target'] -and $Item.Target) {
+        return @($Item.Target)[0]
+    }
+    return $null
+}
+
+# Resolve-PhysicalPath <path> - the path with every reparse point resolved.
+#
+# Walks the path a component at a time, because a junction partway along is
+# invisible from the end of it: Get-Item on the final file reports no link,
+# and GetFullPath only tidies the text. So
+#
+#   C:\Users\alice\AppData\Roaming\Claude   -> junction outside the profile
+#   C:\Users\alice\AppData\Roaming\Claude\config.json
+#
+# reads as a path inside the profile while the file is somewhere else. The
+# macOS and Linux collectors get this free from pwd -P; Windows has no
+# equivalent that works on both Windows PowerShell and PowerShell 7, so the
+# walk is done here.
+#
+# Following a link starts the walk again from the root rather than carrying
+# on from where the link was. The target has parents of its own, and any of
+# them can be a junction:
+#
+#   C:\Users\alice\a   -> link to C:\Users\alice\b\sub
+#   C:\Users\alice\b   -> junction outside the profile
+#
+# Continuing from the target would land on C:\Users\alice\b\sub\config.json,
+# which reads as inside the profile and is not.
+function Resolve-PhysicalPath {
+    param([string]$Path, [int]$Hops = 0)
+    if (-not $Path) { return $null }
+    if ($Hops -gt 40) { return $null }   # a link loop, or someone being clever
+
+    $full = [IO.Path]::GetFullPath($Path)
+    $root = [IO.Path]::GetPathRoot($full)
+    if (-not $root) { return $null }
+
+    $current = $root
+    $parts = $full.Substring($root.Length).Split(
+        [char[]]@('\', '/'), [StringSplitOptions]::RemoveEmptyEntries)
+    for ($i = 0; $i -lt $parts.Count; $i++) {
+        $current = Join-Path $current $parts[$i]
+        if (-not (Test-Path -LiteralPath $current)) { return $null }
+
+        $item = Get-Item -LiteralPath $current -Force -ErrorAction SilentlyContinue
+        $target = Get-LinkTarget $item
+        if ($target) {
+            if (-not [IO.Path]::IsPathRooted($target)) {
+                $target = Join-Path (Split-Path -Parent $current) $target
+            }
+            if ($i + 1 -lt $parts.Count) {
+                $rest = $parts[($i + 1)..($parts.Count - 1)] -join '\'
+                $target = Join-Path $target $rest
+            }
+            return Resolve-PhysicalPath -Path $target -Hops ($Hops + 1)
+        }
+    }
+    [IO.Path]::GetFullPath($current)
+}
+
+# Resolve-UnderHome <path> - the real path if it stays inside the profile,
+# $null if it does not.
+#
+# Test-SafeRelativePath rejects a registry value that tries to escape. This
+# catches the other half: a path that looks fine but resolves elsewhere,
+# because a junction or symlink on the machine points out of the profile. The
+# collector runs as SYSTEM, so following one reads a file the user could not.
+#
+# Links are resolved rather than refused. Redirected profile folders are
+# ordinary on managed Windows, and refusing to follow any of them would drop
+# real findings to prevent an unlikely one.
+function Resolve-UnderHome {
+    param([string]$Path)
+    $real = Resolve-PhysicalPath $Path
+    if (-not $real) { return $null }
+
+    # Resolved once and kept: the profile is physically resolved too, or a
+    # machine whose whole profile is redirected would fail every check. The
+    # trailing separator stops a sibling directory whose name merely starts
+    # the same way from passing.
+    if (-not $script:UserHomeResolved) {
+        $profileRoot = Resolve-PhysicalPath $UserHome
+        if (-not $profileRoot) {
+            $profileRoot = [IO.Path]::GetFullPath($UserHome)
+        }
+        $script:UserHomeResolved = $profileRoot.TrimEnd('\') + '\'
+    }
+    if ($real.StartsWith($script:UserHomeResolved, [StringComparison]::OrdinalIgnoreCase)) {
+        return $real
+    }
+    return $null
+}
+
+function Join-UserPath {
+    param([string]$Rel)
+    if (-not (Test-SafeRelativePath $Rel)) {
+        Write-Output "ai-guard REFUSED: registry path not relative to profile"
+        return $null
+    }
+    $joined = Join-Path $UserHome ($Rel -replace '/', '\')
+    # Not every caller is about to read the file; some only test
+    # existence. Resolve when it exists so the containment check applies
+    # to what would actually be opened, and hand back the joined path
+    # otherwise so a missing file stays missing rather than a refusal.
+    if (Test-Path -LiteralPath $joined) {
+        return (Resolve-UnderHome $joined)
+    }
+    $joined
+}
+
+# Decode a JWT payload and pull one claim. Regex rather than ConvertFrom-Json
+# for the same reason as Get-JsonStringField: never whole-file parse input we
+# do not control.
+function Get-JwtClaim {
+    param([string]$Jwt, [string]$Claim)
+    try {
+        $b64 = $Jwt.Split('.')[1].Replace('-', '+').Replace('_', '/')
+        switch ($b64.Length % 4) { 2 { $b64 += '==' } 3 { $b64 += '=' } }
+        $json = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b64))
+        $m = [regex]::Match($json, '"' + [regex]::Escape($Claim) + '"\s*:\s*"([^"]*)"')
+        if ($m.Success) { return $m.Groups[1].Value }
+    } catch {
+        # A token that will not decode means a finding with no account
+        # domain, which the caller already reports as presence only. Noted
+        # for anyone debugging why a tool shows up without an account.
+        Write-Verbose "jwt claim '$Claim' could not be read: $($_.Exception.Message)"
+    }
+    return ''
+}
+
+# Stop here when only the functions were wanted. Dot-sourcing the whole
+# script otherwise runs a collection, and the exit calls further down would
+# end the caller's session.
+if ($FunctionsOnly) { return }
+
+# ------------------------------------------------------------------ scans --
+
+# cli: tools that store an account identity in a config file. The registry
+# says where the file is and how to read it.
+foreach ($t in $Registry.cli) {
+    if (-not $t.account_json_path) { continue }   # presence-only tools: desktop scan
+    $f = Join-UserPath $t.account_json_path
+    if (-not $f) { continue }
+    if (Test-Path $f) {
+        try {
+            $email = ''
+            if ($t.account_json_keys) {
+                # The last key in the path is the field name. Extracted
+                # line-wise, never whole-file parsed: .claude.json carries
+                # per-project keys that differ only in drive-letter case and
+                # .NET rejects those as duplicates.
+                $email = Get-JsonStringField -Path $f -Field $t.account_json_keys[-1]
+            } elseif ($t.account_jwt_path) {
+                $jwt = Get-JsonStringField -Path $f -Field $t.account_jwt_path[-1]
+                if ($jwt) { $email = Get-JwtClaim -Jwt $jwt -Claim $t.account_jwt_claim }
+            }
+            Send-FindingOnce -Surface 'cli' -Tool $t.tool -Account (Get-Domain $email) `
+                -Evidence "~/$($t.account_json_path)"
+        } catch {
+            Write-Output "ai-guard PARSE-FAILED: $($t.tool) $f ($($_.Exception.Message))"
+            $script:ParseFailures++
+        }
+    } else {
+        foreach ($c in $t.config_paths) {
+            $cp = Join-UserPath $c
+            if ($cp -and (Test-Path $cp)) {
+                Send-FindingOnce -Surface 'cli' -Tool $t.tool -Account '' -Evidence "~/$c"
+                break
+            }
+        }
+    }
+}
+
+# ide: extension directories are named "<extension.id>-<version>". Cursor is a
+# VS Code fork and uses the same IDs. chrome/edge IDs in the registry are
+# browser extensions and are read in the browser section below.
+foreach ($pair in @(@('.vscode\extensions', 'vscode'), @('.cursor\extensions', 'cursor'))) {
+    $dir = Join-Path $UserHome $pair[0]
+    if (-not (Test-Path $dir)) { continue }
+    $subs = Get-ChildItem $dir -Directory -ErrorAction SilentlyContinue
+    foreach ($t in $Registry.ide) {
+        foreach ($ext in $t.extension_ids.vscode) {
+            foreach ($sub in $subs) {
+                if ($sub.Name -like "$ext-*") {
+                    Send-FindingOnce -Surface 'ide' -Tool $t.tool -Account '' `
+                        -Evidence "$($pair[1])/$($sub.Name)"
+                }
+            }
+        }
+    }
+}
+
+# browser: installed browser extensions, matched by extension id against the
+# registry. Presence is the finding: an AI extension reads pages without
+# anything being pasted. Chrome and Brave install from the Chrome store, so
+# both match chrome ids; Edge installs from both stores, so it matches both.
+$BrowserRoots = @(
+    @{ Path = Join-Path $env:LOCALAPPDATA 'Google\Chrome\User Data';               Label = 'Chrome'; Kinds = @('chrome') },
+    @{ Path = Join-Path $env:LOCALAPPDATA 'BraveSoftware\Brave-Browser\User Data'; Label = 'Brave';  Kinds = @('chrome') },
+    @{ Path = Join-Path $env:LOCALAPPDATA 'Microsoft\Edge\User Data';              Label = 'Edge';   Kinds = @('chrome', 'edge') }
+)
+foreach ($b in $BrowserRoots) {
+    if (-not (Test-Path $b.Path)) { continue }
+    $profiles = Get-ChildItem $b.Path -Directory -ErrorAction SilentlyContinue |
+                Where-Object { $_.Name -eq 'Default' -or $_.Name -like 'Profile *' }
+    foreach ($p in $profiles) {
+        $extDir = Join-Path $p.FullName 'Extensions'
+        if (-not (Test-Path $extDir)) { continue }
+        $installed = @((Get-ChildItem $extDir -Directory -ErrorAction SilentlyContinue).Name)
+        if (-not $installed) { continue }
+        foreach ($t in $Registry.ide) {
+            foreach ($kind in $b.Kinds) {
+                foreach ($id in $t.extension_ids.$kind) {
+                    if ($installed -contains $id) {
+                        Send-FindingOnce -Surface 'browser' -Tool $t.tool -Account '' `
+                            -Evidence "$($b.Label)/$($p.Name) extension $id"
+                    }
+                }
+            }
+        }
+    }
+}
+
+# desktop: installed applications and local runtimes. Intune inventory also
+# reports Windows desktop apps, but on a ~24h cycle; this is same-run.
+$ProgramDirs = @($env:ProgramFiles, ${env:ProgramFiles(x86)},
+                 (Join-Path $UserHome 'AppData\Local\Programs')) | Where-Object { $_ }
+foreach ($t in $Registry.desktop) {
+    foreach ($name in $t.app_names) {
+        if ($name -like '*.app') { continue }   # macOS bundle name
+        foreach ($base in $ProgramDirs) {
+            if (Test-Path (Join-Path $base $name)) {
+                Send-FindingOnce -Surface 'desktop' -Tool $t.tool -Account '' -Evidence "$name installed"
+            }
+        }
+    }
+}
+foreach ($t in $Registry.cli) {
+    if ($t.account_json_path) { continue }
+    foreach ($c in $t.config_paths) {
+        $cp = Join-UserPath $c
+        if ($cp -and (Test-Path $cp)) {
+            Send-FindingOnce -Surface 'desktop' -Tool $t.tool -Account '' -Evidence "~/$c"
+            break
+        }
+    }
+}
+
+# mcp: which MCP servers each tool has wired in.
+foreach ($m in $Registry.mcp) {
+    if ($m.os -notin @('any', 'windows')) { continue }
+    $f = Join-UserPath $m.path
+    if (-not $f) { continue }
+    if (-not (Test-Path $f)) { continue }
+    try {
+        $names = Get-McpServerNames -Path $f
+        if ($names) {
+            # The tool is the tool. The server list is evidence, not
+            # identity: folding it into the name made every distinct
+            # combination of servers a separate tool, so a machine with
+            # figma and context7 looked unrelated to a machine with figma
+            # alone. About twenty two near-identical rows where there
+            # should have been three.
+            Send-FindingOnce -Surface 'mcp' -Tool "$($m.tool)-mcp" -Account '' `
+                -Evidence "$($m.path) mcpServers: $names"
+        }
+    } catch {
+        Write-Output "ai-guard PARSE-FAILED: mcp $f ($($_.Exception.Message))"
+        $script:ParseFailures++
+    }
+}
+
+# ---------------------------------------------------------------- summary --
+New-Item -ItemType Directory -Path $StateDir -Force | Out-Null
+$StateNew | ConvertTo-Json | Set-Content $StateFile -Encoding UTF8
+
+$postStatus = "posted=$Posted suppressed=$Suppressed"
+if ($PostFailures -gt 0) { $postStatus = "POST-FAILED=$PostFailures $postStatus" }
+if ($ParseFailures -gt 0) { $postStatus = "PARSE-FAILED=$ParseFailures $postStatus" }
+if (-not $Endpoint) { $postStatus = 'print-only' }
+$summary = if ($SummaryParts.Count -eq 0) { 'none' } else { $SummaryParts -join '; ' }
+"$summary [$postStatus] ($Now)" | Set-Content $Breadcrumb -Encoding UTF8
+Write-Output "ai-guard: $summary [$postStatus]"
+
+# Remediation semantics: exit 1 = "needs attention" in the Intune console.
+# Warn findings and broken reporting both qualify.
+if ($PostFailures -gt 0 -or $WarnCount -gt 0 -or $ParseFailures -gt 0) { exit 1 }
+exit 0

--- a/portal/tests/test_managed_portal.py
+++ b/portal/tests/test_managed_portal.py
@@ -1,0 +1,236 @@
+"""Managed mode in the portal: the proxy, the artifacts, the script copies.
+
+Route functions are called directly, like every other test in this suite -
+the portal deliberately has no HTTP client dependency (TestClient needs
+httpx), and the write path's HTTP wiring is FastAPI dependency defaults
+whose behaviour lives in `_admin_forward`, which is tested by name. Config
+is monkeypatched onto the module rather than reloaded: every route reads
+the globals at call time, and a reload would rebuild the app out from under
+the other test files.
+"""
+
+import os
+from pathlib import Path
+
+os.environ.setdefault("PORTAL_AUTH", "none")
+
+import pytest
+from fastapi import HTTPException
+
+from app import main, managed
+
+PORTAL = Path(__file__).parent.parent
+REPO = PORTAL.parent
+SCRIPTS = PORTAL / "collector-scripts"
+
+
+# ------------------------------------------------------- the script copies --
+
+
+def test_the_script_copies_match_their_sources():
+    """Same pattern as the chart's bundled registry: the portal image cannot
+    see endpoint/ at build time, so it ships verified copies, and this test
+    is the verification. A drifted copy means artifacts deploy an older
+    collector than the repo says exists."""
+    pairs = [
+        ("collector-macos.sh", "endpoint/macos/ai-guard-collector.sh"),
+        ("collector-linux.sh", "endpoint/linux/ai-guard-collector.sh"),
+        ("collector-windows.ps1", "endpoint/windows/ai-guard-collector.ps1"),
+    ]
+    for copy, source in pairs:
+        assert (SCRIPTS / copy).read_bytes() == (REPO / source).read_bytes(), (
+            "portal/collector-scripts/%s no longer matches %s - re-copy it"
+            % (copy, source))
+
+
+def test_every_anchor_matches_its_script_exactly_once():
+    """The anchors are the scripts' own fallback syntax. A collector edit
+    that reshapes one of those lines must fail here, at build time, rather
+    than produce artifacts that quietly bake nothing."""
+    for kind, spec in managed.ARTIFACTS.items():
+        content = (SCRIPTS / spec["file"]).read_text()
+        for anchor, _ in spec["anchors"]:
+            assert content.count(anchor) == 1, (
+                "%s: anchor not found exactly once: %r" % (kind, anchor))
+
+
+# ------------------------------------------------------------- generation --
+
+
+def test_generation_bakes_defaults_not_hardcodes():
+    """The substitution targets fallback syntax, so an MDM-supplied value
+    still wins. Baking a hardcode instead would make the Jamf parameter a
+    lie: set, honoured-looking, and ignored."""
+    url, tok = "https://rx.example.com", "aige_TESTTOKEN"
+
+    name, out = managed.generate("collector-macos", str(SCRIPTS), url, tok)
+    assert name == "ai-guard-collector.sh"
+    assert 'RECEIVER_BASE="${4:-https://rx.example.com}"' in out
+    assert 'TOKEN="${5:-aige_TESTTOKEN}"' in out
+
+    _, out = managed.generate("collector-linux", str(SCRIPTS), url, tok)
+    assert 'RECEIVER_BASE="${AIGUARD_RECEIVER_BASE:-https://rx.example.com}"' in out
+    assert 'TOKEN="${AIGUARD_TOKEN:-aige_TESTTOKEN}"' in out
+
+    name, out = managed.generate("collector-windows", str(SCRIPTS), url, tok)
+    assert name == "ai-guard-collector.ps1"
+    assert "$ReceiverBase    = 'https://rx.example.com'" in out
+    assert "$Token           = 'aige_TESTTOKEN'" in out
+    assert "__RECEIVER_TOKEN__" not in out
+
+
+def test_generation_refuses_values_that_could_escape_their_quoting():
+    """The values land inside shell and PowerShell quoting. Anything that
+    could break out is refused by name rather than escaped, because both are
+    operator configuration and a rejection is a misconfiguration surfaced."""
+    for bad in ("https://x.example/'", 'https://x.example/"', "https://x)$(reboot",
+                "https://x.example/ payload", "https://x\\y"):
+        with pytest.raises(managed.ArtifactError):
+            managed.generate("collector-linux", str(SCRIPTS), bad, "aige_ok")
+    with pytest.raises(managed.ArtifactError):
+        managed.generate("collector-linux", str(SCRIPTS),
+                         "https://x.example", "aige_'injected")
+    with pytest.raises(managed.ArtifactError):
+        managed.generate("nonsense", str(SCRIPTS), "https://x.example", "aige_ok")
+
+
+# ------------------------------------------------------------- the routes --
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setattr(main, "RECEIVER_URL", "http://receiver.internal:8080")
+    monkeypatch.setattr(main, "RECEIVER_PUBLIC_URL", "https://rx.example.com")
+    monkeypatch.setattr(main, "COLLECTOR_SCRIPTS_DIR", str(SCRIPTS))
+
+
+@pytest.fixture
+def receiver(monkeypatch, configured):
+    """A fake receiver_request that records every call. Canned answers cover
+    the routes under test; a test that needs a refusal swaps in its own."""
+    calls = []
+
+    def fake(base, method, path, admin_token, body=None):
+        calls.append({"base": base, "method": method, "path": path,
+                      "token": admin_token, "body": body})
+        if path == "/admin/devices":
+            return {"devices": [{"id": "d1", "platform": "macos"}]}
+        if method == "POST" and path == "/admin/enrollment-tokens":
+            return {"id": "tok1", "token": "aige_MINTED",
+                    "expires_at": "2027-01-01T00:00:00+00:00"}
+        return {"tokens": []}
+
+    monkeypatch.setattr(main.managed, "receiver_request", fake)
+    return calls
+
+
+def http_error(fn, *args, **kw) -> HTTPException:
+    with pytest.raises(HTTPException) as e:
+        fn(*args, **kw)
+    return e.value
+
+
+def test_unconfigured_managed_routes_say_what_is_missing(monkeypatch):
+    monkeypatch.setattr(main, "RECEIVER_URL", "")
+    err = http_error(main._admin_forward, x_admin_token="anything")
+    assert err.status_code == 503
+    assert "RECEIVER_URL" in err.detail
+
+
+def test_a_missing_admin_header_is_a_401_that_explains_the_model(configured):
+    err = http_error(main._admin_forward, x_admin_token="")
+    assert err.status_code == 401
+    assert "never stores" in err.detail
+
+
+def test_the_admin_token_is_forwarded_verbatim(receiver):
+    out = main.fleet(_=None, token="the-admin-token")
+    assert out["devices"][0]["id"] == "d1"
+    assert receiver[0]["token"] == "the-admin-token"
+    assert receiver[0]["path"] == "/admin/devices"
+    assert receiver[0]["base"] == "http://receiver.internal:8080"
+
+
+def test_a_receiver_refusal_passes_through_with_its_meaning(monkeypatch, configured):
+    """A 401 must reach the operator as "bad token", not as a portal error:
+    the receiver is the authorizer and its answer is the answer."""
+    def refuse(*a, **kw):
+        raise managed.ReceiverError(401, "bad token")
+    monkeypatch.setattr(main.managed, "receiver_request", refuse)
+    err = http_error(main.fleet, _=None, token="wrong")
+    assert err.status_code == 401
+    assert err.detail == "bad token"
+
+
+def test_minting_forwards_note_and_ttl(receiver):
+    out = main.mint_enrollment_token(
+        main.MintRequest(note="macOS rollout", ttl_days=30), _=None, token="t")
+    assert out["token"] == "aige_MINTED"
+    assert receiver[0]["body"] == {"note": "macOS rollout", "ttl_days": 30}
+
+
+def test_mint_bounds_are_enforced_at_the_model():
+    """ttl_days=0 must never reach the receiver as a request: the portal's
+    model carries the same bounds the receiver enforces, so a bad value is a
+    422 at the edge rather than a proxied refusal."""
+    with pytest.raises(ValueError):
+        main.MintRequest(ttl_days=0)
+    with pytest.raises(ValueError):
+        main.MintRequest(note="x" * 201)
+
+
+def test_malformed_ids_never_reach_the_receiver(receiver):
+    err = http_error(main.revoke_device, "bad*id", _=None, token="t")
+    assert err.status_code == 422
+    err = http_error(main.revoke_enrollment_token, "../devices", _=None, token="t")
+    assert err.status_code == 422
+    assert receiver == []
+
+
+def test_an_artifact_mints_its_own_token_and_downloads_configured(receiver):
+    resp = main.artifact("collector-macos", _=None, token="t")
+    assert 'filename="ai-guard-collector.sh"' in resp.headers["content-disposition"]
+    assert resp.headers["x-enrollment-token-id"] == "tok1"
+    body = resp.body.decode()
+    assert 'RECEIVER_BASE="${4:-https://rx.example.com}"' in body
+    assert 'TOKEN="${5:-aige_MINTED}"' in body
+    # Provenance: the minted token names the artifact it left inside.
+    assert receiver[0]["body"]["note"] == "portal artifact: collector-macos"
+
+
+def test_an_artifact_without_a_public_url_is_refused_before_minting(
+        monkeypatch, receiver):
+    """The internal RECEIVER_URL baked into a Jamf script would enroll
+    nothing, and the refusal has to come before a token is minted for an
+    artifact that never existed."""
+    monkeypatch.setattr(main, "RECEIVER_PUBLIC_URL", "")
+    err = http_error(main.artifact, "collector-macos", _=None, token="t")
+    assert err.status_code == 503
+    assert "RECEIVER_PUBLIC_URL" in err.detail
+    assert receiver == []
+
+
+def test_an_unknown_artifact_is_404_before_minting(receiver):
+    err = http_error(main.artifact, "collector-solaris", _=None, token="t")
+    assert err.status_code == 404
+    assert receiver == []
+
+
+def test_config_names_which_managed_flag_is_missing(monkeypatch):
+    monkeypatch.setattr(main, "RECEIVER_URL", "http://r.internal:8080")
+    monkeypatch.setattr(main, "RECEIVER_PUBLIC_URL", "")
+    assert main.config(_=None)["managed"] == {
+        "enabled": True, "artifacts_ready": False}
+
+
+# --------------------------------------------------------- receiver client --
+
+
+def test_receiver_errors_carry_the_class_name_not_the_message():
+    """The URL and the error text are for the log. An unreachable receiver
+    must not echo connection strings into the browser."""
+    with pytest.raises(managed.ReceiverError) as e:
+        managed.receiver_request("http://127.0.0.1:1", "GET", "/admin/devices", "t")
+    assert e.value.status == 502
+    assert "127.0.0.1" not in e.value.detail
+    assert "could not reach the receiver" in e.value.detail


### PR DESCRIPTION
The portal gains a Managed section and its first write path, kept deliberately thin: every action forwards the operator's admin token to the receiver in an X-Admin-Token header, and the receiver authorizes. The token is entered once per session, held in the tab's memory, and never stored - the portal still has no database and no credentials, so a compromised portal yields readable findings, which it always did, and nothing that can mint or revoke. The custom header is also what makes the write path CSRF-proof. Governance decisions stay in the file; these routes manage operational credentials, a different kind of thing.

Fleet lists enrolled devices from the receiver's registry - who holds a credential, rather than who has spoken lately - with per-device revoke. Enrollment tokens mints with a note and TTL, shows the plaintext exactly once (the receiver stores a hash), and revokes. The Setup view's endpoint rows gain a Download button producing a pre-configured collector script: each download mints its own token, noted with the artifact kind, so the token list shows where every credential went and one artifact can be revoked without touching the rest.

Substitution bakes the values as the scripts' own fallback defaults, so an MDM-supplied parameter still wins, and refuses values that could escape their quoting rather than escaping them. Corporate domains are never baked - the receiver serves those at runtime. RECEIVER_URL (where the portal proxies, since the browser's CSP keeps it on 'self') is deliberately separate from RECEIVER_PUBLIC_URL (what gets baked): a cluster-internal service name baked into a Jamf script would enroll nothing. The chart defaults the first to its own receiver service and the second to the receiver ingress host.

The proxy is stdlib urllib, matching the Loki reader, so the portal gains no HTTP dependency; receiver 4xx detail passes through (a 401 must reach the operator as "bad token"), everything unreachable is a 502 naming only the exception class. The portal image ships verified copies of the collector scripts (its build context cannot see endpoint/), byte-equality asserted by a test - the chart's bundled registry pattern.

Portal tests 240 (16 new, direct-call style: the portal has no httpx for TestClient and is staying that way). Verified end to end in a browser against the demo stack with managed mode on: gate, mint with show-once pane, per-source download with baked defaults, revoke with confirm. Chart 0.8.7.