### PR TITLE
chart 0.8.9, appVersion 0.9.5

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.8.8
+version: 0.8.9
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.9.4"
+appVersion: "0.9.5"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -52,14 +52,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.4
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.5
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.4
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.5
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -128,7 +128,7 @@ On the compose route it is already there, on port 8091. Otherwise:
 docker run --rm -p 8091:8091 \
   -e LOKI_URL=http://your-loki:3100 \
   -e PORTAL_USER=admin -e PORTAL_PASSWORD=... \
-  ghcr.io/amansk5/shadow-ai-guard/portal:0.9.4
+  ghcr.io/amansk5/shadow-ai-guard/portal:0.9.5
 ```
 
 It refuses to start without authentication, because it names who runs what on

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.4
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.5
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Release prep for v0.9.5: managed mode (central config #109, enrollment and per-device credentials #110, portal write path #111, homelab friction fixes #112). Chart and raw-manifest image pin bumped; tag v0.9.5 goes on the merge commit and CI builds the 0.9.5 images from it.

Classic file/env mode is unchanged and remains the default.