### PR TITLE
the shared token's off-switch: REQUIRE_DEVICE_CREDENTIALS

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.8.9
+version: 0.8.10
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/README.md
+++ b/charts/ai-guard/README.md
@@ -125,6 +125,7 @@ the portal.
 | `managed.adminToken.existingSecret` | `""` | a Secret you created yourself, key `adminToken` |
 | `managed.persistence.size` | `1Gi` | the state PVC. Annotated `helm.sh/resource-policy: keep`: uninstalling the chart does not unenroll the fleet |
 | `managed.persistence.existingClaim` | `""` | use a PVC you created yourself |
+| `managed.requireDeviceCredentials` | `false` | the shared token's off-switch, once every surface has enrolled: ingest accepts device credentials only and refuses the shared token with a 401 that says "enroll". Flip it back and unenrolled machines report again |
 | `portal.receiverUrl` | receiver service | managed mode: where the portal proxies admin actions; defaults to the chart's own receiver service |
 | `portal.receiverPublicUrl` | ingress host | managed mode: the ingest URL baked into downloaded deployment artifacts; defaults to the receiver ingress host when one is enabled |
 | `registry.create` | `true` | ship the compiled registry as a ConfigMap |

--- a/charts/ai-guard/templates/deployment.yaml
+++ b/charts/ai-guard/templates/deployment.yaml
@@ -88,6 +88,10 @@ spec:
             {{- if .Values.managed.enabled }}
             - name: MANAGED_MODE
               value: "true"
+            {{- if .Values.managed.requireDeviceCredentials }}
+            - name: REQUIRE_DEVICE_CREDENTIALS
+              value: "true"
+            {{- end }}
             - name: STATE_DB_PATH
               value: /var/lib/ai-guard/state.db
             - name: ADMIN_TOKEN

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -93,6 +93,13 @@ managed:
     size: 1Gi
     storageClass: ""     # empty means the cluster default
     existingClaim: ""    # use a PVC you created yourself
+  # The off-switch for the shared token, once every collector, browser
+  # profile and scanner has enrolled: /report and /registry then accept
+  # device credentials only, and the shared token is refused with a 401 that
+  # says "enroll". The final step of the migration, not a mode - flip it back
+  # and unenrolled machines report again. The shared token Secret stays
+  # (the receiver still requires it at startup); it just stops being accepted.
+  requireDeviceCredentials: false
 
 # The compiled registry ships with the chart, so the receiver has an
 # identifier list on first install with nothing to build. Set create: false to

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -211,7 +211,8 @@ in `secrets/auth_token`. That token goes into your MDM script parameters, your
 managed browser configuration, and your scanner environment. With the managed
 overlay, an enrollment token minted in the portal goes in those same places
 instead, and each collector, browser profile and scanner exchanges it once for a
-credential of its own.
+credential of its own; `REQUIRE_DEVICE_CREDENTIALS=true` in `.env` then turns
+the shared token off for ingest once everything has enrolled.
 
 The portal authenticates separately with HTTP basic auth, and **refuses to start
 without it**. It names who runs what on which machine, so coming up open because

--- a/deploy/compose/docker-compose.managed.yml
+++ b/deploy/compose/docker-compose.managed.yml
@@ -27,6 +27,11 @@ services:
       MANAGED_MODE: "true"
       ADMIN_TOKEN_FILE: /run/secrets/admin_token
       STATE_DB_PATH: /var/lib/ai-guard/state.db
+      # Once every collector, browser profile and scanner has enrolled, set
+      # REQUIRE_DEVICE_CREDENTIALS=true in .env: the shared token is then
+      # refused for ingest (with a 401 that says "enroll"), and only device
+      # credentials report. Flip it back and unenrolled machines report again.
+      REQUIRE_DEVICE_CREDENTIALS: ${REQUIRE_DEVICE_CREDENTIALS:-false}
     volumes:
       - managed-state:/var/lib/ai-guard
       - ./secrets/admin_token:/run/secrets/admin_token:ro

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -140,7 +140,9 @@ Optional, all off by default:
   the same `/admin` API with curl. Enrollment tokens go wherever the shared
   token goes today - collector parameters, the extension's managed policy,
   the scanner Secret - one surface at a time; each enrolls and holds its own
-  credential. See the receiver and portal READMEs for the details.
+  credential. Once every surface has, `managed.requireDeviceCredentials:
+  true` turns the shared token off for ingest. See the receiver and portal
+  READMEs for the details.
 
 Confirm it is up:
 

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -39,6 +39,8 @@ device id plus a per-profile install id) and `scanner` (serial is the
 scanner's configured id). Every authenticated request with a device
 credential - a report or a registry read - stamps the device's `last_seen`,
 and its agent version when the request carries `X-AiGuard-Agent-Version`.
+When every surface has enrolled, `REQUIRE_DEVICE_CREDENTIALS=true` turns the
+shared token off for ingest (see the configuration table).
 
 | method | path | auth | what |
 |--------|------|------|------|
@@ -75,6 +77,7 @@ Everything is environment variables. Only the token is required.
 | `MANAGED_MODE` | unset | `true` enables device enrollment, per-device credentials, revocation and a fleet inventory (see below). Unset means byte-for-byte the classic receiver: no state file, `/enroll` and `/admin/*` answer 404 |
 | `ADMIN_TOKEN` | required in managed mode | the credential that mints and revokes enrollment tokens and devices. Deliberately a separate secret from `AUTH_TOKEN`, which sits on every machine in the fleet - which is exactly why it must not be able to mint credentials |
 | `STATE_DB_PATH` | `/var/lib/ai-guard/state.db` | where the managed-mode SQLite file lives. The one non-disposable thing: it holds the device registry and its credential hashes |
+| `REQUIRE_DEVICE_CREDENTIALS` | unset | managed mode only: `true` turns the shared token off for ingest. `/report` and `/registry` accept device credentials only; the shared token gets a 401 that says "enroll". The final step of the migration once every surface has enrolled, not a mode - unset it and unenrolled machines report again. Refuses to start without `MANAGED_MODE` |
 
 Any of these can be given as `NAME_FILE` pointing at a file instead:
 `AUTH_TOKEN_FILE=/run/secrets/auth_token` rather than `AUTH_TOKEN`. That

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -125,7 +125,10 @@ def _ingest_token_ok(header: str) -> tuple[bool, dict | None]:
     constant-time scan.
     """
     if _token_ok(header):
-        return True, None
+        # The shared token: the estate's anonymous credential - until the
+        # operator turns it off, at which point it is a known string that
+        # is no longer a credential at all.
+        return (not REQUIRE_DEVICE_CREDENTIALS), None
     if STATE is not None and header.startswith("Bearer " + _state.DEVICE_PREFIX):
         dev = STATE.device_for(header[len("Bearer "):])
         if dev is not None:
@@ -246,6 +249,21 @@ if MANAGED_MODE:
     # mint credentials.
     _EXPECTED_ADMIN = b"Bearer " + _secret("ADMIN_TOKEN").encode()
     STATE = _state.State(os.environ.get("STATE_DB_PATH", "/var/lib/ai-guard/state.db"))
+
+# The off-switch for the shared token, once every surface has enrolled: with
+# this set, /report and /registry accept device credentials only and the
+# shared AUTH_TOKEN is refused with a 401 that says so. It is the final step
+# of a migration, not a mode: flip it back and unenrolled machines report
+# again. Meaningless without managed mode - there would be no other credential
+# to require - so that combination is a startup error rather than a receiver
+# that silently rejects everything.
+REQUIRE_DEVICE_CREDENTIALS = os.environ.get(
+    "REQUIRE_DEVICE_CREDENTIALS", "").lower() in ("1", "true", "yes")
+if REQUIRE_DEVICE_CREDENTIALS and not MANAGED_MODE:
+    raise SystemExit(
+        "REQUIRE_DEVICE_CREDENTIALS needs MANAGED_MODE=true: without enrollment"
+        " there is no credential to require"
+    )
 
 # "network" is a DNS/flow observation from SentinelOne: a device resolved a
 # domain, but the resolving process may be a browser, a desktop app, a CLI or
@@ -454,9 +472,15 @@ async def authenticate_before_reading(request: Request, call_next):
     """
     path = request.url.path
     if path.startswith(_PROTECTED):
-        ok, device = _ingest_token_ok(request.headers.get("authorization", ""))
+        auth = request.headers.get("authorization", "")
+        ok, device = _ingest_token_ok(auth)
         if not ok:
-            return JSONResponse({"detail": "bad token"}, status_code=401)
+            # Named when it is the shared token being turned away: the
+            # straggler's MDM log should say "enroll", not "bad token".
+            detail = ("shared token not accepted: this receiver requires device"
+                      " credentials; enroll with an enrollment token"
+                      if REQUIRE_DEVICE_CREDENTIALS and _token_ok(auth) else "bad token")
+            return JSONResponse({"detail": detail}, status_code=401)
         # Which device authenticated, for /report to stamp last_seen. None
         # when the shared token did, which is not an identity.
         request.state.device = device

--- a/receiver/tests/test_managed.py
+++ b/receiver/tests/test_managed.py
@@ -296,6 +296,52 @@ def test_an_actively_reporting_device_cannot_be_displaced(managed):
     assert _enroll(token).status_code == 200
 
 
+# ------------------------------------------------------ the off-switch --
+
+
+def test_requiring_device_credentials_turns_the_shared_token_away(managed, monkeypatch,
+                                                                  tmp_path):
+    """The final step of the migration: once every surface has enrolled, the
+    shared token stops being a credential. Device credentials, enrollment and
+    admin all keep working; the refusal names itself so a straggler's MDM
+    log says enroll rather than bad token."""
+    from app import main
+
+    reg = tmp_path / "collector.json"
+    reg.write_text('{"version": 1}')
+    monkeypatch.setattr(main, "COLLECTOR_REGISTRY_PATH", str(reg))
+
+    cred = _enroll(_mint()["token"]).json()["device_token"]
+    monkeypatch.setattr(main, "REQUIRE_DEVICE_CREDENTIALS", True)
+
+    for path, call, kw in (("/report", client.post, {"json": {"tool": "x"}}),
+                           ("/registry/collector", client.get, {})):
+        resp = call(path, headers=AUTH, **kw)
+        assert resp.status_code == 401
+        assert "enroll" in resp.json()["detail"]
+        assert call(path, headers={"Authorization": f"Bearer {cred}"}, **kw).status_code == 200
+    # A wrong token is still just a bad token, not an invitation.
+    assert client.post("/report", json={"tool": "x"},
+                       headers={"Authorization": "Bearer nope"}).json()["detail"] == "bad token"
+    assert _enroll(_mint()["token"], serial="OTHER").status_code == 200
+    assert client.get("/admin/devices", headers=ADMIN).status_code == 200
+
+
+def test_requiring_device_credentials_without_managed_mode_refuses_to_start():
+    """Nothing could authenticate: a startup error, not a receiver that
+    silently 401s the whole estate."""
+    import subprocess
+    import sys
+
+    env = {**os.environ, "AUTH_TOKEN": "x", "REQUIRE_DEVICE_CREDENTIALS": "true"}
+    env.pop("MANAGED_MODE", None)
+    proc = subprocess.run([sys.executable, "-c", "import app.main"], env=env,
+                          capture_output=True, text=True,
+                          cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    assert proc.returncode != 0
+    assert "MANAGED_MODE" in proc.stderr
+
+
 # ------------------------------------------------------------- edge cases --
 
 


### PR DESCRIPTION
Once every collector, browser profile and scanner has enrolled, the shared AUTH_TOKEN is a known string spread across the estate that no longer needs to be a credential. With REQUIRE_DEVICE_CREDENTIALS=true (chart managed.requireDeviceCredentials, compose .env) the receiver accepts device credentials only on /report, /flag and /registry, and turns the shared token away with a 401 that says "enroll" - so a straggler's MDM log explains itself rather than reading "bad token". Enrollment and the admin API are untouched; flip it back and unenrolled machines report again. Meaningless without managed mode, so that combination refuses to start instead of silently rejecting the whole estate. Chart 0.8.10.