### PR TITLE
Portal login mode: sessions replace basic auth and the typed-in admin token (v0.9.7 increment 2)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -54,9 +54,13 @@ the shared token is on every machine in the fleet.
 
 ### The portal
 
-The portal authenticates separately, and it is worth being plain about what
-that is. It is HTTP basic auth: one shared credential, no per-user trail, and
-plaintext without TLS in front of it. That is a floor, not a ceiling.
+The portal authenticates separately, and what that is depends on the mode.
+In managed mode it is a real login: an admin account in the receiver's state
+DB (scrypt-hashed password, created on first boot with a one-time setup code
+the receiver prints to its log), a session carried as an HttpOnly
+SameSite=Strict cookie, validated against the receiver per request.
+Classically it is HTTP basic auth: one shared credential, no per-user trail,
+and plaintext without TLS in front of it. That is a floor, not a ceiling.
 
 It refuses to start without it. Coming up open because a variable was missed is
 the failure that matters for this component: it is reachable, it looks like it

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.8.11
+version: 0.8.12
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/templates/NOTES.txt
+++ b/charts/ai-guard/templates/NOTES.txt
@@ -52,6 +52,16 @@ are reporting versus silent.
   It is running WITHOUT AUTHENTICATION (portal.auth.mode=none). It shows which
   people use which AI tools on which machines. Correct behind something that
   authenticates for it; wrong on anything reachable.
+{{- else if .Values.managed.enabled }}
+
+  Sign in with the admin account. On a fresh install none exists yet: the
+  receiver prints a one-time setup code to its log at every boot until one
+  does. Read it, then open the portal and create the account:
+
+    kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "ai-guard.fullname" . }} | grep setup_code
+
+  Everything after that happens in the portal: corporate domains, enrollment
+  tokens, pre-configured collector downloads, the fleet.
 {{- else }}
 
   Log in as {{ .Values.portal.auth.username }}. Read the password:

--- a/charts/ai-guard/templates/deployment.yaml
+++ b/charts/ai-guard/templates/deployment.yaml
@@ -94,11 +94,16 @@ spec:
             {{- end }}
             - name: STATE_DB_PATH
               value: /var/lib/ai-guard/state.db
+            {{- if or .Values.managed.adminToken.value .Values.managed.adminToken.existingSecret }}
+            # Optional since 0.8.12: the admin API credential for automation
+            # and break-glass. Humans sign in through the portal instead
+            # (first boot prints a one-time setup code to this pod's log).
             - name: ADMIN_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.managed.adminToken.existingSecret | default (printf "%s-admin" (include "ai-guard.fullname" .)) }}
                   key: adminToken
+            {{- end }}
             {{- end }}
           volumeMounts:
             - name: registry

--- a/charts/ai-guard/templates/managed-secret.yaml
+++ b/charts/ai-guard/templates/managed-secret.yaml
@@ -1,20 +1,12 @@
-{{- if and .Values.managed.enabled (not .Values.managed.adminToken.existingSecret) }}
+{{- if and .Values.managed.enabled .Values.managed.adminToken.value (not .Values.managed.adminToken.existingSecret) }}
 {{/*
-  Same precedence as the auth token in secret.yaml: an explicit value wins;
-  otherwise reuse the token already in the cluster so upgrades do not rotate
-  it out from under whoever holds it; otherwise generate one. Its own Secret
-  rather than a key on the auth one, because auth.existingSecret can disable
-  that template entirely and the admin credential must not vanish with it.
+  The optional admin API credential, rendered only when the operator sets a
+  value. Nothing is generated any more: since 0.8.12 the receiver needs no
+  pre-provisioned admin secret at all - the first boot prints a one-time
+  setup code and the portal login takes it from there. This Secret exists
+  for automation against /admin/* and for break-glass recovery, both of
+  which start with an operator deliberately choosing a value.
 */}}
-{{- $existing := lookup "v1" "Secret" .Release.Namespace (printf "%s-admin" (include "ai-guard.fullname" .)) -}}
-{{- $token := "" -}}
-{{- if .Values.managed.adminToken.value -}}
-{{- $token = .Values.managed.adminToken.value -}}
-{{- else if and $existing $existing.data.adminToken -}}
-{{- $token = ($existing.data.adminToken | b64dec) -}}
-{{- else -}}
-{{- $token = randAlphaNum 48 -}}
-{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -23,5 +15,5 @@ metadata:
     {{- include "ai-guard.labels" . | nindent 4 }}
 type: Opaque
 data:
-  adminToken: {{ $token | b64enc | quote }}
+  adminToken: {{ .Values.managed.adminToken.value | b64enc | quote }}
 {{- end }}

--- a/charts/ai-guard/templates/portal-deployment.yaml
+++ b/charts/ai-guard/templates/portal-deployment.yaml
@@ -74,7 +74,10 @@ spec:
             # something that authenticates for it; wrong on anything reachable.
             - name: PORTAL_AUTH
               value: "none"
-            {{- else }}
+            {{- else if not .Values.managed.enabled }}
+            # Classic mode only. In managed mode the portal login (the
+            # receiver's admin account) replaces basic auth, and the portal
+            # ignores this pair with a warning - so it is not rendered.
             - name: PORTAL_USER
               value: {{ .Values.portal.auth.username | quote }}
             - name: PORTAL_PASSWORD

--- a/charts/ai-guard/templates/portal-secret.yaml
+++ b/charts/ai-guard/templates/portal-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.portal.enabled (not .Values.portal.auth.existingSecret) }}
+{{- if and .Values.portal.enabled (not .Values.portal.auth.existingSecret) (not .Values.managed.enabled) }}
 {{/*
   Same precedence as the bearer token: an explicit value wins; otherwise reuse
   what is already in the cluster so an upgrade does not lock the operator out
@@ -7,6 +7,10 @@
   The portal refuses to start without a password, so generating one matters
   more here than convenience: without it, enabling the portal would add a
   workload that crash-loops until someone reads the logs to find out why.
+
+  Not rendered in managed mode: the portal login (the receiver's admin
+  account) replaces basic auth there, and a generated password nothing will
+  ever accept is worse than none.
 */}}
 {{- $existing := lookup "v1" "Secret" .Release.Namespace (include "ai-guard.portal.fullname" .) -}}
 {{- $password := "" -}}

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -81,11 +81,13 @@ corpDomains: []
 #     {"op":"replace","path":"/spec/strategy/type","value":"Recreate"}]'
 managed:
   enabled: false
-  # The credential that mints and revokes enrollment tokens and devices.
-  # Deliberately a separate secret from the shared token, which sits on every
-  # machine in the fleet. Leave both unset and the chart generates one on
-  # first install and keeps it across upgrades. Read it back with:
-  #   kubectl get secret <release>-ai-guard-admin -o jsonpath='{.data.adminToken}' | base64 -d
+  # OPTIONAL since 0.8.12: an API credential for /admin/* - automation, and
+  # break-glass recovery when the portal password is lost. Humans need
+  # nothing here: the receiver's first boot prints a one-time setup code to
+  # its log, and creating the admin account in the portal is the whole
+  # story. Leave both unset (the default) and no admin secret exists at all.
+  # Deliberately a separate secret from the shared token, which sits on
+  # every machine in the fleet.
   adminToken:
     value: ""
     existingSecret: ""   # a Secret with an `adminToken` key
@@ -169,10 +171,17 @@ portal:
   # The portal names who runs what on which machine, so it refuses to start
   # without authentication.
   #
+  # In MANAGED mode (managed.enabled above) this whole block is moot unless
+  # mode is none: the portal gets a real login backed by the receiver's
+  # admin account - created on first boot with the setup code the receiver
+  # prints to its log - and basic auth is not rendered at all.
+  #
+  # Classic mode:
   #   mode: basic   username plus a password, generated if you do not set one
   #   mode: none    no authentication. Correct behind a proxy or a mesh that
   #                 authenticates for it; wrong on anything reachable. Logs a
-  #                 warning on every start.
+  #                 warning on every start. (Also honoured in managed mode:
+  #                 reads are open, admin actions still need the login.)
   #
   # Basic auth is one shared credential with no per-user trail. If your
   # ingress can do OIDC or mTLS, do it there and set mode: none.

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -214,15 +214,19 @@ instead, and each collector, browser profile and scanner exchanges it once for a
 credential of its own; `REQUIRE_DEVICE_CREDENTIALS=true` in `.env` then turns
 the shared token off for ingest once everything has enrolled.
 
-The portal authenticates separately with HTTP basic auth, and **refuses to start
-without it**. It names who runs what on which machine, so coming up open because
-a variable was missed is the failure that matters.
+The portal authenticates separately, and **refuses to start without it**. It
+names who runs what on which machine, so coming up open because a variable
+was missed is the failure that matters.
 
-Basic auth is one shared credential with no per-user trail. If you already run a
-reverse proxy, authenticate there instead - it can do OIDC, mTLS or an
-allowlist against whatever you already have - and run the portal with
-`PORTAL_AUTH=none` behind it. That opt-out logs a warning on every start, so an
-unauthenticated deployment is never something nobody noticed.
+With the managed overlay the portal has a real login: the receiver prints a
+one-time setup code to its log on first boot (`docker compose logs receiver
+| grep setup_code`), and the portal's first screen turns it into the admin
+account. Without the overlay it is HTTP basic auth - one shared credential
+with no per-user trail. If you already run a reverse proxy, authenticate
+there instead - it can do OIDC, mTLS or an allowlist against whatever you
+already have - and run the portal with `PORTAL_AUTH=none` behind it. That
+opt-out logs a warning on every start, so an unauthenticated deployment is
+never something nobody noticed.
 
 ## The registry
 

--- a/deploy/compose/docker-compose.managed.yml
+++ b/deploy/compose/docker-compose.managed.yml
@@ -3,30 +3,33 @@
 #
 # Classic deployments never touch this file. To enable managed mode:
 #
-#   1. Create the admin credential (mints and revokes enrollment tokens and
-#      devices - deliberately a separate secret from the shared token, which
-#      sits on every machine in the fleet):
-#        umask 077; openssl rand -base64 36 > secrets/admin_token
-#   2. Start with both files:
-#        docker compose -f docker-compose.yml -f docker-compose.managed.yml up -d
+#   docker compose -f docker-compose.yml -f docker-compose.managed.yml up -d
 #
-# Then mint an enrollment token and put it in your MDM in place of the shared
-# token, one platform at a time:
-#   curl -s -X POST -H "Authorization: Bearer $(cat secrets/admin_token)" \
-#     -H 'Content-Type: application/json' -d '{"note":"macos rollout"}' \
-#     http://127.0.0.1:8080/admin/enrollment-tokens
+# That is the whole server side. The portal now has a real login instead of
+# basic auth: on first boot no admin account exists, and the receiver prints
+# a one-time setup code to its log until one does. Read it, open the portal,
+# create the account:
+#
+#   docker compose logs receiver | grep setup_code
+#
+# Everything after that happens in the portal - enrollment tokens,
+# pre-configured collector downloads, the fleet, revocation.
 #
 # The state volume is the one thing in this deployment that is not
-# disposable: it holds the device registry and its credential hashes.
-# `docker compose down` leaves named volumes in place; only `down -v`
-# destroys it, which unenrolls the entire fleet.
+# disposable: it holds the device registry, the admin account and the
+# credential hashes. `docker compose down` leaves named volumes in place;
+# only `down -v` destroys it, which unenrolls the entire fleet.
 
 services:
   receiver:
     environment:
       MANAGED_MODE: "true"
-      ADMIN_TOKEN_FILE: /run/secrets/admin_token
       STATE_DB_PATH: /var/lib/ai-guard/state.db
+      # OPTIONAL: an API credential for /admin/* - automation, and
+      # break-glass recovery when the portal password is lost (set it, POST
+      # /admin/password with just {"new": ...}, unset it). Humans need the
+      # portal login, not this. Empty means it does not exist.
+      ADMIN_TOKEN: ${AIGUARD_ADMIN_TOKEN:-}
       # Once every collector, browser profile and scanner has enrolled, set
       # REQUIRE_DEVICE_CREDENTIALS=true in .env: the shared token is then
       # refused for ingest (with a 401 that says "enroll"), and only device
@@ -34,7 +37,6 @@ services:
       REQUIRE_DEVICE_CREDENTIALS: ${REQUIRE_DEVICE_CREDENTIALS:-false}
     volumes:
       - managed-state:/var/lib/ai-guard
-      - ./secrets/admin_token:/run/secrets/admin_token:ro
 
   portal:
     environment:
@@ -44,6 +46,10 @@ services:
       # URL, not a compose service name. Set it in .env.
       RECEIVER_URL: http://receiver:8080
       RECEIVER_PUBLIC_URL: ${RECEIVER_PUBLIC_URL:-}
+      # Managed mode replaces basic auth with the portal login, so the base
+      # file's pair is cleared rather than left to be ignored with a warning.
+      PORTAL_USER: ""
+      PORTAL_PASSWORD_FILE: ""
 
 volumes:
   managed-state:

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -132,17 +132,20 @@ Optional, all off by default:
   this list to their locally configured one, so a change here reaches the
   fleet on its next check-in with no MDM re-push per platform.
 - `managed.enabled` - device enrollment, per-device credentials and
-  revocation, backed by SQLite on a PVC. The chart generates an admin token
-  into `<release>-ai-guard-admin` on first install; read it back the same way
-  as the auth token. The portal gains a Managed section for this: enter that
-  admin token there to see the fleet, mint and revoke enrollment tokens, and
-  download pre-configured collector scripts from the Setup view - or drive
-  the same `/admin` API with curl. Enrollment tokens go wherever the shared
-  token goes today - collector parameters, the extension's managed policy,
-  the scanner Secret - one surface at a time; each enrolls and holds its own
-  credential. Once every surface has, `managed.requireDeviceCredentials:
-  true` turns the shared token off for ingest. See the receiver and portal
-  READMEs for the details.
+  revocation, backed by SQLite on a PVC. The portal gets a real login in
+  this mode: on first boot the receiver prints a one-time setup code to its
+  log (`kubectl logs deploy/<release>-ai-guard | grep setup_code` - NOTES
+  prints the exact command), and the portal's first screen turns it into
+  the admin account. From there the Managed section shows the fleet, mints
+  and revokes enrollment tokens, and downloads pre-configured collector
+  scripts from the Setup view. No admin secret is provisioned by default;
+  set `managed.adminToken.value` only if automation drives the `/admin` API
+  with curl, or as break-glass when the portal password is lost. Enrollment
+  tokens go wherever the shared token goes today - collector parameters,
+  the extension's managed policy, the scanner Secret - one surface at a
+  time; each enrolls and holds its own credential. Once every surface has,
+  `managed.requireDeviceCredentials: true` turns the shared token off for
+  ingest. See the receiver and portal READMEs for the details.
 
 Confirm it is up:
 

--- a/portal/README.md
+++ b/portal/README.md
@@ -37,6 +37,11 @@ thing the platform produces. Coming up open because a variable was missed is
 the failure that matters: the portal is reachable, it looks like it works, and
 nothing says the door is off. So it fails closed and says why.
 
+In **managed mode** (`RECEIVER_URL` set) none of the below applies: the
+portal has a real login backed by the receiver's admin account, and the
+basic-auth pair is ignored with a warning. See "Managed mode" further down.
+Classic mode:
+
     PORTAL_USER=admin
     PORTAL_PASSWORD=...
 
@@ -64,8 +69,8 @@ about the estate.
 
 | Variable | Required | Meaning |
 |---|---|---|
-| `PORTAL_USER` | yes* | basic auth username |
-| `PORTAL_PASSWORD` | yes* | basic auth password |
+| `PORTAL_USER` | yes* | basic auth username (classic mode; ignored in managed mode) |
+| `PORTAL_PASSWORD` | yes* | basic auth password (classic mode; ignored in managed mode) |
 | `PORTAL_AUTH` | yes* | `none` to run without auth, deliberately |
 | `LOKI_URL` | yes | Loki base URL, the same one the receiver writes to |
 | `LOKI_TOKEN` | no | bearer token, if your Loki needs one |
@@ -87,25 +92,37 @@ about the estate.
 | `RECEIVER_PUBLIC_URL` | no | the ingest URL agents can reach, baked into downloaded deployment artifacts. Different from `RECEIVER_URL` on purpose: a cluster-internal service name baked into a Jamf script would enroll nothing |
 | `COLLECTOR_SCRIPTS_DIR` | no | verified copies of the endpoint collector scripts, shipped in the image; override for development |
 
-## Managed mode: the one write path
+## Managed mode: the login, and the one write path
 
 With `RECEIVER_URL` set (and `MANAGED_MODE=true` on the receiver), the
-portal gains a Managed section: a fleet view of enrolled devices, an
-enrollment-token view that mints and revokes, and per-source Download
+portal is in **login mode**: basic auth is replaced by a real sign-in
+against the admin account that lives in the receiver's state DB.
+`PORTAL_USER`/`PORTAL_PASSWORD` are ignored, with a warning. On a fresh
+deployment no account exists yet - the receiver prints a one-time setup
+code to its log at every boot until one does (`kubectl logs ... | grep
+setup_code`, or `docker compose logs receiver`), and the portal's first
+screen turns it into the admin account. The session is an HttpOnly,
+SameSite=Strict cookie that page script can never read; the portal
+validates it against the receiver per request (with a 60-second positive
+cache, which bounds revocation latency) and stores nothing. `PORTAL_AUTH=none`
+still means what it always did - reads are open for a reverse proxy that
+authenticates - but admin actions still require the login, because the
+receiver demands a credential either way.
+
+The portal also gains a Managed section: a fleet view of enrolled devices,
+an enrollment-token view that mints and revokes, and per-source Download
 buttons on the Setup view that generate a pre-configured collector script
 with a fresh enrollment token baked in as the script's own fallback default
 (MDM-supplied values still win; corporate domains are never baked - the
 receiver serves those at runtime).
 
 Every one of those actions is authorized by the **receiver**, not the
-portal: the operator enters the receiver's admin token in the UI, it is
-held in the tab's memory only, forwarded per request in an `X-Admin-Token`
-header, and never stored anywhere in the portal. The portal still holds no
-database and no credentials - a compromised portal yields readable
-findings, which it always did, and nothing that can mint or revoke.
-Governance decisions remain in the file ([docs/governance.md](../docs/governance.md));
-these routes manage operational credentials, which is a different kind of
-thing.
+portal: the operator's own session token is forwarded per request and never
+stored anywhere in the portal. The portal still holds no database and no
+credentials - a compromised portal yields readable findings, which it
+always did, and nothing that can mint or revoke. Governance decisions
+remain in the file ([docs/governance.md](../docs/governance.md)); these
+routes manage operational credentials, which is a different kind of thing.
 
 ### Reading from a hosted log store
 

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -12,15 +12,23 @@ one stateless container either way.
 
 Authentication is required, not optional. This page names who runs what on
 which machine, which is the most sensitive thing the platform produces, so it
-refuses to start rather than come up open by accident. Set PORTAL_USER and
-PORTAL_PASSWORD, or set PORTAL_AUTH=none deliberately for localhost. Basic auth
-is a floor, not a ceiling: it is one shared credential with no per-user trail,
-so anyone already running a reverse proxy should authenticate there instead and
-run this with PORTAL_AUTH=none behind it.
+refuses to start rather than come up open by accident. Three shapes:
+
+  managed (RECEIVER_URL set): a real login. The operator signs in with the
+    admin account that lives in the receiver's state DB; the session rides
+    as an HttpOnly cookie and the portal validates it against the receiver
+    per request (with a short positive cache). PORTAL_USER/PORTAL_PASSWORD
+    are ignored, with a warning, because two auth systems on one page is
+    how one of them quietly stops being real.
+  classic basic auth: PORTAL_USER and PORTAL_PASSWORD, as ever.
+  PORTAL_AUTH=none: no portal auth, for localhost or behind a reverse proxy
+    that authenticates. In managed mode reads are then open but admin
+    actions still require the login - the receiver demands a credential
+    and the session is how a person gets one.
 
 Configuration, all optional except LOKI_URL and the auth pair:
-  PORTAL_USER       basic auth username
-  PORTAL_PASSWORD   basic auth password
+  PORTAL_USER       basic auth username (classic mode only)
+  PORTAL_PASSWORD   basic auth password (classic mode only)
 
 Any of PORTAL_USER, PORTAL_PASSWORD, LOKI_TOKEN and LOKI_PASSWORD can be given as
 NAME_FILE pointing at a file instead. Compose has no real secret story: an
@@ -70,7 +78,7 @@ import time
 import urllib.parse
 from pathlib import Path
 
-from fastapi import Depends, FastAPI, Header, HTTPException, Query
+from fastapi import Depends, FastAPI, HTTPException, Query, Request
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel, Field
@@ -112,36 +120,27 @@ PORTAL_USER = _secret("PORTAL_USER")
 PORTAL_PASSWORD = _secret("PORTAL_PASSWORD")
 PORTAL_AUTH = os.environ.get("PORTAL_AUTH", "").lower()
 
-# Fail closed. Coming up open because a variable was missed is the failure
-# that matters here: the portal is reachable, it looks like it works, and
-# nothing says the door is off. Refusing to start is loud and immediate.
-if PORTAL_AUTH == "none":
-    log.warning(
-        "PORTAL_AUTH=none: this portal is running WITHOUT AUTHENTICATION. It "
-        "shows which people use which AI tools on which machines. That is fine "
-        "on localhost and behind a proxy that authenticates for it, and it is "
-        "not fine on anything reachable."
-    )
-elif not (PORTAL_USER and PORTAL_PASSWORD):
-    raise SystemExit(
-        "refusing to start without authentication.\n\n"
-        "This portal shows which people use which AI tools on which machines.\n"
-        "Set PORTAL_USER and PORTAL_PASSWORD, or set PORTAL_AUTH=none if you\n"
-        "mean it - localhost, or behind a proxy that authenticates for you.\n\n"
-        "Basic auth is one shared credential with no per-user trail. If you\n"
-        "already run a reverse proxy, authenticate there instead and run this\n"
-        "with PORTAL_AUTH=none behind it."
-    )
-
 _basic = HTTPBasic(auto_error=False)
 
 
-def require_auth(creds: HTTPBasicCredentials = Depends(_basic)):
-    """Compared with compare_digest so a wrong username and a wrong password
-    take the same time to reject: a difference there is enough to enumerate a
-    valid username one character at a time."""
+def require_auth(request: Request,
+                 creds: HTTPBasicCredentials = Depends(_basic)):
+    """The gate on every data route, in whichever shape this deployment runs.
+
+    Managed mode: the session cookie, validated against the receiver (which
+    owns the accounts) with a short positive cache. Classic mode: basic auth,
+    compared with compare_digest so a wrong username and a wrong password
+    take the same time to reject - a difference there is enough to enumerate
+    a valid username one character at a time.
+    """
     if PORTAL_AUTH == "none":
         return
+    if LOGIN_MODE:
+        token = request.cookies.get(SESSION_COOKIE, "")
+        if token and _session_ok(token):
+            return
+        # No WWW-Authenticate: the login is a page, not a browser dialog.
+        raise HTTPException(status_code=401, detail="login required")
     if creds is None:
         raise HTTPException(
             status_code=401,
@@ -156,6 +155,20 @@ def require_auth(creds: HTTPBasicCredentials = Depends(_basic)):
             detail="invalid credentials",
             headers={"WWW-Authenticate": "Basic"},
         )
+
+
+def require_page_auth(request: Request,
+                      creds: HTTPBasicCredentials = Depends(_basic)):
+    """The gate on the HTML shell and the logo.
+
+    In managed mode these are open: the shell is a static file holding no
+    estate data, it has to load for the login screen to exist at all, and
+    every API it calls is behind require_auth above. Classic mode keeps
+    basic auth on them, as ever.
+    """
+    if LOGIN_MODE:
+        return
+    require_auth(request, creds)
 
 
 def require_http_url(name, url):
@@ -222,6 +235,50 @@ DEPLOY_NAMESPACE = os.environ.get("DEPLOY_NAMESPACE", "")
 RECEIVER_URL = require_http_url("RECEIVER_URL", os.environ.get("RECEIVER_URL", ""))
 RECEIVER_PUBLIC_URL = require_http_url(
     "RECEIVER_PUBLIC_URL", os.environ.get("RECEIVER_PUBLIC_URL", ""))
+
+# Managed mode is also login mode: one switch, not two that can disagree.
+# The receiver owns the admin account (created first-boot with the setup
+# code it prints); the portal signs in against it, carries the session as
+# an HttpOnly cookie, and validates per request below. Basic auth belongs
+# to classic mode only.
+LOGIN_MODE = bool(RECEIVER_URL)
+SESSION_COOKIE = "aiguard_session"
+# How long a positive validation is trusted before the receiver is asked
+# again. Bounds the revocation latency, and only the positive answer is
+# cached: a refused session is refused every time.
+SESSION_CACHE_TTL = 60
+_session_cache: dict[str, tuple[float, str]] = {}  # token -> (until, username)
+
+# Fail closed. Coming up open because a variable was missed is the failure
+# that matters here: the portal is reachable, it looks like it works, and
+# nothing says the door is off. Refusing to start is loud and immediate.
+# Checked here rather than beside PORTAL_USER above because the answer
+# depends on RECEIVER_URL: managed mode brings its own login and needs no
+# basic-auth pair.
+if PORTAL_AUTH == "none":
+    log.warning(
+        "PORTAL_AUTH=none: this portal is running WITHOUT AUTHENTICATION. It "
+        "shows which people use which AI tools on which machines. That is fine "
+        "on localhost and behind a proxy that authenticates for it, and it is "
+        "not fine on anything reachable."
+    )
+elif LOGIN_MODE:
+    if PORTAL_USER or PORTAL_PASSWORD:
+        log.warning(
+            "PORTAL_USER/PORTAL_PASSWORD are ignored in managed mode: the "
+            "portal login (the receiver's admin account) replaces basic auth. "
+            "Unset them to remove the ambiguity."
+        )
+elif not (PORTAL_USER and PORTAL_PASSWORD):
+    raise SystemExit(
+        "refusing to start without authentication.\n\n"
+        "This portal shows which people use which AI tools on which machines.\n"
+        "Set PORTAL_USER and PORTAL_PASSWORD, or set PORTAL_AUTH=none if you\n"
+        "mean it - localhost, or behind a proxy that authenticates for you.\n\n"
+        "Basic auth is one shared credential with no per-user trail. If you\n"
+        "already run a reverse proxy, authenticate there instead and run this\n"
+        "with PORTAL_AUTH=none behind it."
+    )
 # Verified copies of the endpoint collector scripts, shipped in the image
 # because the build cannot see the endpoint/ tree (same pattern as the
 # chart's bundled registry; a test asserts byte equality with the sources).
@@ -291,6 +348,31 @@ async def security_headers(request, call_next):
     response.headers.setdefault("X-Frame-Options", "DENY")
     response.headers.setdefault("Cache-Control", "no-store")
     return response
+
+@app.middleware("http")
+async def json_posts_only(request, call_next):
+    """The CSRF half that cookies made necessary.
+
+    The old write path was immune by construction: the credential lived in
+    JS memory and rode a custom header no cross-site request can set. A
+    cookie goes wherever the browser goes, so two things stand in for that
+    header now: SameSite=Strict on the cookie itself, and this rule - every
+    POST under /api must declare application/json, which a cross-site form
+    cannot (forms speak urlencoded, multipart and text/plain only, and a
+    fetch that sets the header triggers CORS preflight, which 'self' fails).
+    Enforced in login mode only: classic mode has no cookie to protect and
+    its callers were never asked for the header.
+    """
+    if (LOGIN_MODE and request.method == "POST"
+            and request.url.path.startswith("/api")
+            and not request.headers.get("content-type", "")
+                                    .startswith("application/json")):
+        return JSONResponse(
+            {"detail": "POST bodies here are JSON: send "
+                       "Content-Type: application/json"},
+            status_code=415)
+    return await call_next(request)
+
 
 # A derived graph, kept briefly. Not state in any meaningful sense: it rebuilds
 # from Loki on the next miss and on every restart. Without it, a 7 day query
@@ -506,7 +588,8 @@ def diagnostics(_=Depends(require_auth)):
             "loki_last_error": _last_loki_error,
             "lookback_hours": LOOKBACK_HOURS,
             "cache_ttl_seconds": CACHE_TTL,
-            "auth_mode": PORTAL_AUTH or "basic",
+            "auth_mode": ("login" if LOGIN_MODE and PORTAL_AUTH != "none"
+                          else PORTAL_AUTH or "basic"),
             "auth_configured": bool(PORTAL_AUTH != "none"),
             "registry_loaded": reg_ok,
             "registry_tools": reg_tools,
@@ -751,12 +834,14 @@ def suggest_identities(hours: float = Query(default=None, gt=0, le=24 * 90),
 
 
 # ----------------------------------------------------------- managed mode --
-# The portal's first write path, and it is deliberately a thin one: every
-# route below forwards the operator's admin token to the receiver, which is
+# The portal's write path, and it is deliberately a thin one: every route
+# below forwards the operator's own session token to the receiver, which is
 # the component that actually authorizes and records. The portal checks
 # nothing but shape, stores nothing, and a portal database still does not
-# exist. Governance decisions remain in the file (docs/governance.md); these
-# routes manage operational credentials, which is a different kind of thing.
+# exist: the session lives in the operator's browser (an HttpOnly cookie)
+# and in the receiver's state DB, never here. Governance decisions remain
+# in the file (docs/governance.md); these routes manage operational
+# credentials, which is a different kind of thing.
 
 # Receiver-assigned ids are hex, but the exact alphabet is the receiver's
 # business; this guard only ensures a path segment cannot smuggle separators
@@ -764,18 +849,166 @@ def suggest_identities(hours: float = Query(default=None, gt=0, le=24 * 90),
 _ID_RE = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
 
 
-def _admin_forward(x_admin_token: str = Header(default="")) -> str:
-    """The operator's admin token, from the header, or the refusal that
-    explains the model: forwarded per request, never stored here."""
+def _session_ok(token: str) -> bool:
+    """Is this session live, by the receiver's word?
+
+    The receiver owns sessions; the portal only asks. A yes is trusted for
+    SESSION_CACHE_TTL so a page of API calls costs one validation rather
+    than ten, which bounds revocation latency at a minute. A no is never
+    cached, and a receiver that cannot be reached is a 502 rather than
+    either answer: unreachable must not read as revoked, and it must
+    certainly not read as valid.
+    """
+    now = time.time()
+    hit = _session_cache.get(token)
+    if hit and hit[0] > now:
+        return True
+    try:
+        who = managed.receiver_request(RECEIVER_URL, "GET", "/admin/session",
+                                       token)
+    except managed.ReceiverError as e:
+        if e.status == 502:
+            log.warning("receiver call failed for %s: %s",
+                        _redact_url(RECEIVER_URL), e.detail)
+            raise HTTPException(
+                502, "could not reach the receiver to validate the session")
+        return False
+    if len(_session_cache) > 512:
+        # The cache is per live session and sessions expire in hours, so
+        # growth past this is garbage from old logins; sweep it.
+        for k in [k for k, v in _session_cache.items() if v[0] <= now]:
+            _session_cache.pop(k, None)
+    _session_cache[token] = (now + SESSION_CACHE_TTL,
+                             str(who.get("username", "")))
+    return True
+
+
+def _cookie_secure(request: Request) -> bool:
+    """Whether the session cookie should carry Secure.
+
+    Judged from how the login actually arrived: direct TLS, or a TLS
+    ingress saying so in X-Forwarded-Proto. A hard-coded True would break
+    the documented localhost and plain-HTTP-behind-a-proxy paths silently -
+    the cookie would simply never come back.
+    """
+    return (request.url.scheme == "https"
+            or request.headers.get("x-forwarded-proto", "") == "https")
+
+
+def _login_mode_only():
+    if not LOGIN_MODE:
+        # Classic portals have no login; the route should not advertise one.
+        raise HTTPException(404, "Not Found")
+
+
+def _session_response(out: dict, request: Request) -> JSONResponse:
+    """The logged-in answer: session details for the page, token in an
+    HttpOnly cookie the page can never read. SameSite=Strict plus the
+    JSON-only rule on POSTs (middleware below) is the CSRF story."""
+    resp = JSONResponse({"ok": True,
+                         "username": str(out.get("username", "")),
+                         "expires_at": out.get("expires_at")})
+    resp.set_cookie(SESSION_COOKIE, str(out.get("token", "")),
+                    httponly=True, samesite="strict",
+                    secure=_cookie_secure(request), path="/")
+    return resp
+
+
+class LoginRequest(BaseModel):
+    username: str = Field(min_length=1, max_length=64)
+    password: str = Field(min_length=1, max_length=256)
+
+
+class SetupRequest(BaseModel):
+    setup_code: str = Field(min_length=1, max_length=128)
+    username: str = Field(min_length=1, max_length=64)
+    password: str = Field(min_length=12, max_length=256)
+
+
+@app.get("/api/auth")
+def auth_state(request: Request):
+    """What the login screen needs before anyone has authenticated.
+
+    Unauthenticated on purpose, and it says nothing about the estate: the
+    mode, whether this browser holds a live session, who that is, and
+    whether the receiver is still waiting for its first admin account (so
+    the page can honestly offer create-account instead of sign-in).
+    """
+    if not LOGIN_MODE:
+        return {"mode": PORTAL_AUTH or "basic", "authenticated": None,
+                "username": "", "setup_needed": False}
+    token = request.cookies.get(SESSION_COOKIE, "")
+    authenticated = bool(token) and _session_ok(token)
+    setup_needed = False
+    if not authenticated:
+        try:
+            setup_needed = bool(managed.receiver_request(
+                RECEIVER_URL, "GET", "/admin/setup", "").get("needed"))
+        except managed.ReceiverError as e:
+            # A login screen that cannot say whether an account exists should
+            # say why, not guess a form.
+            raise HTTPException(e.status, e.detail)
+    return {"mode": "login" if PORTAL_AUTH != "none" else "none",
+            "authenticated": authenticated,
+            "username": (_session_cache.get(token) or (0, ""))[1],
+            "setup_needed": setup_needed}
+
+
+@app.post("/api/login")
+def api_login(req: LoginRequest, request: Request):
+    _login_mode_only()
+    out = _receiver("POST", "/admin/login", "",
+                    {"username": req.username, "password": req.password})
+    return _session_response(out, request)
+
+
+@app.post("/api/setup")
+def api_setup(req: SetupRequest, request: Request):
+    """First boot: claim the receiver's boot-printed setup code, create the
+    admin account, and arrive signed in - the receiver returns a session."""
+    _login_mode_only()
+    out = _receiver("POST", "/admin/setup",  "",
+                    {"setup_code": req.setup_code, "username": req.username,
+                     "password": req.password})
+    return _session_response(out, request)
+
+
+@app.post("/api/logout")
+def api_logout(request: Request):
+    _login_mode_only()
+    token = request.cookies.get(SESSION_COOKIE, "")
+    _session_cache.pop(token, None)
+    if token:
+        try:
+            managed.receiver_request(RECEIVER_URL, "POST", "/admin/logout",
+                                     token)
+        except managed.ReceiverError:
+            # The cookie dies either way; a receiver hiccup must not trap
+            # someone in a session they asked to leave. The receiver-side
+            # session then simply expires on its own TTL.
+            pass
+    resp = JSONResponse({"ok": True})
+    resp.delete_cookie(SESSION_COOKIE, path="/")
+    return resp
+
+
+def _admin_forward(request: Request) -> str:
+    """The operator's session, bound for the receiver's admin API.
+
+    The receiver authorizes; the portal only carries. Nothing here checks
+    the session first - the receiver's own answer comes back through the
+    proxy, and checking twice would just be a second place to be wrong.
+    """
     if not RECEIVER_URL:
         raise HTTPException(
             503, "RECEIVER_URL is not set. Managed mode needs the portal to "
                  "reach the receiver's admin API; see the portal README.")
-    if not x_admin_token:
+    token = request.cookies.get(SESSION_COOKIE, "")
+    if not token:
         raise HTTPException(
-            401, "X-Admin-Token required: the receiver's admin token. The "
-                 "portal forwards it per request and never stores it.")
-    return x_admin_token
+            401, "login required: managed actions use your portal session, "
+                 "forwarded to the receiver per request and never stored.")
+    return token
 
 
 def _receiver(method: str, path: str, token: str, body: dict | None = None):
@@ -868,7 +1101,7 @@ def artifact(kind: str, _=Depends(require_auth),
 
 
 @app.get("/")
-def index(_=Depends(require_auth)):
+def index(_=Depends(require_page_auth)):
     return FileResponse(STATIC / "index.html")
 
 
@@ -877,7 +1110,7 @@ def index(_=Depends(require_auth)):
 # the dependency is that this portal does not answer to anyone who has not
 # authenticated.
 @app.get("/logo.png")
-def logo(_=Depends(require_auth)):
+def logo(_=Depends(require_page_auth)):
     return FileResponse(STATIC / "logo.png", media_type="image/png")
 
 

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -140,14 +140,13 @@ h2{font-size:19px;margin:0 0 4px}
    constraint on the prose only makes it stop short of the table it
    introduces, which reads as a broken line rather than a measure. */
 input{background:var(--sf2);border:1px solid var(--bd);color:var(--fg);border-radius:6px;padding:6px 10px;font:inherit;min-width:220px}
-/* Managed views: small action buttons, the admin-token field, and the
-   one-time pane a minted token appears in. */
+/* Managed views: small action buttons, the login fields, and the one-time
+   pane a minted token appears in. */
 button.mini{font:inherit;font-size:12px;padding:3px 10px;border:1px solid var(--line,#8884);border-radius:6px;background:transparent;color:var(--pri);cursor:pointer}
 button.mini:hover{border-color:var(--pri)}
 .mfield{font:inherit;font-size:13px;padding:5px 8px;border:1px solid var(--line,#8884);border-radius:6px;background:transparent;color:inherit;min-width:260px}
 .tokpane{border:1px solid var(--pri);border-radius:8px;padding:12px 14px;margin:14px 0}
 .tokpane code{word-break:break-all}
-.adminbar{margin:10px 0 14px;font-size:12px;color:var(--mut)}
 </style>
 <div class="shell">
   <aside>
@@ -164,6 +163,8 @@ button.mini:hover{border-color:var(--pri)}
       <input id="q" placeholder="filter…">
       <span id="freshness" class="mono" style="font-size:11px;color:var(--mut)"></span>
       <button id="refresh" class="back" style="margin:0">refresh</button>
+      <span id="who" class="mono" style="font-size:11px;color:var(--mut);margin-left:auto"></span>
+      <button id="signout" class="back" style="margin:0;display:none">sign out</button>
     </div>
     <main id="app"></main>
   </div>
@@ -181,15 +182,72 @@ let PG = null;
 let FLEET = null;
 let TOKENS = null;
 let S = null, CFG = {}, loadError = '';
-// The receiver admin token, held in this tab's memory for the session and
-// sent per request as a header. Never written to storage of any kind: the
-// portal's whole security story for the write path is that it stores no
-// credential, and localStorage would quietly undo that.
-let ADMIN = '';
-// The one moment a minted token is visible. Kept until dismissed or the
-// admin token is forgotten, because a pane that vanishes on the next click
-// loses a credential that cannot be recovered.
+// What /api/auth said: {mode, authenticated, username, setup_needed}.
+// The session itself is an HttpOnly cookie this script can never read -
+// the portal's whole security story for the write path is that nothing
+// credential-shaped is reachable from page script.
+let AUTH = null;
+// The one moment a minted token is visible. Kept until dismissed, because a
+// pane that vanishes on the next click loses a credential that cannot be
+// recovered.
 let MINTED = null;
+
+// The login screen replaces the whole page, so the chrome around it (nav,
+// filter, refresh) goes quiet rather than sitting there doing nothing.
+function chrome(on) {
+  document.querySelector('.topbar').style.display = on ? '' : 'none';
+  document.getElementById('nav').style.display = on ? '' : 'none';
+  const so = document.getElementById('signout'), who = document.getElementById('who');
+  const login = AUTH && AUTH.mode === 'login';
+  so.style.display = on && login ? '' : 'none';
+  who.textContent = on && login && AUTH.username ? AUTH.username : '';
+}
+
+function showLogin(msg) {
+  // A minted token's show-once pane must not outlive the session that
+  // minted it: signing out and back in would show the plaintext again.
+  MINTED = null; FLEET = null; TOKENS = null;
+  chrome(false);
+  const create = AUTH && AUTH.setup_needed;
+  app.innerHTML = `<div style="max-width:440px;margin:8vh auto 0">
+    <h2>${create ? 'Create the admin account' : 'Sign in'}</h2>
+    <p class="lede">${create
+      ? `No admin account exists yet. The receiver printed a one-time setup
+         code to its log at boot — <code>kubectl logs deploy/&lt;release&gt;-ai-guard
+         | grep setup_code</code>, or <code>docker compose logs receiver</code>.
+         Enter it here; it is consumed on use and a restart mints a fresh one.`
+      : `The portal signs in against the receiver's admin account. The session
+         is an HttpOnly cookie: nothing is stored where page script can read it.`}</p>
+    ${msg ? `<div class="note">${esc(msg)}</div>` : ''}
+    ${create ? `<p><input id="li-code" class="mfield" style="width:100%"
+      placeholder="setup code (aigs_…)" autocomplete="off"></p>` : ''}
+    <p><input id="li-user" class="mfield" style="width:100%"
+      placeholder="username" autocomplete="username"></p>
+    <p><input id="li-pass" class="mfield" style="width:100%" type="password"
+      placeholder="${create ? 'password (12 characters or more)' : 'password'}"
+      autocomplete="${create ? 'new-password' : 'current-password'}"></p>
+    <button class="mini" style="padding:6px 16px"
+      data-act="${create ? 'do-setup' : 'do-login'}">${create ? 'Create account' : 'Sign in'}</button>
+  </div>`;
+  const u = document.getElementById(create ? 'li-code' : 'li-user');
+  if (u) u.focus();
+}
+
+// A 401 mid-session means the session expired or was revoked; the honest
+// response is the login screen with a line saying why, not a broken view.
+async function sessionLost() {
+  if (AUTH) AUTH.authenticated = false;
+  try { AUTH = await (await fetch('/api/auth')).json(); } catch (e) { /* keep what we had */ }
+  showLogin('Signed out — the session expired or was revoked. Sign in again.');
+}
+
+async function boot() {
+  try { AUTH = await (await fetch('/api/auth')).json(); }
+  catch (e) { AUTH = null; }
+  if (AUTH && AUTH.mode === 'login' && !AUTH.authenticated) { showLogin(); return; }
+  chrome(true);
+  load();
+}
 
 async function load(force) {
   app.innerHTML = '<p class="lede">Reading findings…</p>';
@@ -198,7 +256,9 @@ async function load(force) {
   // button refreshes some of the page and silently not the rest.
   if (force) { DIAG = null; REG = null; EV = null; PG = null; FLEET = null; TOKENS = null; }
   try {
-    CFG = await (await fetch('/api/config')).json();
+    const cr = await fetch('/api/config');
+    if (cr.status === 401 && AUTH && AUTH.mode === 'login') { sessionLost(); return; }
+    CFG = await cr.json();
     const gr = await fetch('/api/graph' + q);
     if (!gr.ok) throw new Error((await gr.json()).detail || gr.statusText);
     G = await gr.json();
@@ -1170,9 +1230,10 @@ function dashboard() {
 }
 
 // ------------------------------------------------------------- managed --
-// These two views call the receiver's admin API through the portal. The
-// admin token is entered once per session, held in the ADMIN variable, and
-// forwarded per request; forgetting it (or a 401) drops back to the gate.
+// These two views call the receiver's admin API through the portal, on the
+// same session the whole page runs on: the portal forwards the cookie's
+// token per request and the receiver authorizes. Nothing to enter, nothing
+// held in page script.
 
 function managedGate(title) {
   if (!CFG.managed || !CFG.managed.enabled) return `<h2>${esc(title)}</h2>
@@ -1180,32 +1241,22 @@ function managedGate(title) {
   on the portal (and <code>MANAGED_MODE=true</code> on the receiver) to manage
   enrollment tokens and devices from here. The classic file-and-token flow
   keeps working without it.</p>`;
-  if (!ADMIN) return `<h2>${esc(title)}</h2>
-  <p class="lede">This view calls the receiver's admin API. Enter the
-  receiver's admin token: it is held in this tab's memory only, sent with
-  each request, and never stored — the portal keeps holding no credentials.</p>
-  <input type="password" id="admin-token-input" class="mfield"
-    placeholder="receiver admin token">
-  <button class="mini" data-act="admin-save">Unlock</button>`;
   return '';
 }
 
-const adminBar = () => `<div class="adminbar">admin token held in memory —
-  <button class="mini" data-act="admin-forget">forget it</button></div>`;
-
 async function mfetch(path, opts) {
+  // Content-Type on every request, body or not: in login mode the portal
+  // refuses POSTs without it, which is the CSRF rule cookies made necessary.
   return fetch(path, {...(opts || {}), headers: {
-    'X-Admin-Token': ADMIN, 'Content-Type': 'application/json',
+    'Content-Type': 'application/json',
     ...((opts || {}).headers || {})}});
 }
 
 async function managedError(r, title) {
+  if (r.status === 401) { sessionLost(); return ''; }
   let d = r.statusText;
   try { d = (await r.json()).detail || d; } catch (e) { /* keep statusText */ }
-  if (r.status === 401) ADMIN = '';
-  return `<h2>${esc(title)}</h2><div class="note">${esc(String(d))}</div>`
-    + (r.status === 401 ? `<p class="lede">The admin token was refused; enter
-      it again from the view menu.</p>` : '');
+  return `<h2>${esc(title)}</h2><div class="note">${esc(String(d))}</div>`;
 }
 
 async function fleet() {
@@ -1223,7 +1274,6 @@ async function fleet() {
   request and touches nothing else. A device that re-enrolled (a reimaged
   laptop, a scanner that enrolls every run — or a serial someone else
   enrolled while it was silent) keeps its row and says so under "enrolled".</p>
-  ${adminBar()}
   ${ds.length ? `<table><tr><th>device</th><th>platform</th><th>serial</th>
     <th>enrolled</th><th>last seen</th><th>agent</th><th>status</th><th></th></tr>
   ${ds.map(d => `<tr>
@@ -1257,7 +1307,6 @@ async function tokens() {
   it once for their own credential. It can create auditable device records and
   nothing else, which is why a long life inside an MDM artifact is
   acceptable; revoke it here the moment it is not.</p>
-  ${adminBar()}
   ${MINTED ? (MINTED.error
     ? `<div class="note">${esc(MINTED.error)}
        <button class="mini" data-act="dismiss-minted">dismiss</button></div>`
@@ -1281,23 +1330,36 @@ async function tokens() {
   </tr>`; }).join('')}</table>` : '<div class="note">No enrollment tokens yet.</div>'}`;
 }
 
+const _val = id => (document.getElementById(id)?.value || '').trim();
+
 async function managedAction(act, el) {
-  if (act === 'admin-save') {
-    const v = document.getElementById('admin-token-input');
-    ADMIN = ((v && v.value) || '').trim();
-    FLEET = null; TOKENS = null; render(); return;
-  }
-  if (act === 'admin-forget') {
-    ADMIN = ''; FLEET = null; TOKENS = null; MINTED = null; render(); return;
+  if (act === 'do-login' || act === 'do-setup') {
+    const body = act === 'do-setup'
+      ? {setup_code: _val('li-code'), username: _val('li-user'), password: _val('li-pass')}
+      : {username: _val('li-user'), password: _val('li-pass')};
+    const r = await mfetch(act === 'do-setup' ? '/api/setup' : '/api/login',
+      {method: 'POST', body: JSON.stringify(body)});
+    if (r.ok) {
+      const o = await r.json();
+      AUTH = {mode: 'login', authenticated: true, username: o.username, setup_needed: false};
+      chrome(true); load();
+    } else {
+      let d = r.statusText;
+      try {
+        const e = await r.json();
+        // 422 is pydantic refusing the shape (a short password, an empty
+        // field); its detail is a list, so name the field rule instead.
+        d = r.status === 422 ? 'Check the fields: the password needs 12 '
+          + 'characters or more and nothing may be empty.' : e.detail || d;
+      } catch (e) { /* keep statusText */ }
+      showLogin(String(d));
+    }
+    return;
   }
   if (act === 'dismiss-minted') { MINTED = null; render(); return; }
   if (act === 'copy') {
     try { await navigator.clipboard.writeText(el.getAttribute('data-copy') || '');
           el.textContent = 'copied'; } catch (e) { /* clipboard denied */ }
-    return;
-  }
-  if (!ADMIN) {
-    alert('Enter the receiver admin token first — Managed section, either view.');
     return;
   }
   if (act === 'mint') {
@@ -1307,8 +1369,8 @@ async function managedAction(act, el) {
       {method: 'POST', body: JSON.stringify({note, ttl_days: ttl})});
     if (r.ok) { MINTED = await r.json(); TOKENS = null; }
     else {
+      if (r.status === 401) { sessionLost(); return; }
       let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
-      if (r.status === 401) ADMIN = '';
       MINTED = {error: String(d)};
     }
     render(); return;
@@ -1323,8 +1385,8 @@ async function managedAction(act, el) {
       : '/api/devices/' + encodeURIComponent(id) + '/revoke';
     const r = await mfetch(path, {method: 'POST'});
     if (!r.ok) {
+      if (r.status === 401) { sessionLost(); return; }
       let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
-      if (r.status === 401) ADMIN = '';
       alert('Revoke failed: ' + d);
     }
     FLEET = null; TOKENS = null; render(); return;
@@ -1333,8 +1395,8 @@ async function managedAction(act, el) {
     const kind = el.getAttribute('data-key');
     const r = await mfetch('/api/artifacts/' + encodeURIComponent(kind), {method: 'POST'});
     if (!r.ok) {
+      if (r.status === 401) { sessionLost(); return; }
       let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
-      if (r.status === 401) ADMIN = '';
       alert('Could not generate the artifact: ' + d);
       return;
     }
@@ -1421,7 +1483,20 @@ window.addEventListener('hashchange', () => {
   const h = fromHash();
   if (h !== view) { view = h; detail = null; drawNav(); render(); }
 });
+// Enter in a login field is the same as clicking its button. Delegated like
+// the clicks, because the form is re-rendered on every failed attempt.
+app.addEventListener('keydown', e => {
+  if (e.key !== 'Enter') return;
+  if (!e.target.matches || !e.target.matches('#li-user,#li-pass,#li-code')) return;
+  const btn = app.querySelector('[data-act="do-login"],[data-act="do-setup"]');
+  if (btn) btn.click();
+});
 q.oninput = e => { filter = e.target.value.toLowerCase(); detail = null; render(); };
 document.getElementById('refresh').onclick = () => load(true);
-load();
+document.getElementById('signout').onclick = async () => {
+  await mfetch('/api/logout', {method: 'POST'});
+  AUTH = {mode: 'login', authenticated: false, username: '', setup_needed: false};
+  showLogin('Signed out.');
+};
+boot();
 </script>

--- a/portal/tests/test_login.py
+++ b/portal/tests/test_login.py
@@ -1,0 +1,330 @@
+"""The portal login: sessions from the receiver, carried as a cookie.
+
+Managed mode is login mode - the receiver owns the admin account, the portal
+signs in against it, and the session rides as an HttpOnly cookie the page
+script can never read. These tests call route functions and dependencies
+directly, like the rest of the suite (no TestClient: the portal deliberately
+has no HTTP client dependency), with receiver_request stubbed and recorded.
+"""
+
+import asyncio
+import os
+
+os.environ.setdefault("PORTAL_AUTH", "none")
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app import main, managed
+
+
+def _request(cookie_token=None, scheme="http", headers=()):
+    hs = [(b"host", b"portal")] + [(k.encode(), v.encode()) for k, v in headers]
+    if cookie_token is not None:
+        hs.append((b"cookie",
+                   ("%s=%s" % (main.SESSION_COOKIE, cookie_token)).encode()))
+    return Request({"type": "http", "method": "GET", "path": "/",
+                    "scheme": scheme, "headers": hs, "query_string": b""})
+
+
+@pytest.fixture
+def login_mode(monkeypatch):
+    """Managed mode with real auth (the test env sets PORTAL_AUTH=none at
+    import, which would short-circuit require_auth), a recorded receiver,
+    and a clean session cache."""
+    calls = []
+
+    def fake(base, method, path, token, body=None):
+        calls.append({"method": method, "path": path, "token": token,
+                      "body": body})
+        if path == "/admin/session":
+            return {"username": "aman", "expires_at": "2027-01-01T00:00:00+00:00"}
+        if method == "POST" and path == "/admin/login":
+            return {"token": "aigt_NEW", "username": body["username"],
+                    "expires_at": "2027-01-01T00:00:00+00:00"}
+        if method == "GET" and path == "/admin/setup":
+            return {"needed": True}
+        if method == "POST" and path == "/admin/setup":
+            return {"token": "aigt_FIRST", "username": body["username"],
+                    "expires_at": "2027-01-01T00:00:00+00:00"}
+        return {"ok": True}
+
+    monkeypatch.setattr(main, "PORTAL_AUTH", "")
+    monkeypatch.setattr(main, "RECEIVER_URL", "http://receiver.internal:8080")
+    monkeypatch.setattr(main, "LOGIN_MODE", True)
+    monkeypatch.setattr(main.managed, "receiver_request", fake)
+    monkeypatch.setattr(main, "_session_cache", {})
+    return calls
+
+
+def http_error(fn, *args, **kw) -> HTTPException:
+    with pytest.raises(HTTPException) as e:
+        fn(*args, **kw)
+    return e.value
+
+
+# ------------------------------------------------------------ the read gate --
+
+
+def test_no_cookie_is_a_401_page_not_a_browser_dialog(login_mode):
+    err = http_error(main.require_auth, _request(), None)
+    assert err.status_code == 401
+    # No WWW-Authenticate: the login is a page the SPA draws, and the header
+    # would put a basic-auth dialog in front of it.
+    assert not (err.headers or {}).get("WWW-Authenticate")
+
+
+def test_a_live_session_passes_and_is_cached(login_mode):
+    main.require_auth(_request(cookie_token="aigt_s"), None)
+    main.require_auth(_request(cookie_token="aigt_s"), None)
+    # One validation for the pair: the second ran inside the positive cache.
+    assert len(login_mode) == 1
+    assert login_mode[0] == {"method": "GET", "path": "/admin/session",
+                             "token": "aigt_s", "body": None}
+
+
+def test_a_refused_session_is_401_and_never_cached(login_mode, monkeypatch):
+    def refuse(base, method, path, token, body=None):
+        login_mode.append({"path": path})
+        raise managed.ReceiverError(401, "bad token")
+    monkeypatch.setattr(main.managed, "receiver_request", refuse)
+
+    for _ in range(2):
+        err = http_error(main.require_auth, _request(cookie_token="aigt_dead"), None)
+        assert err.status_code == 401
+    # Refused twice, asked twice: a no is never cached, so a revocation
+    # holds from the next request.
+    assert len(login_mode) == 2
+
+
+def test_an_unreachable_receiver_is_a_502_not_an_answer(login_mode, monkeypatch):
+    """Unreachable must not read as revoked, and it must certainly not read
+    as valid."""
+    def down(base, method, path, token, body=None):
+        raise managed.ReceiverError(502, "could not reach the receiver (X)")
+    monkeypatch.setattr(main.managed, "receiver_request", down)
+
+    err = http_error(main.require_auth, _request(cookie_token="aigt_s"), None)
+    assert err.status_code == 502
+
+
+def test_the_page_shell_is_open_in_login_mode(login_mode):
+    """The shell holds no estate data and has to load for the login screen
+    to exist; every API it calls is still gated."""
+    assert main.require_page_auth(_request(), None) is None
+
+
+def test_classic_mode_keeps_basic_auth_on_the_shell(monkeypatch):
+    monkeypatch.setattr(main, "LOGIN_MODE", False)
+    monkeypatch.setattr(main, "PORTAL_AUTH", "")
+    monkeypatch.setattr(main, "PORTAL_USER", "u")
+    monkeypatch.setattr(main, "PORTAL_PASSWORD", "p")
+    err = http_error(main.require_page_auth, _request(), None)
+    assert err.status_code == 401
+    assert (err.headers or {}).get("WWW-Authenticate") == "Basic"
+
+
+# ----------------------------------------------------------------- /api/auth --
+
+
+def test_auth_state_in_classic_mode_names_the_mode_and_calls_nothing(monkeypatch):
+    calls = []
+    monkeypatch.setattr(main, "LOGIN_MODE", False)
+    monkeypatch.setattr(main, "PORTAL_AUTH", "")
+    monkeypatch.setattr(main.managed, "receiver_request",
+                        lambda *a, **k: calls.append(a))
+    out = main.auth_state(_request())
+    assert out["mode"] == "basic" and out["setup_needed"] is False
+    assert calls == []
+
+
+def test_auth_state_offers_create_account_on_a_fresh_receiver(login_mode):
+    out = main.auth_state(_request())
+    assert out == {"mode": "login", "authenticated": False, "username": "",
+                   "setup_needed": True}
+    # It asked the receiver's unauthenticated one-bit probe, nothing else.
+    assert [c["path"] for c in login_mode] == ["/admin/setup"]
+
+
+def test_auth_state_with_a_live_session_says_who(login_mode):
+    out = main.auth_state(_request(cookie_token="aigt_s"))
+    assert out["authenticated"] is True and out["username"] == "aman"
+    assert out["setup_needed"] is False
+
+
+# ------------------------------------------------------------- login/logout --
+
+
+def _cookie(resp):
+    return resp.headers.get("set-cookie") or ""
+
+
+def test_login_proxies_and_sets_the_cookie_the_page_cannot_read(login_mode):
+    resp = main.api_login(main.LoginRequest(username="aman", password="pw"),
+                          _request())
+    c = _cookie(resp)
+    assert "aiguard_session=aigt_NEW" in c
+    assert "HttpOnly" in c and "SameSite=strict" in c.replace("Strict", "strict")
+    assert "Path=/" in c
+    # Plain HTTP login: no Secure, or the cookie would never come back on
+    # the documented localhost and behind-a-plain-proxy paths.
+    assert "Secure" not in c
+    assert login_mode[0]["path"] == "/admin/login"
+    assert login_mode[0]["body"] == {"username": "aman", "password": "pw"}
+
+
+def test_the_cookie_is_secure_when_the_login_arrived_over_tls(login_mode):
+    for req in (_request(scheme="https"),
+                _request(headers=[("x-forwarded-proto", "https")])):
+        resp = main.api_login(
+            main.LoginRequest(username="aman", password="pw"), req)
+        assert "Secure" in _cookie(resp)
+
+
+def test_a_refused_login_passes_the_receivers_answer_through(login_mode, monkeypatch):
+    def refuse(base, method, path, token, body=None):
+        raise managed.ReceiverError(401, "bad username or password")
+    monkeypatch.setattr(main.managed, "receiver_request", refuse)
+    err = http_error(main.api_login,
+                     main.LoginRequest(username="aman", password="no"),
+                     _request())
+    assert err.status_code == 401
+    assert err.detail == "bad username or password"
+
+
+def test_setup_claims_the_code_and_arrives_signed_in(login_mode):
+    resp = main.api_setup(
+        main.SetupRequest(setup_code="aigs_code", username="aman",
+                          password="a-long-enough-password"), _request())
+    assert "aiguard_session=aigt_FIRST" in _cookie(resp)
+    assert login_mode[0]["body"]["setup_code"] == "aigs_code"
+
+
+def test_setup_enforces_the_password_floor_at_the_edge():
+    with pytest.raises(ValueError):
+        main.SetupRequest(setup_code="c", username="u", password="short")
+
+
+def test_logout_revokes_remotely_flushes_the_cache_and_kills_the_cookie(login_mode):
+    main.require_auth(_request(cookie_token="aigt_s"), None)  # warm the cache
+    resp = main.api_logout(_request(cookie_token="aigt_s"))
+    assert [c["path"] for c in login_mode] == ["/admin/session", "/admin/logout"]
+    assert login_mode[1]["token"] == "aigt_s"
+    assert "aigt_s" not in main._session_cache
+    c = _cookie(resp)
+    assert "aiguard_session=" in c and ("Max-Age=0" in c or "expires" in c.lower())
+
+
+def test_logout_still_clears_the_cookie_when_the_receiver_is_down(login_mode, monkeypatch):
+    def down(base, method, path, token, body=None):
+        raise managed.ReceiverError(502, "could not reach the receiver (X)")
+    monkeypatch.setattr(main.managed, "receiver_request", down)
+    resp = main.api_logout(_request(cookie_token="aigt_s"))
+    assert "Max-Age=0" in _cookie(resp) or "expires" in _cookie(resp).lower()
+
+
+def test_login_routes_do_not_exist_in_classic_mode(monkeypatch):
+    monkeypatch.setattr(main, "LOGIN_MODE", False)
+    for call in (
+        lambda: main.api_login(
+            main.LoginRequest(username="u", password="p"), _request()),
+        lambda: main.api_setup(
+            main.SetupRequest(setup_code="c", username="u",
+                              password="a-long-enough-password"), _request()),
+        lambda: main.api_logout(_request()),
+    ):
+        assert http_error(call).status_code == 404
+
+
+# -------------------------------------------------------------------- CSRF --
+
+
+def _post_through_middleware(path, content_type):
+    class _Url:
+        pass
+
+    class _Req:
+        method = "POST"
+        url = _Url()
+        headers = {"content-type": content_type} if content_type else {}
+    _Req.url.path = path
+
+    async def _next(req):
+        return "passed"
+
+    async def run():
+        return await main.json_posts_only(_Req(), _next)
+    return asyncio.run(run())
+
+
+def test_a_post_without_json_content_type_is_refused(login_mode):
+    """The CSRF half that cookies made necessary: a cross-site form cannot
+    declare application/json, so requiring it (with SameSite=Strict) closes
+    what the old in-memory header token used to close by construction."""
+    resp = _post_through_middleware("/api/enrollment-tokens", "text/plain")
+    assert resp.status_code == 415
+    resp = _post_through_middleware("/api/login", None)
+    assert resp.status_code == 415
+    assert _post_through_middleware("/api/login", "application/json") == "passed"
+
+
+def test_the_json_rule_is_login_mode_only(monkeypatch):
+    monkeypatch.setattr(main, "LOGIN_MODE", False)
+    assert _post_through_middleware("/api/login", "text/plain") == "passed"
+
+
+# ------------------------------------------------------------ startup shapes --
+
+
+def _import_portal(env):
+    import subprocess
+    import sys
+
+    base = {k: v for k, v in os.environ.items()
+            if k not in ("PORTAL_AUTH", "PORTAL_USER", "PORTAL_PASSWORD",
+                         "RECEIVER_URL")}
+    return subprocess.run(
+        [sys.executable, "-c", "import app.main"], env={**base, **env},
+        capture_output=True, text=True,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def test_managed_mode_starts_without_a_basic_auth_pair():
+    """The fresh-install path: helm install sets RECEIVER_URL and nothing
+    else auth-shaped, and the portal must come up with its login rather
+    than refuse to start."""
+    proc = _import_portal({"RECEIVER_URL": "http://receiver:8080"})
+    assert proc.returncode == 0, proc.stderr
+
+
+def test_classic_mode_still_fails_closed():
+    proc = _import_portal({})
+    assert proc.returncode != 0
+    assert "refusing to start" in proc.stderr
+
+
+def test_a_basic_auth_pair_in_managed_mode_is_named_as_ignored():
+    proc = _import_portal({"RECEIVER_URL": "http://receiver:8080",
+                           "PORTAL_USER": "u", "PORTAL_PASSWORD": "p"})
+    assert proc.returncode == 0
+    assert "ignored in managed mode" in proc.stderr
+
+
+# -------------------------------------------------------------- the page --
+
+
+def test_the_page_no_longer_carries_an_admin_token_field():
+    html = (main.STATIC / "index.html").read_text()
+    assert "X-Admin-Token" not in html
+    assert "admin-token-input" not in html
+    # And it carries the login instead, wired through delegated handlers
+    # like everything else.
+    for needle in ("do-login", "do-setup", "/api/auth", "/api/login",
+                   "/api/setup", "/api/logout"):
+        assert needle in html, needle
+
+
+def test_diagnostics_report_the_login_mode(login_mode):
+    out = main.diagnostics(_=None)
+    assert out["runtime"]["auth_mode"] == "login"

--- a/portal/tests/test_managed_portal.py
+++ b/portal/tests/test_managed_portal.py
@@ -130,17 +130,36 @@ def http_error(fn, *args, **kw) -> HTTPException:
     return e.value
 
 
+def _request(cookie_token=None, scheme="http", headers=()):
+    """A bare Starlette request, the shape _admin_forward and require_auth
+    read: no client, no body, just cookies and headers."""
+    from starlette.requests import Request
+
+    hs = [(b"host", b"portal")] + [(k.encode(), v.encode()) for k, v in headers]
+    if cookie_token is not None:
+        hs.append((b"cookie",
+                   ("%s=%s" % (main.SESSION_COOKIE, cookie_token)).encode()))
+    return Request({"type": "http", "method": "GET", "path": "/",
+                    "scheme": scheme, "headers": hs, "query_string": b""})
+
+
 def test_unconfigured_managed_routes_say_what_is_missing(monkeypatch):
     monkeypatch.setattr(main, "RECEIVER_URL", "")
-    err = http_error(main._admin_forward, x_admin_token="anything")
+    err = http_error(main._admin_forward, _request(cookie_token="aigt_x"))
     assert err.status_code == 503
     assert "RECEIVER_URL" in err.detail
 
 
-def test_a_missing_admin_header_is_a_401_that_explains_the_model(configured):
-    err = http_error(main._admin_forward, x_admin_token="")
+def test_a_missing_session_is_a_401_that_explains_the_model(configured):
+    err = http_error(main._admin_forward, _request())
     assert err.status_code == 401
-    assert "never stores" in err.detail
+    assert "never stored" in err.detail
+
+
+def test_the_session_cookie_is_what_gets_forwarded(configured):
+    """The write path forwards the operator's own session; there is no
+    portal-held credential and no header to type a token into any more."""
+    assert main._admin_forward(_request(cookie_token="aigt_sess")) == "aigt_sess"
 
 
 def test_the_admin_token_is_forwarded_verbatim(receiver):


### PR DESCRIPTION
Second increment of v0.9.7, on top of #118.

- **Login mode** is managed mode: with `RECEIVER_URL` set the portal replaces basic auth with a sign-in against the receiver's admin account. `PORTAL_USER`/`PORTAL_PASSWORD` are ignored with a warning; `PORTAL_AUTH=none` still opens reads for reverse-proxy SSO while admin actions keep needing the login.
- First-boot: `GET /api/auth` (unauthenticated, says one bit more than nothing) lets the page honestly offer **create account** (setup code from the receiver's log) vs **sign in**; `/api/setup` claims the code and arrives signed in.
- Session = HttpOnly SameSite=Strict cookie (Secure when the login arrived over TLS), validated per request against `GET /admin/session` with a 60s positive cache — negative answers never cached, unreachable receiver is a 502 rather than either answer.
- Managed writes forward the operator's own session token; **X-Admin-Token is removed** — the portal UI never asks for a credential again and still stores nothing.
- CSRF: cookies made it real again, so every POST under `/api` must declare `Content-Type: application/json` (415 otherwise, login mode only) on top of SameSite=Strict.
- Chart 0.8.12: managed mode no longer generates the `-admin` Secret (set `managed.adminToken.value` only for automation/break-glass) or the portal password Secret; NOTES prints the setup-code kubectl one-liner. Compose overlay drops the admin_token file and clears the basic-auth pair.
- Show-once minted-token pane is cleared on sign-out (found in the browser pass).

Verified: 265 portal + 67 receiver tests (27 new portal tests incl. subprocess startup shapes), helm lint + template across managed shapes, compose config, live receiver+portal E2E over curl, and a Chrome click-through of create-account → managed views → mint → sign out → sign in.