### PR TITLE
homelab friction: the chart owns its update strategy, and a lost device credential is loud

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.8.7
+version: 0.8.8
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/templates/deployment.yaml
+++ b/charts/ai-guard/templates/deployment.yaml
@@ -14,6 +14,19 @@ spec:
   # wedge waiting for a mount the old pod still holds.
   strategy:
     type: Recreate
+  {{- else }}
+  # Spelled out although it is the default, and not for readability: server-
+  # side apply only clears fields the chart owns, so a release that never
+  # declared rollingUpdate cannot later switch to Recreate - the defaulted
+  # block stays behind, unowned, and the API server rejects the combination.
+  # Owning it from the start is what makes managed.enabled a clean flip.
+  # (Releases installed before this block need one manual step first; see
+  # the managed.enabled comment in values.yaml.)
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
   {{- end }}
   selector:
     matchLabels:

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -69,6 +69,16 @@ corpDomains: []
 # SQLite has one writer, so managed mode requires replicaCount: 1 (the chart
 # refuses to render otherwise) and uses a Recreate strategy so two pods never
 # hold the volume at once.
+#
+# Enabling this on a release installed with chart 0.8.7 or older needs one
+# manual step first: those charts never declared an update strategy, so the
+# API server's defaulted rollingUpdate block is owned by nobody and server-
+# side apply cannot clear it when the strategy switches to Recreate. Either
+# upgrade to this chart once with managed off (the chart takes ownership),
+# or clear it directly and upgrade straight to managed:
+#   kubectl patch deployment <release>-ai-guard --type=json -p='[
+#     {"op":"remove","path":"/spec/strategy/rollingUpdate"},
+#     {"op":"replace","path":"/spec/strategy/type","value":"Recreate"}]'
 managed:
   enabled: false
   # The credential that mints and revokes enrollment tokens and devices.

--- a/endpoint/linux/ai-guard-collector.sh
+++ b/endpoint/linux/ai-guard-collector.sh
@@ -420,10 +420,22 @@ case "$TOKEN" in
           CRED=$(sed -n 's/.*"device_token":"\([^"]*\)".*/\1/p' "$ENROLL_RESP")
         fi
         if [ -n "$CRED" ]; then
-          ( umask 077; printf '%s' "$CRED" > "$CRED_FILE" )
-          chmod 600 "$CRED_FILE" 2>/dev/null
-          TOKEN="$CRED"
-          echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+          if ( umask 077; printf '%s' "$CRED" > "$CRED_FILE" ) 2>/dev/null; then
+            chmod 600 "$CRED_FILE" 2>/dev/null
+            TOKEN="$CRED"
+            echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+          else
+            # Loud and fatal, like an enrollment refusal: the receiver just
+            # minted this device a credential, and losing it here means every
+            # future run enrolls again - device churn in the fleet view and,
+            # once a run reports, a 409 that blocks the fix for an hour.
+            # Exiting before the scan keeps this device silent, so a correctly
+            # privileged run supersedes it immediately.
+            echo "[ai-guard] enrolled, but cannot write $CRED_FILE (run as root?)"
+            echo "[ai-guard] refusing to scan: the credential would be lost and every run would re-enroll"
+            rm -f "$ENROLL_RESP"
+            exit 1
+          fi
         fi
       else
         # Loud and fatal: an enrollment token cannot report findings, so

--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -353,10 +353,22 @@ case "$TOKEN" in
       if [ "$ENROLL_CODE" = "200" ]; then
         CRED=$(json_get "$ENROLL_RESP" device_token)
         if [ -n "$CRED" ]; then
-          ( umask 077; /usr/bin/printf '%s' "$CRED" > "$CRED_FILE" )
-          /bin/chmod 600 "$CRED_FILE" 2>/dev/null
-          TOKEN="$CRED"
-          echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+          if ( umask 077; /usr/bin/printf '%s' "$CRED" > "$CRED_FILE" ) 2>/dev/null; then
+            /bin/chmod 600 "$CRED_FILE" 2>/dev/null
+            TOKEN="$CRED"
+            echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+          else
+            # Loud and fatal, like an enrollment refusal: the receiver just
+            # minted this device a credential, and losing it here means every
+            # future run enrolls again - device churn in the fleet view and,
+            # once a run reports, a 409 that blocks the fix for an hour.
+            # Exiting before the scan keeps this device silent, so a correctly
+            # privileged run supersedes it immediately.
+            echo "[ai-guard] enrolled, but cannot write $CRED_FILE (run as root?)"
+            echo "[ai-guard] refusing to scan: the credential would be lost and every run would re-enroll"
+            /bin/rm -f "$ENROLL_RESP"
+            exit 1
+          fi
         fi
       else
         # Loud and fatal: an enrollment token cannot report findings, so

--- a/endpoint/windows/ai-guard-collector.ps1
+++ b/endpoint/windows/ai-guard-collector.ps1
@@ -301,11 +301,30 @@ if (-not $FunctionsOnly) {
                 -Method Post -TimeoutSec 15 `
                 -Headers @{ Authorization = "Bearer $Token" } `
                 -ContentType 'application/json' -Body $enrollBody -ErrorAction Stop
-            Set-Content -Path $CredFile -Value $r.device_token -NoNewline
+            try {
+                Set-Content -Path $CredFile -Value $r.device_token -NoNewline -ErrorAction Stop
+            } catch {
+                # Loud and fatal, like an enrollment refusal: the receiver
+                # just minted this device a credential, and losing it here
+                # means every run enrolls again - device churn in the fleet
+                # view and, once a run reports, a 409 that blocks the fix for
+                # an hour. Exiting before the scan keeps this device silent,
+                # so a correctly privileged run supersedes it immediately.
+                Write-Output "ai-guard: enrolled, but cannot write $CredFile (run as SYSTEM or elevated?)"
+                Write-Output 'ai-guard: refusing to scan - the credential would be lost and every run would re-enroll'
+                exit 1
+            }
             # The state dir inherits ProgramData's ACL, which lets ordinary
             # users read. A device credential must not be readable by the
-            # people whose AI accounts it reports on.
+            # people whose AI accounts it reports on - so an ACL that cannot
+            # be restricted means the file must not stay behind either.
             icacls $CredFile /inheritance:r /grant 'SYSTEM:(F)' 'Administrators:(F)' | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Remove-Item $CredFile -Force -ErrorAction SilentlyContinue
+                Write-Output "ai-guard: enrolled, but could not restrict $CredFile to SYSTEM/Administrators"
+                Write-Output 'ai-guard: refusing to scan - a device credential readable by every user is worse than none'
+                exit 1
+            }
             $Token = $r.device_token
             Write-Output "ai-guard: enrolled, device credential stored in $CredFile"
         } catch {

--- a/portal/collector-scripts/collector-linux.sh
+++ b/portal/collector-scripts/collector-linux.sh
@@ -420,10 +420,22 @@ case "$TOKEN" in
           CRED=$(sed -n 's/.*"device_token":"\([^"]*\)".*/\1/p' "$ENROLL_RESP")
         fi
         if [ -n "$CRED" ]; then
-          ( umask 077; printf '%s' "$CRED" > "$CRED_FILE" )
-          chmod 600 "$CRED_FILE" 2>/dev/null
-          TOKEN="$CRED"
-          echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+          if ( umask 077; printf '%s' "$CRED" > "$CRED_FILE" ) 2>/dev/null; then
+            chmod 600 "$CRED_FILE" 2>/dev/null
+            TOKEN="$CRED"
+            echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+          else
+            # Loud and fatal, like an enrollment refusal: the receiver just
+            # minted this device a credential, and losing it here means every
+            # future run enrolls again - device churn in the fleet view and,
+            # once a run reports, a 409 that blocks the fix for an hour.
+            # Exiting before the scan keeps this device silent, so a correctly
+            # privileged run supersedes it immediately.
+            echo "[ai-guard] enrolled, but cannot write $CRED_FILE (run as root?)"
+            echo "[ai-guard] refusing to scan: the credential would be lost and every run would re-enroll"
+            rm -f "$ENROLL_RESP"
+            exit 1
+          fi
         fi
       else
         # Loud and fatal: an enrollment token cannot report findings, so

--- a/portal/collector-scripts/collector-macos.sh
+++ b/portal/collector-scripts/collector-macos.sh
@@ -353,10 +353,22 @@ case "$TOKEN" in
       if [ "$ENROLL_CODE" = "200" ]; then
         CRED=$(json_get "$ENROLL_RESP" device_token)
         if [ -n "$CRED" ]; then
-          ( umask 077; /usr/bin/printf '%s' "$CRED" > "$CRED_FILE" )
-          /bin/chmod 600 "$CRED_FILE" 2>/dev/null
-          TOKEN="$CRED"
-          echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+          if ( umask 077; /usr/bin/printf '%s' "$CRED" > "$CRED_FILE" ) 2>/dev/null; then
+            /bin/chmod 600 "$CRED_FILE" 2>/dev/null
+            TOKEN="$CRED"
+            echo "[ai-guard] enrolled: device credential stored in $CRED_FILE"
+          else
+            # Loud and fatal, like an enrollment refusal: the receiver just
+            # minted this device a credential, and losing it here means every
+            # future run enrolls again - device churn in the fleet view and,
+            # once a run reports, a 409 that blocks the fix for an hour.
+            # Exiting before the scan keeps this device silent, so a correctly
+            # privileged run supersedes it immediately.
+            echo "[ai-guard] enrolled, but cannot write $CRED_FILE (run as root?)"
+            echo "[ai-guard] refusing to scan: the credential would be lost and every run would re-enroll"
+            /bin/rm -f "$ENROLL_RESP"
+            exit 1
+          fi
         fi
       else
         # Loud and fatal: an enrollment token cannot report findings, so

--- a/portal/collector-scripts/collector-windows.ps1
+++ b/portal/collector-scripts/collector-windows.ps1
@@ -301,11 +301,30 @@ if (-not $FunctionsOnly) {
                 -Method Post -TimeoutSec 15 `
                 -Headers @{ Authorization = "Bearer $Token" } `
                 -ContentType 'application/json' -Body $enrollBody -ErrorAction Stop
-            Set-Content -Path $CredFile -Value $r.device_token -NoNewline
+            try {
+                Set-Content -Path $CredFile -Value $r.device_token -NoNewline -ErrorAction Stop
+            } catch {
+                # Loud and fatal, like an enrollment refusal: the receiver
+                # just minted this device a credential, and losing it here
+                # means every run enrolls again - device churn in the fleet
+                # view and, once a run reports, a 409 that blocks the fix for
+                # an hour. Exiting before the scan keeps this device silent,
+                # so a correctly privileged run supersedes it immediately.
+                Write-Output "ai-guard: enrolled, but cannot write $CredFile (run as SYSTEM or elevated?)"
+                Write-Output 'ai-guard: refusing to scan - the credential would be lost and every run would re-enroll'
+                exit 1
+            }
             # The state dir inherits ProgramData's ACL, which lets ordinary
             # users read. A device credential must not be readable by the
-            # people whose AI accounts it reports on.
+            # people whose AI accounts it reports on - so an ACL that cannot
+            # be restricted means the file must not stay behind either.
             icacls $CredFile /inheritance:r /grant 'SYSTEM:(F)' 'Administrators:(F)' | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                Remove-Item $CredFile -Force -ErrorAction SilentlyContinue
+                Write-Output "ai-guard: enrolled, but could not restrict $CredFile to SYSTEM/Administrators"
+                Write-Output 'ai-guard: refusing to scan - a device credential readable by every user is worse than none'
+                exit 1
+            }
             $Token = $r.device_token
             Write-Output "ai-guard: enrolled, device credential stored in $CredFile"
         } catch {


### PR DESCRIPTION
Two defects from deploying managed mode to a real cluster.

Enabling managed.enabled on an existing release failed: the chart never declared an update strategy, so the API server's defaulted rollingUpdate block was owned by nobody, and server-side apply cannot clear an unowned field when the strategy switches to Recreate. The chart now spells out RollingUpdate when managed mode is off, owning the fields from the start so the flip is clean; releases installed with 0.8.7 or older need a one-time kubectl patch, documented in values.yaml. Chart 0.8.8.

The collectors printed "enrolled: device credential stored" even when the write failed, so an unprivileged run claimed success, lost the credential, and enrolled a fresh device every run - churn in the fleet view and, once a run reported, an hour-long 409 blocking the fix. All three now refuse to scan instead, keeping the stranded device silent so a correctly privileged run supersedes it immediately. Windows also gets -ErrorAction Stop on the write (a non-terminating error never reached the catch) and deletes the credential when icacls cannot restrict it.

Portal script copies re-synced; portal 240, receiver 47, Linux container suite 14 all pass.