### PR TITLE
enrollment everywhere: the browser extension and the scanners hold their own credentials

### DIFF
--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -208,7 +208,10 @@ traffic before it arrives is what protects everything else on the host.
 
 The receiver authenticates reporting sources with a shared bearer token, the one
 in `secrets/auth_token`. That token goes into your MDM script parameters, your
-managed browser configuration, and your scanner environment.
+managed browser configuration, and your scanner environment. With the managed
+overlay, an enrollment token minted in the portal goes in those same places
+instead, and each collector, browser profile and scanner exchanges it once for a
+credential of its own.
 
 The portal authenticates separately with HTTP basic auth, and **refuses to start
 without it**. It names who runs what on which machine, so coming up open because

--- a/discovery/discover.py
+++ b/discovery/discover.py
@@ -14,7 +14,14 @@ Human stays the approval gate: nothing enters detection until the MR merges.
 
 Env:
   S1_BASE_URL, S1_API_TOKEN
-  RECEIVER_URL, RECEIVER_TOKEN          (to fetch the live registry)
+  RECEIVER_URL, RECEIVER_TOKEN          (to fetch the live registry; the token
+                                         may be an enrollment token, aige_...,
+                                         from a managed-mode receiver - the run
+                                         then enrolls as a scanner first)
+  AIGUARD_SCANNER_ID                    (identity on the receiver, default
+                                         "discovery")
+  AIGUARD_STATE_DIR                     (optional: keeps the device credential
+                                         between runs; unset enrolls per run)
   ANTHROPIC_API_KEY                     (classification)
   ANTHROPIC_MODEL                       (default claude-sonnet-4-6)
   GITLAB_URL, GITLAB_TOKEN, GITLAB_PROJECT_ID
@@ -25,6 +32,7 @@ Env:
 import json
 import os
 import re
+import socket
 import sys
 import time
 from collections import defaultdict
@@ -88,14 +96,81 @@ def etld1(host: str) -> str:
     return ".".join(parts[-2:]) if len(parts) >= 2 else host
 
 
+# ---------------------------------------------------------- enrollment ------
+# Managed mode, mirrored from scanner/receiver_reporter.py (discovery ships as
+# its own image and deliberately imports nothing from the scanner package).
+# RECEIVER_TOKEN may be an enrollment token: the run exchanges it at /enroll
+# for this job's own device credential and reads the registry with that. With
+# no AIGUARD_STATE_DIR the job enrolls on every run and the receiver reissues
+# the same device's credential in place, so the fleet shows one "discovery"
+# row. A schedule tighter than hourly needs the state dir on a volume.
+
+ENROLL_PREFIX = "aige_"
+DEVICE_PREFIX = "aigd_"
+AGENT_VERSION = "discovery/1"
+SCANNER_ID = os.environ.get("AIGUARD_SCANNER_ID", "discovery")
+STATE_DIR = os.environ.get("AIGUARD_STATE_DIR", "")
+
+
+def resolve_credential(url: str, token: str, scanner_id: str, state_dir: str) -> str:
+    """A stored device credential wins; an enrollment token is exchanged for
+    one; anything else is used as-is. Refusal exits: an enrollment token
+    cannot read the registry, and a run without a registry is no run."""
+    if not token.startswith(ENROLL_PREFIX):
+        return token
+    cred_path = os.path.join(state_dir, "device.cred") if state_dir else ""
+    if cred_path and os.path.exists(cred_path):
+        try:
+            with open(cred_path) as f:
+                stored = f.read().strip()
+        except OSError as e:
+            sys.exit(f"cannot read {cred_path} ({e.strerror})")
+        if stored.startswith(DEVICE_PREFIX):
+            return stored
+    body = {"platform": "scanner", "serial": scanner_id,
+            "hostname": socket.gethostname(), "agent_version": AGENT_VERSION}
+    try:
+        r = httpx.post(f"{url}/enroll", json=body, timeout=15,
+                       headers={"Authorization": f"Bearer {token}"})
+    except httpx.HTTPError as e:
+        sys.exit(f"enrollment failed: {type(e).__name__} reaching {url}")
+    if r.status_code != 200:
+        try:
+            detail = r.json().get("detail", "")
+        except ValueError:
+            detail = ""
+        sys.exit(f"enrollment failed: HTTP {r.status_code} from {url}/enroll"
+                 + (f": {detail}" if detail else ""))
+    cred = r.json().get("device_token", "")
+    if not cred.startswith(DEVICE_PREFIX):
+        sys.exit("enrollment failed: receiver returned no device credential")
+    if cred_path:
+        try:
+            os.makedirs(state_dir, exist_ok=True)
+            fd = os.open(cred_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
+                f.write(cred)
+        except OSError as e:
+            sys.exit(f"enrolled, but cannot write {cred_path} ({e.strerror}); refusing to"
+                     " run: the credential would be lost and every run would re-enroll")
+    print(f"enrolled as scanner {scanner_id!r}")
+    return cred
+
+
 # ------------------------------------------------------------ registry ------
 
-def fetch_registry() -> dict:
+def fetch_registry(token: str = "") -> dict:
     r = httpx.get(
         f"{RECEIVER_URL}/registry",
-        headers={"Authorization": f"Bearer {RECEIVER_TOKEN}"},
+        headers={"Authorization": f"Bearer {token or RECEIVER_TOKEN}",
+                 "X-AiGuard-Agent-Version": AGENT_VERSION},
         timeout=15,
     )
+    if r.status_code == 401 and (token or RECEIVER_TOKEN).startswith(DEVICE_PREFIX):
+        # Never re-enrolled from here: a revoked job must be visible in its
+        # log, and the operator removes the stored credential to enroll again.
+        sys.exit("the receiver refused this job's device credential (revoked?); delete"
+                 " device.cred under AIGUARD_STATE_DIR and supply a valid enrollment token")
     r.raise_for_status()
     return r.json()
 
@@ -459,7 +534,8 @@ def open_mr(groups: list[dict], registry: dict):
 # ------------------------------------------------------------------- main ---
 
 def main():
-    registry = fetch_registry()
+    token = resolve_credential(RECEIVER_URL, RECEIVER_TOKEN, SCANNER_ID, STATE_DIR)
+    registry = fetch_registry(token)
     known = known_domains(registry)
     allow = set()
     if ALLOWLIST_FILE.exists():

--- a/discovery/tests/test_enrollment.py
+++ b/discovery/tests/test_enrollment.py
@@ -1,0 +1,105 @@
+"""Managed mode: RECEIVER_TOKEN may be an enrollment token, and discovery -
+which only ever reads the registry - enrolls as a scanner first and reads it
+with its own credential. Mirrors scanner/receiver_reporter.py; the copy is
+deliberate (discovery imports nothing from the scanner package), so the
+behaviour is pinned here on its own.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import discover
+
+
+class FakeReceiver:
+    def __init__(self):
+        self.requests = []
+        self.live = set()
+        self.issued = 0
+        self.enroll_status = 200
+
+    def handler(self, request):
+        self.requests.append(request)
+        bearer = request.headers.get("authorization", "").removeprefix("Bearer ")
+        if request.url.path == "/enroll":
+            if not bearer.startswith("aige_"):
+                return httpx.Response(401, json={"detail": "bad token"})
+            if self.enroll_status != 200:
+                return httpx.Response(self.enroll_status, json={"detail": "refused"})
+            self.issued += 1
+            self.live.add(f"aigd_{self.issued}")
+            return httpx.Response(200, json={"device_id": "d1",
+                                             "device_token": f"aigd_{self.issued}"})
+        if bearer in self.live or bearer == "shared":
+            return httpx.Response(200, json={"tools": []})
+        return httpx.Response(401, json={"detail": "bad token"})
+
+
+@pytest.fixture
+def receiver(monkeypatch):
+    rx = FakeReceiver()
+    transport = httpx.MockTransport(rx.handler)
+    real = httpx.Client
+    monkeypatch.setattr(discover.httpx, "post",
+                        lambda url, **kw: real(transport=transport).post(url, **kw))
+    monkeypatch.setattr(discover.httpx, "get",
+                        lambda url, **kw: real(transport=transport).get(url, **kw))
+    monkeypatch.setattr(discover, "RECEIVER_URL", "https://r.example")
+    monkeypatch.setattr(discover.socket, "gethostname", lambda: "discovery-pod")
+    return rx
+
+
+def test_a_shared_token_is_used_as_is(receiver):
+    assert discover.resolve_credential("https://r.example", "shared", "discovery", "") == "shared"
+    assert receiver.requests == []
+
+
+def test_an_enrollment_token_enrolls_as_a_scanner_and_reads_the_registry(receiver):
+    cred = discover.resolve_credential("https://r.example", "aige_x", "discovery", "")
+    assert cred == "aigd_1"
+    assert discover.fetch_registry(cred) == {"tools": []}
+    enroll, read = receiver.requests
+    assert json.loads(enroll.content) == {"platform": "scanner", "serial": "discovery",
+                                          "hostname": "discovery-pod",
+                                          "agent_version": discover.AGENT_VERSION}
+    assert read.headers["authorization"] == "Bearer aigd_1"
+    assert read.headers["x-aiguard-agent-version"] == discover.AGENT_VERSION
+
+
+def test_a_state_dir_keeps_the_credential_between_runs(receiver, tmp_path):
+    a = discover.resolve_credential("https://r.example", "aige_x", "discovery", str(tmp_path))
+    b = discover.resolve_credential("https://r.example", "aige_x", "discovery", str(tmp_path))
+    assert a == b and receiver.issued == 1
+    assert (tmp_path / "device.cred").stat().st_mode & 0o777 == 0o600
+
+
+def test_a_refused_enrollment_exits_and_names_the_status(receiver):
+    receiver.enroll_status = 401
+    with pytest.raises(SystemExit) as e:
+        discover.resolve_credential("https://r.example", "aige_x", "discovery", "")
+    assert "HTTP 401" in str(e.value) and "refused" in str(e.value)
+
+
+def test_an_unreadable_stored_credential_exits_with_a_name(receiver, tmp_path):
+    cred = tmp_path / "device.cred"
+    cred.write_text("aigd_stored")
+    cred.chmod(0o000)
+    try:
+        with pytest.raises(SystemExit) as e:
+            discover.resolve_credential("https://r.example", "aige_x", "discovery", str(tmp_path))
+        assert "cannot read" in str(e.value)
+    finally:
+        cred.chmod(0o600)
+
+
+def test_a_revoked_credential_exits_loudly_and_never_reenrolls(receiver):
+    with pytest.raises(SystemExit) as e:
+        discover.fetch_registry("aigd_revoked")
+    assert "revoked" in str(e.value)
+    assert all(r.url.path != "/enroll" for r in receiver.requests)

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -26,7 +26,9 @@ but nothing downstream can tell.
 
 **The bearer token.** One shared token that every collector, scanner and the
 browser extension authenticate with. Where it lives differs; what it does does
-not.
+not. In managed mode each of them can instead carry an enrollment token and
+exchange it once for a credential of its own, which is what makes one machine,
+one browser profile or one scanner revocable on its own.
 
 **The log store.** Neither route bundles one for production. The receiver
 writes JSON lines to stdout regardless, and pushes to Loki when

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -80,7 +80,8 @@ kubectl -n "$NS" create secret generic ai-guard-receiver \
 ```
 
 Every source authenticates with this one token: collectors, scanners and the
-browser extension.
+browser extension. (With `managed.enabled`, each of those can carry an
+enrollment token instead and hold a credential of its own - see below.)
 
 ### 2. The registry
 
@@ -136,9 +137,10 @@ Optional, all off by default:
   as the auth token. The portal gains a Managed section for this: enter that
   admin token there to see the fleet, mint and revoke enrollment tokens, and
   download pre-configured collector scripts from the Setup view - or drive
-  the same `/admin` API with curl. Enrollment tokens go in the MDM in place
-  of the shared token, one platform at a time. See the receiver and portal
-  READMEs for the details.
+  the same `/admin` API with curl. Enrollment tokens go wherever the shared
+  token goes today - collector parameters, the extension's managed policy,
+  the scanner Secret - one surface at a time; each enrolls and holds its own
+  credential. See the receiver and portal READMEs for the details.
 
 Confirm it is up:
 

--- a/extension/README.md
+++ b/extension/README.md
@@ -236,10 +236,45 @@ content anywhere in it.
 | --- | --- | --- |
 | `allowedDomains` | array | Account domains not flagged (your corporate domains) |
 | `reportEndpoint` | string | Receiver URL for finding POSTs |
-| `authToken` | string | Bearer token (write-only credential: it can submit findings, not read them) |
+| `authToken` | string | Bearer token (write-mostly credential: it can submit findings and read the registry, nothing else). The receiver's shared `AUTH_TOKEN`, or an enrollment token (`aige_...`) from a managed-mode receiver - see below |
 | `deviceIdentifier` | string | Device attribution value stamped by the MDM |
 | `pasteGuardMode` | string | `off`, `warn`, or `block`; unset behaves as `warn` |
 | `classificationMarkings` | array | Labels from your document classification policy |
+
+## Enrolling with a managed-mode receiver
+
+With a receiver running in managed mode, `authToken` can carry an
+**enrollment token** (`aige_...`, minted in the portal or via `/admin`)
+instead of the shared token. The prefix is the switch - no other key
+changes, and the same policy value works for both. Each browser profile then:
+
+1. On its first report, POSTs `/enroll` (derived from `reportEndpoint` by
+   dropping the trailing `/report`) with `platform: browser` and a serial of
+   `<deviceIdentifier>/<install id>` - the install id is eight hex characters
+   made once per profile, because one machine legitimately runs several
+   managed profiles (Chrome and Edge, two Chrome profiles) and they must not
+   displace each other on the receiver.
+2. Keeps the credential it receives in the extension's `storage.local` and
+   reports with it from then on, sending its version in
+   `X-AiGuard-Agent-Version`. The profile appears in the portal's Fleet view
+   as platform `browser`.
+3. If the receiver refuses that credential (revoked in the Fleet view), the
+   profile goes quiet and says so in the service worker console; the hourly
+   heartbeat retry keeps checking. It re-enrolls **only when the policy
+   carries a different enrollment token** than the one its credential last
+   reported under (a rotation while the credential still worked is recorded
+   as such, so only a rotation *after* the revoke counts). Revoking a profile
+   therefore sticks until you rotate the token - the browser analogue of
+   deleting a collector's `device.cred` - and rotating it is also how an
+   accidental revoke is undone.
+
+A profile whose extension storage is wiped (reinstall, profile reset) makes
+a new install id and appears as a new row; the old row stays, with its last
+seen time, until you revoke it. The receiver knows the two belong to one
+machine only by the shared device identifier prefix.
+
+The shared token keeps working alongside, which is the migration path: flip
+the policy value per browser, per platform, at your own pace.
 
 ## Rollout advice
 

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -17,6 +17,15 @@ const FALLBACK_DEVICE = "";   // optional: set a label for LOCAL testing only
 const FALLBACK_AUTH_TOKEN = ""; // optional: set for LOCAL testing only
 const DEDUPE_WINDOW_MS = 6 * 60 * 60 * 1000; // one flag per tool+domain per 6h
 
+// Managed mode. authToken in the policy may be an enrollment token (aige_...)
+// instead of the shared token: this profile then exchanges it once at /enroll
+// for its own device credential (aigd_...), kept in storage.local, and reports
+// with that. The prefix is the switch - the same contract as the endpoint
+// collectors, so an operator flips one policy value when ready.
+const ENROLL_PREFIX = "aige_";
+const ENROLLMENT_KEY = "enrollment";
+const AGENT_VERSION = api.runtime.getManifest().version;
+
 // Dedupe state for personal-account flags. This was a module-level Map, which
 // lives exactly as long as the service worker does: Chrome stops an MV3
 // worker after roughly thirty seconds idle and content.js checks every five
@@ -139,7 +148,7 @@ async function heartbeat(reason) {
       surface: "browser",
       source: "paste_guard",
       severity: "info",
-      evidence: "heartbeat version=" + api.runtime.getManifest().version +
+      evidence: "heartbeat version=" + AGENT_VERSION +
                 " mode=" + mode + " reason=" + reason,
       reported_at: new Date().toISOString(),
     });
@@ -211,9 +220,119 @@ function detectOs() {
   return osPromise;
 }
 
+// ---- enrollment (managed mode) ----
+
+// The receiver base is the report endpoint minus its path. The policy carries
+// the full endpoint, as it always has, so nothing new is configured.
+function receiverBase(endpoint) {
+  // A query string on the endpoint is allowed and dropped; the path must
+  // end in /report (or the legacy /flag) for /enroll to be derivable.
+  const m = /^(.*)\/(report|flag)\/?(\?.*)?$/.exec(endpoint);
+  return m ? m[1] : null;
+}
+
+// Eight hex characters, made once per browser profile. It is part of this
+// profile's serial, not a secret: uniqueness is all it provides, and the
+// fallback exists for a runtime without crypto.
+function newInstallId() {
+  const bytes = new Uint8Array(4);
+  try { crypto.getRandomValues(bytes); } catch (e) {
+    for (let i = 0; i < 4; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+async function storedEnrollment() {
+  try {
+    const state = await api.storage.local.get(ENROLLMENT_KEY);
+    return (state && state[ENROLLMENT_KEY]) || null;
+  } catch (e) { return null; }
+}
+
+// One in-flight enrollment at a time. A worker that wakes to a startup
+// heartbeat and a content-script flag at once would otherwise enroll twice,
+// and the second would displace the first.
+let enrollPromise = null;
+
+function enrollOnce(cfg, prior) {
+  if (!enrollPromise) {
+    enrollPromise = enroll(cfg, prior).finally(() => { enrollPromise = null; });
+  }
+  return enrollPromise;
+}
+
+async function enroll(cfg, prior) {
+  const base = receiverBase(cfg.endpoint);
+  if (!base) {
+    throw new Error("cannot enroll: reportEndpoint must end in /report to derive /enroll");
+  }
+  // The serial is the MDM-stamped device id plus a per-profile id. One
+  // machine legitimately runs several managed profiles (Chrome and Edge, two
+  // Chrome profiles); with the bare device id they would take turns
+  // displacing each other on the receiver. The id is kept across
+  // re-enrollments so the receiver sees the same profile, not a new one.
+  const installId = (prior && prior.installId) || newInstallId();
+  const serial = cfg.device + "/" + installId;
+  const response = await fetch(base + "/enroll", {
+    method: "POST",
+    headers: { "Content-Type": "application/json",
+               "Authorization": "Bearer " + cfg.authToken },
+    body: JSON.stringify({ platform: "browser", serial: serial, hostname: "",
+                           agent_version: AGENT_VERSION }),
+  });
+  if (!response.ok) {
+    // An expired or revoked enrollment token is an operations task, and the
+    // console is the only log this worker has; the heartbeat retry keeps
+    // asking hourly, so a fixed policy takes effect without a restart.
+    throw new Error("enrollment failed: receiver returned HTTP " + response.status);
+  }
+  let body = null;
+  try { body = await response.json(); } catch (e) { /* handled below */ }
+  if (!body || typeof body.device_token !== "string" || !body.device_token.startsWith("aigd_")) {
+    // A 200 from something that is not the receiver (a captive portal, a
+    // default backend) must not become an empty credential that then reads
+    // as "revoked" on every report.
+    throw new Error("enrollment failed: the response carried no device credential");
+  }
+  // "with" records which enrollment token issued this credential. A refused
+  // credential is re-enrolled only once the policy carries a different token
+  // (see report), so revoking a profile sticks until an operator rotates it.
+  const enrollment = { cred: body.device_token, installId: installId, with: cfg.authToken };
+  await api.storage.local.set({ [ENROLLMENT_KEY]: enrollment });
+  console.log("[ai-account-guard] enrolled as " + serial);
+  return enrollment;
+}
+
+// The bearer for this report, and the enrollment it came from (null when the
+// policy carries a shared token and there is nothing to re-enroll).
+async function resolveBearer(cfg) {
+  if (!cfg.authToken.startsWith(ENROLL_PREFIX)) {
+    return { bearer: cfg.authToken, enrollment: null };
+  }
+  let enrollment = await storedEnrollment();
+  if (!enrollment || !enrollment.cred) enrollment = await enrollOnce(cfg, enrollment);
+  return { bearer: enrollment.cred, enrollment: enrollment };
+}
+
+// After a 401 on a device credential. Another caller may already have
+// re-enrolled between our read and our refusal, so storage is read again
+// first: a credential that differs from the refused one is the answer.
+async function reenroll(cfg, refusedCred) {
+  const current = await storedEnrollment();
+  if (current && current.cred && current.cred !== refusedCred) return current;
+  return enrollOnce(cfg, current);
+}
+
+function post(endpoint, bearer, payload) {
+  const headers = { "Content-Type": "application/json",
+                    "X-AiGuard-Agent-Version": AGENT_VERSION };
+  if (bearer) headers["Authorization"] = "Bearer " + bearer;
+  return fetch(endpoint, { method: "POST", headers: headers, body: JSON.stringify(payload) });
+}
+
 async function report(payload) {
-  const { endpoint, device, authToken } = await getConfig();
-  payload.device = device;
+  const cfg = await getConfig();
+  payload.device = cfg.device;
 
   // Set here rather than at each call site: three callers had three chances
   // to forget it, and all three did. The receiver coerced the missing field
@@ -221,26 +340,47 @@ async function report(payload) {
   // nothing said why.
   if (!payload.os) payload.os = await detectOs();
 
-  if (!endpoint) {
+  if (!cfg.endpoint) {
     // No endpoint set (e.g. loaded unpacked with no MDM config). Surface the
     // flag in the service worker console so local testing is visible.
     console.log("[ai-account-guard] FLAG (no endpoint set):", payload);
     return false;
   }
 
-  const headers = { "Content-Type": "application/json" };
-  if (authToken) headers["Authorization"] = "Bearer " + authToken;
+  let { bearer, enrollment } = await resolveBearer(cfg);
+  let response = await post(cfg.endpoint, bearer, payload);
 
-  const response = await fetch(endpoint, {
-    method: "POST",
-    headers: headers,
-    body: JSON.stringify(payload),
-  });
+  if (response.status === 401 && enrollment) {
+    // This profile's own credential was refused: revoked on the receiver, or
+    // reissued to another enrollment of the same serial. It re-enrolls only
+    // if the policy now carries a different enrollment token than the one
+    // this credential came from - the browser analogue of the collector's
+    // "delete device.cred": revoking a profile sticks until an operator
+    // rotates the token, rather than being undone by the next heartbeat.
+    if (cfg.authToken === enrollment.with) {
+      throw new Error("receiver refused this profile's device credential (revoked?);"
+                      + " it re-enrolls when the policy carries a new enrollment token");
+    }
+    console.warn("[ai-account-guard] device credential refused and the enrollment token"
+                 + " has changed: re-enrolling");
+    enrollment = await reenroll(cfg, bearer);
+    response = await post(cfg.endpoint, enrollment.cred, payload);
+  }
 
   // fetch only rejects on a network-level failure, so a 401 or a 500 arrives
   // here looking like success unless the status is checked.
   if (!response.ok) {
     throw new Error("receiver returned HTTP " + response.status);
+  }
+
+  // The policy token rotated (the 180-day TTL makes that routine) while
+  // this credential kept working: record the current token as the one this
+  // credential stands under. Otherwise a rotation months before a revoke
+  // would count as the rotation *after* it, and the revoke would not stick.
+  if (enrollment && enrollment.with !== cfg.authToken) {
+    try {
+      await api.storage.local.set({ [ENROLLMENT_KEY]: { ...enrollment, with: cfg.authToken } });
+    } catch (e) { /* next success tries again */ }
   }
   return true;
 }

--- a/extension/src/managed-schema.json
+++ b/extension/src/managed-schema.json
@@ -19,7 +19,7 @@
     },
     "authToken": {
       "title": "Auth token",
-      "description": "Bearer token sent to the report endpoint (matches the receiver's AUTH_TOKEN)",
+      "description": "Bearer token sent to the report endpoint: the receiver's shared AUTH_TOKEN, or an enrollment token (aige_...) from a managed-mode receiver, which this browser profile exchanges once for its own device credential",
       "type": "string"
     },
     "pasteGuardMode": {

--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Guard",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Flags AI tools signed in with a non-corporate account and stops secrets being pasted into them. Reports detector ids and account domains only, never content.",
   "permissions": [
     "storage",

--- a/extension/tests/test_enrollment.js
+++ b/extension/tests/test_enrollment.js
@@ -1,0 +1,235 @@
+// Managed mode: the policy's authToken may be an enrollment token, and the
+// profile must exchange it once for its own credential and then behave like a
+// device - same contract as the endpoint collectors.
+//
+// What is asserted, in order:
+//   - an aige_ token is never sent to /report; /enroll is called once, with
+//     platform "browser" and a serial of <deviceIdentifier>/<install id>, and
+//     the credential it returns is what every later report carries
+//   - the credential survives a worker restart (storage.local), so a second
+//     boot does not enroll again
+//   - two reports racing on a fresh profile share one enrollment
+//   - a 401 on the credential with the SAME policy token does not re-enroll:
+//     revoking a profile sticks until an operator rotates the token
+//   - a 401 with a DIFFERENT policy token re-enrolls, keeps the install id
+//     (same serial, same device on the receiver) and retries the report
+//   - a shared token is sent as-is, with no /enroll traffic
+//   - a reportEndpoint that does not end in /report cannot enroll, loudly
+//
+// No test framework, same as the other two. Run it with:
+//     node extension/tests/test_enrollment.js
+
+const assert = require("assert");
+const fs = require("fs");
+const path = require("path");
+
+const src = fs.readFileSync(path.join(__dirname, "..", "src", "background.js"), "utf8");
+
+function makeStorage(backing) {
+  return {
+    get: (key) => Promise.resolve(key in backing ? { [key]: backing[key] } : {}),
+    set: (obj) => { Object.assign(backing, obj); return Promise.resolve(); },
+  };
+}
+
+// Boot the worker against a managed config and a scripted receiver.
+// `receiver(url, opts)` returns {status, body}; every call is recorded.
+function boot(localBacking, managed, receiver) {
+  const calls = [];
+  let onMessage = null, onStartup = null;
+  const api = {
+    storage: {
+      session: makeStorage({}),
+      local: makeStorage(localBacking),
+      managed: { get: () => Promise.resolve(managed) },
+    },
+    runtime: {
+      onMessage: { addListener: (fn) => { onMessage = fn; } },
+      onStartup: { addListener: (fn) => { onStartup = fn; } },
+      onInstalled: { addListener: () => {} },
+      getManifest: () => ({ version: "9.9.9" }),
+      getPlatformInfo: () => Promise.resolve({ os: "mac" }),
+    },
+    alarms: { create: () => {}, onAlarm: { addListener: () => {} } },
+  };
+  const fetch = (url, opts) => {
+    const call = { url, headers: opts.headers, body: JSON.parse(opts.body) };
+    calls.push(call);
+    const r = receiver(url, call);
+    return Promise.resolve({
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      json: () => Promise.resolve(r.body || {}),
+    });
+  };
+  new Function("globalThis", "fetch", "console", src).call({},
+    { browser: api }, fetch, { warn: () => {}, log: () => {} });
+  return {
+    calls,
+    flag: (tool) => onMessage({ type: "paste-guard", tool, action: "blocked", detectors: ["x"], ts: "t" }),
+    startup: () => onStartup(),
+  };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+async function settle() { for (let i = 0; i < 20; i++) await tick(); }
+
+const POLICY = { reportEndpoint: "https://r.example/report", deviceIdentifier: "C02DEV1",
+                 authToken: "aige_first" };
+
+// A receiver that enrolls anyone and accepts any aigd_ credential it issued.
+function happyReceiver() {
+  const issued = new Set();
+  let n = 0;
+  return {
+    issued,
+    handle: (url, call) => {
+      if (url.endsWith("/enroll")) {
+        const cred = "aigd_" + (++n);
+        issued.add(cred);
+        return { status: 200, body: { device_id: "d1", device_token: cred } };
+      }
+      const bearer = (call.headers.Authorization || "").replace("Bearer ", "");
+      return { status: issued.has(bearer) ? 200 : 401 };
+    },
+  };
+}
+
+(async () => {
+  // ---- first run enrolls once, then reports with the credential ----------
+  {
+    const rx = happyReceiver();
+    const local = {};
+    const w = boot(local, POLICY, rx.handle);
+    w.flag("chatgpt.com");
+    await settle();
+    w.flag("claude.ai");
+    await settle();
+
+    const enrolls = w.calls.filter((c) => c.url.endsWith("/enroll"));
+    const reports = w.calls.filter((c) => c.url.endsWith("/report"));
+    assert.strictEqual(enrolls.length, 1, "exactly one enrollment");
+    assert.strictEqual(enrolls[0].headers.Authorization, "Bearer aige_first");
+    assert.strictEqual(enrolls[0].body.platform, "browser");
+    assert.match(enrolls[0].body.serial, /^C02DEV1\/[0-9a-f]{8}$/, "serial is device id + install id");
+    assert.strictEqual(enrolls[0].body.agent_version, "9.9.9");
+    assert.strictEqual(reports.length, 2);
+    for (const r of reports) {
+      assert.strictEqual(r.headers.Authorization, "Bearer aigd_1", "reports carry the credential");
+      assert.strictEqual(r.headers["X-AiGuard-Agent-Version"], "9.9.9");
+      assert.strictEqual(r.body.device, "C02DEV1");
+    }
+    assert.strictEqual(local.enrollment.cred, "aigd_1");
+    assert.strictEqual(local.enrollment.with, "aige_first");
+
+    // ---- restart: credential comes from storage, no second enrollment ----
+    const w2 = boot(local, POLICY, rx.handle);
+    w2.flag("gemini.google.com");
+    await settle();
+    assert.strictEqual(w2.calls.filter((c) => c.url.endsWith("/enroll")).length, 0,
+      "a restarted worker reuses the stored credential");
+    assert.strictEqual(w2.calls[0].headers.Authorization, "Bearer aigd_1");
+  }
+
+  // ---- concurrent first reports share one enrollment ---------------------
+  {
+    const rx = happyReceiver();
+    const w = boot({}, POLICY, rx.handle);
+    w.flag("a.example"); w.flag("b.example"); w.flag("c.example");
+    await settle();
+    assert.strictEqual(w.calls.filter((c) => c.url.endsWith("/enroll")).length, 1,
+      "three racing reports, one enrollment");
+    assert.strictEqual(w.calls.filter((c) => c.url.endsWith("/report")).length, 3);
+  }
+
+  // ---- revoked, same policy token: stays refused, no re-enroll -----------
+  {
+    const rx = happyReceiver();
+    const local = { enrollment: { cred: "aigd_revoked", installId: "deadbeef", with: "aige_first" } };
+    const w = boot(local, POLICY, rx.handle);
+    w.startup();  // heartbeat: observable through lastHeartbeat
+    await settle();
+    assert.strictEqual(w.calls.filter((c) => c.url.endsWith("/enroll")).length, 0,
+      "no re-enrollment while the policy still carries the token this credential came from");
+    assert.strictEqual(local.lastHeartbeat, undefined, "the refused heartbeat is not recorded as delivered");
+    assert.strictEqual(local.enrollment.cred, "aigd_revoked", "state untouched");
+  }
+
+  // ---- revoked, rotated policy token: re-enrolls, same install id, retries -
+  {
+    const rx = happyReceiver();
+    const local = { enrollment: { cred: "aigd_revoked", installId: "deadbeef", with: "aige_first" } };
+    const rotated = { ...POLICY, authToken: "aige_second" };
+    const w = boot(local, rotated, rx.handle);
+    w.startup();
+    await settle();
+    const enrolls = w.calls.filter((c) => c.url.endsWith("/enroll"));
+    assert.strictEqual(enrolls.length, 1, "one re-enrollment");
+    assert.strictEqual(enrolls[0].headers.Authorization, "Bearer aige_second");
+    assert.strictEqual(enrolls[0].body.serial, "C02DEV1/deadbeef", "install id kept: same profile on the receiver");
+    const reports = w.calls.filter((c) => c.url.endsWith("/report"));
+    assert.deepStrictEqual(reports.map((r) => r.headers.Authorization),
+      ["Bearer aigd_revoked", "Bearer aigd_1"], "refused, re-enrolled, retried");
+    assert.ok(local.lastHeartbeat, "the retried heartbeat counts as delivered");
+    assert.strictEqual(local.enrollment.with, "aige_second");
+  }
+
+  // ---- rotation while the credential still works re-stamps "with" --------
+  {
+    const rx = happyReceiver();
+    rx.issued.add("aigd_live");
+    const local = { enrollment: { cred: "aigd_live", installId: "deadbeef", with: "aige_first" } };
+    const w = boot(local, { ...POLICY, authToken: "aige_second" }, rx.handle);
+    w.flag("chatgpt.com");
+    await settle();
+    assert.strictEqual(w.calls.filter((c) => c.url.endsWith("/enroll")).length, 0,
+      "a working credential is not re-enrolled on rotation");
+    assert.strictEqual(local.enrollment.with, "aige_second",
+      "the credential now stands under the current token, so a later revoke sticks");
+    assert.strictEqual(local.enrollment.cred, "aigd_live");
+  }
+
+  // ---- a 200 without a credential is an enrollment failure, not a cred ---
+  {
+    const local = {};
+    const w = boot(local, POLICY, (url) => url.endsWith("/enroll")
+      ? { status: 200, body: { hello: "captive portal" } } : { status: 200 });
+    w.startup();
+    await settle();
+    assert.strictEqual(local.enrollment, undefined, "nothing stored");
+    assert.strictEqual(w.calls.filter((c) => c.url.endsWith("/report")).length, 0, "no report without a credential");
+    assert.strictEqual(local.lastHeartbeat, undefined);
+  }
+
+  // ---- a query string on the endpoint is fine ----------------------------
+  {
+    const rx = happyReceiver();
+    const w = boot({}, { ...POLICY, reportEndpoint: "https://r.example/report?src=ext" }, rx.handle);
+    w.flag("chatgpt.com");
+    await settle();
+    assert.deepStrictEqual(w.calls.map((c) => c.url),
+      ["https://r.example/enroll", "https://r.example/report?src=ext"]);
+  }
+
+  // ---- shared token: unchanged behaviour ---------------------------------
+  {
+    const w = boot({}, { ...POLICY, authToken: "shared-secret" }, () => ({ status: 200 }));
+    w.flag("chatgpt.com");
+    await settle();
+    assert.strictEqual(w.calls.length, 1);
+    assert.strictEqual(w.calls[0].url, "https://r.example/report");
+    assert.strictEqual(w.calls[0].headers.Authorization, "Bearer shared-secret");
+  }
+
+  // ---- endpoint without /report: cannot derive /enroll, nothing is sent ---
+  {
+    const local = {};
+    const w = boot(local, { ...POLICY, reportEndpoint: "https://r.example/ingest" }, () => ({ status: 200 }));
+    w.startup();
+    await settle();
+    assert.strictEqual(w.calls.length, 0, "no enrollment token is ever sent to an unknown path");
+    assert.strictEqual(local.lastHeartbeat, undefined);
+  }
+
+  console.log("ok - enrollment");
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -792,8 +792,9 @@ def status_from(findings):
          "extension/README.md",
          "Push the extension by managed policy (Jamf for Chrome/Edge on macOS, "
          "Intune ADMX on Windows) with the receiver URL and token in the "
-         "managed configuration. Reports which account is signed into an AI "
-         "tool in the browser."),
+         "managed configuration - in managed mode an enrollment token, which "
+         "each browser profile exchanges once for its own credential. Reports "
+         "which account is signed into an AI tool in the browser."),
         ("browser", "paste_guard", "Browser extension: paste guard",
          "extension/README.md",
          "Part of the same extension. Reports pastes it stopped or flagged, "

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -1219,15 +1219,17 @@ async function fleet() {
   return `<h2>Fleet</h2>
   <p class="lede">Enrolled devices, from the receiver's registry — who holds a
   credential, rather than who has reported lately (the Devices view derives
-  that from findings). Revoking stops that one machine's credential on its
-  next request and touches nothing else.</p>
+  that from findings). Revoking stops that one credential on its next
+  request and touches nothing else. A device that re-enrolled (a reimaged
+  laptop, a scanner that enrolls every run — or a serial someone else
+  enrolled while it was silent) keeps its row and says so under "enrolled".</p>
   ${adminBar()}
   ${ds.length ? `<table><tr><th>device</th><th>platform</th><th>serial</th>
     <th>enrolled</th><th>last seen</th><th>agent</th><th>status</th><th></th></tr>
   ${ds.map(d => `<tr>
     <td>${esc(d.hostname || d.serial)}<br><span class="mono" style="font-size:11px;color:var(--mut)">${esc(d.id)}</span></td>
     <td>${esc(d.platform)}</td><td class="mono">${esc(d.serial)}</td>
-    <td>${when(d.enrolled_at)}</td><td>${when(d.last_seen)}</td>
+    <td>${when(d.enrolled_at)}${d.reenrolled_at ? `<br><span style="font-size:11px;color:var(--mut)">re-enrolled ×${esc(String((d.enrollments || 1) - 1))}, last ${when(d.reenrolled_at)}</span>` : ''}</td><td>${when(d.last_seen)}</td>
     <td>${esc(d.agent_version || '—')}</td>
     <td>${d.revoked_at ? '<span class="pill p-mut">revoked</span>'
                        : '<span class="pill p-ok">active</span>'}</td>

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -28,18 +28,25 @@ migration path).
 ### Managed mode
 
 `MANAGED_MODE=true` adds device enrollment on top: an operator mints an
-enrollment token (`aige_...`), puts it in the MDM where the shared token
-goes, and each machine exchanges it once at `/enroll` for its own credential
-(`aigd_...`). One machine can then be revoked without touching any other,
-and the inventory knows who exists rather than inferring it from silence.
+enrollment token (`aige_...`), puts it where the shared token goes - the MDM
+script parameters, the browser extension's managed policy, the scanner's
+Secret - and each endpoint collector, browser profile and scanner exchanges
+it once at `/enroll` for its own credential (`aigd_...`). One of them can
+then be revoked without touching any other, and the inventory knows who
+exists rather than inferring it from silence. Platforms are `macos`, `linux`,
+`windows`, `browser` (one row per managed browser profile: serial is the MDM
+device id plus a per-profile install id) and `scanner` (serial is the
+scanner's configured id). Every authenticated request with a device
+credential - a report or a registry read - stamps the device's `last_seen`,
+and its agent version when the request carries `X-AiGuard-Agent-Version`.
 
 | method | path | auth | what |
 |--------|------|------|------|
-| POST | `/enroll` | enrollment token | exchange for this machine's device credential; same-serial re-enroll supersedes a silent device, 409s an active one |
+| POST | `/enroll` | enrollment token | exchange for this device's own credential; a same-serial re-enroll reissues a silent device's credential in place (same id, old credential dead, `reenrolled_at` and `enrollments` say it happened - the reimaged laptop, or a stateless scanner enrolling every run) and 409s a device seen within the hour. Platform `scanner` is exempt from that guard: it enrolls every run by design |
 | POST | `/admin/enrollment-tokens` | admin | mint (`note`, `ttl_days`, default 180) |
 | GET  | `/admin/enrollment-tokens` | admin | list - ids, notes and expiry, never token material |
 | POST | `/admin/enrollment-tokens/{id}/revoke` | admin | |
-| GET  | `/admin/devices` | admin | the fleet: platform, serial, hostname, last seen, agent version |
+| GET  | `/admin/devices` | admin | the fleet: platform, serial, hostname, enrolled / re-enrolled, last seen, agent version |
 | POST | `/admin/devices/{id}/revoke` | admin | that machine's credential stops working on its next request |
 
 Only SHA-256 hashes of credentials are stored: a copied database file is a

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -541,8 +541,9 @@ def metrics():
 
 
 @app.get("/registry")
-def registry(authorization: str = Header(default="")):
+def registry(request: Request, authorization: str = Header(default="")):
     _auth(authorization)
+    _touch_device(request)
     reg = _load_registry()
     if reg is None:
         raise HTTPException(503, "registry not available")
@@ -550,7 +551,7 @@ def registry(authorization: str = Header(default="")):
 
 
 @app.get("/registry/collector")
-def registry_collector(authorization: str = Header(default="")):
+def registry_collector(request: Request, authorization: str = Header(default="")):
     """cli/ide/desktop/mcp identifiers for the endpoint collectors.
 
     Served so a new AI tool is a registry merge request rather than an edit
@@ -562,6 +563,7 @@ def registry_collector(authorization: str = Header(default="")):
     pre-dates the key ignores it.
     """
     _auth(authorization)
+    _touch_device(request)
     try:
         with open(COLLECTOR_REGISTRY_PATH) as f:
             reg = json.load(f)
@@ -580,6 +582,25 @@ def _auth(authorization: str):
         raise HTTPException(401, "bad token")
 
 
+def _touch_device(request: Request):
+    """Stamp last_seen (and the agent version, when sent) for the device that
+    authenticated this request.
+
+    A device credential is an identity; the shared token is not. Called from
+    every authenticated route, registry reads included, because "seen" should
+    mean seen: discovery only ever reads the registry, and a collector's
+    registry fetch precedes its report. The version travels as a header so
+    the finding schema stays untouched. That stamp is what turns the
+    inventory from inferred-from-silence into one that knows who exists and
+    what they run.
+    """
+    device = getattr(request.state, "device", None)
+    if device is not None and STATE is not None:
+        STATE.touch_device(
+            device["id"], request.headers.get("x-aiguard-agent-version", "")[:32]
+        )
+
+
 def _admin_auth(authorization: str):
     # Defence in depth for /admin/*, like _auth for ingest. 404 when managed
     # mode is off: routes that do not exist should not confirm they exist.
@@ -589,6 +610,14 @@ def _admin_auth(authorization: str):
         authorization.encode("latin-1"), _EXPECTED_ADMIN
     ):
         raise HTTPException(401, "bad token")
+
+
+# What can enroll. The three collector platforms, one browser profile
+# (platform "browser", serial = MDM device id plus a per-profile install id,
+# since one machine legitimately runs several managed profiles), and a scanner
+# (platform "scanner", serial = its configured id). The (platform, serial) key
+# is what keeps a laptop's browser profile from colliding with its collector.
+PLATFORMS = ("macos", "linux", "windows", "browser", "scanner")
 
 
 class EnrollRequest(BaseModel):
@@ -616,8 +645,8 @@ def enroll(req: EnrollRequest, authorization: str = Header(default="")):
     """
     if STATE is None:
         raise HTTPException(404, "Not Found")
-    if req.platform not in ("macos", "linux", "windows"):
-        raise HTTPException(422, "platform must be macos, linux or windows")
+    if req.platform not in PLATFORMS:
+        raise HTTPException(422, "platform must be one of " + ", ".join(PLATFORMS))
     token = authorization[len("Bearer "):] if authorization.startswith("Bearer ") else ""
     try:
         result = STATE.enroll(token, req.platform, req.serial, req.hostname,
@@ -785,17 +814,7 @@ async def _fire_alert(f: Finding):
 @app.post("/flag")  # legacy path, kept for older browser extension versions
 async def report(f: Finding, request: Request, authorization: str = Header(default="")):
     _auth(authorization)
-
-    # A device credential is an identity; the shared token is not. Stamping
-    # last_seen (and the script version, sent as a header so the finding
-    # schema stays untouched) on every authenticated report is what turns
-    # the inventory from inferred-from-silence into one that knows who
-    # exists and what they run.
-    device = getattr(request.state, "device", None)
-    if device is not None and STATE is not None:
-        STATE.touch_device(
-            device["id"], request.headers.get("x-aiguard-agent-version", "")[:32]
-        )
+    _touch_device(request)
 
     if f.surface not in VALID_SURFACES:
         f.surface = "browser"

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -34,12 +34,22 @@ from datetime import datetime, timedelta, timezone
 ENROLL_PREFIX = "aige_"
 DEVICE_PREFIX = "aigd_"
 
-# A device that authenticated a report this recently is alive, and a
-# same-serial enrollment must not displace it silently: that is the stolen
-# token scenario, not the reimaged laptop one. A reimaged machine stops
-# reporting the moment its disk is wiped, so the legitimate case sails
-# through after at most this long.
+# A device that authenticated this recently is alive, and a same-serial
+# enrollment must not displace it silently: that is the stolen token
+# scenario, not the reimaged laptop one. A reimaged machine stops reporting
+# the moment its disk is wiped, so the legitimate case sails through after at
+# most this long. A stateless scanner that enrolls on every run is bound by
+# the same window, which is why a sub-hourly schedule needs a state dir.
 SUPERSEDE_QUIET_SECONDS = 3600
+
+# Platforms whose agents keep no state between runs and so enroll on every
+# run by design. The active guard above would misfire for them: an hourly
+# scanner's previous run is still inside the window when the next starts,
+# and a Job retried after its registry fetch is "actively reporting" itself.
+# For these a same-serial enrollment always reissues. The guard bought at
+# most an hour's delay against a stolen enrollment token anyway; the lever
+# for a scanner is revoking the enrollment token it carries.
+STATELESS_PLATFORMS = ("scanner",)
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS enrollment_tokens (
@@ -69,6 +79,17 @@ CREATE TABLE IF NOT EXISTS events (
   detail TEXT NOT NULL
 );
 """
+
+# Columns added after the first release, applied to databases that predate
+# them. CREATE TABLE IF NOT EXISTS leaves an existing table alone, so a
+# deployment that upgraded keeps its rows and gains the columns here.
+_DEVICE_COLUMNS_ADDED = (
+    # A same-serial re-enrollment reissues the credential in place, so the
+    # row keeps its id; these are the visible trace that it happened (the
+    # reimaged laptop, the stateless scanner - or a displaced device).
+    ("reenrolled_at", "TEXT"),
+    ("enrollments", "INTEGER NOT NULL DEFAULT 1"),
+)
 
 
 def _now() -> str:
@@ -105,6 +126,10 @@ class State:
             self._db.execute("PRAGMA journal_mode=WAL")
             self._db.execute("PRAGMA foreign_keys=ON")
             self._db.executescript(_SCHEMA)
+            have = {r["name"] for r in self._db.execute("PRAGMA table_info(devices)")}
+            for name, decl in _DEVICE_COLUMNS_ADDED:
+                if name not in have:
+                    self._db.execute(f"ALTER TABLE devices ADD COLUMN {name} {decl}")
             self._db.commit()
 
     def _event(self, kind: str, detail: dict):
@@ -173,7 +198,7 @@ class State:
                 " WHERE platform = ? AND serial = ? AND revoked_at IS NULL",
                 (platform, serial),
             ).fetchone()
-            if prior is not None:
+            if prior is not None and platform not in STATELESS_PLATFORMS:
                 quiet_since = (
                     datetime.now(timezone.utc) - timedelta(seconds=SUPERSEDE_QUIET_SECONDS)
                 ).isoformat()
@@ -189,21 +214,39 @@ class State:
                     raise EnrollError(
                         409, "a device with this serial is actively reporting; revoke it first"
                     )
-                self._db.execute(
-                    "UPDATE devices SET revoked_at = ? WHERE id = ?", (now, prior["id"]),
-                )
-                self._event("superseded", {"old": prior["id"], "serial": serial})
 
             cred = DEVICE_PREFIX + secrets.token_urlsafe(32)
-            did = secrets.token_hex(8)
-            self._db.execute(
-                "INSERT INTO devices (id, platform, serial, hostname, cred_hash,"
-                " enrolled_at, enrolled_with, agent_version)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (did, platform, serial, hostname, _hash(cred), now, row["id"], agent_version),
-            )
-            self._event("enrolled", {"device": did, "platform": platform,
-                                     "serial": serial, "with": row["id"]})
+            if prior is not None:
+                # Reissue in place: same device, new credential. The old one
+                # is dead the instant the hash is replaced, which is the same
+                # property revoke-and-insert had, but the device keeps its id
+                # across a reimage and a stateless scanner that enrolls on
+                # every run does not leave a revoked row behind each time.
+                # enrolled_at stays the first enrollment; reenrolled_at and
+                # the count are the operator-visible trace, in place of the
+                # revoked row that used to sit beside the new one. A
+                # *manually* revoked row is not a prior here (revoked_at set),
+                # so it stays as history and a fresh row is made instead.
+                did = prior["id"]
+                self._db.execute(
+                    "UPDATE devices SET hostname = ?, cred_hash = ?, reenrolled_at = ?,"
+                    " enrollments = enrollments + 1, enrolled_with = ?, agent_version = ?"
+                    " WHERE id = ?",
+                    (hostname, _hash(cred), now, row["id"], agent_version, did),
+                )
+                self._event("reenrolled", {"device": did, "platform": platform,
+                                           "serial": serial, "with": row["id"]})
+            else:
+                did = secrets.token_hex(8)
+                self._db.execute(
+                    "INSERT INTO devices (id, platform, serial, hostname, cred_hash,"
+                    " enrolled_at, enrolled_with, agent_version)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                    (did, platform, serial, hostname, _hash(cred), now, row["id"],
+                     agent_version),
+                )
+                self._event("enrolled", {"device": did, "platform": platform,
+                                         "serial": serial, "with": row["id"]})
             self._db.commit()
         return {"device_id": did, "device_token": cred}
 
@@ -239,7 +282,7 @@ class State:
         with self._lock:
             rows = self._db.execute(
                 "SELECT id, platform, serial, hostname, enrolled_at, enrolled_with,"
-                " last_seen, agent_version, revoked_at"
+                " reenrolled_at, enrollments, last_seen, agent_version, revoked_at"
                 " FROM devices ORDER BY enrolled_at DESC"
             ).fetchall()
         return [dict(r) for r in rows]

--- a/receiver/tests/test_managed.py
+++ b/receiver/tests/test_managed.py
@@ -115,6 +115,29 @@ def test_device_credential_reads_the_registry(managed, tmp_path, monkeypatch):
     assert resp.status_code == 200
 
 
+def test_a_registry_read_counts_as_seen(managed, tmp_path, monkeypatch):
+    """Discovery only ever reads the registry, and a collector's registry
+    fetch precedes its report. Either should show the device alive, with the
+    version it sent, rather than leaving last_seen empty until a finding."""
+    from app import main
+
+    reg = tmp_path / "collector.json"
+    reg.write_text('{"version": 1}')
+    monkeypatch.setattr(main, "COLLECTOR_REGISTRY_PATH", str(reg))
+
+    enrolled = _enroll(_mint()["token"], platform="linux", serial="srv-1").json()
+    resp = client.get("/registry/collector", headers={
+        "Authorization": f"Bearer {enrolled['device_token']}",
+        "X-AiGuard-Agent-Version": "2.0.1"})
+    assert resp.status_code == 200
+    (d,) = client.get("/admin/devices", headers=ADMIN).json()["devices"]
+    assert d["last_seen"] is not None and d["agent_version"] == "2.0.1"
+
+    # And the 1h active guard sees it: a second enrollment now is the
+    # stolen-token shape, not the reimaged one.
+    assert _enroll(_mint()["token"], platform="linux", serial="srv-1").status_code == 409
+
+
 def test_shared_token_still_works_in_managed_mode(managed):
     """The migration path: unenrolled machines keep reporting."""
     resp = client.post("/report", headers=AUTH,
@@ -168,22 +191,87 @@ def test_token_listing_carries_no_secrets(managed):
     assert all(t["expires_at"] for t in tokens)  # what an operator judges by
 
 
-# ------------------------------------------------------------ supersession --
+# ------------------------------------------------------------ re-enrollment --
 
 
-def test_a_silent_device_is_superseded_by_reenrollment(managed):
-    """The reimaged laptop: its old record is revoked, its new one works, and
-    nobody had to notice the machine never said goodbye."""
+def test_a_silent_device_is_reissued_in_place_by_reenrollment(managed):
+    """The reimaged laptop, and the stateless scanner that enrolls every run:
+    same device id, new credential, and no revoked row left behind. The old
+    credential is dead the instant the new one exists."""
     token = _mint()["token"]
-    first = _enroll(token).json()
-    second = _enroll(token).json()
-    assert second["device_id"] != first["device_id"]
+    first = _enroll(token, hostname="old-name").json()
+    second = _enroll(token, hostname="new-name", agent_version="2.1.0").json()
+    assert second["device_id"] == first["device_id"]
+    assert second["device_token"] != first["device_token"]
 
-    # Old credential dead, new one live.
     assert client.post("/report", json={"tool": "x"}, headers={
         "Authorization": f"Bearer {first['device_token']}"}).status_code == 401
     assert client.post("/report", json={"tool": "x"}, headers={
         "Authorization": f"Bearer {second['device_token']}"}).status_code == 200
+
+    devices = client.get("/admin/devices", headers=ADMIN).json()["devices"]
+    assert len(devices) == 1  # one row, not one per run
+    assert devices[0]["hostname"] == "new-name"
+    assert devices[0]["agent_version"] == "2.1.0"
+    assert devices[0]["revoked_at"] is None
+    # The visible trace that a re-enrollment happened, for the operator who
+    # would otherwise see one tidy row where a device was displaced.
+    assert devices[0]["enrollments"] == 2 and devices[0]["reenrolled_at"] is not None
+    kinds = [r["kind"] for r in managed._db.execute("SELECT kind FROM events")]
+    assert kinds.count("enrolled") == 1 and "reenrolled" in kinds
+
+
+def test_a_stateless_scanner_reenrolls_even_while_active(managed):
+    """A scanner keeps nothing between runs and enrolls every time. An hourly
+    schedule, or a Job retried after its registry fetch, would trip the
+    active guard that protects laptops; for scanners it always reissues."""
+    token = _mint()["token"]
+    first = _enroll(token, platform="scanner", serial="nightly").json()
+    client.post("/report", json={"tool": "x"}, headers={
+        "Authorization": f"Bearer {first['device_token']}"})  # active right now
+    second = _enroll(token, platform="scanner", serial="nightly")
+    assert second.status_code == 200
+    assert second.json()["device_id"] == first["device_id"]
+
+
+def test_a_database_from_before_the_added_columns_is_upgraded(tmp_path):
+    """The homelab has a state.db from 0.9.5. Opening it must add the new
+    device columns and keep every row."""
+    import sqlite3
+    path = tmp_path / "old.db"
+    db = sqlite3.connect(path)
+    db.executescript(state_mod._SCHEMA)
+    db.execute("INSERT INTO enrollment_tokens VALUES ('t1', X'00', '', '2026-01-01', '2027-01-01', NULL)")
+    db.execute("INSERT INTO devices (id, platform, serial, cred_hash, enrolled_at, enrolled_with)"
+               " VALUES ('d1', 'macos', 'S', X'01', '2026-01-01', 't1')")
+    db.commit()
+    # Simulate the pre-upgrade shape by recreating the table without the
+    # added columns.
+    db.executescript("""
+        CREATE TABLE devices_old AS SELECT id, platform, serial, hostname, cred_hash,
+          enrolled_at, enrolled_with, last_seen, agent_version, revoked_at FROM devices;
+        DROP TABLE devices;
+        ALTER TABLE devices_old RENAME TO devices;
+    """)
+    db.commit()
+    db.close()
+
+    st = state_mod.State(str(path))
+    (d,) = st.list_devices()
+    assert d["id"] == "d1" and d["enrollments"] == 1 and d["reenrolled_at"] is None
+
+
+def test_a_manually_revoked_device_stays_as_history_when_it_reenrolls(managed):
+    """Revocation is a deliberate record. The stolen-credential recovery path
+    (revoke, then re-enroll from the real machine) keeps the revoked row and
+    makes a fresh one, so the audit trail still shows what was cut off."""
+    token = _mint()["token"]
+    first = _enroll(token).json()
+    client.post(f"/admin/devices/{first['device_id']}/revoke", headers=ADMIN)
+    second = _enroll(token).json()
+    assert second["device_id"] != first["device_id"]
+    devices = client.get("/admin/devices", headers=ADMIN).json()["devices"]
+    assert sorted(bool(d["revoked_at"]) for d in devices) == [False, True]
 
 
 def test_an_actively_reporting_device_cannot_be_displaced(managed):
@@ -214,6 +302,12 @@ def test_an_actively_reporting_device_cannot_be_displaced(managed):
 def test_enroll_validates_platform_and_caps_the_body(managed):
     token = _mint()["token"]
     assert _enroll(token, platform="solaris").status_code == 422
+    # The non-collector surfaces enroll too, keyed apart by platform so a
+    # laptop's browser profile never collides with its collector.
+    assert _enroll(token, platform="browser", serial="C02TEST/3f9a1c2e").status_code == 200
+    assert _enroll(token, platform="scanner", serial="scanner").status_code == 200
+    assert _enroll(token, platform="macos", serial="C02TEST").status_code == 200
+    assert len(client.get("/admin/devices", headers=ADMIN).json()["devices"]) == 3
     resp = client.post("/enroll",
                        headers={"Authorization": f"Bearer {token}",
                                 "Content-Length": "9999999"})

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -109,6 +109,24 @@ environment variables (receiver URL and token, corporate domain,
 credentials from your Kubernetes Secret or secret store). The `.env`
 mechanism is for local CLI use only; deployed scanners do not use it.
 
+With a receiver in managed mode, `RECEIVER_TOKEN` can be an **enrollment
+token** (`aige_...`) instead of the shared token; the prefix is the switch.
+The run then enrolls as `platform: scanner` with the serial in
+`AIGUARD_SCANNER_ID` (default `scanner`; `discovery` for the discovery job -
+set it per deployment if you run several) and uses the credential it
+receives for the registry fetch and every report, so the scanner shows in
+the portal's Fleet view with a last-seen time and can be revoked on its own.
+A CronJob pod keeps nothing between runs, so by default it enrolls on every
+run and the receiver reissues the same device's credential in place - one
+Fleet row per scanner, not one per run, at any schedule. That also means
+revoking a stateless scanner's row in the Fleet view only cuts the current
+run; the lever for it is the enrollment token it carries (mint one per
+scanner and the lever is precise) or the Secret. Set `AIGUARD_STATE_DIR` to
+a writable volume to keep `device.cred` between runs instead; then the row's
+revoke sticks until you delete that file. A refused enrollment, or a stored
+credential the receiver no longer accepts, is fatal before any scanning and
+names the reason in the job log. `DRY_RUN` never enrolls.
+
 ## Entra app registration
 
 The Entra, Exchange and Intune scanners share one app registration.

--- a/scanner/ai_guard/registry/__init__.py
+++ b/scanner/ai_guard/registry/__init__.py
@@ -92,17 +92,27 @@ class Registry:
     instead of iterating the full service list per event.
     """
 
-    def __init__(self, path: Optional[Path] = None, url: Optional[str] = None):
+    def __init__(self, path: Optional[Path] = None, url: Optional[str] = None,
+                 token: Optional[str] = None):
         self.path = path or REGISTRY_PATH
 
         # When set, the registry is fetched from the receiver rather than read
         # from disk. Pass url="" explicitly to force the bundled copy.
         self.url = url if url is not None else os.environ.get("AIGUARD_REGISTRY_URL", "")
+        # The bearer for that fetch. The entrypoint passes the credential it
+        # resolved for the run (a device credential in managed mode); the CLI
+        # and older callers fall back to the environment as before.
+        self.token = token if token is not None else os.environ.get("RECEIVER_TOKEN", "")
 
         # Which source actually supplied the data. Worth logging: otherwise a
         # silently failing fetch means scanning against a stale registry for
         # weeks without noticing.
         self.source = "bundled"
+        # The HTTP status of a failed fetch, when the failure was an HTTP
+        # status at all. The entrypoint reads it: a 401 on a device
+        # credential means the credential was revoked, which must not be
+        # absorbed into a quiet bundled-registry fallback.
+        self.fetch_status: Optional[int] = None
 
         self.services: list[AIService] = []
         self.bridge_targets: list[BridgeTarget] = []
@@ -128,8 +138,15 @@ class Registry:
         """
         import httpx
 
-        token = os.environ.get("RECEIVER_TOKEN", "")
-        headers = {"Authorization": f"Bearer {token}"} if token else {}
+        headers = {}
+        if self.token:
+            from ai_guard import __version__
+
+            # The version rides on the registry read as on every report, so a
+            # managed-mode receiver's inventory knows what a scanner runs even
+            # on a run that finds nothing to report.
+            headers = {"Authorization": f"Bearer {self.token}",
+                       "X-AiGuard-Agent-Version": __version__}
         try:
             response = httpx.get(self.url, headers=headers, timeout=15)
             response.raise_for_status()
@@ -137,6 +154,7 @@ class Registry:
             self.source = self.url
             return data
         except Exception as e:  # noqa: BLE001 - any failure means fall back
+            self.fetch_status = getattr(getattr(e, "response", None), "status_code", None)
             logger.warning(
                 "Using bundled registry fallback; detection coverage may be reduced"
             )

--- a/scanner/entrypoint.py
+++ b/scanner/entrypoint.py
@@ -11,7 +11,13 @@ Differs from `ai-guard scan` on a laptop in three ways:
 
 Environment:
   RECEIVER_URL           http://ai-guard-receiver.<namespace>.svc.cluster.local
-  RECEIVER_TOKEN         bearer token, same secret the extension uses
+  RECEIVER_TOKEN         the shared bearer token, or an enrollment token
+                         (aige_...) from a managed-mode receiver: the run then
+                         enrolls as a scanner and reports with its own credential
+  AIGUARD_SCANNER_ID     this scanner's identity on the receiver (default
+                         "scanner"; set per deployment if you run several)
+  AIGUARD_STATE_DIR      optional writable dir that keeps the device credential
+                         between runs (device.cred); unset means enroll per run
   AIGUARD_REGISTRY_URL   $RECEIVER_URL/registry  (set by the CronJob)
   CORPORATE_DOMAIN       example.com
   AIGUARD_*              scanner credentials, from the ai-guard-scanner secret
@@ -19,7 +25,7 @@ Environment:
 
 Exit codes:
   0  scan completed, findings reported (or none found)
-  1  no scanner could run, or any finding failed to report
+  1  enrollment refused, no scanner could run, or any finding failed to report
 """
 from __future__ import annotations
 
@@ -39,7 +45,8 @@ from ai_guard.scanners.intune import IntuneScanner
 from ai_guard.scanners.jamf import JAMFScanner
 from ai_guard.scanners.sentinelone import SentinelOneScanner
 
-from receiver_reporter import ReceiverReporter
+from receiver_reporter import (DEVICE_PREFIX, ENROLL_PREFIX, EnrollmentError,
+                               ReceiverReporter, resolve_credential)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -64,7 +71,36 @@ async def run() -> int:
     policy_path = Path(os.environ.get("POLICY_PATH", "policy.yaml"))
     config = Config.from_file(policy_path) if policy_path.exists() else Config.default()
 
-    registry = Registry()  # picks up AIGUARD_REGISTRY_URL from the environment
+    # The bearer for the whole run: the registry fetch and every report. In
+    # managed mode this is where the scanner enrolls; refused is fatal before
+    # any scanning, so the CronJob fails rather than reporting nothing. A dry
+    # run does not enroll: it would reissue the real scanner's credential in
+    # place (or 409 against it), and printing payloads needs no identity.
+    token = os.environ.get("RECEIVER_TOKEN", "")
+    if DRY_RUN:
+        if token.startswith(ENROLL_PREFIX):
+            log.info("dry run: not enrolling; the registry fetch will fall back to the bundled copy")
+    else:
+        try:
+            token = resolve_credential(
+                os.environ.get("RECEIVER_URL", ""), token,
+                os.environ.get("AIGUARD_SCANNER_ID", "scanner"),
+            )
+        except EnrollmentError as e:
+            log.error("%s", e)
+            return 1
+
+    registry = Registry(token=token)  # picks up AIGUARD_REGISTRY_URL from the environment
+    if registry.fetch_status == 401 and token.startswith(DEVICE_PREFIX):
+        # The stored credential was revoked (or reissued elsewhere). The
+        # registry fallback would let the run carry on, find nothing, and
+        # exit 0 - a dead scanner with a green CronJob. Loud and fatal instead,
+        # and never re-enrolled from here: the operator deletes the stored
+        # credential to enroll again.
+        log.error("the receiver refused this scanner's device credential (revoked?);"
+                  " delete device.cred under AIGUARD_STATE_DIR and supply a valid"
+                  " enrollment token to re-enroll")
+        return 1
     log.info(
         "registry loaded from %s: %d services, %d bridge targets",
         registry.source,
@@ -112,7 +148,7 @@ async def run() -> int:
         log.info("scan complete: no findings")
         return 0
 
-    reporter = ReceiverReporter(dry_run=DRY_RUN)
+    reporter = ReceiverReporter(token=token, dry_run=DRY_RUN)
     sent, failed = reporter.send(all_findings)
 
     if DRY_RUN:

--- a/scanner/receiver_reporter.py
+++ b/scanner/receiver_reporter.py
@@ -31,14 +31,117 @@ import json
 import logging
 import os
 import re
+import socket
 import unicodedata
 from typing import Optional
 
 import httpx
 
+from ai_guard import __version__ as AGENT_VERSION
 from ai_guard.scanners.base import DetectionSource, Finding, occurrence_unit
 
 logger = logging.getLogger(__name__)
+
+# Managed mode. RECEIVER_TOKEN may be an enrollment token (aige_...) from a
+# managed-mode receiver instead of the shared token: the run then exchanges it
+# at /enroll for this scanner's own device credential (aigd_...) and uses that
+# for the registry fetch and every report. The prefix is the switch, the same
+# contract as the endpoint collectors and the browser extension, so the
+# operator changes one Secret value when ready.
+#
+# A CronJob pod has no disk of its own, so by default the scanner enrolls on
+# every run: the receiver reissues the same device's credential in place
+# (platform "scanner", serial AIGUARD_SCANNER_ID, exempt from the one-hour
+# active guard that protects laptops), so the fleet shows one row per scanner,
+# not one per run. Set AIGUARD_STATE_DIR to a writable volume to keep the
+# credential between runs instead; then revoking the scanner's row in the
+# fleet view sticks, whereas a stateless scanner simply enrolls again next run
+# and the lever for it is revoking the enrollment token it carries.
+ENROLL_PREFIX = "aige_"
+DEVICE_PREFIX = "aigd_"
+CRED_FILENAME = "device.cred"
+
+
+class EnrollmentError(Exception):
+    """Enrollment was refused or the credential could not be kept. Fatal
+    before any scanning: an enrollment token cannot report findings, so
+    carrying on would 401 every POST and look like a clean estate."""
+
+
+def resolve_credential(
+    url: str,
+    token: str,
+    scanner_id: str,
+    state_dir: Optional[str] = None,
+    timeout: float = 15.0,
+) -> str:
+    """The bearer this run reports with.
+
+    A stored device credential wins; an enrollment token is exchanged for
+    one; anything else is used as-is (the shared token, classic mode).
+    """
+    if not token.startswith(ENROLL_PREFIX):
+        return token
+    if state_dir is None:
+        state_dir = os.environ.get("AIGUARD_STATE_DIR", "")
+    cred_path = os.path.join(state_dir, CRED_FILENAME) if state_dir else ""
+
+    if cred_path and os.path.exists(cred_path):
+        try:
+            with open(cred_path) as f:
+                stored = f.read().strip()
+        except OSError as e:
+            # A volume written under another uid, typically. Named, not a
+            # traceback: it is the same class of deployment mistake as an
+            # unwritable state dir.
+            raise EnrollmentError(f"cannot read {cred_path} ({e.strerror})") from e
+        if stored.startswith(DEVICE_PREFIX):
+            return stored
+        logger.warning("%s does not hold a device credential; enrolling again", cred_path)
+
+    body = {
+        "platform": "scanner",
+        "serial": scanner_id,
+        "hostname": socket.gethostname(),
+        "agent_version": AGENT_VERSION,
+    }
+    try:
+        r = httpx.post(f"{url.rstrip('/')}/enroll", json=body, timeout=timeout,
+                       headers={"Authorization": f"Bearer {token}"})
+    except httpx.HTTPError as e:
+        raise EnrollmentError(f"enrollment failed: {type(e).__name__} reaching {url}") from e
+    if r.status_code != 200:
+        detail = ""
+        try:
+            detail = r.json().get("detail", "")
+        except ValueError:
+            pass
+        raise EnrollmentError(
+            f"enrollment failed: HTTP {r.status_code} from {url.rstrip('/')}/enroll"
+            + (f": {detail}" if detail else "")
+        )
+    cred = r.json().get("device_token", "")
+    if not cred.startswith(DEVICE_PREFIX):
+        raise EnrollmentError("enrollment failed: receiver returned no device credential")
+
+    if cred_path:
+        # Loud and fatal, like the collectors: a run that enrolled but could
+        # not keep the credential would enroll again next time, and an
+        # unwritable state dir is a deployment mistake to fix, not to mask.
+        try:
+            os.makedirs(state_dir, exist_ok=True)
+            fd = os.open(cred_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w") as f:
+                f.write(cred)
+        except OSError as e:
+            raise EnrollmentError(
+                f"enrolled, but cannot write {cred_path} ({e.strerror}); refusing to scan:"
+                " the credential would be lost and every run would re-enroll"
+            ) from e
+        logger.info("enrolled as scanner %r; credential stored in %s", scanner_id, cred_path)
+    else:
+        logger.info("enrolled as scanner %r for this run (no AIGUARD_STATE_DIR)", scanner_id)
+    return cred
 
 # DetectionSource -> (surface, os). Surfaces match the receiver's vocabulary:
 # browser, cli, ide, desktop, mcp, cloud.
@@ -221,7 +324,10 @@ class ReceiverReporter:
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
+            # So the receiver's inventory knows which scanner version reported.
+            "X-AiGuard-Agent-Version": AGENT_VERSION,
         }
+        revoked_said = False
         with httpx.Client(timeout=self.timeout) as client:
             for f in findings:
                 body = {k: v for k, v in self.payload(f).items() if v is not None}
@@ -232,4 +338,16 @@ class ReceiverReporter:
                 except httpx.HTTPError as e:
                     failed += 1
                     logger.warning("receiver: %s (%s)", e, body.get("tool"))
+                    status = getattr(getattr(e, "response", None), "status_code", None)
+                    if (status == 401 and self.token.startswith(DEVICE_PREFIX)
+                            and not revoked_said):
+                        # Said once, not per finding. Never re-enrolled from
+                        # here: a revoked scanner must be visible in the job
+                        # log, and the operator removes the stored credential
+                        # (or the state dir) to enroll it again.
+                        revoked_said = True
+                        logger.error(
+                            "this scanner's device credential was refused (revoked?);"
+                            " delete %s under AIGUARD_STATE_DIR and supply a valid"
+                            " enrollment token to re-enroll", CRED_FILENAME)
         return sent, failed

--- a/scanner/tests/test_enrollment.py
+++ b/scanner/tests/test_enrollment.py
@@ -1,0 +1,171 @@
+"""Managed mode: RECEIVER_TOKEN may be an enrollment token.
+
+The prefix is the switch, as for the collectors and the extension. The run
+exchanges it once for a device credential, keeps it when a state dir is
+given, uses it for the registry fetch and every report, and is loud and
+fatal when the receiver refuses - an enrollment token cannot report, so a
+scan that carried on would look like a clean estate.
+"""
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import receiver_reporter as rr
+from ai_guard.registry import Registry
+
+
+class FakeReceiver:
+    """Records every request; enrolls anyone with an aige_ bearer."""
+
+    def __init__(self, enroll_status=200):
+        self.requests = []
+        self.enroll_status = enroll_status
+        self.issued = 0
+        self.live = set()
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        bearer = request.headers.get("authorization", "").removeprefix("Bearer ")
+        if request.url.path == "/enroll":
+            if not bearer.startswith("aige_"):
+                return httpx.Response(401, json={"detail": "bad token"})
+            if self.enroll_status != 200:
+                return httpx.Response(self.enroll_status, json={"detail": "refused"})
+            self.issued += 1
+            self.live.add(f"aigd_{self.issued}")
+            return httpx.Response(200, json={"device_id": "d1",
+                                             "device_token": f"aigd_{self.issued}"})
+        if bearer in self.live or bearer == "shared":
+            return httpx.Response(200, json={"ok": True})
+        return httpx.Response(401, json={"detail": "bad token"})
+
+
+@pytest.fixture
+def receiver(monkeypatch):
+    rx = FakeReceiver()
+    transport = httpx.MockTransport(rx.handler)
+    real_client = httpx.Client
+    # Route module-level httpx.post/get and Client() through the fake.
+    monkeypatch.setattr(httpx, "post", lambda url, **kw: real_client(transport=transport).post(url, **kw))
+    monkeypatch.setattr(httpx, "get", lambda url, **kw: real_client(transport=transport).get(url, **kw))
+    monkeypatch.setattr(httpx, "Client", lambda **kw: real_client(transport=transport, **kw))
+    return rx
+
+
+def test_a_shared_token_is_used_as_is(receiver):
+    assert rr.resolve_credential("https://r.example", "shared", "scanner", state_dir="") == "shared"
+    assert receiver.requests == []
+
+
+def test_an_enrollment_token_is_exchanged_for_a_device_credential(receiver, monkeypatch):
+    monkeypatch.setattr(rr.socket, "gethostname", lambda: "scanner-pod-1")
+    cred = rr.resolve_credential("https://r.example/", "aige_x", "nightly", state_dir="")
+    assert cred == "aigd_1"
+    (req,) = receiver.requests
+    assert req.url == "https://r.example/enroll"
+    assert req.headers["authorization"] == "Bearer aige_x"
+    import json
+    body = json.loads(req.content)
+    assert body == {"platform": "scanner", "serial": "nightly",
+                    "hostname": "scanner-pod-1", "agent_version": rr.AGENT_VERSION}
+
+
+def test_a_state_dir_keeps_the_credential_between_runs(receiver, tmp_path):
+    first = rr.resolve_credential("https://r.example", "aige_x", "scanner", state_dir=str(tmp_path))
+    second = rr.resolve_credential("https://r.example", "aige_x", "scanner", state_dir=str(tmp_path))
+    assert first == second == "aigd_1"
+    assert receiver.issued == 1, "the second run read device.cred instead of enrolling"
+    cred_file = tmp_path / "device.cred"
+    assert cred_file.read_text() == "aigd_1"
+    assert (cred_file.stat().st_mode & 0o777) == 0o600
+
+
+def test_without_a_state_dir_every_run_enrolls(receiver):
+    rr.resolve_credential("https://r.example", "aige_x", "scanner", state_dir="")
+    rr.resolve_credential("https://r.example", "aige_x", "scanner", state_dir="")
+    assert receiver.issued == 2  # the receiver reissues in place; one fleet row
+
+
+def test_a_refused_enrollment_is_fatal_and_names_the_status(receiver):
+    receiver.enroll_status = 401
+    with pytest.raises(rr.EnrollmentError) as e:
+        rr.resolve_credential("https://r.example", "aige_x", "scanner", state_dir="")
+    assert "HTTP 401" in str(e.value) and "refused" in str(e.value)
+
+
+def test_an_unreadable_stored_credential_is_named_not_a_traceback(receiver, tmp_path):
+    cred = tmp_path / "device.cred"
+    cred.write_text("aigd_stored")
+    cred.chmod(0o000)
+    try:
+        with pytest.raises(rr.EnrollmentError) as e:
+            rr.resolve_credential("https://r.example", "aige_x", "scanner", state_dir=str(tmp_path))
+        assert "cannot read" in str(e.value)
+    finally:
+        cred.chmod(0o600)
+
+
+def test_a_registry_fetch_refused_on_a_device_credential_is_visible(receiver):
+    """The entrypoint turns this into exit 1. Without it a revoked scanner
+    would scan against the bundled registry, find nothing, and exit 0."""
+    reg = Registry(url="https://r.example/registry", token="aigd_revoked")
+    assert reg.fetch_status == 401
+    assert reg.source.startswith("bundled")
+
+
+def test_an_unwritable_state_dir_is_fatal(receiver, tmp_path):
+    ro = tmp_path / "ro"
+    ro.mkdir()
+    ro.chmod(0o500)
+    try:
+        with pytest.raises(rr.EnrollmentError) as e:
+            rr.resolve_credential("https://r.example", "aige_x", "scanner", state_dir=str(ro))
+        assert "refusing to scan" in str(e.value)
+    finally:
+        ro.chmod(0o700)
+
+
+def test_the_resolved_credential_reaches_the_registry_and_every_report(receiver):
+    """The same bearer for both requests. A credential that can report but
+    not fetch the registry would scan against nothing."""
+    from ai_guard.scanners.base import DetectionSource, Finding
+    from ai_guard.registry import AIService
+
+    cred = rr.resolve_credential("https://r.example", "aige_x", "scanner", state_dir="")
+    # Registry() falls back to the bundled copy if the fetch fails; what is
+    # asserted here is the request it made, not the JSON it got back.
+    Registry(url="https://r.example/registry", token=cred)
+    reporter = rr.ReceiverReporter(url="https://r.example", token=cred)
+    svc = AIService(name="ChatGPT", vendor="OpenAI", category="chat", risk_tier="high",
+                    id="chatgpt")
+    finding = Finding(service=svc, source=DetectionSource.JAMF_APP, risk_tier="high", detail="present",
+                      device_name="C02TEST")
+    sent, failed = reporter.send([finding])
+    assert (sent, failed) == (1, 0)
+
+    paths = [r.url.path for r in receiver.requests]
+    assert paths == ["/enroll", "/registry", "/report"]
+    for r in receiver.requests[1:]:
+        assert r.headers["authorization"] == "Bearer aigd_1"
+        assert r.headers["x-aiguard-agent-version"] == rr.AGENT_VERSION
+
+
+def test_a_revoked_credential_fails_the_report_and_says_why(receiver, caplog):
+    from ai_guard.scanners.base import DetectionSource, Finding
+    from ai_guard.registry import AIService
+
+    reporter = rr.ReceiverReporter(url="https://r.example", token="aigd_revoked")
+    svc = AIService(name="ChatGPT", vendor="OpenAI", category="chat", risk_tier="high",
+                    id="chatgpt")
+    finding = Finding(service=svc, source=DetectionSource.JAMF_APP, risk_tier="high", detail="present",
+                      device_name="C02TEST")
+    sent, failed = reporter.send([finding, finding])
+    assert (sent, failed) == (0, 2)
+    revoked = [r for r in caplog.records if "revoked" in r.getMessage()]
+    assert len(revoked) == 1, "said once, not per finding"
+    assert not any(r.url.path == "/enroll" for r in receiver.requests), "never re-enrolls on its own"


### PR DESCRIPTION
Every surface that talks to the receiver can now carry an enrollment token in place of the shared AUTH_TOKEN and exchange it for a credential of its own. The prefix is the switch on all of them, as it already was for the endpoint collectors.

Receiver: /enroll accepts platforms browser and scanner. A same-serial re-enrollment of a silent device reissues its credential in place (same device id, old credential dead) instead of revoking and inserting, with reenrolled_at and an enrollment count as the visible trace (ALTER TABLE migration for existing state files); manually revoked rows stay as history. Platform scanner is exempt from the one-hour active guard, since a stateless scanner enrolls on every run by design. Registry reads stamp last_seen too, because discovery only ever reads the registry.

Extension 1.4.0: authToken may be an aige_ token; the profile enrolls at <endpoint minus /report>/enroll with a serial of <deviceIdentifier>/<per- profile install id> so several managed profiles on one machine do not displace each other, keeps the credential in storage.local, sends X-AiGuard-Agent-Version, and re-enrolls after a 401 only when the policy carries a token rotated after the revoke.

Scanners and discovery: RECEIVER_TOKEN may be an aige_ token; the run enrolls as platform scanner (AIGUARD_SCANNER_ID), optionally keeps the credential under AIGUARD_STATE_DIR, uses it for the registry fetch and every report, and is loud and fatal - never silently fallen back - when a stored credential is refused. Dry runs never enroll.