### PR TITLE
Central settings and portal-edited governance decisions (v0.9.7 increment 3)

### DIFF
--- a/docs/governance.md
+++ b/docs/governance.md
@@ -218,14 +218,26 @@ rendered by running the demo.
 
 ## The audit trail
 
-There is no write path. Decisions are edited in the file, and the file goes
-through whatever review your repository already has.
+In classic mode there is no write path. Decisions are edited in the file, and
+the file goes through whatever review your repository already has.
 
 That is not a limitation to be apologised for. A merge request is signed,
 timestamped, reviewable, and carries a diff of exactly what changed and who
 approved the change. Most governance portals build something weaker and call it
 an audit log.
 
-If, after living with it, the recurring thought is *I wish I could change this
-in the portal*, that is evidence for a write path. If editing the file turns
-out to be fine, a great deal of engineering has been avoided.
+This document used to end: *if, after living with it, the recurring thought is
+"I wish I could change this in the portal", that is evidence for a write
+path.* Managed mode is that thought, made deliberate. With it enabled, the
+register's cards gain an **edit** control: decisions (status, owner, review
+date, reason) are recorded centrally in the receiver's state DB, every write
+is stamped with who and when in the receiver's event log, and the same rules
+the file's validator enforces apply on the write path - an approval without a
+review date is refused there too.
+
+The two coexist per tool: a portal-recorded decision wins, the file fills the
+gaps, and the register labels which kind of decision it is showing ("set in
+the portal"). Exceptions - scoped, expiring departures - remain file-only:
+they are rarer, and the review a merge request gives them is worth more than
+the convenience of an editor. The file-based path stays first-class either
+way, so the argument above still holds for classic mode.

--- a/portal/README.md
+++ b/portal/README.md
@@ -116,13 +116,22 @@ with a fresh enrollment token baked in as the script's own fallback default
 (MDM-supplied values still win; corporate domains are never baked - the
 receiver serves those at runtime).
 
+The Settings view grows a **Central settings** card: corporate domains and
+the extension ID are saved into the receiver's state DB and served to the
+fleet at runtime, with the source of each value named - a saved list shows
+what environment value it is shadowing, and clearing it falls back. The AI
+register's cards gain an **edit** control for governance decisions (status,
+owner, review date, reason), stored the same way and merged per tool with
+the governance file - the recorded decision wins, the file fills the gaps,
+and the card says "set in the portal" so the two are never mistaken for one
+another. Exceptions stay file-only
+([docs/governance.md](../docs/governance.md)).
+
 Every one of those actions is authorized by the **receiver**, not the
 portal: the operator's own session token is forwarded per request and never
 stored anywhere in the portal. The portal still holds no database and no
 credentials - a compromised portal yields readable findings, which it
-always did, and nothing that can mint or revoke. Governance decisions
-remain in the file ([docs/governance.md](../docs/governance.md)); these
-routes manage operational credentials, which is a different kind of thing.
+always did, and nothing that can mint or revoke.
 
 ### Reading from a hosted log store
 

--- a/portal/app/governance.py
+++ b/portal/app/governance.py
@@ -251,7 +251,11 @@ def decide(tool_id, governance, registry_approved, today=None, exceptions=None):
             "owner": rec.get("owner") or "",
             "review_due": rec["review_due"].isoformat() if rec.get("review_due") else "",
             "days_overdue": days_overdue(rec, today),
-            "source": "governance",
+            # Where the record came from. "governance" is the file, as it
+            # always was; a record the portal wrote in managed mode arrives
+            # with origin "portal" so the register can say which kind of
+            # decision it is showing.
+            "source": rec.get("origin") or "governance",
         })
 
     if registry_approved is None:

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -646,7 +646,8 @@ def status(hours: float = Query(default=None, gt=0, le=24 * 90),
 
 
 @app.get("/api/evidence")
-def evidence_snapshot(hours: float = Query(default=None, gt=0, le=24 * 90),
+def evidence_snapshot(request: Request,
+                      hours: float = Query(default=None, gt=0, le=24 * 90),
                       download: bool = Query(default=False),
                       _=Depends(require_auth)):
     """A checksummed statement of what the platform observed, for export.
@@ -663,7 +664,7 @@ def evidence_snapshot(hours: float = Query(default=None, gt=0, le=24 * 90),
     findings = _findings(hours)
     reg = derive.load_registry(REGISTRY_PATH)
     domain_map = derive.load_domain_map_from(reg)
-    gov, exceptions = governance.load_governance(GOVERNANCE_PATH)
+    gov, exceptions, _portal = _merged_governance(request)
 
     doc = evidence.evidence_from(
         derive.register_from(findings, reg, domain_map, gov, exceptions),
@@ -720,7 +721,8 @@ def paste_guard_events(hours: float = Query(default=None, gt=0, le=24 * 90),
 
 
 @app.get("/api/register")
-def register(hours: float = Query(default=None, gt=0, le=24 * 90),
+def register(request: Request,
+             hours: float = Query(default=None, gt=0, le=24 * 90),
              fmt: str = Query(default="json", pattern="^(json|csv)$"),
              refresh: bool = Query(default=False),
              _=Depends(require_auth)):
@@ -748,10 +750,14 @@ def register(hours: float = Query(default=None, gt=0, le=24 * 90),
     if refresh:
         _cache.pop("register", None)
 
+    # Fetched outside the cached build: the unmatched section below needs it
+    # on every request, and in managed mode it carries the portal-recorded
+    # decisions merged over the file.
+    gov, exceptions, portal_decisions = _merged_governance(request)
+
     def build():
         findings = _findings(hours)
         reg = derive.load_registry(REGISTRY_PATH)
-        gov, exceptions = governance.load_governance(GOVERNANCE_PATH)
         return derive.register_from(findings, reg,
                                     derive.load_domain_map_from(reg), gov,
                                     exceptions)
@@ -770,14 +776,16 @@ def register(hours: float = Query(default=None, gt=0, le=24 * 90),
             headers={"Content-Disposition": 'attachment; filename="%s"' % name},
         )
 
-    gov, exceptions = governance.load_governance(GOVERNANCE_PATH)
     known = [t.get("id") for t in (
         derive.load_registry(REGISTRY_PATH).get("tools") or [])]
     return JSONResponse({
         "rows": rows,
         "derived_at": at,
         "hours": hours,
-        "governance_configured": bool(GOVERNANCE_PATH),
+        # A governance file, or at least one decision recorded in the
+        # portal: either means somebody is deciding, and the "nothing is
+        # configured" note would be false.
+        "governance_configured": bool(GOVERNANCE_PATH) or portal_decisions > 0,
         # Decisions naming a tool the registry does not know. Reported rather
         # than dropped: the likely cause is a typo, and a decision that
         # silently matches nothing is how an organisation believes it has
@@ -992,6 +1000,47 @@ def api_logout(request: Request):
     return resp
 
 
+def _merged_governance(request: Request):
+    """(gov, exceptions, portal_decisions) - the effective governance.
+
+    The file as ever, plus, in managed mode, the decisions recorded in the
+    portal: merged per tool with the DB record winning and the file filling
+    the gaps, the same DB-wins-when-set rule every setting follows. Each DB
+    record carries origin "portal" so the register can label which kind of
+    decision it shows. Exceptions stay file-only on purpose.
+
+    A receiver that cannot answer is an error, not a silent fall-back to
+    the file: showing yesterday's decisions as if they were current is the
+    kind of quiet wrongness this project exists to avoid.
+    """
+    gov, exceptions = governance.load_governance(GOVERNANCE_PATH)
+    portal_count = 0
+    if LOGIN_MODE:
+        token = request.cookies.get(SESSION_COOKIE, "")
+        try:
+            out = managed.receiver_request(
+                RECEIVER_URL, "GET", "/admin/governance", token)
+        except managed.ReceiverError as e:
+            if e.status == 502:
+                log.warning("receiver call failed for %s: %s",
+                            _redact_url(RECEIVER_URL), e.detail)
+            raise HTTPException(
+                e.status, "could not read governance decisions from the "
+                          "receiver (%s)" % e.detail)
+        db = {}
+        for d in out.get("decisions", []):
+            db[str(d.get("tool_id"))] = {
+                "status": str(d.get("status") or ""),
+                "owner": str(d.get("owner") or ""),
+                "review_due": governance._parse_date(d.get("review_due")),
+                "reason": str(d.get("reason") or ""),
+                "origin": "portal",
+            }
+        portal_count = len(db)
+        gov = {**gov, **db}
+    return gov, exceptions, portal_count
+
+
 def _admin_forward(request: Request) -> str:
     """The operator's session, bound for the receiver's admin API.
 
@@ -1062,6 +1111,83 @@ def revoke_device(did: str, _=Depends(require_auth),
     if not _ID_RE.match(did):
         raise HTTPException(422, "malformed device id")
     return _receiver("POST", "/admin/devices/%s/revoke" % did, token)
+
+
+# Settings and governance writes. POST rather than PUT on the portal side,
+# because the CSRF rule (JSON-only POSTs) is what protects cookie-carried
+# writes and widening it to more methods is more surface than one verb
+# buys; the receiver side keeps its PUT.
+
+
+class SettingsWrite(BaseModel):
+    # extra=forbid, same as the receiver: an unknown key here would be
+    # silently dropped from model_fields_set and someone would believe a
+    # setting took effect.
+    model_config = {"extra": "forbid"}
+    corp_domains: list[str] | None = Field(default=None, max_length=200)
+    extension_id: str | None = Field(default=None, max_length=128)
+    onboarding_done: bool | None = None
+
+
+class DecisionWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool_id: str = Field(min_length=1, max_length=100)
+    status: str = Field(min_length=1, max_length=32)
+    owner: str = Field(default="", max_length=200)
+    review_due: str = Field(default="", max_length=10)
+    reason: str = Field(default="", max_length=1000)
+
+
+class GovernanceWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    decisions: list[DecisionWrite] = Field(default_factory=list, max_length=200)
+    delete: list[str] = Field(default_factory=list, max_length=200)
+
+
+class PasswordWrite(BaseModel):
+    current: str = Field(default="", max_length=256)
+    new: str = Field(min_length=12, max_length=256)
+
+
+@app.get("/api/settings")
+def api_settings(_=Depends(require_auth), token: str = Depends(_admin_forward)):
+    return _receiver("GET", "/admin/settings", token)
+
+
+@app.post("/api/settings")
+def api_settings_write(req: SettingsWrite, _=Depends(require_auth),
+                       token: str = Depends(_admin_forward)):
+    """Forward exactly the keys that were sent - a null deletes (fall back
+    to env), an absent key is untouched - and the receiver validates and
+    answers with the fresh effective view."""
+    body = {k: getattr(req, k) for k in req.model_fields_set}
+    return _receiver("PUT", "/admin/settings", token, body)
+
+
+@app.get("/api/governance-decisions")
+def api_governance(_=Depends(require_auth), token: str = Depends(_admin_forward)):
+    return _receiver("GET", "/admin/governance", token)
+
+
+@app.post("/api/governance-decisions")
+def api_governance_write(req: GovernanceWrite, _=Depends(require_auth),
+                         token: str = Depends(_admin_forward)):
+    out = _receiver("PUT", "/admin/governance", token, req.model_dump())
+    # The register is derived with governance folded in and cached for
+    # CACHE_TTL; a decision just changed, so that cache is now a view of
+    # the world before the operator acted.
+    _cache.pop("register", None)
+    return out
+
+
+@app.post("/api/password")
+def api_password(req: PasswordWrite, _=Depends(require_auth),
+                 token: str = Depends(_admin_forward)):
+    """The receiver enforces the rules (current password on the session
+    path, other sessions revoked); this session survives because it is the
+    bearer of the request."""
+    return _receiver("POST", "/admin/password",  token,
+                     {"current": req.current, "new": req.new})
 
 
 @app.post("/api/artifacts/{kind}")

--- a/portal/app/managed.py
+++ b/portal/app/managed.py
@@ -50,7 +50,7 @@ def receiver_request(base: str, method: str, path: str, admin_token: str,
     req = urllib.request.Request(
         base.rstrip("/") + path,
         method=method,
-        data=data if method == "POST" else None,
+        data=data if method in ("POST", "PUT") else None,
         headers={
             "Authorization": "Bearer " + admin_token,
             "Content-Type": "application/json",

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -139,7 +139,8 @@ h2{font-size:19px;margin:0 0 4px}
 /* No max-width here. main is already capped and centred, so a second
    constraint on the prose only makes it stop short of the table it
    introduces, which reads as a broken line rather than a measure. */
-input{background:var(--sf2);border:1px solid var(--bd);color:var(--fg);border-radius:6px;padding:6px 10px;font:inherit;min-width:220px}
+input,select{background:var(--sf2);border:1px solid var(--bd);color:var(--fg);border-radius:6px;padding:6px 10px;font:inherit;min-width:220px}
+select.mfield{min-width:160px}
 /* Managed views: small action buttons, the login fields, and the one-time
    pane a minted token appears in. */
 button.mini{font:inherit;font-size:12px;padding:3px 10px;border:1px solid var(--line,#8884);border-radius:6px;background:transparent;color:var(--pri);cursor:pointer}
@@ -181,6 +182,13 @@ let EV = null;
 let PG = null;
 let FLEET = null;
 let TOKENS = null;
+let SETTINGS = null;
+// Governance editing: which tool's card shows the form, prefill fetched
+// from the recorded decision (the row lacks the free-text reason, and an
+// owner edit must not silently blank it), and the last refusal to show.
+let GOVEDIT = null, GOVPRE = null, GOVERR = '';
+// One-line outcome of the last Settings action ("saved", or a refusal).
+let SETMSG = '';
 let S = null, CFG = {}, loadError = '';
 // What /api/auth said: {mode, authenticated, username, setup_needed}.
 // The session itself is an HttpOnly cookie this script can never read -
@@ -206,7 +214,8 @@ function chrome(on) {
 function showLogin(msg) {
   // A minted token's show-once pane must not outlive the session that
   // minted it: signing out and back in would show the plaintext again.
-  MINTED = null; FLEET = null; TOKENS = null;
+  MINTED = null; FLEET = null; TOKENS = null; SETTINGS = null;
+  GOVEDIT = null; GOVPRE = null; GOVERR = ''; SETMSG = '';
   chrome(false);
   const create = AUTH && AUTH.setup_needed;
   app.innerHTML = `<div style="max-width:440px;margin:8vh auto 0">
@@ -254,7 +263,7 @@ async function load(force) {
   const q = force ? '?refresh=true' : '';
   // Refresh must clear the views that read a second endpoint too, or the
   // button refreshes some of the page and silently not the rest.
-  if (force) { DIAG = null; REG = null; EV = null; PG = null; FLEET = null; TOKENS = null; }
+  if (force) { DIAG = null; REG = null; EV = null; PG = null; FLEET = null; TOKENS = null; SETTINGS = null; }
   try {
     const cr = await fetch('/api/config');
     if (cr.status === 401 && AUTH && AUTH.mode === 'login') { sessionLost(); return; }
@@ -672,6 +681,31 @@ function personal() {
 }
 
 
+// The inline decision editor on a register card. Prefilled from the
+// recorded decision when one exists (GOVPRE), else from what the row shows,
+// so editing one field does not silently rewrite the others.
+function govForm(r) {
+  const pre = GOVPRE || {};
+  const status = pre.status || r.stored_status || 'reviewing';
+  const opt = (v, lbl) => `<option value="${v}"${status === v ? ' selected' : ''}>${lbl}</option>`;
+  return `${GOVERR ? `<div class="note">${esc(GOVERR)}</div>` : ''}
+  <div style="display:flex;flex-direction:column;gap:6px">
+    <select id="gov-status" class="mfield">
+      ${opt('approved', 'approved')}${opt('not_approved', 'not approved')}${opt('reviewing', 'reviewing')}
+    </select>
+    <input id="gov-owner" class="mfield" placeholder="owner, e.g. Security"
+      value="${esc(pre.owner ?? r.owner ?? '')}">
+    <input id="gov-review" class="mfield" placeholder="review due (YYYY-MM-DD, required for approved)"
+      value="${esc(pre.review_due ?? r.review_due ?? '')}">
+    <input id="gov-reason" class="mfield" placeholder="reason (optional)"
+      value="${esc(pre.reason ?? '')}">
+    <div>
+      <button class="mini" data-act="gov-save" data-key="${esc(r.id)}">save decision</button>
+      <button class="mini" data-act="gov-cancel">cancel</button>
+    </div>
+  </div>`;
+}
+
 async function register() {
   if (!REG) {
     try { REG = await (await fetch('/api/register')).json(); }
@@ -742,10 +776,16 @@ async function register() {
       return wrap('<span class="pill p-warn">not in registry</span>');
     }
 
-    if (r.status_source === 'governance') {
+    if (r.status_source === 'governance' || r.status_source === 'portal') {
       let out = `<span class="pill ${PILL[r.status]||'p-mut'}">${LABEL[r.status]||esc(r.status)}</span>`;
       if (r.status_reason === 'approval_expired') {
         out += `<span class="gov-sub">was ${LABEL[r.stored_status]||''}</span>`;
+      }
+      // A decision recorded in the portal says so: a reader auditing the
+      // governance file should not go hunting for a record that lives in
+      // the receiver's database instead.
+      if (r.status_source === 'portal') {
+        out += `<span class="gov-sub">set in the portal</span>`;
       }
       return wrap(out);
     }
@@ -796,11 +836,17 @@ async function register() {
     <div><dt>${REG.known_not_observed}</dt><dd>watched for, not seen</dd></div>
   </dl>
 
-  ${!REG.governance_configured ? `<p class="lede">No governance file is
+  ${!REG.governance_configured ? (CFG.managed && CFG.managed.enabled
+    ? `<p class="lede">No decisions recorded yet, so status falls back to the
+    registry's own flag - a shipped default rather than a decision anyone
+    made. Record one with <b>edit</b> on any card; it is stored centrally
+    and a governance file (<span class="mono">GOVERNANCE_PATH</span>) still
+    works alongside.</p>`
+    : `<p class="lede">No governance file is
   configured, so status falls back to the registry's own flag and every tool
   reads as not approved. That is a shipped default rather than a decision
   anyone made. Set <span class="mono">GOVERNANCE_PATH</span> to record
-  approvals, owners and review dates.</p>` : ''}
+  approvals, owners and review dates.</p>`) : ''}
 
   ${((REG.governance_unmatched || []).length
      || (REG.exceptions_unmatched || []).length) ? `<div class="note">
@@ -847,10 +893,14 @@ async function register() {
     </dl>
     <hr>
     <div class="card-section">governance</div>
-    <dl class="card-kv">
+    ${GOVEDIT === r.id ? govForm(r) : `<dl class="card-kv">
       <dt>owner</dt><dd>${r.owner ? esc(r.owner) : dash}</dd>
       <dt>review</dt><dd>${review(r)}</dd>
     </dl>
+    ${CFG.managed && CFG.managed.enabled ? `<div style="margin-top:8px">
+      <button class="mini" data-act="gov-edit" data-key="${esc(r.id)}">edit</button>
+      ${r.status_source === 'portal' ? `<button class="mini" data-act="gov-clear"
+        data-key="${esc(r.id)}">clear decision</button>` : ''}</div>` : ''}`}
     ${exceptionBlock(r)}
   </div>`).join('')}
   </div>` : `<p class="lede">No AI tools observed in the last ${esc(win)}.
@@ -1025,11 +1075,69 @@ async function iso() {
   <a href="/api/evidence?download=true" style="color:var(--pri)">Download JSON</a></p>`;
 }
 
+// The editable deployment settings, managed mode only: what the receiver
+// stores centrally and serves to the fleet at runtime. Everything below it
+// in the Settings view stays the read-only diagnostics it always was.
+function managedSettings() {
+  if (!SETTINGS) return '';
+  const s = SETTINGS.settings || {};
+  const cd = s.corp_domains || {value: [], source: 'unset', env: []};
+  const srcNote = cd.source === 'db'
+    ? (cd.env || []).length
+      ? `Saved in the portal, shadowing the deployment's
+         <span class="mono">CORP_DOMAINS</span> (${esc(cd.env.join(', '))});
+         clearing falls back to it.`
+      : 'Saved in the portal.'
+    : cd.source === 'env'
+      ? `From the deployment's <span class="mono">CORP_DOMAINS</span>;
+         saving here overrides it without touching the deployment.`
+      : 'Not set anywhere yet.';
+  return `<div class="wcard" style="margin-bottom:10px"><h3>Central settings</h3>
+  <p class="lede" style="margin-bottom:10px">Stored in the receiver and served
+  to the fleet at runtime: collectors pick a change up on their next check-in,
+  no MDM re-push. A value saved here wins over the matching environment
+  variable.</p>
+  ${SETMSG ? `<div class="note">${esc(SETMSG)}</div>` : ''}
+  <dl class="kv">
+    <dt>Corporate domains</dt><dd>
+      <input id="set-domains" class="mfield" style="min-width:340px"
+        placeholder="example.com, example.co.uk"
+        value="${esc((cd.value || []).join(', '))}">
+      <button class="mini" data-act="save-domains">save</button>
+      ${cd.source === 'db' ? `<button class="mini" data-act="clear-domains">clear (fall back)</button>` : ''}
+      <div class="src-note">${srcNote}</div></dd>
+    <dt>Extension ID</dt><dd>
+      <input id="set-extid" class="mfield" style="min-width:340px"
+        placeholder="the browser extension's ID"
+        value="${esc((s.extension_id || {}).value || '')}">
+      <button class="mini" data-act="save-extid">save</button>
+      <div class="src-note">Used to generate the extension's managed-policy
+      artifact. Empty clears it.</div></dd>
+  </dl></div>
+
+  <div class="wcard" style="margin-bottom:10px"><h3>Admin account</h3>
+  <dl class="kv">
+    <dt>Change password</dt><dd>
+      <input id="set-curpass" class="mfield" type="password"
+        placeholder="current password" autocomplete="current-password">
+      <input id="set-newpass" class="mfield" type="password"
+        placeholder="new password (12+ characters)" autocomplete="new-password">
+      <button class="mini" data-act="change-password">change</button>
+      <div class="src-note">Every other session is signed out with the old
+      password; this one stays.</div></dd>
+  </dl></div>`;
+}
+
 async function settings() {
   if (!DIAG) {
     try { DIAG = await (await fetch('/api/diagnostics')).json(); }
     catch (e) { return `<h2>Settings</h2><div class="note">Could not read
       diagnostics: ${esc(String(e.message || e))}</div>`; }
+  }
+  if (CFG.managed && CFG.managed.enabled && !SETTINGS) {
+    const r = await mfetch('/api/settings');
+    if (r.ok) SETTINGS = await r.json();
+    else if (r.status === 401) { sessionLost(); return ''; }
   }
   const r = DIAG.runtime, d = DIAG.deployment;
   const yn = v => v ? '<span class="pill p-ok">yes</span>'
@@ -1040,10 +1148,16 @@ async function settings() {
     : Math.floor(sec/3600) + 'h ' + Math.round(sec%3600/60) + 'm';
 
   return `<h2>Settings and diagnostics</h2>
-  <p class="lede">Read only. Everything under the first four headings is
+  <p class="lede">${CFG.managed && CFG.managed.enabled
+    ? `Central settings are editable and reach the fleet at runtime.
+       Everything below them is read only: what the portal verified about
+       itself, and - labelled at the bottom - what it was merely told.`
+    : `Read only. Everything under the first four headings is
   something the portal verified about itself. Anything it was merely told is
   grouped at the bottom and labelled, so a value nobody updated cannot be
-  mistaken for one something checked.</p>
+  mistaken for one something checked.`}</p>
+
+  ${managedSettings()}
 
   <div class="wcard" style="margin-bottom:10px"><h3>Application</h3>
   <dl class="kv">
@@ -1355,6 +1469,82 @@ async function managedAction(act, el) {
       showLogin(String(d));
     }
     return;
+  }
+  if (act === 'gov-edit') {
+    const id = el.getAttribute('data-key');
+    GOVPRE = null; GOVERR = '';
+    const r = await mfetch('/api/governance-decisions');
+    if (r.ok) {
+      GOVPRE = ((await r.json()).decisions || []).find(d => d.tool_id === id) || null;
+    } else if (r.status === 401) { sessionLost(); return; }
+    GOVEDIT = id; render(); return;
+  }
+  if (act === 'gov-cancel') { GOVEDIT = null; GOVPRE = null; GOVERR = ''; render(); return; }
+  if (act === 'gov-save') {
+    const id = el.getAttribute('data-key');
+    const body = {decisions: [{
+      tool_id: id,
+      status: _val('gov-status'),
+      owner: _val('gov-owner'),
+      review_due: _val('gov-review'),
+      reason: _val('gov-reason'),
+    }]};
+    const r = await mfetch('/api/governance-decisions',
+      {method: 'POST', body: JSON.stringify(body)});
+    if (r.ok) { GOVEDIT = null; GOVPRE = null; GOVERR = ''; REG = null; EV = null; }
+    else {
+      if (r.status === 401) { sessionLost(); return; }
+      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+      GOVERR = typeof d === 'string' ? d : 'Check the fields: dates are YYYY-MM-DD.';
+      // The redraw prefills from GOVPRE; without this a refusal would also
+      // throw away everything the operator just typed.
+      GOVPRE = body.decisions[0];
+    }
+    render(); return;
+  }
+  if (act === 'gov-clear') {
+    const id = el.getAttribute('data-key');
+    if (!confirm('Clear the recorded decision for ' + id + '? Status falls '
+                 + 'back to the governance file or the registry default.')) return;
+    const r = await mfetch('/api/governance-decisions',
+      {method: 'POST', body: JSON.stringify({delete: [id]})});
+    if (!r.ok) {
+      if (r.status === 401) { sessionLost(); return; }
+      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+      alert('Could not clear the decision: ' + d);
+    }
+    REG = null; EV = null; render(); return;
+  }
+  if (act === 'save-domains' || act === 'clear-domains' || act === 'save-extid') {
+    const body = act === 'save-domains'
+      ? {corp_domains: _val('set-domains').split(',').map(s => s.trim()).filter(Boolean)}
+      : act === 'clear-domains' ? {corp_domains: null}
+      : {extension_id: _val('set-extid')};
+    const r = await mfetch('/api/settings',
+      {method: 'POST', body: JSON.stringify(body)});
+    if (r.ok) { SETTINGS = await r.json(); SETMSG = 'Saved. The fleet hears it on its next check-in.'; }
+    else {
+      if (r.status === 401) { sessionLost(); return; }
+      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+      SETMSG = 'Not saved: ' + (typeof d === 'string' ? d : 'check the values.');
+    }
+    render(); return;
+  }
+  if (act === 'change-password') {
+    const r = await mfetch('/api/password', {method: 'POST', body: JSON.stringify(
+      {current: _val('set-curpass'), new: _val('set-newpass')})});
+    if (r.ok) SETMSG = 'Password changed. Every other session was signed out.';
+    else {
+      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+      // A wrong current password is also a 401, from the receiver rather
+      // than the session gate; only the gate's refusal means signed out.
+      if (r.status === 401 && String(d).indexOf('current password') < 0) {
+        sessionLost(); return;
+      }
+      SETMSG = 'Password unchanged: ' + (typeof d === 'string' ? d
+        : 'the new password needs 12 characters or more.');
+    }
+    render(); return;
   }
   if (act === 'dismiss-minted') { MINTED = null; render(); return; }
   if (act === 'copy') {

--- a/portal/tests/test_central_settings.py
+++ b/portal/tests/test_central_settings.py
@@ -1,0 +1,189 @@
+"""Central settings and portal-recorded governance, portal side.
+
+The receiver stores and validates; these tests cover what the portal adds:
+the per-tool merge (DB wins, file fills gaps, origin labelled), the proxy
+routes forwarding exactly what was sent, and the register cache dying when
+a decision changes. Same direct-call harness as the rest of the suite.
+"""
+
+import os
+from datetime import date
+
+os.environ.setdefault("PORTAL_AUTH", "none")
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app import governance, main, managed
+
+
+def _request(cookie_token="aigt_s"):
+    hs = [(b"host", b"portal")]
+    if cookie_token is not None:
+        hs.append((b"cookie",
+                   ("%s=%s" % (main.SESSION_COOKIE, cookie_token)).encode()))
+    return Request({"type": "http", "method": "GET", "path": "/",
+                    "scheme": "http", "headers": hs, "query_string": b""})
+
+
+@pytest.fixture
+def login_mode(monkeypatch):
+    calls = []
+
+    def fake(base, method, path, token, body=None):
+        calls.append({"method": method, "path": path, "token": token,
+                      "body": body})
+        if path == "/admin/governance" and method == "GET":
+            return {"decisions": [
+                {"tool_id": "chatgpt", "status": "approved", "owner": "Security",
+                 "review_due": "2027-06-01", "reason": "pilot",
+                 "updated_at": "2026-08-23", "updated_by": "aman"}]}
+        return {"ok": True}
+
+    monkeypatch.setattr(main, "PORTAL_AUTH", "")
+    monkeypatch.setattr(main, "RECEIVER_URL", "http://receiver.internal:8080")
+    monkeypatch.setattr(main, "LOGIN_MODE", True)
+    monkeypatch.setattr(main.managed, "receiver_request", fake)
+    monkeypatch.setattr(main, "_session_cache", {})
+    return calls
+
+
+# ------------------------------------------------------- governance merge --
+
+
+def test_classic_mode_reads_the_file_and_calls_no_receiver(monkeypatch):
+    calls = []
+    monkeypatch.setattr(main, "LOGIN_MODE", False)
+    monkeypatch.setattr(main.managed, "receiver_request",
+                        lambda *a, **k: calls.append(a))
+    gov, exceptions, n = main._merged_governance(_request())
+    assert gov == {} and n == 0 and calls == []
+
+
+def test_a_portal_decision_wins_over_the_file_and_says_so(login_mode,
+                                                          monkeypatch, tmp_path):
+    """DB wins per tool, file fills the gaps - the same rule every setting
+    follows - and the record carries its origin so decide() can label it."""
+    gov_file = tmp_path / "governance.yaml"
+    gov_file.write_text(
+        "tools:\n"
+        "  chatgpt: {status: not_approved, owner: IT}\n"
+        "  claude: {status: reviewing, owner: Legal}\n")
+    monkeypatch.setattr(main, "GOVERNANCE_PATH", str(gov_file))
+
+    gov, _exceptions, n = main._merged_governance(_request())
+    assert n == 1
+    # The DB record displaced the file's chatgpt entirely...
+    assert gov["chatgpt"]["status"] == "approved"
+    assert gov["chatgpt"]["owner"] == "Security"
+    assert gov["chatgpt"]["review_due"] == date(2027, 6, 1)
+    assert gov["chatgpt"]["origin"] == "portal"
+    # ...and the file still speaks where the DB is silent.
+    assert gov["claude"]["status"] == "reviewing"
+    assert "origin" not in gov["claude"]
+
+    # decide() labels each source honestly.
+    assert governance.decide("chatgpt", gov, False)["source"] == "portal"
+    assert governance.decide("claude", gov, False)["source"] == "governance"
+
+
+def test_an_unreachable_receiver_fails_loud_not_stale(login_mode, monkeypatch):
+    """Showing yesterday's decisions as if current is the quiet wrongness
+    this project exists to avoid: file-only fallback would do exactly that."""
+    def down(base, method, path, token, body=None):
+        raise managed.ReceiverError(502, "could not reach the receiver (X)")
+    monkeypatch.setattr(main.managed, "receiver_request", down)
+
+    with pytest.raises(HTTPException) as e:
+        main._merged_governance(_request())
+    assert e.value.status_code == 502
+    assert "governance decisions" in e.value.detail
+
+
+def test_the_merge_forwards_the_requesters_own_session(login_mode):
+    main._merged_governance(_request(cookie_token="aigt_mine"))
+    assert login_mode[0]["token"] == "aigt_mine"
+
+
+# ------------------------------------------------------------ proxy routes --
+
+
+def test_settings_write_forwards_only_what_was_sent(login_mode):
+    main.api_settings_write(
+        main.SettingsWrite(corp_domains=["Example.com"]), _=None, token="t")
+    assert login_mode[0]["method"] == "PUT"
+    assert login_mode[0]["path"] == "/admin/settings"
+    # Only the provided key rides; normalisation is the receiver's job.
+    assert login_mode[0]["body"] == {"corp_domains": ["Example.com"]}
+
+
+def test_an_explicit_null_rides_through_as_the_delete_it_is(login_mode):
+    main.api_settings_write(
+        main.SettingsWrite(corp_domains=None), _=None, token="t")
+    assert login_mode[0]["body"] == {"corp_domains": None}
+
+
+def test_an_unknown_settings_key_is_refused_at_the_edge():
+    with pytest.raises(ValueError):
+        main.SettingsWrite(corp_domain=["typo.com"])
+
+
+def test_a_governance_write_kills_the_register_cache(login_mode):
+    main._cache["register"] = {"value": ["stale"], "at": 9e12, "hours": 168}
+    main.api_governance_write(
+        main.GovernanceWrite(decisions=[main.DecisionWrite(
+            tool_id="chatgpt", status="not_approved")]), _=None, token="t")
+    assert "register" not in main._cache
+    assert login_mode[0]["method"] == "PUT"
+    assert login_mode[0]["path"] == "/admin/governance"
+    assert login_mode[0]["body"]["decisions"][0]["tool_id"] == "chatgpt"
+
+
+def test_password_change_forwards_on_the_callers_session(login_mode):
+    main.api_password(main.PasswordWrite(current="old",
+                                         new="a-long-enough-password"),
+                      _=None, token="aigt_mine")
+    assert login_mode[0] == {"method": "POST", "path": "/admin/password",
+                             "token": "aigt_mine",
+                             "body": {"current": "old",
+                                      "new": "a-long-enough-password"}}
+
+
+def test_the_receiver_client_sends_put_bodies():
+    """receiver_request only attached data to POST; a PUT with a silently
+    dropped body would reach the receiver as an empty update that changes
+    nothing and reports success."""
+    import json as _json
+    from unittest.mock import patch
+
+    seen = {}
+
+    class _Resp:
+        def read(self):
+            return b"{}"
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=None):
+        seen["data"] = req.data
+        return _Resp()
+
+    with patch.object(managed.urllib.request, "urlopen", fake_urlopen):
+        managed.receiver_request("http://r", "PUT", "/admin/settings", "t",
+                                 {"corp_domains": ["a.com"]})
+    assert _json.loads(seen["data"]) == {"corp_domains": ["a.com"]}
+
+
+# ---------------------------------------------------------------- the page --
+
+
+def test_the_page_carries_the_editors():
+    html = (main.STATIC / "index.html").read_text()
+    for needle in ("gov-edit", "gov-save", "gov-clear", "save-domains",
+                   "clear-domains", "save-extid", "change-password",
+                   "/api/settings", "/api/governance-decisions",
+                   "/api/password", "set in the portal"):
+        assert needle in html, needle

--- a/portal/tests/test_evidence.py
+++ b/portal/tests/test_evidence.py
@@ -356,7 +356,7 @@ def test_the_endpoint_produces_a_verifiable_snapshot():
     with patch.object(pm, "_findings", lambda h: findings), \
             patch.object(derive, "load_registry", lambda p: reg):
         pm._cache.clear()
-        body = json.loads(bytes(pm.evidence_snapshot(hours=168).body))
+        body = json.loads(bytes(pm.evidence_snapshot(None, hours=168).body))
 
     assert ev.verify(body) is True
     assert body["tools_observed"] == 2
@@ -378,7 +378,7 @@ def test_the_download_carries_provenance_in_the_filename():
     with patch.object(pm, "_findings", lambda h: []), \
             patch.object(derive, "load_registry", lambda p: {"tools": []}):
         pm._cache.clear()
-        resp = pm.evidence_snapshot(hours=168, download=True)
+        resp = pm.evidence_snapshot(None, hours=168, download=True)
 
     disposition = resp.headers["content-disposition"]
     assert "ai-guard-evidence-" in disposition

--- a/portal/tests/test_register.py
+++ b/portal/tests/test_register.py
@@ -350,7 +350,7 @@ def test_an_unobserved_tool_is_not_in_the_endpoints_rows():
     with patch.object(pm, "_findings", lambda h: [_f()]), \
             patch.object(derive, "load_registry", lambda p: REGISTRY):
         pm._cache.clear()
-        body = json.loads(bytes(pm.register(hours=168).body))
+        body = json.loads(bytes(pm.register(None, hours=168).body))
 
     assert [r["id"] for r in body["rows"]] == ["claude"]
     # The watchlist is still reported, as a count.

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -56,6 +56,10 @@ shared token off for ingest (see the configuration table).
 | POST | `/admin/logout` | admin | revoke the presented session |
 | GET  | `/admin/session` | admin | who this session is and until when; the portal's validity probe |
 | POST | `/admin/password` | admin | change the password (`current` + `new`). With the `ADMIN_TOKEN` credential, `current` is not required - the break-glass reset. Every other session dies with the old password |
+| GET  | `/admin/settings` | admin | each central setting with its effective value and its source (`db`, `env`, `unset`), so a saved value shadowing an environment one is visible as such |
+| PUT  | `/admin/settings` | admin | partial upsert of `corp_domains`, `extension_id`, `onboarding_done`; a saved value wins over the matching env var, an explicit `null` deletes the row and falls back to it. Unknown keys are 422 |
+| GET  | `/admin/governance` | admin | the portal-recorded governance decisions |
+| PUT  | `/admin/governance` | admin | upsert (`decisions`) and delete (`delete`) decisions, validated to the governance file's own rules - an approval needs a `review_due` date. The whole batch validates before anything is written |
 
 **Admin auth** is either of two things: a session from `/admin/login`, or
 the optional `ADMIN_TOKEN` API credential. Humans get the first; automation
@@ -88,7 +92,7 @@ Everything is environment variables. Only the token is required.
 | `REGISTRY_PATH` | `/etc/ai-guard/registry.json` | where the compiled registry is mounted |
 | `COLLECTOR_REGISTRY_PATH` | `/etc/ai-guard/collector.json` | where the collector view is mounted |
 | `DISPLAY_TZ` | `UTC` | timezone for the human-readable timestamp on alerts only; machine timestamps are always UTC |
-| `CORP_DOMAINS` | unset | corporate domains, comma-separated. When set, served to the endpoint collectors inside `/registry/collector` as `config.corp_domains`; collectors prefer that list to their locally configured one, so a change here reaches the fleet on its next check-in with no MDM re-push. Unset means collectors keep using their local configuration |
+| `CORP_DOMAINS` | unset | corporate domains, comma-separated. When set, served to the endpoint collectors inside `/registry/collector` as `config.corp_domains`; collectors prefer that list to their locally configured one, so a change here reaches the fleet on its next check-in with no MDM re-push. Unset means collectors keep using their local configuration. In managed mode a list saved in the portal (`/admin/settings`) wins over this, and clearing it there falls back here |
 | `MANAGED_MODE` | unset | `true` enables device enrollment, per-device credentials, revocation and a fleet inventory (see below). Unset means byte-for-byte the classic receiver: no state file, `/enroll` and `/admin/*` answer 404 |
 | `ADMIN_TOKEN` | unset | optional API credential for `/admin/*` - automation, and break-glass recovery when the portal password is lost. Humans use an account and a session instead (see managed mode above). Deliberately a separate secret from `AUTH_TOKEN`, which sits on every machine in the fleet - which is exactly why it must not be able to mint credentials |
 | `STATE_DB_PATH` | `/var/lib/ai-guard/state.db` | where the managed-mode SQLite file lives. The one non-disposable thing: it holds the device registry and its credential hashes |

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -27,12 +27,13 @@ import hmac
 import json
 import logging
 import os
+import re
 import secrets
 import sys
 import threading
 import time
 import urllib.parse
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import httpx
@@ -492,8 +493,13 @@ def _admin_header_ok(header: str) -> bool:
 
 
 def _body_size_response(request: Request):
-    """The 4xx a too-large or unsized POST body earns, or None if fine."""
-    if request.method != "POST":
+    """The 4xx a too-large or unsized POST/PUT body earns, or None if fine.
+
+    PUT joined POST when /admin/settings arrived: a method check that names
+    only POST is a size cap the next body-carrying method silently walks
+    past.
+    """
+    if request.method not in ("POST", "PUT"):
         return None
     declared = request.headers.get("content-length")
     if declared is None:
@@ -643,9 +649,26 @@ def registry_collector(request: Request, authorization: str = Header(default="")
             reg = json.load(f)
     except (OSError, json.JSONDecodeError):
         raise HTTPException(503, "collector registry not available")
-    if CORP_DOMAINS and isinstance(reg, dict):
-        reg.setdefault("config", {})["corp_domains"] = CORP_DOMAINS
+    domains = _effective_corp_domains()
+    if domains and isinstance(reg, dict):
+        reg.setdefault("config", {})["corp_domains"] = domains
     return reg
+
+
+def _effective_corp_domains() -> list[str]:
+    """The corp domains the fleet should hear: the portal-saved list when
+    one exists, the environment otherwise.
+
+    The DB row wins even when empty - an operator who saved an empty list
+    said "none", and falling back to the env there would resurrect the very
+    value they removed. Deleting the row (set_setting None) is how the env
+    comes back into effect.
+    """
+    if STATE is not None:
+        stored = STATE.get_setting("corp_domains")
+        if stored is not None:
+            return stored
+    return CORP_DOMAINS
 
 
 def _auth(authorization: str):
@@ -867,6 +890,165 @@ def session_info(authorization: str = Header(default="")):
         if u is not None:
             return {"username": u["username"], "expires_at": u["expires_at"]}
     return {"username": "", "expires_at": None}
+
+
+# ------------------------------------------------------- central settings --
+# Deployment configuration the portal edits and the fleet hears at runtime.
+# Precedence is DB-wins-when-set: a saved value overrides the matching
+# environment variable, and clearing it (null) falls back. The environment
+# stays the whole story for classic mode, which has no DB to consult.
+
+
+def _admin_actor(authorization: str) -> str:
+    """Who to stamp on a write: the session's username, or "api" for the
+    ADMIN_TOKEN credential - a credential, not a person."""
+    token = _bearer(authorization)
+    if STATE is not None and token.startswith(_state.SESSION_PREFIX):
+        u = STATE.session_user(token)
+        if u is not None:
+            return u["username"]
+    return "api"
+
+
+class SettingsUpdate(BaseModel):
+    # extra=forbid: an unknown key is a typo or a version mismatch, and
+    # accepting it silently is how someone believes a setting is in effect.
+    model_config = {"extra": "forbid"}
+    corp_domains: list[str] | None = Field(default=None, max_length=200)
+    extension_id: str | None = Field(default=None, max_length=128)
+    onboarding_done: bool | None = None
+
+
+@app.get("/admin/settings")
+def get_settings(authorization: str = Header(default="")):
+    """Each setting with its effective value AND where it came from, because
+    the portal must show when a saved value is shadowing an environment one
+    rather than let two sources of truth look like one."""
+    _admin_auth(authorization)
+    stored = STATE.get_settings()
+    corp = stored.get("corp_domains")
+    return {"settings": {
+        "corp_domains": {
+            "value": corp if corp is not None else CORP_DOMAINS,
+            "source": ("db" if corp is not None
+                       else "env" if CORP_DOMAINS else "unset"),
+            # The env list rides along so the portal can say what a saved
+            # value is shadowing, and what clearing it would fall back to.
+            "env": CORP_DOMAINS,
+        },
+        "extension_id": {
+            "value": stored.get("extension_id") or "",
+            "source": "db" if stored.get("extension_id") is not None else "unset",
+        },
+        "onboarding_done": {
+            "value": bool(stored.get("onboarding_done")),
+            "source": "db" if stored.get("onboarding_done") is not None else "unset",
+        },
+    }}
+
+
+@app.put("/admin/settings")
+def put_settings(req: SettingsUpdate, authorization: str = Header(default="")):
+    """Partial upsert: only the keys sent change. An explicit null deletes
+    the row, which is how the environment value comes back into effect."""
+    _admin_auth(authorization)
+    by = _admin_actor(authorization)
+
+    if "corp_domains" in req.model_fields_set:
+        if req.corp_domains is None:
+            STATE.set_setting("corp_domains", None, by)
+        else:
+            # The same normalisation the env path applies, for the same
+            # reason: the macOS collector matches with a comma-anchored
+            # case pattern, and a stray space or upper-case letter served
+            # here would silently turn a work account into a warn.
+            domains = _parse_corp_domains(",".join(req.corp_domains))
+            for d in domains:
+                if len(d) > 253:
+                    raise HTTPException(422, "corp domain too long: %s" % d[:60])
+            STATE.set_setting("corp_domains", domains, by)
+
+    if "extension_id" in req.model_fields_set:
+        eid = (req.extension_id or "").strip()
+        if not eid:
+            STATE.set_setting("extension_id", None, by)
+        else:
+            if any(c.isspace() or ord(c) < 32 for c in eid):
+                raise HTTPException(422, "extension id cannot contain whitespace")
+            STATE.set_setting("extension_id", eid, by)
+
+    if "onboarding_done" in req.model_fields_set:
+        STATE.set_setting("onboarding_done", req.onboarding_done, by)
+
+    return get_settings(authorization)
+
+
+# What a portal-recorded decision may look like. Same three states and the
+# same review-date discipline the governance file's validator enforces: an
+# approval with no review date is the one that outlives the person who made
+# it, and the write path must not be the way around that rule.
+_VALID_STATUSES = ("approved", "not_approved", "reviewing")
+_TOOL_ID_RE = re.compile(r"^[A-Za-z0-9._:-]{1,100}$")
+
+
+class DecisionWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool_id: str = Field(min_length=1, max_length=100)
+    status: str = Field(min_length=1, max_length=32)
+    owner: str = Field(default="", max_length=200)
+    review_due: str = Field(default="", max_length=10)
+    reason: str = Field(default="", max_length=1000)
+
+
+class GovernanceUpdate(BaseModel):
+    model_config = {"extra": "forbid"}
+    decisions: list[DecisionWrite] = Field(default_factory=list, max_length=200)
+    delete: list[str] = Field(default_factory=list, max_length=200)
+
+
+@app.get("/admin/governance")
+def get_governance(authorization: str = Header(default="")):
+    _admin_auth(authorization)
+    return {"decisions": STATE.list_decisions()}
+
+
+@app.put("/admin/governance")
+def put_governance(req: GovernanceUpdate, authorization: str = Header(default="")):
+    """Upsert and delete decisions, validated to the same rules as the file.
+
+    Validation happens for the whole batch before anything is written, so a
+    422 means nothing changed rather than half a batch applied.
+    """
+    _admin_auth(authorization)
+    by = _admin_actor(authorization)
+
+    for d in req.decisions:
+        if not _TOOL_ID_RE.match(d.tool_id):
+            raise HTTPException(422, "malformed tool id: %s" % d.tool_id[:60])
+        if d.status not in _VALID_STATUSES:
+            raise HTTPException(
+                422, "status must be one of " + ", ".join(_VALID_STATUSES))
+        if d.review_due:
+            try:
+                date.fromisoformat(d.review_due)
+            except ValueError:
+                raise HTTPException(
+                    422, "review_due must be an ISO date (YYYY-MM-DD)")
+        if d.status == "approved" and not d.review_due:
+            raise HTTPException(
+                422, "an approval needs a review_due date: an approval with"
+                     " no expiry is the one that outlives the person who"
+                     " made it")
+    for tid in req.delete:
+        if not _TOOL_ID_RE.match(tid):
+            raise HTTPException(422, "malformed tool id: %s" % tid[:60])
+
+    for d in req.decisions:
+        STATE.upsert_decision(d.tool_id, d.status, d.owner.strip(),
+                              d.review_due, d.reason.strip(), by)
+    for tid in req.delete:
+        STATE.delete_decision(tid, by)
+    return {"decisions": STATE.list_decisions()}
 
 
 @app.post("/admin/password")

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -101,6 +101,21 @@ CREATE TABLE IF NOT EXISTS sessions (
   expires_at TEXT NOT NULL,
   revoked_at TEXT
 );
+CREATE TABLE IF NOT EXISTS settings (
+  key        TEXT PRIMARY KEY,
+  value      TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  updated_by TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE IF NOT EXISTS governance_decisions (
+  tool_id    TEXT PRIMARY KEY,
+  status     TEXT NOT NULL,
+  owner      TEXT NOT NULL DEFAULT '',
+  review_due TEXT NOT NULL DEFAULT '',
+  reason     TEXT NOT NULL DEFAULT '',
+  updated_at TEXT NOT NULL,
+  updated_by TEXT NOT NULL DEFAULT ''
+);
 """
 
 # Columns added after the first release, applied to databases that predate
@@ -452,6 +467,94 @@ class State:
             )
             if cur.rowcount:
                 self._event("logout", {})
+            self._db.commit()
+        return bool(cur.rowcount)
+
+    # ------------------------------------------------ settings (managed) --
+    # Deployment configuration the portal edits and the receiver serves to
+    # the fleet at runtime. Values are stored as JSON so a key can be a
+    # list (corp domains) or a flag without a second schema. Precedence is
+    # the caller's business: a row here wins over the matching environment
+    # variable, and deleting the row falls back to it - main.py implements
+    # that, this just stores.
+
+    def get_setting(self, key: str):
+        """The parsed value, or None when no row exists. A stored null is
+        not a state this API can create - set_setting(None) deletes - so
+        None is unambiguous."""
+        with self._lock:
+            row = self._db.execute(
+                "SELECT value FROM settings WHERE key = ?", (key,)
+            ).fetchone()
+        return json.loads(row["value"]) if row else None
+
+    def get_settings(self) -> dict:
+        with self._lock:
+            rows = self._db.execute("SELECT key, value FROM settings").fetchall()
+        return {r["key"]: json.loads(r["value"]) for r in rows}
+
+    def set_setting(self, key: str, value, by: str = ""):
+        """Upsert one setting; value None deletes the row (fall back to
+        whatever the deployment's environment says)."""
+        with self._lock:
+            if value is None:
+                cur = self._db.execute(
+                    "DELETE FROM settings WHERE key = ?", (key,))
+                if cur.rowcount:
+                    self._event("setting_cleared", {"key": key, "by": by})
+            else:
+                self._db.execute(
+                    "INSERT INTO settings (key, value, updated_at, updated_by)"
+                    " VALUES (?, ?, ?, ?)"
+                    " ON CONFLICT(key) DO UPDATE SET value = excluded.value,"
+                    " updated_at = excluded.updated_at,"
+                    " updated_by = excluded.updated_by",
+                    (key, json.dumps(value), _now(), by),
+                )
+                # The key and who, never the value: corp domains are not a
+                # secret, but the event log's rule is ids only and one
+                # exception is how the second one happens.
+                self._event("setting_changed", {"key": key, "by": by})
+            self._db.commit()
+
+    # -------------------------------------- governance decisions (managed) --
+    # What the organisation decided about a tool, editable in the portal.
+    # The same record shape the governance file holds, minus exceptions -
+    # those stay file-only. The portal merges per tool: a row here wins,
+    # the file fills the gaps.
+
+    def list_decisions(self) -> list[dict]:
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT tool_id, status, owner, review_due, reason,"
+                " updated_at, updated_by FROM governance_decisions"
+                " ORDER BY tool_id"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def upsert_decision(self, tool_id: str, status: str, owner: str,
+                        review_due: str, reason: str, by: str = ""):
+        with self._lock:
+            self._db.execute(
+                "INSERT INTO governance_decisions"
+                " (tool_id, status, owner, review_due, reason, updated_at, updated_by)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)"
+                " ON CONFLICT(tool_id) DO UPDATE SET status = excluded.status,"
+                " owner = excluded.owner, review_due = excluded.review_due,"
+                " reason = excluded.reason, updated_at = excluded.updated_at,"
+                " updated_by = excluded.updated_by",
+                (tool_id, status, owner, review_due, reason, _now(), by),
+            )
+            self._event("decision_recorded", {"tool": tool_id, "status": status,
+                                              "by": by})
+            self._db.commit()
+
+    def delete_decision(self, tool_id: str, by: str = "") -> bool:
+        with self._lock:
+            cur = self._db.execute(
+                "DELETE FROM governance_decisions WHERE tool_id = ?", (tool_id,))
+            if cur.rowcount:
+                self._event("decision_cleared", {"tool": tool_id, "by": by})
             self._db.commit()
         return bool(cur.rowcount)
 

--- a/receiver/tests/test_settings.py
+++ b/receiver/tests/test_settings.py
@@ -1,0 +1,239 @@
+"""Central settings and portal-recorded governance decisions.
+
+Precedence under test is the managed-mode promise: a portal-saved value
+wins over the environment, clearing it falls back, and classic mode never
+consults a DB that does not exist. Same harness shape as test_managed.
+"""
+
+import os
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import state as state_mod
+from app.main import app
+
+client = TestClient(app)
+
+AUTH = {"Authorization": "Bearer test-token-for-ci"}
+ADMIN = {"Authorization": "Bearer admin-test-token"}
+
+
+@pytest.fixture
+def managed(tmp_path, monkeypatch):
+    from app import main
+
+    st = state_mod.State(str(tmp_path / "state.db"))
+    monkeypatch.setattr(main, "STATE", st)
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"Bearer admin-test-token")
+    return st
+
+
+@pytest.fixture
+def collector_registry(tmp_path, monkeypatch):
+    from app import main
+
+    reg = tmp_path / "collector.json"
+    reg.write_text('{"version": 1}')
+    monkeypatch.setattr(main, "COLLECTOR_REGISTRY_PATH", str(reg))
+
+
+def _served_domains():
+    reg = client.get("/registry/collector", headers=AUTH).json()
+    return (reg.get("config") or {}).get("corp_domains")
+
+
+# ------------------------------------------------------------ mode gating --
+
+
+def test_settings_routes_do_not_exist_in_classic_mode():
+    assert client.get("/admin/settings", headers=ADMIN).status_code == 404
+    assert client.put("/admin/settings", headers=ADMIN, json={}).status_code == 404
+    assert client.get("/admin/governance", headers=ADMIN).status_code == 404
+
+
+def test_settings_require_admin(managed):
+    assert client.get("/admin/settings").status_code == 401
+    assert client.get("/admin/settings", headers=AUTH).status_code == 401
+
+
+# -------------------------------------------------------------- settings --
+
+
+def test_a_saved_value_names_its_source_and_shadows_the_env(managed, monkeypatch):
+    from app import main
+
+    monkeypatch.setattr(main, "CORP_DOMAINS", ["fromenv.com"])
+    out = client.get("/admin/settings", headers=ADMIN).json()["settings"]
+    assert out["corp_domains"] == {"value": ["fromenv.com"], "source": "env",
+                                  "env": ["fromenv.com"]}
+
+    resp = client.put("/admin/settings", headers=ADMIN,
+                      json={"corp_domains": ["Portal.Com", " portal.com "]})
+    assert resp.status_code == 200
+    cd = resp.json()["settings"]["corp_domains"]
+    # Normalised exactly as the env path normalises: trimmed, lowered,
+    # deduplicated - and the response still names what it is shadowing.
+    assert cd == {"value": ["portal.com"], "source": "db", "env": ["fromenv.com"]}
+
+
+def test_the_fleet_hears_the_saved_list_not_the_env(managed, monkeypatch,
+                                                    collector_registry):
+    from app import main
+
+    monkeypatch.setattr(main, "CORP_DOMAINS", ["fromenv.com"])
+    assert _served_domains() == ["fromenv.com"]
+
+    client.put("/admin/settings", headers=ADMIN,
+               json={"corp_domains": ["portal.com"]})
+    assert _served_domains() == ["portal.com"]
+
+
+def test_an_explicit_empty_list_means_none_not_fall_back(managed, monkeypatch,
+                                                         collector_registry):
+    """An operator who saved an empty list said "none"; resurrecting the env
+    value would undo the very thing they removed."""
+    from app import main
+
+    monkeypatch.setattr(main, "CORP_DOMAINS", ["fromenv.com"])
+    client.put("/admin/settings", headers=ADMIN, json={"corp_domains": []})
+    assert _served_domains() is None
+    out = client.get("/admin/settings", headers=ADMIN).json()["settings"]
+    assert out["corp_domains"]["value"] == [] and out["corp_domains"]["source"] == "db"
+
+
+def test_clearing_a_setting_falls_back_to_the_env(managed, monkeypatch,
+                                                  collector_registry):
+    from app import main
+
+    monkeypatch.setattr(main, "CORP_DOMAINS", ["fromenv.com"])
+    client.put("/admin/settings", headers=ADMIN,
+               json={"corp_domains": ["portal.com"]})
+    resp = client.put("/admin/settings", headers=ADMIN,
+                      json={"corp_domains": None})
+    assert resp.json()["settings"]["corp_domains"]["source"] == "env"
+    assert _served_domains() == ["fromenv.com"]
+
+
+def test_classic_serving_is_untouched(monkeypatch, collector_registry):
+    """No DB exists in classic mode, and the env path must behave exactly
+    as it did before settings existed."""
+    from app import main
+
+    monkeypatch.setattr(main, "CORP_DOMAINS", ["fromenv.com"])
+    assert _served_domains() == ["fromenv.com"]
+
+
+def test_an_unknown_key_is_refused_by_name(managed):
+    resp = client.put("/admin/settings", headers=ADMIN,
+                      json={"corp_domain": ["typo.com"]})
+    assert resp.status_code == 422
+
+
+def test_a_partial_update_leaves_other_keys_alone(managed):
+    client.put("/admin/settings", headers=ADMIN,
+               json={"corp_domains": ["a.com"], "extension_id": "abcdef"})
+    out = client.put("/admin/settings", headers=ADMIN,
+                     json={"onboarding_done": True}).json()["settings"]
+    assert out["corp_domains"]["value"] == ["a.com"]
+    assert out["extension_id"] == {"value": "abcdef", "source": "db"}
+    assert out["onboarding_done"] == {"value": True, "source": "db"}
+
+
+def test_extension_id_rejects_whitespace_and_empties_delete(managed):
+    assert client.put("/admin/settings", headers=ADMIN,
+                      json={"extension_id": "has space"}).status_code == 422
+    client.put("/admin/settings", headers=ADMIN, json={"extension_id": "abc"})
+    out = client.put("/admin/settings", headers=ADMIN,
+                     json={"extension_id": ""}).json()["settings"]
+    assert out["extension_id"] == {"value": "", "source": "unset"}
+
+
+def test_writes_are_stamped_with_who(managed):
+    """A session write carries the username; the API credential is "api"."""
+    from app import main
+
+    # An account and a session, no monkeypatched shortcuts.
+    st = managed
+    st.create_admin("aman", "a-long-enough-password")
+    token = st.login("aman", "a-long-enough-password")["token"]
+
+    client.put("/admin/settings", headers={"Authorization": f"Bearer {token}"},
+               json={"corp_domains": ["a.com"]})
+    client.put("/admin/settings", headers=ADMIN, json={"extension_id": "abc"})
+    rows = {r["key"]: r["updated_by"] for r in st._db.execute(
+        "SELECT key, updated_by FROM settings")}
+    assert rows == {"corp_domains": "aman", "extension_id": "api"}
+
+
+# ------------------------------------------------------------- governance --
+
+
+def _decide(**kw):
+    return {"tool_id": "chatgpt", "status": "not_approved", **kw}
+
+
+def test_governance_decision_lifecycle(managed):
+    resp = client.put("/admin/governance", headers=ADMIN, json={
+        "decisions": [_decide(status="approved", owner="Security",
+                              review_due="2027-06-01", reason="pilot")]})
+    assert resp.status_code == 200
+    (d,) = resp.json()["decisions"]
+    assert d["tool_id"] == "chatgpt" and d["status"] == "approved"
+    assert d["owner"] == "Security" and d["updated_by"] == "api"
+
+    resp = client.put("/admin/governance", headers=ADMIN,
+                      json={"delete": ["chatgpt"]})
+    assert resp.json()["decisions"] == []
+
+
+def test_an_approval_without_a_review_date_is_refused(managed):
+    """The file validator's rule, enforced on the write path too: an
+    approval with no expiry is the one that outlives its maker."""
+    resp = client.put("/admin/governance", headers=ADMIN, json={
+        "decisions": [_decide(status="approved")]})
+    assert resp.status_code == 422
+    assert "review_due" in resp.json()["detail"]
+
+
+def test_validation_refuses_the_batch_before_writing_any_of_it(managed):
+    resp = client.put("/admin/governance", headers=ADMIN, json={
+        "decisions": [_decide(), _decide(tool_id="x", status="banned")]})
+    assert resp.status_code == 422
+    # The valid first entry must not have been applied.
+    assert client.get("/admin/governance", headers=ADMIN).json()["decisions"] == []
+
+
+def test_bad_dates_and_ids_are_422(managed):
+    assert client.put("/admin/governance", headers=ADMIN, json={
+        "decisions": [_decide(review_due="junk")]}).status_code == 422
+    assert client.put("/admin/governance", headers=ADMIN, json={
+        "decisions": [_decide(tool_id="bad id")]}).status_code == 422
+    assert client.put("/admin/governance", headers=ADMIN, json={
+        "delete": ["../etc"]}).status_code == 422
+
+
+def test_a_database_from_before_settings_gains_the_tables(tmp_path):
+    """The homelab's state.db predates these tables; opening it must add
+    them and keep every existing row."""
+    import sqlite3
+
+    path = tmp_path / "old.db"
+    db = sqlite3.connect(path)
+    # The pre-0.9.7 schema: no settings, no governance_decisions.
+    db.executescript("""
+      CREATE TABLE enrollment_tokens (id TEXT PRIMARY KEY, token_hash BLOB
+        NOT NULL UNIQUE, note TEXT NOT NULL DEFAULT '', created_at TEXT NOT
+        NULL, expires_at TEXT NOT NULL, revoked_at TEXT);
+      INSERT INTO enrollment_tokens VALUES
+        ('t1', X'00', '', '2026-01-01', '2027-01-01', NULL);
+    """)
+    db.commit()
+    db.close()
+
+    st = state_mod.State(str(path))
+    assert st.get_settings() == {}
+    assert st.list_decisions() == []
+    assert st.list_tokens()[0]["id"] == "t1"


### PR DESCRIPTION
Third increment of v0.9.7: the write path for configuration, on top of the login (#119).

**Receiver**
- Two new state-DB tables: `settings` (JSON values) and `governance_decisions`. Both appear automatically on upgrade; a pre-0.9.7 DB keeps every row.
- `GET /admin/settings` returns each setting's effective value **and its source** (`db`/`env`/`unset`) plus the env value it may be shadowing. `PUT` is a partial upsert (`corp_domains`, `extension_id`, `onboarding_done`; unknown keys 422); an explicit `null` deletes the row and falls back to env. An explicitly saved empty domain list means *none*, not fall-back.
- `/registry/collector` serves the saved corp domains when a row exists, env otherwise — a change in the portal reaches the fleet on its next check-in. Classic mode byte-for-byte unchanged.
- `GET/PUT /admin/governance`: decisions upsert/delete, validated to the file validator's own rules (status ∈ three states, ISO dates, **an approval needs a review_due**), whole batch validated before anything is written, every write stamped with the session's username (`api` for the ADMIN_TOKEN credential).
- Body-size gate now covers PUT, not just POST.

**Portal**
- Governance merge for display: per tool, the recorded decision wins and the file fills the gaps; `decide()` labels origin so cards say **"set in the portal"**. Exceptions stay file-only. A receiver that can't answer is a loud 502, never a silent fall-back to stale file decisions.
- Settings view grows a **Central settings** card (corp domains with shadowing note + clear/fall-back, extension ID) and an **Admin account** card (password change; a wrong current password is not mistaken for a lost session).
- Register cards gain **edit / clear decision** controls with an inline form; a validation refusal shows the receiver's message and keeps what was typed. Governance writes invalidate the portal's register cache.
- `receiver_request` now sends PUT bodies (it silently dropped them before — covered by a test).
- `docs/governance.md` updated: the write path it pre-argued for now exists; the merge-request argument still holds for classic mode.

Verified: 276 portal + 83 receiver tests (11 portal + 16 receiver new), live E2E against a real receiver + stubbed Loki (save → fleet hears it → clear → env returns; decision → register shows `portal` source), and a Chrome click-through of the Settings card, the domain save/shadow note, and the full decision editor including the approval-without-review-date refusal.