### PR TITLE
Receiver-backed admin accounts and sessions (v0.9.7 increment 1)

### DIFF
--- a/receiver/README.md
+++ b/receiver/README.md
@@ -50,13 +50,28 @@ shared token off for ingest (see the configuration table).
 | POST | `/admin/enrollment-tokens/{id}/revoke` | admin | |
 | GET  | `/admin/devices` | admin | the fleet: platform, serial, hostname, enrolled / re-enrolled, last seen, agent version |
 | POST | `/admin/devices/{id}/revoke` | admin | that machine's credential stops working on its next request |
+| GET  | `/admin/setup` | none | one bit: does an admin account need creating? The portal chooses its first screen with it |
+| POST | `/admin/setup` | setup code | claim the boot-printed code, create the admin account, leave with a session |
+| POST | `/admin/login` | none | username + password for a session token (`aigt_...`) |
+| POST | `/admin/logout` | admin | revoke the presented session |
+| GET  | `/admin/session` | admin | who this session is and until when; the portal's validity probe |
+| POST | `/admin/password` | admin | change the password (`current` + `new`). With the `ADMIN_TOKEN` credential, `current` is not required - the break-glass reset. Every other session dies with the old password |
 
-Only SHA-256 hashes of credentials are stored: a copied database file is a
-list of devices, not a bag of credentials. Enrollment tokens default to a
-180-day life because they sit inside MDM artifacts, where a short TTL means
-the deployment silently breaks for new machines - their safety comes from
-what they cannot do (only create auditable device records) and from instant
-revocation, not from a short life.
+**Admin auth** is either of two things: a session from `/admin/login`, or
+the optional `ADMIN_TOKEN` API credential. Humans get the first; automation
+and break-glass recovery get the second. On a fresh managed deployment no
+admin account exists yet, and until one does, **every boot prints a one-time
+setup code** to the receiver's log as a JSON line with `"kind":
+"setup_code"`. Enter it in the portal (or POST it to `/admin/setup`) to
+create the account; the code is consumed on use, never stored, and once an
+account exists boots print nothing.
+
+Only SHA-256 hashes of credentials are stored (passwords: scrypt): a copied
+database file is a list of devices, not a bag of credentials. Enrollment
+tokens default to a 180-day life because they sit inside MDM artifacts,
+where a short TTL means the deployment silently breaks for new machines -
+their safety comes from what they cannot do (only create auditable device
+records) and from instant revocation, not from a short life.
 
 ## Configuration
 
@@ -75,8 +90,9 @@ Everything is environment variables. Only the token is required.
 | `DISPLAY_TZ` | `UTC` | timezone for the human-readable timestamp on alerts only; machine timestamps are always UTC |
 | `CORP_DOMAINS` | unset | corporate domains, comma-separated. When set, served to the endpoint collectors inside `/registry/collector` as `config.corp_domains`; collectors prefer that list to their locally configured one, so a change here reaches the fleet on its next check-in with no MDM re-push. Unset means collectors keep using their local configuration |
 | `MANAGED_MODE` | unset | `true` enables device enrollment, per-device credentials, revocation and a fleet inventory (see below). Unset means byte-for-byte the classic receiver: no state file, `/enroll` and `/admin/*` answer 404 |
-| `ADMIN_TOKEN` | required in managed mode | the credential that mints and revokes enrollment tokens and devices. Deliberately a separate secret from `AUTH_TOKEN`, which sits on every machine in the fleet - which is exactly why it must not be able to mint credentials |
+| `ADMIN_TOKEN` | unset | optional API credential for `/admin/*` - automation, and break-glass recovery when the portal password is lost. Humans use an account and a session instead (see managed mode above). Deliberately a separate secret from `AUTH_TOKEN`, which sits on every machine in the fleet - which is exactly why it must not be able to mint credentials |
 | `STATE_DB_PATH` | `/var/lib/ai-guard/state.db` | where the managed-mode SQLite file lives. The one non-disposable thing: it holds the device registry and its credential hashes |
+| `SESSION_TTL_HOURS` | `24` | how long a portal login lasts before it asks again |
 | `REQUIRE_DEVICE_CREDENTIALS` | unset | managed mode only: `true` turns the shared token off for ingest. `/report` and `/registry` accept device credentials only; the shared token gets a 401 that says "enroll". The final step of the migration once every surface has enrolled, not a mode - unset it and unenrolled machines report again. Refuses to start without `MANAGED_MODE` |
 
 Any of these can be given as `NAME_FILE` pointing at a file instead:

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -27,6 +27,7 @@ import hmac
 import json
 import logging
 import os
+import secrets
 import sys
 import threading
 import time
@@ -242,13 +243,28 @@ MANAGED_MODE = os.environ.get("MANAGED_MODE", "").lower() in ("1", "true", "yes"
 STATE = None
 _EXPECTED_ADMIN = b""
 if MANAGED_MODE:
-    # Required, not defaulted: managed mode without an admin credential is a
-    # deployment that can never mint an enrollment token, which nobody means.
-    # Deliberately a separate secret from AUTH_TOKEN - the shared token is on
-    # every machine in the fleet, which is exactly why it must not be able to
-    # mint credentials.
-    _EXPECTED_ADMIN = b"Bearer " + _secret("ADMIN_TOKEN").encode()
+    # Optional since 0.9.7: the admin API credential for automation and for
+    # break-glass (locked out of the portal: set this, call the API, reset
+    # the password). Humans authenticate with an account and a session
+    # instead - see /admin/setup below - so a fresh deployment needs no
+    # pre-provisioned admin secret at all. Still deliberately separate from
+    # AUTH_TOKEN: the shared token is on every machine in the fleet, which
+    # is exactly why it must not be able to mint credentials.
+    _admin_api_token = _secret("ADMIN_TOKEN", "")
+    if _admin_api_token:
+        _EXPECTED_ADMIN = b"Bearer " + _admin_api_token.encode()
     STATE = _state.State(os.environ.get("STATE_DB_PATH", "/var/lib/ai-guard/state.db"))
+
+# How long a portal login lasts. Sessions stand in for a person at a
+# keyboard, so they expire on their own; 24 hours means logging in about
+# once a working day.
+SESSION_TTL_HOURS = int(os.environ.get("SESSION_TTL_HOURS", "24"))
+
+# What a failed login costs, beyond the scrypt derivation itself. A flat
+# pause rather than progressive lockout: this credential is behind the
+# operator's ingress, and a counter that can lock the real admin out is a
+# denial-of-service lever pointed at the person who would respond.
+LOGIN_FAILURE_DELAY_SECONDS = 0.5
 
 # The off-switch for the shared token, once every surface has enrolled: with
 # this set, /report and /registry accept device credentials only and the
@@ -277,6 +293,22 @@ VALID_OS = {"macos", "windows", "linux", "unknown"}
 
 logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="%(message)s")
 log = logging.getLogger("ai-guard")
+
+# The first-boot door. While no admin account exists, every boot mints a
+# fresh one-time setup code and prints it to the log - the one channel an
+# operator who has just run `helm install` provably has. It lives only in
+# this process (never the database), dies when claimed, and once an account
+# exists boots print nothing. kubectl logs deploy/ai-guard-receiver | grep
+# setup_code is the whole retrieval story, and NOTES.txt says so.
+_SETUP_CODE = None
+if STATE is not None and not STATE.has_admin():
+    _SETUP_CODE = _state.SETUP_PREFIX + secrets.token_urlsafe(24)
+    log.info(json.dumps({
+        "app": "ai-guard-receiver", "kind": "setup_code",
+        "setup_code": _SETUP_CODE,
+        "hint": "no admin account exists yet; enter this code in the portal"
+                " to create one",
+    }))
 
 # ----------------------------------------------------------------- metrics --
 
@@ -435,6 +467,29 @@ app = FastAPI(title="ai-guard-receiver", version=APP_VERSION)
 _PROTECTED = ("/report", "/flag", "/registry")
 _MANAGED = ("/enroll", "/admin")
 
+# The two doors into admin auth. Exempt from the admin gate - they are how a
+# session comes to exist - but not from the body-size gate, and they answer
+# 404 like everything managed when managed mode is off.
+_ADMIN_OPEN = ("/admin/setup", "/admin/login")
+
+
+def _admin_header_ok(header: str) -> bool:
+    """Is this Authorization header an admin?
+
+    Two shapes: the optional API credential (ADMIN_TOKEN, for automation and
+    break-glass), or a live portal session minted by /admin/login. The
+    emptiness guard is not redundant: compare_digest holds two empty strings
+    equal, so without it a deployment with no ADMIN_TOKEN would let an empty
+    header in.
+    """
+    if _EXPECTED_ADMIN and hmac.compare_digest(
+        header.encode("latin-1"), _EXPECTED_ADMIN
+    ):
+        return True
+    if STATE is not None and header.startswith("Bearer " + _state.SESSION_PREFIX):
+        return STATE.session_user(header[len("Bearer "):]) is not None
+    return False
+
 
 def _body_size_response(request: Request):
     """The 4xx a too-large or unsized POST body earns, or None if fine."""
@@ -495,12 +550,7 @@ async def authenticate_before_reading(request: Request, call_next):
             return JSONResponse({"detail": "Not Found"}, status_code=404)
         auth = request.headers.get("authorization", "")
         if path.startswith("/admin"):
-            # The emptiness guard is not redundant: compare_digest holds two
-            # empty strings equal, so without it a deployment that somehow
-            # had state but no admin credential would let an empty header in.
-            if not _EXPECTED_ADMIN or not hmac.compare_digest(
-                auth.encode("latin-1"), _EXPECTED_ADMIN
-            ):
+            if path not in _ADMIN_OPEN and not _admin_header_ok(auth):
                 return JSONResponse({"detail": "bad token"}, status_code=401)
         else:
             # /enroll authenticates against the DB inside the handler; here
@@ -630,9 +680,7 @@ def _admin_auth(authorization: str):
     # mode is off: routes that do not exist should not confirm they exist.
     if STATE is None:
         raise HTTPException(404, "Not Found")
-    if not _EXPECTED_ADMIN or not hmac.compare_digest(
-        authorization.encode("latin-1"), _EXPECTED_ADMIN
-    ):
+    if not _admin_header_ok(authorization):
         raise HTTPException(401, "bad token")
 
 
@@ -716,6 +764,131 @@ def revoke_device(did: str, authorization: str = Header(default="")):
     _admin_auth(authorization)
     if not STATE.revoke_device(did):
         raise HTTPException(404, "no such active device")
+    return {"ok": True}
+
+
+# ------------------------------------------------------- admin accounts --
+
+
+def _bearer(authorization: str) -> str:
+    return (authorization[len("Bearer "):]
+            if authorization.startswith("Bearer ") else "")
+
+
+class SetupRequest(BaseModel):
+    setup_code: str = Field(min_length=1, max_length=128)
+    username: str = Field(min_length=1, max_length=64)
+    # Length is the whole policy. Composition rules produce Password1! and
+    # a false sense of review; twelve characters of anything does better.
+    password: str = Field(min_length=12, max_length=256)
+
+
+class LoginRequest(BaseModel):
+    username: str = Field(min_length=1, max_length=64)
+    password: str = Field(min_length=1, max_length=256)
+
+
+class PasswordChangeRequest(BaseModel):
+    current: str = Field(default="", max_length=256)
+    new: str = Field(min_length=12, max_length=256)
+
+
+@app.get("/admin/setup")
+def setup_needed():
+    """Whether the create-account door is open. Unauthenticated by design:
+    it says one bit, and the portal needs that bit to choose between the
+    sign-in form and the create-account form honestly."""
+    if STATE is None:
+        raise HTTPException(404, "Not Found")
+    return {"needed": not STATE.has_admin()}
+
+
+@app.post("/admin/setup")
+def setup(req: SetupRequest):
+    """Claim the boot-printed setup code and become the admin.
+
+    Returns a session directly: the operator who just chose this password
+    proving it again at a login screen is a step with no security content.
+    The code dies here whether or not it ever leaked - a fresh boot mints a
+    fresh one, and once the account exists boots mint none at all.
+    """
+    global _SETUP_CODE
+    if STATE is None:
+        raise HTTPException(404, "Not Found")
+    if STATE.has_admin():
+        raise HTTPException(409, "an admin account already exists")
+    # Compared as bytes: compare_digest raises on a non-ASCII str, and the
+    # submitted code is arbitrary JSON - same trap _token_ok documents.
+    if _SETUP_CODE is None or not hmac.compare_digest(
+        req.setup_code.encode(), _SETUP_CODE.encode()
+    ):
+        time.sleep(LOGIN_FAILURE_DELAY_SECONDS)
+        raise HTTPException(401, "bad setup code")
+    STATE.create_admin(req.username, req.password)
+    _SETUP_CODE = None
+    log.info(json.dumps({"app": "ai-guard-receiver", "kind": "admin_created",
+                         "username": req.username}))
+    return STATE.login(req.username, req.password, SESSION_TTL_HOURS)
+
+
+@app.post("/admin/login")
+def login(req: LoginRequest):
+    if STATE is None:
+        raise HTTPException(404, "Not Found")
+    try:
+        return STATE.login(req.username, req.password, SESSION_TTL_HOURS)
+    except _state.AuthError as e:
+        time.sleep(LOGIN_FAILURE_DELAY_SECONDS)
+        raise HTTPException(e.status, e.detail)
+
+
+@app.post("/admin/logout")
+def logout(authorization: str = Header(default="")):
+    _admin_auth(authorization)
+    token = _bearer(authorization)
+    if token.startswith(_state.SESSION_PREFIX):
+        STATE.logout(token)
+    # The API credential cannot log out - it is configuration, not a
+    # session - and saying ok either way keeps the portal's logout simple.
+    return {"ok": True}
+
+
+@app.get("/admin/session")
+def session_info(authorization: str = Header(default="")):
+    """The portal's validity probe: who is this session, until when.
+
+    The API credential answers too (it passed the gate), with an empty
+    username - it is a credential, not a person.
+    """
+    _admin_auth(authorization)
+    token = _bearer(authorization)
+    if token.startswith(_state.SESSION_PREFIX):
+        u = STATE.session_user(token)
+        if u is not None:
+            return {"username": u["username"], "expires_at": u["expires_at"]}
+    return {"username": "", "expires_at": None}
+
+
+@app.post("/admin/password")
+def change_password(req: PasswordChangeRequest,
+                    authorization: str = Header(default="")):
+    """Change the admin password, proving the current one.
+
+    With the API credential the current password is not required: that is
+    the break-glass path, and whoever can set the receiver's environment
+    already owns the box. Every other session dies with the old password.
+    """
+    _admin_auth(authorization)
+    token = _bearer(authorization)
+    is_session = token.startswith(_state.SESSION_PREFIX)
+    try:
+        STATE.change_password(
+            req.new,
+            current=req.current if is_session else None,
+            keep_session=token if is_session else None,
+        )
+    except _state.AuthError as e:
+        raise HTTPException(e.status, e.detail)
     return {"ok": True}
 
 

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -21,9 +21,16 @@ identifiable in a log:
             cannot do and from instant revocation, not from a short life.
   aigd_...  device credential: one machine's bearer for /report and
             /registry, valid until revoked.
+  aigt_...  admin session: what a portal login yields, valid for hours
+            rather than until revoked, because it stands in for a person at
+            a keyboard, not a machine on a schedule.
+  aigs_...  setup code: never stored here at all. Generated in memory at
+            boot while no admin account exists, printed to the log, and
+            good for exactly one thing - creating the first account.
 """
 
 import hashlib
+import hmac
 import json
 import os
 import secrets
@@ -33,6 +40,8 @@ from datetime import datetime, timedelta, timezone
 
 ENROLL_PREFIX = "aige_"
 DEVICE_PREFIX = "aigd_"
+SESSION_PREFIX = "aigt_"
+SETUP_PREFIX = "aigs_"
 
 # A device that authenticated this recently is alive, and a same-serial
 # enrollment must not displace it silently: that is the stolen token
@@ -78,6 +87,20 @@ CREATE TABLE IF NOT EXISTS events (
   kind   TEXT NOT NULL,
   detail TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS admin_users (
+  id            TEXT PRIMARY KEY,
+  username      TEXT NOT NULL UNIQUE,
+  password_hash TEXT NOT NULL,
+  created_at    TEXT NOT NULL,
+  last_login_at TEXT
+);
+CREATE TABLE IF NOT EXISTS sessions (
+  token_hash BLOB NOT NULL UNIQUE,
+  user_id    TEXT NOT NULL REFERENCES admin_users(id),
+  created_at TEXT NOT NULL,
+  expires_at TEXT NOT NULL,
+  revoked_at TEXT
+);
 """
 
 # Columns added after the first release, applied to databases that predate
@@ -100,8 +123,50 @@ def _hash(token: str) -> bytes:
     return hashlib.sha256(token.encode()).digest()
 
 
+# scrypt from the stdlib, so a password store costs no new dependency. The
+# parameters ride inside each stored hash, so raising them later only
+# affects passwords set after the change - old rows keep verifying.
+_SCRYPT_N, _SCRYPT_R, _SCRYPT_P = 16384, 8, 1
+
+
+def _hash_password(password: str) -> str:
+    salt = secrets.token_bytes(16)
+    h = hashlib.scrypt(password.encode(), salt=salt,
+                       n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P)
+    return "scrypt$%d$%d$%d$%s$%s" % (_SCRYPT_N, _SCRYPT_R, _SCRYPT_P,
+                                      salt.hex(), h.hex())
+
+
+def _verify_password(password: str, stored: str) -> bool:
+    try:
+        algo, n, r, p, salt, expect = stored.split("$")
+        if algo != "scrypt":
+            return False
+        h = hashlib.scrypt(password.encode(), salt=bytes.fromhex(salt),
+                           n=int(n), r=int(r), p=int(p))
+        return hmac.compare_digest(h.hex(), expect)
+    except (ValueError, TypeError):
+        return False
+
+
+# Verified against when a login names a username that does not exist, so
+# that failure runs the same one scrypt derivation as a wrong password for
+# a real user. Computed once: deriving it per attempt would make the
+# unknown-username path cost two derivations and stand out on a stopwatch.
+_DUMMY_HASH = _hash_password(secrets.token_hex(8))
+
+
 class EnrollError(Exception):
     """A refused enrollment, carrying the HTTP status it should become."""
+
+    def __init__(self, status: int, detail: str):
+        self.status = status
+        self.detail = detail
+        super().__init__(detail)
+
+
+class AuthError(Exception):
+    """A refused admin-auth operation, carrying its HTTP status."""
 
     def __init__(self, status: int, detail: str):
         self.status = status
@@ -297,3 +362,128 @@ class State:
                 self._event("revoked", {"device": did})
             self._db.commit()
         return bool(cur.rowcount)
+
+    # ------------------------------------------------ admin auth (portal) --
+
+    def has_admin(self) -> bool:
+        with self._lock:
+            row = self._db.execute("SELECT 1 FROM admin_users LIMIT 1").fetchone()
+        return row is not None
+
+    def create_admin(self, username: str, password: str) -> dict:
+        """The first (and for now only) admin account.
+
+        Refuses once any account exists: creating an account is what the
+        one-time setup code authorizes, and after that the door is shut.
+        More accounts, when they come, will be minted by an admin from
+        inside, not by anyone holding a boot log.
+        """
+        uid = secrets.token_hex(8)
+        with self._lock:
+            if self._db.execute("SELECT 1 FROM admin_users LIMIT 1").fetchone():
+                raise AuthError(409, "an admin account already exists")
+            self._db.execute(
+                "INSERT INTO admin_users (id, username, password_hash, created_at)"
+                " VALUES (?, ?, ?, ?)",
+                (uid, username, _hash_password(password), _now()),
+            )
+            self._event("admin_created", {"user": uid, "username": username})
+            self._db.commit()
+        return {"id": uid, "username": username}
+
+    def login(self, username: str, password: str, ttl_hours: int = 24) -> dict:
+        """A session token for a correct username and password.
+
+        One failure message for both a wrong username and a wrong password:
+        naming which half was wrong tells an attacker which usernames exist.
+        The scrypt derivation runs either way, so the two failures cost the
+        same time as well as carry the same words.
+        """
+        now = _now()
+        with self._lock:
+            row = self._db.execute(
+                "SELECT id, password_hash FROM admin_users WHERE username = ?",
+                (username,),
+            ).fetchone()
+            stored = row["password_hash"] if row else _DUMMY_HASH
+            if not _verify_password(password, stored) or row is None:
+                self._event("login_failed", {"username": username[:64]})
+                self._db.commit()
+                raise AuthError(401, "bad username or password")
+
+            # Expired sessions have nothing left to say; a login is the
+            # natural moment to sweep them out.
+            self._db.execute("DELETE FROM sessions WHERE expires_at <= ?", (now,))
+            token = SESSION_PREFIX + secrets.token_urlsafe(32)
+            expires = (datetime.now(timezone.utc)
+                       + timedelta(hours=ttl_hours)).isoformat()
+            self._db.execute(
+                "INSERT INTO sessions (token_hash, user_id, created_at, expires_at)"
+                " VALUES (?, ?, ?, ?)",
+                (_hash(token), row["id"], now, expires),
+            )
+            self._db.execute(
+                "UPDATE admin_users SET last_login_at = ? WHERE id = ?",
+                (now, row["id"]),
+            )
+            self._event("login", {"user": row["id"]})
+            self._db.commit()
+        # The one moment the plaintext exists, same as every credential here.
+        return {"token": token, "expires_at": expires, "username": username}
+
+    def session_user(self, token: str) -> dict | None:
+        """Who this session belongs to, or None if it is not a live one."""
+        with self._lock:
+            row = self._db.execute(
+                "SELECT s.user_id, s.expires_at, u.username"
+                " FROM sessions s JOIN admin_users u ON u.id = s.user_id"
+                " WHERE s.token_hash = ? AND s.revoked_at IS NULL"
+                " AND s.expires_at > ?",
+                (_hash(token), _now()),
+            ).fetchone()
+        return dict(row) if row else None
+
+    def logout(self, token: str) -> bool:
+        with self._lock:
+            cur = self._db.execute(
+                "UPDATE sessions SET revoked_at = ? WHERE token_hash = ?"
+                " AND revoked_at IS NULL",
+                (_now(), _hash(token)),
+            )
+            if cur.rowcount:
+                self._event("logout", {})
+            self._db.commit()
+        return bool(cur.rowcount)
+
+    def change_password(self, new_password: str, current: str | None = None,
+                        keep_session: str | None = None):
+        """Set the sole admin's password, optionally proving the current one.
+
+        current=None is the break-glass path, reached only with the API
+        credential (the operator who can set the receiver's environment
+        already owns the box). Every session except keep_session dies with
+        the old password - a stolen session must not outlive the password
+        change that was made because of it.
+        """
+        with self._lock:
+            row = self._db.execute(
+                "SELECT id, password_hash FROM admin_users LIMIT 1"
+            ).fetchone()
+            if row is None:
+                raise AuthError(409, "no admin account exists")
+            if current is not None and not _verify_password(
+                current, row["password_hash"]
+            ):
+                raise AuthError(401, "current password is wrong")
+            self._db.execute(
+                "UPDATE admin_users SET password_hash = ? WHERE id = ?",
+                (_hash_password(new_password), row["id"]),
+            )
+            keep = _hash(keep_session) if keep_session else b""
+            self._db.execute(
+                "UPDATE sessions SET revoked_at = ? WHERE user_id = ?"
+                " AND revoked_at IS NULL AND token_hash != ?",
+                (_now(), row["id"], keep),
+            )
+            self._event("password_changed", {"user": row["id"]})
+            self._db.commit()

--- a/receiver/tests/test_auth.py
+++ b/receiver/tests/test_auth.py
@@ -1,0 +1,238 @@
+"""Admin accounts and sessions: the portal's login, backed by the receiver.
+
+Same testing shape as test_managed: the module is imported classic and
+managed mode is switched on per-test through the globals, which mirrors
+production (every code path reads them at call time) and avoids re-importing
+the module. LOGIN_FAILURE_DELAY_SECONDS is zeroed so failure tests do not
+spend half a second each proving a sleep happens.
+"""
+
+import os
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import state as state_mod
+from app.main import app
+
+client = TestClient(app)
+
+API_ADMIN = {"Authorization": "Bearer admin-test-token"}
+PASSWORD = "a-long-enough-password"
+
+
+@pytest.fixture
+def managed(tmp_path, monkeypatch):
+    """Managed mode with a boot-printed setup code and NO API credential,
+    which is the fresh-install shape the wizard is designed for."""
+    from app import main
+
+    st = state_mod.State(str(tmp_path / "state.db"))
+    monkeypatch.setattr(main, "STATE", st)
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"")
+    monkeypatch.setattr(main, "_SETUP_CODE", "aigs_test-setup-code")
+    monkeypatch.setattr(main, "LOGIN_FAILURE_DELAY_SECONDS", 0)
+    return st
+
+
+def _setup(**kw):
+    return client.post("/admin/setup", json={
+        "setup_code": "aigs_test-setup-code", "username": "aman",
+        "password": PASSWORD, **kw})
+
+
+def _login(username="aman", password=PASSWORD):
+    return client.post("/admin/login",
+                       json={"username": username, "password": password})
+
+
+def _hdr(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ------------------------------------------------------------ mode gating --
+
+
+def test_auth_routes_do_not_exist_in_classic_mode():
+    assert client.get("/admin/setup").status_code == 404
+    assert _setup().status_code == 404
+    assert _login().status_code == 404
+
+
+# ------------------------------------------------------------- first boot --
+
+
+def test_the_first_boot_flow(managed):
+    """The acceptance test's opening move: fresh install, setup code from
+    the logs, create the account, and leave already signed in."""
+    assert client.get("/admin/setup").json() == {"needed": True}
+
+    resp = _setup()
+    assert resp.status_code == 200
+    token = resp.json()["token"]
+    assert token.startswith("aigt_")
+
+    # The session from setup is immediately an admin.
+    assert client.get("/admin/devices", headers=_hdr(token)).status_code == 200
+    assert client.get("/admin/setup").json() == {"needed": False}
+
+    # And it is a named person, not a credential.
+    who = client.get("/admin/session", headers=_hdr(token)).json()
+    assert who["username"] == "aman" and who["expires_at"]
+
+
+def test_a_wrong_setup_code_is_refused(managed):
+    assert _setup(setup_code="aigs_guessed").status_code == 401
+    # Non-ASCII must be a 401, not a compare_digest TypeError and a 500.
+    assert _setup(setup_code="aigs_guéssed").status_code == 401
+    assert client.get("/admin/setup").json() == {"needed": True}
+
+
+def test_the_door_shuts_after_the_first_account(managed):
+    _setup()
+    resp = _setup(username="second")
+    assert resp.status_code == 409
+    # Consumed even for the holder of the real code: one boot, one claim.
+    from app import main
+    assert main._SETUP_CODE is None
+
+
+def test_a_short_password_is_refused_at_the_door(managed):
+    assert _setup(password="short").status_code == 422
+    assert client.get("/admin/setup").json() == {"needed": True}
+
+
+def test_a_fresh_managed_boot_without_admin_token_starts_and_prints_a_code(tmp_path):
+    """ADMIN_TOKEN used to be required in managed mode. A fresh install now
+    boots without it and prints the setup code to its log."""
+    import subprocess
+    import sys
+
+    env = {**os.environ, "AUTH_TOKEN": "x", "MANAGED_MODE": "true",
+           "STATE_DB_PATH": str(tmp_path / "state.db")}
+    env.pop("ADMIN_TOKEN", None)
+    proc = subprocess.run(
+        [sys.executable, "-c", "import app.main"], env=env,
+        capture_output=True, text=True,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    assert proc.returncode == 0, proc.stderr
+    assert '"kind": "setup_code"' in proc.stdout
+    assert "aigs_" in proc.stdout
+
+
+def test_a_boot_with_an_existing_admin_prints_no_code(tmp_path):
+    import subprocess
+    import sys
+
+    st = state_mod.State(str(tmp_path / "state.db"))
+    st.create_admin("aman", PASSWORD)
+    env = {**os.environ, "AUTH_TOKEN": "x", "MANAGED_MODE": "true",
+           "STATE_DB_PATH": str(tmp_path / "state.db")}
+    proc = subprocess.run(
+        [sys.executable, "-c", "import app.main"], env=env,
+        capture_output=True, text=True,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    assert proc.returncode == 0, proc.stderr
+    assert "setup_code" not in proc.stdout
+
+
+# --------------------------------------------------------------- sessions --
+
+
+def test_login_logout_lifecycle(managed):
+    _setup()
+    assert _login(password="wrong").status_code == 401
+    assert _login(username="nobody").status_code == 401
+    # One message for both failures: naming which half was wrong tells an
+    # attacker which usernames exist.
+    assert (_login(password="wrong").json()["detail"]
+            == _login(username="nobody").json()["detail"])
+
+    token = _login().json()["token"]
+    assert client.get("/admin/devices", headers=_hdr(token)).status_code == 200
+    assert client.post("/admin/logout", headers=_hdr(token)).status_code == 200
+    assert client.get("/admin/devices", headers=_hdr(token)).status_code == 401
+
+
+def test_an_expired_session_is_refused(managed):
+    _setup()
+    token = _login().json()["token"]
+    managed._db.execute("UPDATE sessions SET expires_at = '2000-01-01T00:00:00+00:00'")
+    managed._db.commit()
+    assert client.get("/admin/devices", headers=_hdr(token)).status_code == 401
+
+
+def test_sessions_store_no_plaintext(managed):
+    _setup()
+    token = _login().json()["token"]
+    rows = managed._db.execute("SELECT token_hash FROM sessions").fetchall()
+    assert rows and all(token.encode() not in bytes(r["token_hash"]) for r in rows)
+    stored = managed._db.execute(
+        "SELECT password_hash FROM admin_users").fetchone()["password_hash"]
+    assert PASSWORD not in stored and stored.startswith("scrypt$")
+
+
+def test_a_session_is_not_an_ingest_credential_and_vice_versa(managed):
+    """Same boundary discipline as every other prefix: a session
+    administrates, it does not report, and the fleet's tokens do not
+    administrate."""
+    token = _setup().json()["token"]
+    assert client.post("/report", headers=_hdr(token),
+                       json={"tool": "x"}).status_code == 401
+    mint = client.post("/admin/enrollment-tokens", headers=_hdr(token),
+                       json={"note": "t"})
+    assert mint.status_code == 200
+    enroll = client.post("/enroll", headers=_hdr(mint.json()["token"]),
+                         json={"platform": "macos", "serial": "S"})
+    cred = enroll.json()["device_token"]
+    assert client.get("/admin/devices", headers=_hdr(cred)).status_code == 401
+
+
+# --------------------------------------------------------------- password --
+
+
+def test_password_change_requires_the_current_one_and_kills_other_sessions(managed):
+    mine = _setup().json()["token"]
+    other = _login().json()["token"]
+
+    resp = client.post("/admin/password", headers=_hdr(mine),
+                       json={"current": "wrong", "new": "another-long-password"})
+    assert resp.status_code == 401
+
+    resp = client.post("/admin/password", headers=_hdr(mine),
+                       json={"current": PASSWORD, "new": "another-long-password"})
+    assert resp.status_code == 200
+
+    # The session that made the change lives; the stolen one dies with the
+    # password it was stolen under.
+    assert client.get("/admin/devices", headers=_hdr(mine)).status_code == 200
+    assert client.get("/admin/devices", headers=_hdr(other)).status_code == 401
+    assert _login(password=PASSWORD).status_code == 401
+    assert _login(password="another-long-password").status_code == 200
+
+
+def test_the_api_credential_is_break_glass(managed, monkeypatch):
+    """Locked out: set ADMIN_TOKEN, reset the password without knowing the
+    old one, log back in."""
+    from app import main
+
+    _setup()
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"Bearer admin-test-token")
+    resp = client.post("/admin/password", headers=API_ADMIN,
+                       json={"new": "recovered-long-password"})
+    assert resp.status_code == 200
+    assert _login(password="recovered-long-password").status_code == 200
+    # The credential is not a person: the probe says so.
+    who = client.get("/admin/session", headers=API_ADMIN).json()
+    assert who == {"username": "", "expires_at": None}
+
+
+def test_password_change_with_no_account_is_409(managed, monkeypatch):
+    from app import main
+
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"Bearer admin-test-token")
+    resp = client.post("/admin/password", headers=API_ADMIN,
+                       json={"new": "recovered-long-password"})
+    assert resp.status_code == 409


### PR DESCRIPTION
First increment of the v0.9.7 onboarding work (design: real portal login backed by the receiver's state DB).

- `admin_users` + `sessions` tables in the state DB; scrypt (stdlib) password hashes with parameters stored per-hash; `aigt_` session tokens stored hash-only, `SESSION_TTL_HOURS` default 24.
- Fresh managed boot needs no ADMIN_TOKEN any more: while no admin account exists, each boot prints a one-time `aigs_` setup code to the log (`"kind": "setup_code"`). `POST /admin/setup` claims it, creates the account, and returns a session directly.
- New routes: `GET/POST /admin/setup`, `POST /admin/login` (flat 0.5s failure delay, one indistinguishable error for wrong user vs wrong password), `POST /admin/logout`, `GET /admin/session`, `POST /admin/password` (session path proves the current password and revokes every other session; ADMIN_TOKEN path skips `current` — the break-glass reset).
- `ADMIN_TOKEN` demoted to an optional API credential; everything still 404s in classic mode.
- 14 new tests (67 total receiver suite), including subprocess boots for the setup-code printing, plus a live uvicorn E2E of the whole flow.