### PR TITLE
Runtime log store, alerting and public URL settings (v0.9.8 increment 1)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -59,6 +59,18 @@ In managed mode it is a real login: an admin account in the receiver's state
 DB (scrypt-hashed password, created on first boot with a one-time setup code
 the receiver prints to its log), a session carried as an HttpOnly
 SameSite=Strict cookie, validated against the receiver per request.
+
+A word on what the state DB holds, because it changed in 0.9.8. **Fleet
+credentials** - enrollment tokens, device credentials, sessions, the admin
+password - are stored as hashes only; a copied database file cannot
+impersonate anything. **Integration secrets** are different: a log store
+password saved in the portal is stored recoverable, because the receiver
+must present it to push findings. It is masked everywhere in the UI and in
+the ordinary settings API, and the plaintext exists on exactly one admin
+route the portal uses server-side - but an admin who can set it can read it
+back, and a copied database file now contains it. If that trade is
+unacceptable, leave the log store configured by environment/Secret as
+before; the wizard step is optional and the env path is unchanged.
 Classically it is HTTP basic auth: one shared credential, no per-user trail,
 and plaintext without TLS in front of it. That is a floor, not a ceiling.
 

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -249,6 +249,19 @@ SESSION_COOKIE = "aiguard_session"
 SESSION_CACHE_TTL = 60
 _session_cache: dict[str, tuple[float, str]] = {}  # token -> (until, username)
 
+# The receiver-stored settings, cached briefly so a page of API calls does
+# not re-fetch them. Two caches because they answer different callers: the
+# masked view (display preferences, receiver public URL) and the log-store
+# secrets, which only _log_store below ever touches and no route relays.
+SETTINGS_CACHE_TTL = 30
+_remote_settings_cache: dict = {"at": 0.0, "data": None}
+_log_store_cache: dict = {"at": 0.0, "data": None}
+
+
+def _invalidate_settings_caches():
+    _remote_settings_cache.update(at=0.0, data=None)
+    _log_store_cache.update(at=0.0, data=None)
+
 # Fail closed. Coming up open because a variable was missed is the failure
 # that matters here: the portal is reachable, it looks like it works, and
 # nothing says the door is off. Refusing to start is loud and immediate.
@@ -295,6 +308,25 @@ app = FastAPI(title="ai-guard portal", version=APP_VERSION,
               docs_url=None, redoc_url=None)
 
 
+def _frame_src() -> str:
+    """The Grafana origin frames may load from: env, else the portal-saved
+    setting as last seen in the settings cache.
+
+    The cache only, deliberately: this runs on every response with no
+    session to fetch with. The consequence is one page-load of lag after
+    saving a Grafana URL before frames unblock - the next /api/config call
+    warms the cache - which beats either fetching per response or leaving
+    settings-configured Grafana permanently unframeable.
+    """
+    if GRAFANA_URL:
+        return GRAFANA_URL
+    rs = _remote_settings_cache["data"] or {}
+    entry = rs.get("grafana_url")
+    if isinstance(entry, dict):
+        return (entry.get("value") or "").rstrip("/")
+    return ""
+
+
 @app.middleware("http")
 async def security_headers(request, call_next):
     """Headers that limit what a rendering bug can do.
@@ -337,7 +369,7 @@ async def security_headers(request, call_next):
         "style-src 'self' 'unsafe-inline'; "
         "img-src 'self' data:; "
         "connect-src 'self'; "
-        "frame-src " + (GRAFANA_URL or "'none'") + "; "
+        "frame-src " + (_frame_src() or "'none'") + "; "
         "frame-ancestors 'none'; "
         "form-action 'none'; "
         "base-uri 'none'; "
@@ -413,6 +445,68 @@ def _redact_url(url):
     )
 
 
+def _remote_settings(request) -> dict:
+    """The receiver's stored settings (masked view), or {} outside login
+    mode. Quiet on failure: the callers are display preferences and
+    prefills, and a page that falls back to its env values beats a page
+    that refuses to render because a settings fetch hiccuped. Anything
+    correctness-critical (the log store, artifacts) fetches loudly itself.
+    """
+    if not LOGIN_MODE or request is None:
+        return {}
+    now = time.time()
+    if (_remote_settings_cache["data"] is not None
+            and now - _remote_settings_cache["at"] < SETTINGS_CACHE_TTL):
+        return _remote_settings_cache["data"]
+    token = request.cookies.get(SESSION_COOKIE, "")
+    try:
+        out = managed.receiver_request(
+            RECEIVER_URL, "GET", "/admin/settings", token).get("settings", {})
+    except managed.ReceiverError:
+        return {}
+    _remote_settings_cache.update(at=now, data=out)
+    return out
+
+
+def _remote_value(settings: dict, key: str, env: str = "") -> str:
+    """One effective string from the masked settings view, env fallback."""
+    entry = settings.get(key)
+    v = entry.get("value") if isinstance(entry, dict) else None
+    return v if v else env
+
+
+def _log_store(request):
+    """(url, username, password, source) for reading findings back.
+
+    The portal-saved log store wins; the portal's own env is the fallback,
+    exactly the rule every setting follows. The password crosses only this
+    server-side hop - no route relays it - and a receiver that cannot
+    answer is a loud error, because silently falling back to env here
+    could read a different store than the receiver is writing to.
+    """
+    if LOGIN_MODE and request is not None:
+        now = time.time()
+        if (_log_store_cache["data"] is None
+                or now - _log_store_cache["at"] >= SETTINGS_CACHE_TTL):
+            token = request.cookies.get(SESSION_COOKIE, "")
+            try:
+                _log_store_cache["data"] = managed.receiver_request(
+                    RECEIVER_URL, "GET", "/admin/settings/secrets", token)
+                _log_store_cache["at"] = now
+            except managed.ReceiverError as e:
+                if e.status == 502:
+                    log.warning("receiver call failed for %s: %s",
+                                _redact_url(RECEIVER_URL), e.detail)
+                raise HTTPException(
+                    e.status, "could not read the log-store configuration "
+                              "from the receiver (%s)" % e.detail)
+        s = _log_store_cache["data"]
+        if s.get("log_store_url"):
+            return (s["log_store_url"], s.get("log_store_username") or "",
+                    s.get("log_store_password") or "", "portal")
+    return (LOKI_URL, LOKI_USERNAME or "", LOKI_PASSWORD or "", "env")
+
+
 def _cached(key, hours, builder):
     now = time.time()
     hit = _cache.get(key)
@@ -423,18 +517,22 @@ def _cached(key, hours, builder):
     return value, now
 
 
-def _findings(hours):
-    if not LOKI_URL:
+def _findings(hours, request=None):
+    url, username, password, source = _log_store(request)
+    if not url:
         raise HTTPException(
             status_code=503,
-            detail="LOKI_URL is not set. The portal reads findings from Loki; "
-                   "point it at the same Loki the receiver writes to.",
+            detail="No log store is configured. Save its base URL in "
+                   "Settings (managed mode), or set LOKI_URL - the same "
+                   "store the receiver writes to.",
         )
     global _last_loki_ok, _last_loki_error
     try:
         out = derive.fetch_from_loki(
-            LOKI_URL, hours, LOKI_TOKEN,
-            username=LOKI_USERNAME, password=LOKI_PASSWORD)
+            # The bearer token is env configuration and belongs to the env
+            # store; a portal-saved store authenticates with its own pair.
+            url, hours, LOKI_TOKEN if source == "env" else None,
+            username=username or None, password=password or None)
         _last_loki_ok = time.time()
         _last_loki_error = ""
         return out
@@ -443,7 +541,7 @@ def _findings(hours):
         # is written for an operator reading a stack trace, not for an HTTP
         # body, and LOKI_URL may carry credentials in its userinfo.
         log.warning(
-            "Loki read failed for %s: %s", _redact_url(LOKI_URL), e,
+            "Loki read failed for %s: %s", _redact_url(url), e,
             exc_info=True,
         )
         _last_loki_error = type(e).__name__
@@ -456,7 +554,7 @@ def _findings(hours):
             status_code=502,
             detail="Could not read findings from Loki at %s (%s). "
                    "See the portal logs for detail."
-                   % (_redact_url(LOKI_URL), type(e).__name__),
+                   % (_redact_url(url), type(e).__name__),
         )
 
 
@@ -468,10 +566,23 @@ def healthz():
 
 
 @app.get("/api/config")
-def config(_=Depends(require_auth)):
-    """What the browser needs to know about this deployment."""
+def config(request: Request, _=Depends(require_auth)):
+    """What the browser needs to know about this deployment.
+
+    In login mode the display preferences (Grafana embedding, overview
+    widgets) and the receiver public URL resolve settings-first with env
+    as fallback, so the wizard's answers take effect with no redeploy.
+    """
+    rs = _remote_settings(request)
+    grafana_url = _remote_value(rs, "grafana_url", GRAFANA_URL).rstrip("/")
+    panels_raw = _remote_value(rs, "grafana_panels", GRAFANA_PANELS)
+    dashboard_uid = _remote_value(rs, "grafana_dashboard_uid",
+                                  GRAFANA_DASHBOARD_UID)
+    public_url = _remote_value(rs, "receiver_public_url", RECEIVER_PUBLIC_URL)
+    log_store = _remote_value(rs, "log_store_url", LOKI_URL)
+
     panels = []
-    for spec in GRAFANA_PANELS.split(";"):
+    for spec in panels_raw.split(";"):
         spec = spec.strip()
         if not spec:
             continue
@@ -480,7 +591,7 @@ def config(_=Depends(require_auth)):
             # Said out loud rather than skipped: a panel that silently does not
             # appear looks like Grafana refusing the frame, which sends someone
             # off debugging headers for a typo in an environment variable.
-            panels.append({"error": "malformed GRAFANA_PANELS entry: %s" % spec})
+            panels.append({"error": "malformed grafana panels entry: %s" % spec})
             continue
         panels.append({
             "uid": parts[0],
@@ -489,22 +600,26 @@ def config(_=Depends(require_auth)):
         })
 
     return {
-        "loki_configured": bool(LOKI_URL),
-        "grafana_url": GRAFANA_URL,
+        "loki_configured": bool(log_store),
+        "grafana_url": grafana_url,
         "grafana_panels": panels,
-        "grafana_dashboard_uid": GRAFANA_DASHBOARD_UID,
+        "grafana_dashboard_uid": dashboard_uid,
         "lookback_hours": LOOKBACK_HOURS,
         "identity_map_configured": bool(IDENTITY_MAP and Path(IDENTITY_MAP).exists()),
         "cache_ttl_seconds": CACHE_TTL,
         "version": APP_VERSION,
-        "overview_widgets": _widgets(),
+        "overview_widgets": _widgets(_remote_value(rs, "overview_widgets",
+                                                   OVERVIEW_WIDGETS)),
         # enabled says the portal can reach an admin API; artifacts_ready
         # says downloads can bake a URL agents can reach. Separate flags,
         # because a deployment can sensibly have the first without the
         # second and the UI should name which one is missing.
+        # receiver_public_url_default is the wizard's prefill: the effective
+        # value today, whichever source supplies it.
         "managed": {
             "enabled": bool(RECEIVER_URL),
-            "artifacts_ready": bool(RECEIVER_URL and RECEIVER_PUBLIC_URL),
+            "artifacts_ready": bool(RECEIVER_URL and public_url),
+            "receiver_public_url_default": public_url,
         },
     }
 
@@ -527,13 +642,16 @@ DEFAULT_WIDGETS = ["stat_row", "top_tools", "recent_personal_accounts",
                    "detection_coverage"]
 
 
-def _widgets():
-    """Parse OVERVIEW_WIDGETS into what the browser should draw.
+def _widgets(spec=None):
+    """Parse an overview-widgets string into what the browser should draw.
 
-    grafana:<panel-title> entries are resolved against GRAFANA_PANELS rather
-    than repeating panel ids in two places.
+    grafana:<panel-title> entries are resolved against the panels list
+    rather than repeating panel ids in two places. spec defaults to the
+    env value; login mode passes the effective setting through.
     """
-    raw = [w.strip() for w in OVERVIEW_WIDGETS.split(",") if w.strip()]
+    raw = [w.strip() for w in
+           (OVERVIEW_WIDGETS if spec is None else spec).split(",")
+           if w.strip()]
     if not raw:
         return [{"kind": w} for w in DEFAULT_WIDGETS]
     out = []
@@ -613,7 +731,8 @@ def diagnostics(_=Depends(require_auth)):
 
 
 @app.get("/api/graph")
-def graph(hours: float = Query(default=None, gt=0, le=24 * 90),
+def graph(request: Request,
+          hours: float = Query(default=None, gt=0, le=24 * 90),
           refresh: bool = Query(default=False),
           _=Depends(require_auth)):
     """refresh=true skips the cache. A cache you cannot see past is
@@ -622,7 +741,7 @@ def graph(hours: float = Query(default=None, gt=0, le=24 * 90),
     if refresh:
         _cache.pop("graph", None)
     def build():
-        findings = _findings(hours)
+        findings = _findings(hours, request)
         domain_map = derive.load_domain_map(REGISTRY_PATH)
         identity_map = derive.load_identity_map(IDENTITY_MAP) if IDENTITY_MAP else {}
         return derive.graph_from(findings, domain_map, identity_map)
@@ -632,14 +751,15 @@ def graph(hours: float = Query(default=None, gt=0, le=24 * 90),
 
 
 @app.get("/api/status")
-def status(hours: float = Query(default=None, gt=0, le=24 * 90),
+def status(request: Request,
+           hours: float = Query(default=None, gt=0, le=24 * 90),
            refresh: bool = Query(default=False),
            _=Depends(require_auth)):
     hours = hours or LOOKBACK_HOURS
     if refresh:
         _cache.pop("status", None)
     def build():
-        return derive.status_from(_findings(hours))
+        return derive.status_from(_findings(hours, request))
 
     value, at = _cached("status", hours, build)
     return JSONResponse(dict(value, derived_at=at, hours=hours))
@@ -661,7 +781,7 @@ def evidence_snapshot(request: Request,
     were taken.
     """
     hours = hours or LOOKBACK_HOURS
-    findings = _findings(hours)
+    findings = _findings(hours, request)
     reg = derive.load_registry(REGISTRY_PATH)
     domain_map = derive.load_domain_map_from(reg)
     gov, exceptions, _portal = _merged_governance(request)
@@ -691,7 +811,8 @@ def evidence_snapshot(request: Request,
 
 
 @app.get("/api/paste-guard")
-def paste_guard_events(hours: float = Query(default=None, gt=0, le=24 * 90),
+def paste_guard_events(request: Request,
+                       hours: float = Query(default=None, gt=0, le=24 * 90),
                        refresh: bool = Query(default=False),
                        _=Depends(require_auth)):
     """Paste guard activity: what was stopped, on which tool, how often.
@@ -711,7 +832,7 @@ def paste_guard_events(hours: float = Query(default=None, gt=0, le=24 * 90),
         _cache.pop("paste_guard", None)
 
     def build():
-        findings = _findings(hours)
+        findings = _findings(hours, request)
         reg = derive.load_registry(REGISTRY_PATH)
         return paste_guard.paste_guard_from(
             findings, derive.load_domain_map_from(reg))
@@ -756,7 +877,7 @@ def register(request: Request,
     gov, exceptions, portal_decisions = _merged_governance(request)
 
     def build():
-        findings = _findings(hours)
+        findings = _findings(hours, request)
         reg = derive.load_registry(REGISTRY_PATH)
         return derive.register_from(findings, reg,
                                     derive.load_domain_map_from(reg), gov,
@@ -812,7 +933,8 @@ def register(request: Request,
 
 
 @app.get("/api/suggest-identities")
-def suggest_identities(hours: float = Query(default=None, gt=0, le=24 * 90),
+def suggest_identities(request: Request,
+                       hours: float = Query(default=None, gt=0, le=24 * 90),
                        fmt: str = Query(default="json", pattern="^(json|csv)$"),
                        _=Depends(require_auth)):
     """Proposed device -> identity mappings, for review.
@@ -823,7 +945,7 @@ def suggest_identities(hours: float = Query(default=None, gt=0, le=24 * 90),
     correct it, and point IDENTITY_MAP at it.
     """
     hours = hours or LOOKBACK_HOURS
-    findings = _findings(hours)
+    findings = _findings(hours, request)
     domain_map = derive.load_domain_map(REGISTRY_PATH)
     devices, identities, _t, _b, _u = derive.build(findings, domain_map, {})
     matched, unmatched = derive.suggest_identity_rows(devices, identities)
@@ -1122,11 +1244,22 @@ def revoke_device(did: str, _=Depends(require_auth),
 class SettingsWrite(BaseModel):
     # extra=forbid, same as the receiver: an unknown key here would be
     # silently dropped from model_fields_set and someone would believe a
-    # setting took effect.
+    # setting took effect. The receiver revalidates (URL shapes included);
+    # this model only mirrors the keys and bounds.
     model_config = {"extra": "forbid"}
     corp_domains: list[str] | None = Field(default=None, max_length=200)
     extension_id: str | None = Field(default=None, max_length=128)
     onboarding_done: bool | None = None
+    receiver_public_url: str | None = Field(default=None, max_length=500)
+    log_store_url: str | None = Field(default=None, max_length=500)
+    log_store_push_url: str | None = Field(default=None, max_length=500)
+    log_store_username: str | None = Field(default=None, max_length=256)
+    log_store_password: str | None = Field(default=None, max_length=512)
+    alertmanager_url: str | None = Field(default=None, max_length=500)
+    grafana_url: str | None = Field(default=None, max_length=500)
+    grafana_panels: str | None = Field(default=None, max_length=2000)
+    grafana_dashboard_uid: str | None = Field(default=None, max_length=128)
+    overview_widgets: str | None = Field(default=None, max_length=500)
 
 
 class DecisionWrite(BaseModel):
@@ -1161,7 +1294,11 @@ def api_settings_write(req: SettingsWrite, _=Depends(require_auth),
     to env), an absent key is untouched - and the receiver validates and
     answers with the fresh effective view."""
     body = {k: getattr(req, k) for k in req.model_fields_set}
-    return _receiver("PUT", "/admin/settings", token, body)
+    out = _receiver("PUT", "/admin/settings", token, body)
+    # The portal's cached views of these settings are now stale - a saved
+    # log store must be read from on the very next page, not in 30s.
+    _invalidate_settings_caches()
+    return out
 
 
 @app.get("/api/governance-decisions")
@@ -1178,6 +1315,84 @@ def api_governance_write(req: GovernanceWrite, _=Depends(require_auth),
     # the world before the operator acted.
     _cache.pop("register", None)
     return out
+
+
+class UrlProbe(BaseModel):
+    url: str = Field(min_length=1, max_length=500)
+
+
+@app.post("/api/test/receiver-url")
+def test_receiver_url(req: UrlProbe, _=Depends(require_auth),
+                      token: str = Depends(_admin_forward)):
+    """Probe a candidate public receiver URL before an artifact bakes it.
+
+    Server-side on purpose - the browser's CSP keeps it on 'self', and the
+    point is to catch the URL that LOOKS right in a browser on this machine
+    and resolves nowhere else. Deliberately a requester-supplied URL: this
+    is a prober an admin aims, gated behind the admin session, restricted
+    to http(s), and it reads only /healthz - which returns nothing about
+    the estate even on the real receiver.
+    """
+    import urllib.request as _urlreq
+
+    url = req.url.strip().rstrip("/")
+    if not url.startswith(("http://", "https://")):
+        raise HTTPException(422, "the URL must be http:// or https://")
+    warnings = []
+    host = urllib.parse.urlsplit(url).hostname or ""
+    if "." not in host:
+        warnings.append(
+            "the host has no dot: machines other than this one cannot "
+            "resolve a short name. On Tailscale use the full .ts.net "
+            "address, not the ingress short name.")
+    try:
+        with _urlreq.urlopen(url + "/healthz", timeout=5) as resp:
+            body = json.loads(resp.read() or b"{}")
+    except Exception as e:
+        return {"ok": False, "warnings": warnings,
+                "detail": "could not reach %s/healthz (%s)"
+                          % (_redact_url(url), type(e).__name__)}
+    if not body.get("ok"):
+        return {"ok": False, "warnings": warnings,
+                "detail": "%s answered, but not like an ai-guard receiver"
+                          % _redact_url(url)}
+    return {"ok": True, "warnings": warnings,
+            "version": str(body.get("version", ""))}
+
+
+@app.post("/api/test/log-store-read")
+def test_log_store_read(request: Request, _=Depends(require_auth)):
+    """One tiny query with the effective read configuration: can the portal
+    get findings back out? The other half of the receiver's push test -
+    together they catch the write-only-token trap during setup instead of
+    on the first quiet dashboard."""
+    url, username, password, source = _log_store(request)
+    if not url:
+        raise HTTPException(
+            400, "no log store is configured: save its base URL in "
+                 "Settings, or set LOKI_URL")
+    try:
+        derive.fetch_from_loki(url, 1, LOKI_TOKEN if source == "env" else None,
+                               limit=1, username=username or None,
+                               password=password or None)
+    except Exception as e:
+        out = {"ok": False, "url": _redact_url(url),
+               "detail": "read failed (%s)" % type(e).__name__}
+        code = getattr(e, "code", None)
+        if code in (401, 403):
+            out["hint"] = ("the credentials are wrong or lack read access; "
+                           "on Grafana Cloud the token needs logs:read as "
+                           "well as logs:write")
+        return out
+    return {"ok": True, "url": _redact_url(url)}
+
+
+@app.post("/api/test/log-store-push")
+def test_log_store_push(_=Depends(require_auth),
+                        token: str = Depends(_admin_forward)):
+    """The receiver pushes one synthetic line with ITS effective config
+    and reports what happened, hints included."""
+    return _receiver("POST", "/admin/test/log-store-push", token)
 
 
 @app.post("/api/password")
@@ -1212,18 +1427,23 @@ def artifact(kind: str, _=Depends(require_auth),
     """
     if kind not in managed.ARTIFACTS and kind not in GENERATED_ARTIFACTS:
         raise HTTPException(404, "no such artifact")
-    if not RECEIVER_PUBLIC_URL:
-        raise HTTPException(
-            503, "RECEIVER_PUBLIC_URL is not set. Artifacts bake the ingest "
-                 "URL agents reach from outside, which is not the portal's "
-                 "internal RECEIVER_URL; see the portal README.")
 
-    # The extension policy's preconditions are checked before minting, so a
-    # refusal does not leave a token dangling behind an artifact that never
-    # existed.
+    # Settings first: the wizard-saved receiver public URL wins over the
+    # deployment's env value, same as every setting. Fetched before minting,
+    # so a refusal does not leave a token dangling behind an artifact that
+    # never existed.
+    stored = _receiver("GET", "/admin/settings", token).get("settings", {})
+    public_url = ((stored.get("receiver_public_url") or {}).get("value")
+                  or RECEIVER_PUBLIC_URL)
+    if not public_url:
+        raise HTTPException(
+            503, "no public receiver URL is set. Artifacts bake the ingest "
+                 "URL agents reach from outside; save it in Settings (or "
+                 "set RECEIVER_PUBLIC_URL). It is not the portal's internal "
+                 "RECEIVER_URL; see the portal README.")
+
     extension_id, corp_domains = "", []
     if kind == "extension-policy":
-        stored = _receiver("GET", "/admin/settings", token).get("settings", {})
         extension_id = (stored.get("extension_id") or {}).get("value") or ""
         corp_domains = (stored.get("corp_domains") or {}).get("value") or []
         if not extension_id:
@@ -1236,7 +1456,7 @@ def artifact(kind: str, _=Depends(require_auth),
     try:
         if kind == "extension-policy":
             filename, content = managed.generate_extension_policy(
-                extension_id, RECEIVER_PUBLIC_URL, minted["token"],
+                extension_id, public_url, minted["token"],
                 corp_domains)
         elif kind == "scanner-cronjob":
             # A release build's version is the image tag on ghcr; a dev
@@ -1244,10 +1464,10 @@ def artifact(kind: str, _=Depends(require_auth),
             # nearest thing.
             tag = APP_VERSION if APP_VERSION[:1].isdigit() else "latest"
             filename, content = managed.generate_scanner_cronjob(
-                RECEIVER_PUBLIC_URL, minted["token"], tag)
+                public_url, minted["token"], tag)
         else:
             filename, content = managed.generate(
-                kind, COLLECTOR_SCRIPTS_DIR, RECEIVER_PUBLIC_URL,
+                kind, COLLECTOR_SCRIPTS_DIR, public_url,
                 minted["token"])
     except managed.ArtifactError as e:
         # The token is already minted; say which one so it can be revoked

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1317,25 +1317,28 @@ def api_governance_write(req: GovernanceWrite, _=Depends(require_auth),
     return out
 
 
-class UrlProbe(BaseModel):
-    url: str = Field(min_length=1, max_length=500)
-
-
 @app.post("/api/test/receiver-url")
-def test_receiver_url(req: UrlProbe, _=Depends(require_auth),
+def test_receiver_url(_=Depends(require_auth),
                       token: str = Depends(_admin_forward)):
-    """Probe a candidate public receiver URL before an artifact bakes it.
+    """Probe the EFFECTIVE public receiver URL - the saved setting, else
+    the deployment's env value - before an artifact bakes it.
 
-    Server-side on purpose - the browser's CSP keeps it on 'self', and the
+    Server-side on purpose: the browser's CSP keeps it on 'self', and the
     point is to catch the URL that LOOKS right in a browser on this machine
-    and resolves nowhere else. Deliberately a requester-supplied URL: this
-    is a prober an admin aims, gated behind the admin session, restricted
-    to http(s), and it reads only /healthz - which returns nothing about
-    the estate even on the real receiver.
+    and resolves nowhere else. Deliberately not a requester-supplied URL,
+    matching the log-store tests: save first, then probe what was saved.
+    That is one more click in the wizard and one fewer route that fetches
+    whatever the request names.
     """
     import urllib.request as _urlreq
 
-    url = req.url.strip().rstrip("/")
+    stored = _receiver("GET", "/admin/settings", token).get("settings", {})
+    url = (((stored.get("receiver_public_url") or {}).get("value")
+            or RECEIVER_PUBLIC_URL) or "").strip().rstrip("/")
+    if not url:
+        raise HTTPException(
+            400, "no public receiver URL to probe: save one in Settings "
+                 "first (or set RECEIVER_PUBLIC_URL)")
     if not url.startswith(("http://", "https://")):
         raise HTTPException(422, "the URL must be http:// or https://")
     warnings = []

--- a/portal/tests/test_evidence.py
+++ b/portal/tests/test_evidence.py
@@ -353,7 +353,7 @@ def test_the_endpoint_produces_a_verifiable_snapshot():
                      {"id": "chatgpt", "name": "ChatGPT", "approved": False,
                       "domains": ["chatgpt.com"]}]}
 
-    with patch.object(pm, "_findings", lambda h: findings), \
+    with patch.object(pm, "_findings", lambda h, request=None: findings), \
             patch.object(derive, "load_registry", lambda p: reg):
         pm._cache.clear()
         body = json.loads(bytes(pm.evidence_snapshot(None, hours=168).body))
@@ -375,7 +375,7 @@ def test_the_download_carries_provenance_in_the_filename():
     from app import derive
     from app import main as pm
 
-    with patch.object(pm, "_findings", lambda h: []), \
+    with patch.object(pm, "_findings", lambda h, request=None: []), \
             patch.object(derive, "load_registry", lambda p: {"tools": []}):
         pm._cache.clear()
         resp = pm.evidence_snapshot(None, hours=168, download=True)

--- a/portal/tests/test_managed_portal.py
+++ b/portal/tests/test_managed_portal.py
@@ -213,8 +213,11 @@ def test_an_artifact_mints_its_own_token_and_downloads_configured(receiver):
     body = resp.body.decode()
     assert 'RECEIVER_BASE="${4:-https://rx.example.com}"' in body
     assert 'TOKEN="${5:-aige_MINTED}"' in body
-    # Provenance: the minted token names the artifact it left inside.
-    assert receiver[0]["body"]["note"] == "portal artifact: collector-macos"
+    # Settings are consulted first (they may supply the public URL), then
+    # the mint; the minted token names the artifact it left inside.
+    assert [c["path"] for c in receiver] == ["/admin/settings",
+                                             "/admin/enrollment-tokens"]
+    assert receiver[1]["body"]["note"] == "portal artifact: collector-macos"
 
 
 def test_an_artifact_without_a_public_url_is_refused_before_minting(
@@ -226,7 +229,9 @@ def test_an_artifact_without_a_public_url_is_refused_before_minting(
     err = http_error(main.artifact, "collector-macos", _=None, token="t")
     assert err.status_code == 503
     assert "RECEIVER_PUBLIC_URL" in err.detail
-    assert receiver == []
+    # The settings were consulted (they could have supplied the URL), but
+    # nothing was minted for an artifact that never existed.
+    assert [c["path"] for c in receiver] == ["/admin/settings"]
 
 
 def test_an_unknown_artifact_is_404_before_minting(receiver):
@@ -238,8 +243,9 @@ def test_an_unknown_artifact_is_404_before_minting(receiver):
 def test_config_names_which_managed_flag_is_missing(monkeypatch):
     monkeypatch.setattr(main, "RECEIVER_URL", "http://r.internal:8080")
     monkeypatch.setattr(main, "RECEIVER_PUBLIC_URL", "")
-    assert main.config(_=None)["managed"] == {
-        "enabled": True, "artifacts_ready": False}
+    assert main.config(None, _=None)["managed"] == {
+        "enabled": True, "artifacts_ready": False,
+        "receiver_public_url_default": ""}
 
 
 # --------------------------------------------------------- receiver client --

--- a/portal/tests/test_paste_guard.py
+++ b/portal/tests/test_paste_guard.py
@@ -262,10 +262,10 @@ def test_the_endpoint_returns_metadata_and_excludes_heartbeats():
                 _f(device="D2", tool="chatgpt")]
     reg = {"tools": [{"id": "chatgpt", "domains": ["chatgpt.com"]}]}
 
-    with patch.object(pm, "_findings", lambda h: findings), \
+    with patch.object(pm, "_findings", lambda h, request=None: findings), \
             patch.object(derive, "load_registry", lambda p: reg):
         pm._cache.clear()
-        body = _json.loads(bytes(pm.paste_guard_events(hours=168).body))
+        body = _json.loads(bytes(pm.paste_guard_events(None, hours=168).body))
 
     assert body["events"] == 2
     assert body["overridden"] == 1

--- a/portal/tests/test_register.py
+++ b/portal/tests/test_register.py
@@ -347,7 +347,7 @@ def test_an_unobserved_tool_is_not_in_the_endpoints_rows():
     from app import derive
     from app import main as pm
 
-    with patch.object(pm, "_findings", lambda h: [_f()]), \
+    with patch.object(pm, "_findings", lambda h, request=None: [_f()]), \
             patch.object(derive, "load_registry", lambda p: REGISTRY):
         pm._cache.clear()
         body = json.loads(bytes(pm.register(None, hours=168).body))

--- a/portal/tests/test_runtime_log_store.py
+++ b/portal/tests/test_runtime_log_store.py
@@ -1,0 +1,253 @@
+"""Portal-side runtime configuration: reading findings from the store the
+wizard saved, display preferences from settings, and the connection tests.
+Same direct-call harness as the suite."""
+
+import os
+
+os.environ.setdefault("PORTAL_AUTH", "none")
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from app import main, managed
+
+
+def _request(cookie_token="aigt_s"):
+    hs = [(b"host", b"portal"),
+          (b"cookie", ("%s=%s" % (main.SESSION_COOKIE, cookie_token)).encode())]
+    return Request({"type": "http", "method": "GET", "path": "/",
+                    "scheme": "http", "headers": hs, "query_string": b""})
+
+
+@pytest.fixture
+def login_mode(monkeypatch):
+    calls = []
+    answers = {
+        "/admin/settings/secrets": {
+            "log_store_url": "http://saved-loki:3100",
+            "log_store_push_url": "",
+            "log_store_username": "u1",
+            "log_store_password": "pw1"},
+        "/admin/settings": {"settings": {
+            "grafana_url": {"value": "https://grafana.saved", "source": "db"},
+            "grafana_panels": {"value": "abc:1:Top tools", "source": "db"},
+            "grafana_dashboard_uid": {"value": "", "source": "unset"},
+            "overview_widgets": {"value": "stat_row", "source": "db"},
+            "receiver_public_url": {"value": "https://rx.saved.example",
+                                    "source": "db"},
+            "log_store_url": {"value": "http://saved-loki:3100",
+                              "source": "db"},
+        }},
+    }
+
+    def fake(base, method, path, token, body=None):
+        calls.append({"method": method, "path": path, "token": token,
+                      "body": body})
+        return answers.get(path, {"ok": True})
+
+    monkeypatch.setattr(main, "PORTAL_AUTH", "")
+    monkeypatch.setattr(main, "RECEIVER_URL", "http://receiver.internal:8080")
+    monkeypatch.setattr(main, "LOGIN_MODE", True)
+    monkeypatch.setattr(main.managed, "receiver_request", fake)
+    main._invalidate_settings_caches()
+    return calls
+
+
+# --------------------------------------------------------------- log store --
+
+
+def test_the_saved_store_wins_and_brings_its_own_credentials(login_mode,
+                                                             monkeypatch):
+    monkeypatch.setattr(main, "LOKI_URL", "http://env-loki:3100")
+    monkeypatch.setattr(main, "LOKI_USERNAME", "env-user")
+    monkeypatch.setattr(main, "LOKI_PASSWORD", "env-pass")
+    assert main._log_store(_request()) == (
+        "http://saved-loki:3100", "u1", "pw1", "portal")
+
+
+def test_no_saved_store_falls_back_to_the_env(login_mode, monkeypatch):
+    def fake(base, method, path, token, body=None):
+        return {"log_store_url": "", "log_store_push_url": "",
+                "log_store_username": "", "log_store_password": ""}
+    monkeypatch.setattr(main.managed, "receiver_request", fake)
+    monkeypatch.setattr(main, "LOKI_URL", "http://env-loki:3100")
+    url, _, _, source = main._log_store(_request())
+    assert (url, source) == ("http://env-loki:3100", "env")
+
+
+def test_classic_mode_never_calls_the_receiver(login_mode, monkeypatch):
+    monkeypatch.setattr(main, "LOGIN_MODE", False)
+    monkeypatch.setattr(main, "LOKI_URL", "http://env-loki:3100")
+    assert main._log_store(None)[3] == "env"
+    assert login_mode == []
+
+
+def test_the_secrets_fetch_is_cached_and_a_write_invalidates(login_mode):
+    main._log_store(_request())
+    main._log_store(_request())
+    secrets_calls = [c for c in login_mode if c["path"] == "/admin/settings/secrets"]
+    assert len(secrets_calls) == 1
+
+    # A settings write through the portal makes the cache stale NOW, not
+    # in thirty seconds: the saved store must be read on the next page.
+    main.api_settings_write(main.SettingsWrite(
+        log_store_url="http://other:3100"), _=None, token="t")
+    main._log_store(_request())
+    secrets_calls = [c for c in login_mode if c["path"] == "/admin/settings/secrets"]
+    assert len(secrets_calls) == 2
+
+
+def test_an_unreachable_receiver_is_loud_not_a_silent_env_fallback(login_mode,
+                                                                   monkeypatch):
+    """Falling back to env here could read a different store than the
+    receiver is writing to, which is the quiet-wrongness failure mode."""
+    def down(base, method, path, token, body=None):
+        raise managed.ReceiverError(502, "could not reach the receiver (X)")
+    monkeypatch.setattr(main.managed, "receiver_request", down)
+    with pytest.raises(HTTPException) as e:
+        main._log_store(_request())
+    assert e.value.status_code == 502
+
+
+def test_findings_only_sends_the_env_bearer_to_the_env_store(login_mode,
+                                                             monkeypatch):
+    """LOKI_TOKEN is env configuration; sending it to a portal-saved store
+    would leak one store's bearer to another."""
+    seen = {}
+
+    def fake_fetch(url, hours, token=None, limit=5000, username=None,
+                   password=None):
+        seen.update(url=url, token=token, username=username)
+        return []
+    monkeypatch.setattr(main.derive, "fetch_from_loki", fake_fetch)
+    monkeypatch.setattr(main, "LOKI_TOKEN", "env-bearer")
+
+    main._findings(1, _request())
+    assert seen["url"] == "http://saved-loki:3100"
+    assert seen["token"] is None and seen["username"] == "u1"
+
+
+# ------------------------------------------------------------------ config --
+
+
+def test_config_resolves_display_preferences_from_settings(login_mode,
+                                                           monkeypatch):
+    monkeypatch.setattr(main, "GRAFANA_URL", "https://grafana.env")
+    monkeypatch.setattr(main, "RECEIVER_PUBLIC_URL", "https://rx.env.example")
+    out = main.config(_request(), _=None)
+    assert out["grafana_url"] == "https://grafana.saved"
+    assert out["grafana_panels"] == [
+        {"uid": "abc", "panel_id": "1", "title": "Top tools"}]
+    assert out["overview_widgets"] == [{"kind": "stat_row"}]
+    assert out["loki_configured"] is True
+    assert out["managed"]["artifacts_ready"] is True
+    assert out["managed"]["receiver_public_url_default"] == "https://rx.saved.example"
+
+
+def test_config_in_classic_mode_is_the_env_exactly(monkeypatch):
+    monkeypatch.setattr(main, "LOGIN_MODE", False)
+    monkeypatch.setattr(main, "GRAFANA_URL", "https://grafana.env")
+    out = main.config(None, _=None)
+    assert out["grafana_url"] == "https://grafana.env"
+
+
+def test_the_frame_src_follows_the_cached_setting(login_mode, monkeypatch):
+    monkeypatch.setattr(main, "GRAFANA_URL", "")
+    # Cold cache: nothing to allow yet.
+    assert main._frame_src() == ""
+    # A config call warms the cache; frames unblock from then on.
+    main.config(_request(), _=None)
+    assert main._frame_src() == "https://grafana.saved"
+    # Env, when set, stays authoritative.
+    monkeypatch.setattr(main, "GRAFANA_URL", "https://grafana.env")
+    assert main._frame_src() == "https://grafana.env"
+
+
+def test_artifacts_bake_the_saved_public_url(login_mode, monkeypatch):
+    monkeypatch.setattr(main, "RECEIVER_PUBLIC_URL", "https://rx.env.example")
+    monkeypatch.setattr(main, "COLLECTOR_SCRIPTS_DIR",
+                        str(main.Path(__file__).parent.parent / "collector-scripts"))
+
+    def fake(base, method, path, token, body=None):
+        if path == "/admin/settings":
+            return {"settings": {"receiver_public_url": {
+                "value": "https://rx.saved.example", "source": "db"}}}
+        return {"id": "t1", "token": "aige_MINTED",
+                "expires_at": "2027-01-01T00:00:00+00:00"}
+    monkeypatch.setattr(main.managed, "receiver_request", fake)
+
+    resp = main.artifact("collector-macos", _=None, token="t")
+    assert "https://rx.saved.example" in resp.body.decode()
+    assert "rx.env.example" not in resp.body.decode()
+
+
+# ------------------------------------------------------------------- tests --
+
+
+def test_the_receiver_url_probe_warns_on_a_dotless_host(login_mode, monkeypatch):
+    """The tailscale short-name trap, caught before an artifact bakes it."""
+    class _Resp:
+        def read(self):
+            return b'{"ok": true, "version": "0.9.8"}'
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    import urllib.request as _urlreq
+    monkeypatch.setattr(_urlreq, "urlopen", lambda url, timeout=None: _Resp())
+
+    out = main.test_receiver_url(main.UrlProbe(url="https://ai-guard"),
+                                 _=None, token="t")
+    assert out["ok"] is True and out["version"] == "0.9.8"
+    assert any("no dot" in w for w in out["warnings"])
+
+    out = main.test_receiver_url(
+        main.UrlProbe(url="https://ai-guard.tailfc8950.ts.net"), _=None,
+        token="t")
+    assert out["warnings"] == []
+
+
+def test_the_probe_refuses_non_http_schemes(login_mode):
+    with pytest.raises(HTTPException) as e:
+        main.test_receiver_url(main.UrlProbe(url="file:///etc/passwd"),
+                               _=None, token="t")
+    assert e.value.status_code == 422
+
+
+def test_the_probe_reports_an_unreachable_host_without_crashing(login_mode,
+                                                                monkeypatch):
+    import urllib.request as _urlreq
+
+    def boom(url, timeout=None):
+        raise OSError("nope")
+    monkeypatch.setattr(_urlreq, "urlopen", boom)
+    out = main.test_receiver_url(main.UrlProbe(url="https://rx.example.com"),
+                                 _=None, token="t")
+    assert out["ok"] is False
+    assert "could not reach" in out["detail"]
+
+
+def test_the_read_test_hints_at_missing_read_scope(login_mode, monkeypatch):
+    def refuse(url, hours, token=None, limit=5000, username=None, password=None):
+        import urllib.error
+        raise urllib.error.HTTPError(url, 401, "unauthorized", None, None)
+    monkeypatch.setattr(main.derive, "fetch_from_loki", refuse)
+    out = main.test_log_store_read(_request(), _=None)
+    assert out["ok"] is False
+    assert "logs:read" in out["hint"]
+
+
+def test_the_read_test_passes_through_ok(login_mode, monkeypatch):
+    monkeypatch.setattr(main.derive, "fetch_from_loki",
+                        lambda *a, **kw: [])
+    out = main.test_log_store_read(_request(), _=None)
+    assert out["ok"] is True and "saved-loki" in out["url"]
+
+
+def test_the_push_test_is_a_proxy(login_mode):
+    main.test_log_store_push(_=None, token="aigt_s")
+    assert login_mode[-1] == {"method": "POST",
+                              "path": "/admin/test/log-store-push",
+                              "token": "aigt_s", "body": None}

--- a/portal/tests/test_runtime_log_store.py
+++ b/portal/tests/test_runtime_log_store.py
@@ -178,11 +178,23 @@ def test_artifacts_bake_the_saved_public_url(login_mode, monkeypatch):
     monkeypatch.setattr(main.managed, "receiver_request", fake)
 
     resp = main.artifact("collector-macos", _=None, token="t")
-    assert "https://rx.saved.example" in resp.body.decode()
-    assert "rx.env.example" not in resp.body.decode()
+    # The exact baked fallback line, not a loose substring: the saved URL
+    # must land as the script's default, and the env one must not.
+    body = resp.body.decode()
+    assert 'RECEIVER_BASE="${4:-https://rx.saved.example}"' in body
+    assert 'RECEIVER_BASE="${4:-https://rx.env.example}"' not in body
 
 
 # ------------------------------------------------------------------- tests --
+
+
+def _probe_with_saved_url(monkeypatch, saved):
+    """The probe reads the SAVED public URL (save first, then probe) - the
+    route fetches nothing the request names, by design and for CodeQL."""
+    def fake(base, method, path, token, body=None):
+        return {"settings": {"receiver_public_url": {
+            "value": saved, "source": "db" if saved else "unset"}}}
+    monkeypatch.setattr(main.managed, "receiver_request", fake)
 
 
 def test_the_receiver_url_probe_warns_on_a_dotless_host(login_mode, monkeypatch):
@@ -198,22 +210,24 @@ def test_the_receiver_url_probe_warns_on_a_dotless_host(login_mode, monkeypatch)
     import urllib.request as _urlreq
     monkeypatch.setattr(_urlreq, "urlopen", lambda url, timeout=None: _Resp())
 
-    out = main.test_receiver_url(main.UrlProbe(url="https://ai-guard"),
-                                 _=None, token="t")
+    _probe_with_saved_url(monkeypatch, "https://ai-guard")
+    out = main.test_receiver_url(_=None, token="t")
     assert out["ok"] is True and out["version"] == "0.9.8"
     assert any("no dot" in w for w in out["warnings"])
 
-    out = main.test_receiver_url(
-        main.UrlProbe(url="https://ai-guard.tailfc8950.ts.net"), _=None,
-        token="t")
+    _probe_with_saved_url(monkeypatch, "https://ai-guard.tailfc8950.ts.net")
+    out = main.test_receiver_url(_=None, token="t")
     assert out["warnings"] == []
 
 
-def test_the_probe_refuses_non_http_schemes(login_mode):
+def test_the_probe_with_nothing_saved_falls_back_to_env_then_400(login_mode,
+                                                                 monkeypatch):
+    _probe_with_saved_url(monkeypatch, "")
+    monkeypatch.setattr(main, "RECEIVER_PUBLIC_URL", "")
     with pytest.raises(HTTPException) as e:
-        main.test_receiver_url(main.UrlProbe(url="file:///etc/passwd"),
-                               _=None, token="t")
-    assert e.value.status_code == 422
+        main.test_receiver_url(_=None, token="t")
+    assert e.value.status_code == 400
+    assert "save one in Settings" in e.value.detail
 
 
 def test_the_probe_reports_an_unreachable_host_without_crashing(login_mode,
@@ -223,8 +237,8 @@ def test_the_probe_reports_an_unreachable_host_without_crashing(login_mode,
     def boom(url, timeout=None):
         raise OSError("nope")
     monkeypatch.setattr(_urlreq, "urlopen", boom)
-    out = main.test_receiver_url(main.UrlProbe(url="https://rx.example.com"),
-                                 _=None, token="t")
+    _probe_with_saved_url(monkeypatch, "https://rx.example.com")
+    out = main.test_receiver_url(_=None, token="t")
     assert out["ok"] is False
     assert "could not reach" in out["detail"]
 

--- a/portal/tests/test_wizard.py
+++ b/portal/tests/test_wizard.py
@@ -163,12 +163,15 @@ def test_no_extension_id_refuses_before_minting(receiver, monkeypatch):
     assert [c["path"] for c in receiver] == ["/admin/settings"]
 
 
-def test_the_cronjob_route_needs_no_settings(receiver, monkeypatch):
+def test_the_cronjob_route_requires_nothing_from_settings(receiver, monkeypatch):
     monkeypatch.setattr(main, "APP_VERSION", "0.9.7")
     resp = main.artifact("scanner-cronjob", _=None, token="t")
     assert 'filename="ai-guard-scanner-cronjob.yaml"' in resp.headers["content-disposition"]
     assert "scanner:0.9.7" in resp.body.decode()
-    assert [c["path"] for c in receiver] == ["/admin/enrollment-tokens"]
+    # Settings are read for the public URL, but nothing scanner-specific
+    # is required from them.
+    assert [c["path"] for c in receiver] == ["/admin/settings",
+                                             "/admin/enrollment-tokens"]
 
 
 def test_a_dev_build_bakes_latest_not_a_nonexistent_image(receiver, monkeypatch):

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -56,8 +56,10 @@ shared token off for ingest (see the configuration table).
 | POST | `/admin/logout` | admin | revoke the presented session |
 | GET  | `/admin/session` | admin | who this session is and until when; the portal's validity probe |
 | POST | `/admin/password` | admin | change the password (`current` + `new`). With the `ADMIN_TOKEN` credential, `current` is not required - the break-glass reset. Every other session dies with the old password |
-| GET  | `/admin/settings` | admin | each central setting with its effective value and its source (`db`, `env`, `unset`), so a saved value shadowing an environment one is visible as such |
-| PUT  | `/admin/settings` | admin | partial upsert of `corp_domains`, `extension_id`, `onboarding_done`; a saved value wins over the matching env var, an explicit `null` deletes the row and falls back to it. Unknown keys are 422 |
+| GET  | `/admin/settings` | admin | each central setting with its effective value and its source (`db`, `env`, `unset`), so a saved value shadowing an environment one is visible as such. The log-store password is reported as `{set, source}` only, never its value |
+| PUT  | `/admin/settings` | admin | partial upsert; a saved value wins over the matching env var, an explicit `null` (or empty) deletes the row and falls back to it. Unknown keys are 422. Keys: `corp_domains`, `extension_id`, `onboarding_done`, `receiver_public_url`, `log_store_url` (base - the push endpoint is **derived** as `<base>/loki/api/v1/push`), `log_store_push_url` (explicit override for gateways), `log_store_username`, `log_store_password`, `alertmanager_url`, `grafana_url`, `grafana_panels`, `grafana_dashboard_uid`, `overview_widgets` |
+| GET  | `/admin/settings/secrets` | admin | the stored log-store configuration with the password in plaintext - for the portal's server-side reads; the portal exposes no route that relays it. See SECURITY.md on integration secrets vs fleet credentials |
+| POST | `/admin/test/log-store-push` | admin | push one synthetic `kind:"test"` line with the effective configuration and report what happened, hints included - catches the write-only-token trap at setup time instead of on the first quiet dashboard |
 | GET  | `/admin/governance` | admin | the portal-recorded governance decisions |
 | PUT  | `/admin/governance` | admin | upsert (`decisions`) and delete (`delete`) decisions, validated to the governance file's own rules - an approval needs a `review_due` date. The whole batch validates before anything is written |
 
@@ -70,12 +72,16 @@ setup code** to the receiver's log as a JSON line with `"kind":
 create the account; the code is consumed on use, never stored, and once an
 account exists boots print nothing.
 
-Only SHA-256 hashes of credentials are stored (passwords: scrypt): a copied
-database file is a list of devices, not a bag of credentials. Enrollment
-tokens default to a 180-day life because they sit inside MDM artifacts,
-where a short TTL means the deployment silently breaks for new machines -
-their safety comes from what they cannot do (only create auditable device
-records) and from instant revocation, not from a short life.
+Only SHA-256 hashes of fleet credentials are stored (passwords: scrypt): a
+copied database file cannot impersonate a device or an admin. The one
+exception, since 0.9.8, is an *integration* secret - a log store password
+saved in the portal is stored recoverable because the receiver must present
+it to push; SECURITY.md states the trade and the env/Secret path remains
+for anyone who declines it. Enrollment tokens default to a 180-day life
+because they sit inside MDM artifacts, where a short TTL means the
+deployment silently breaks for new machines - their safety comes from what
+they cannot do (only create auditable device records) and from instant
+revocation, not from a short life.
 
 ## Configuration
 
@@ -84,10 +90,10 @@ Everything is environment variables. Only the token is required.
 | variable | default | what it does |
 |----------|---------|--------------|
 | `AUTH_TOKEN` | required | the one bearer token every source authenticates with |
-| `LOKI_PUSH_URL` | unset | if set, findings are POSTed straight to Loki as well; stdout logging happens regardless. The **full push endpoint**, `/loki/api/v1/push`, not the base URL |
+| `LOKI_PUSH_URL` | unset | if set, findings are POSTed straight to Loki as well; stdout logging happens regardless. The **full push endpoint**, `/loki/api/v1/push`, not the base URL. In managed mode a log store saved in the portal wins over this (its push endpoint is derived from the base, and it brings its own credentials) |
 | `LOKI_USERNAME` | unset | basic auth for the push, if your log store needs it. Hosted Loki usually does; a self-hosted one usually does not |
 | `LOKI_PASSWORD` | unset | with the above. Sent only when a username is set, because an empty credential pair is not the same as sending none |
-| `ALERTMANAGER_URL` | unset | if set, `warn` findings raise Alertmanager alerts; unset means findings are logged and dashboarded but nothing pages |
+| `ALERTMANAGER_URL` | unset | if set, `warn` findings raise Alertmanager alerts; unset means findings are logged and dashboarded but nothing pages. In managed mode a URL saved in the portal wins over this |
 | `ALERT_TTL_MINUTES` | `120` | how long a warn finding counts as already alerted, so a device reporting the same thing repeatedly does not page repeatedly |
 | `REGISTRY_PATH` | `/etc/ai-guard/registry.json` | where the compiled registry is mounted |
 | `COLLECTOR_REGISTRY_PATH` | `/etc/ai-guard/collector.json` | where the collector view is mounted |

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -910,6 +910,24 @@ def _admin_actor(authorization: str) -> str:
     return "api"
 
 
+# Central settings that are plain strings, written through the generic loop
+# in put_settings: (key, must_be_http_url, max_length). Secret keys are the
+# same shape to write but are never echoed by GET /admin/settings.
+_STR_SETTINGS = (
+    ("receiver_public_url", True, 500),
+    ("log_store_url", True, 500),
+    ("log_store_push_url", True, 500),
+    ("log_store_username", False, 256),
+    ("log_store_password", False, 512),
+    ("alertmanager_url", True, 500),
+    ("grafana_url", True, 500),
+    ("grafana_panels", False, 2000),
+    ("grafana_dashboard_uid", False, 128),
+    ("overview_widgets", False, 500),
+)
+SECRET_SETTINGS = ("log_store_password",)
+
+
 class SettingsUpdate(BaseModel):
     # extra=forbid: an unknown key is a typo or a version mismatch, and
     # accepting it silently is how someone believes a setting is in effect.
@@ -917,6 +935,16 @@ class SettingsUpdate(BaseModel):
     corp_domains: list[str] | None = Field(default=None, max_length=200)
     extension_id: str | None = Field(default=None, max_length=128)
     onboarding_done: bool | None = None
+    receiver_public_url: str | None = Field(default=None, max_length=500)
+    log_store_url: str | None = Field(default=None, max_length=500)
+    log_store_push_url: str | None = Field(default=None, max_length=500)
+    log_store_username: str | None = Field(default=None, max_length=256)
+    log_store_password: str | None = Field(default=None, max_length=512)
+    alertmanager_url: str | None = Field(default=None, max_length=500)
+    grafana_url: str | None = Field(default=None, max_length=500)
+    grafana_panels: str | None = Field(default=None, max_length=2000)
+    grafana_dashboard_uid: str | None = Field(default=None, max_length=128)
+    overview_widgets: str | None = Field(default=None, max_length=500)
 
 
 @app.get("/admin/settings")
@@ -927,6 +955,18 @@ def get_settings(authorization: str = Header(default="")):
     _admin_auth(authorization)
     stored = STATE.get_settings()
     corp = stored.get("corp_domains")
+
+    def plain(key, env=""):
+        """One string setting with its effective value and source. env is
+        this component's fallback; keys whose env lives on the portal
+        report db|unset here and the portal overlays its own."""
+        v = stored.get(key)
+        out = {"value": v if v is not None else env,
+               "source": "db" if v is not None else ("env" if env else "unset")}
+        if env:
+            out["env"] = env
+        return out
+
     return {"settings": {
         "corp_domains": {
             "value": corp if corp is not None else CORP_DOMAINS,
@@ -944,7 +984,43 @@ def get_settings(authorization: str = Header(default="")):
             "value": bool(stored.get("onboarding_done")),
             "source": "db" if stored.get("onboarding_done") is not None else "unset",
         },
+        "receiver_public_url": plain("receiver_public_url"),
+        "log_store_url": plain("log_store_url"),
+        "log_store_push_url": plain("log_store_push_url", LOKI_PUSH_URL),
+        "log_store_username": plain("log_store_username", LOKI_USERNAME),
+        # The one secret: set-ness and source, never the value. The
+        # plaintext exists for exactly one caller, /admin/settings/secrets.
+        "log_store_password": {
+            "set": stored.get("log_store_password") is not None
+                   or bool(LOKI_PASSWORD),
+            "source": ("db" if stored.get("log_store_password") is not None
+                       else "env" if LOKI_PASSWORD else "unset"),
+        },
+        "alertmanager_url": plain("alertmanager_url", ALERTMANAGER_URL),
+        "grafana_url": plain("grafana_url"),
+        "grafana_panels": plain("grafana_panels"),
+        "grafana_dashboard_uid": plain("grafana_dashboard_uid"),
+        "overview_widgets": plain("overview_widgets"),
     }}
+
+
+@app.get("/admin/settings/secrets")
+def get_settings_secrets(authorization: str = Header(default="")):
+    """The stored log-store configuration with the password in plaintext.
+
+    Exists for the portal's server-side Loki reads and nothing else: the
+    portal exposes no route that relays it, so the browser never sees the
+    value the Settings view masks. An admin who can call this could also
+    have SET the password, so it grants nothing they lack - but it is the
+    honest statement of the property: integration secrets are recoverable
+    by the admin API, unlike fleet credentials, which are hashes.
+    """
+    _admin_auth(authorization)
+    s = STATE.get_settings()
+    return {"log_store_url": s.get("log_store_url") or "",
+            "log_store_push_url": s.get("log_store_push_url") or "",
+            "log_store_username": s.get("log_store_username") or "",
+            "log_store_password": s.get("log_store_password") or ""}
 
 
 @app.put("/admin/settings")
@@ -980,7 +1056,59 @@ def put_settings(req: SettingsUpdate, authorization: str = Header(default="")):
     if "onboarding_done" in req.model_fields_set:
         STATE.set_setting("onboarding_done", req.onboarding_done, by)
 
+    for key, is_url, _max in _STR_SETTINGS:
+        if key not in req.model_fields_set:
+            continue
+        val = (getattr(req, key) or "").strip()
+        if not val:
+            # Empty and null both delete: an empty URL is not a URL, and
+            # "cleared" falling back to env is the documented shape.
+            STATE.set_setting(key, None, by)
+        else:
+            if is_url and not val.startswith(("http://", "https://")):
+                raise HTTPException(
+                    422, "%s must be http:// or https://" % key)
+            STATE.set_setting(key, val, by)
+
     return get_settings(authorization)
+
+
+@app.post("/admin/test/log-store-push")
+async def test_log_store_push(authorization: str = Header(default="")):
+    """Push one synthetic line with the effective configuration and say
+    what happened, hints included.
+
+    The failure this exists for: a token with logs:write missing (or
+    read-only), where every real finding is accepted with a 200 to the
+    collector and never stored. That is invisible until someone looks at a
+    dashboard; here it is one button during setup.
+    """
+    _admin_auth(authorization)
+    url, username, password = _effective_log_push()
+    if not url:
+        raise HTTPException(
+            400, "no log store is configured: save a base URL in Settings,"
+                 " or set LOKI_PUSH_URL on the receiver")
+    payload = {"streams": [{
+        "stream": {"app": "ai-guard-receiver", "kind": "test"},
+        "values": [[str(time.time_ns()),
+                    json.dumps({"app": "ai-guard-receiver", "kind": "test",
+                                "note": "settings connection test"})]],
+    }]}
+    try:
+        async with httpx.AsyncClient(timeout=5) as client:
+            r = await client.post(url, json=payload,
+                                  auth=(username, password) if username else None)
+    except httpx.HTTPError as e:
+        return {"ok": False, "url": _redact_url(url),
+                "detail": "could not reach the log store (%s)" % type(e).__name__}
+    if r.status_code >= 300:
+        out = {"ok": False, "url": _redact_url(url),
+               "detail": "the log store answered HTTP %d" % r.status_code}
+        if r.status_code in _LOKI_HINTS:
+            out["hint"] = _LOKI_HINTS[r.status_code]
+        return out
+    return {"ok": True, "url": _redact_url(url)}
 
 
 # What a portal-recorded decision may look like. Same three states and the
@@ -1082,7 +1210,49 @@ def change_password(req: PasswordChangeRequest,
 LOKI_FINDING_LABELS = {"surface", "severity", "os"}
 
 
-async def _push_loki(f: Finding, line: str):
+def _effective_log_push() -> tuple[str, str, str]:
+    """(push URL, username, password) the receiver should push with.
+
+    The portal-saved configuration wins: an explicit push override, else
+    the push endpoint derived from the saved base URL - deriving is the
+    point, it makes the base-vs-push mixup impossible to make in the
+    portal. Whichever source supplies the URL supplies the credentials
+    too: pairing a portal-saved URL with environment credentials would
+    send the old store's password to the new store.
+    """
+    if STATE is not None:
+        s = STATE.get_settings()
+        push = s.get("log_store_push_url") or ""
+        base = s.get("log_store_url") or ""
+        if not push and base:
+            push = base.rstrip("/") + "/loki/api/v1/push"
+        if push:
+            return (push, s.get("log_store_username") or "",
+                    s.get("log_store_password") or "")
+    return (LOKI_PUSH_URL, LOKI_USERNAME, LOKI_PASSWORD)
+
+
+def _effective_alertmanager() -> str:
+    if STATE is not None:
+        v = STATE.get_setting("alertmanager_url")
+        if v:
+            return v
+    return ALERTMANAGER_URL
+
+
+# The two status codes behind almost every log-store misconfiguration,
+# shared by the per-finding push and the settings test button so both name
+# the same likely cause.
+_LOKI_HINTS = {
+    404: ("the push URL is probably the base URL rather than the "
+          "push endpoint, which is /loki/api/v1/push"),
+    401: "a username and password are needed, or are wrong",
+    403: "the username and password are wrong, or lack write access",
+}
+
+
+async def _push_loki(f: Finding, line: str, url: str, username: str,
+                     password: str):
     """Fire-and-forget push to Loki. Bounded labels only (no tool/device:
     unbounded values stay inside the JSON line, parsed at query time)."""
     payload = {
@@ -1097,10 +1267,10 @@ async def _push_loki(f: Finding, line: str):
             }
         ]
     }
-    auth = (LOKI_USERNAME, LOKI_PASSWORD) if LOKI_USERNAME else None
+    auth = (username, password) if username else None
     try:
         async with httpx.AsyncClient(timeout=5) as client:
-            r = await client.post(LOKI_PUSH_URL, json=payload, auth=auth)
+            r = await client.post(url, json=payload, auth=auth)
             r.raise_for_status()
     except httpx.HTTPStatusError as e:
         # Logged at error, not info. This was info, and a wrong push URL
@@ -1110,22 +1280,15 @@ async def _push_loki(f: Finding, line: str):
         # from the outside that is indistinguishable from a quiet estate.
         code = e.response.status_code
         LOKI_PUSH_FAILURES.labels(reason=f"http_{code}").inc()
-        # A status code alone sends people to the wrong place. These two
-        # account for almost every misconfiguration, and naming the likely
-        # cause turns a wrong variable into a one-line fix.
-        hints = {
-            404: ("LOKI_PUSH_URL is probably the base URL rather than the "
-                  "push endpoint, which is /loki/api/v1/push"),
-            401: "LOKI_USERNAME and LOKI_PASSWORD are needed, or are wrong",
-            403: "LOKI_USERNAME and LOKI_PASSWORD are wrong, or lack write access",
-        }
+        # A status code alone sends people to the wrong place. _LOKI_HINTS
+        # names the likely cause and turns a wrong value into a one-line fix.
         entry = {
             "app": "ai-guard-receiver", "kind": "error",
             "error": f"loki push rejected with HTTP {code}",
-            "url": _redact_url(LOKI_PUSH_URL),
+            "url": _redact_url(url),
         }
-        if code in hints:
-            entry["hint"] = hints[code]
+        if code in _LOKI_HINTS:
+            entry["hint"] = _LOKI_HINTS[code]
         log.error(json.dumps(entry))
     except httpx.HTTPError as e:
         LOKI_PUSH_FAILURES.labels(reason=type(e).__name__).inc()
@@ -1135,18 +1298,18 @@ async def _push_loki(f: Finding, line: str):
             # the message, which would carry userinfo straight past the
             # redaction above.
             "error": "loki push failed: %s" % type(e).__name__,
-            "url": _redact_url(LOKI_PUSH_URL),
+            "url": _redact_url(url),
         }))
     else:
         LOKI_PUSH_OK.inc()
         LOKI_PUSH_LAST_SUCCESS.set(time.time())
 
 
-async def _fire_alert(f: Finding):
-    if not ALERTMANAGER_URL:
-        # Alerting is opt-in: no ALERTMANAGER_URL set means findings are
-        # logged and dashboarded but nothing pages. Deliberate for adopters
-        # without Alertmanager; set the env var to enable alerts.
+async def _fire_alert(f: Finding, alertmanager_url: str):
+    if not alertmanager_url:
+        # Alerting is opt-in: nothing configured means findings are logged
+        # and dashboarded but nothing pages. Deliberate for adopters
+        # without Alertmanager; set it in the portal (or the env var).
         return
     now = datetime.now(timezone.utc)
     # Alert identity = who + which tool + which account. Deliberately NOT
@@ -1185,7 +1348,7 @@ async def _fire_alert(f: Finding):
         }
     ]
     async with httpx.AsyncClient(timeout=10) as client:
-        r = await client.post(f"{ALERTMANAGER_URL}/api/v2/alerts", json=alert)
+        r = await client.post(f"{alertmanager_url}/api/v2/alerts", json=alert)
         r.raise_for_status()
 
 
@@ -1216,11 +1379,14 @@ async def report(f: Finding, request: Request, authorization: str = Header(defau
         f.tool = canonical
 
     # Loki: every finding, warn and info alike. Stdout always; direct push
-    # when LOKI_PUSH_URL is set (parity with receiver v0.1.1).
+    # when a push target is configured - the portal-saved log store when
+    # one exists, LOKI_PUSH_URL otherwise. Resolved per finding, so a
+    # store configured in the wizard takes effect with no restart.
     line = json.dumps({"app": "ai-guard-receiver", "kind": "finding", **f.model_dump()})
     log.info(line)
-    if LOKI_PUSH_URL:
-        await _push_loki(f, line)
+    push_url, push_user, push_pass = _effective_log_push()
+    if push_url:
+        await _push_loki(f, line, push_url, push_user, push_pass)
 
     FINDINGS.labels(
         surface=f.surface, severity=f.severity, os=f.os
@@ -1247,15 +1413,16 @@ async def report(f: Finding, request: Request, authorization: str = Header(defau
         suppress = (f.source == "sentinelone_bridge")
         # Always refresh Alertmanager so endsAt extends; dedup of Slack pings
         # is governed by the route's repeat_interval, as in 0.1.2.
+        am_url = _effective_alertmanager()
         try:
-            if not suppress:
-                await _fire_alert(f)
+            if not suppress and am_url:
+                await _fire_alert(f, am_url)
                 alert_fired = True
         except httpx.HTTPError as e:
             log.error(json.dumps({
                 "app": "ai-guard-receiver", "kind": "error",
                 "error": "alertmanager: %s" % type(e).__name__,
-                "url": _redact_url(ALERTMANAGER_URL),
+                "url": _redact_url(am_url),
             }))
 
     return {"ok": True, "severity": f.severity, "alerted": alert_fired}

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -5,10 +5,13 @@ single SQLite file. Everything else stays disposable, and with MANAGED_MODE
 unset State() is never instantiated and no file is created, so classic
 deployments keep the property that losing any component loses nothing.
 
-Only credential hashes are stored. The plaintext of an enrollment token or a
-device credential exists exactly once, in the response that minted it, and
-cannot be recovered from here - a copied database file is a list of devices,
-not a bag of credentials.
+Fleet credentials are stored as hashes only. The plaintext of an enrollment
+token or a device credential exists exactly once, in the response that
+minted it, and cannot be recovered from here - a copied database file
+cannot impersonate a device or an admin. Integration secrets (a log store
+password saved in the portal, in the settings table) are the stated
+exception: recoverable by design, because the receiver must present them
+outward. SECURITY.md carries the trade.
 
 Two credential kinds, distinguishable by prefix so the receiver can route a
 presented bearer without trying every table, and so a leaked string is

--- a/receiver/tests/test_runtime_config.py
+++ b/receiver/tests/test_runtime_config.py
@@ -1,0 +1,183 @@
+"""Runtime configuration: the log store, alerting and the secret setting.
+
+The property under test is DB-wins-when-set applied to where findings GO:
+a store saved in the portal takes effect on the next finding with no
+restart, the push endpoint is derived from the base so the base-vs-push
+mixup cannot be made there, and the one secret is stored recoverable but
+never echoed. Same harness shape as the rest of the suite.
+"""
+
+import os
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import state as state_mod
+from app.main import app
+
+client = TestClient(app)
+
+ADMIN = {"Authorization": "Bearer admin-test-token"}
+
+
+@pytest.fixture
+def managed(tmp_path, monkeypatch):
+    from app import main
+
+    st = state_mod.State(str(tmp_path / "state.db"))
+    monkeypatch.setattr(main, "STATE", st)
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"Bearer admin-test-token")
+    return st
+
+
+def _put(**kw):
+    return client.put("/admin/settings", headers=ADMIN, json=kw)
+
+
+# ---------------------------------------------------------- push resolution --
+
+
+def test_a_saved_base_url_derives_the_push_endpoint(managed):
+    """Deriving is the point: the portal asks for one base URL and the
+    base-vs-push mixup stops being possible to make there."""
+    from app import main
+
+    _put(log_store_url="http://loki.monitoring.svc:3100")
+    url, user, pw = main._effective_log_push()
+    assert url == "http://loki.monitoring.svc:3100/loki/api/v1/push"
+    assert (user, pw) == ("", "")
+
+
+def test_an_explicit_push_override_wins_over_derivation(managed):
+    _put(log_store_url="http://loki:3100",
+         log_store_push_url="http://gateway:8080/custom/push")
+    from app import main
+
+    url, _, _ = main._effective_log_push()
+    assert url == "http://gateway:8080/custom/push"
+
+
+def test_the_url_source_supplies_the_credentials(managed, monkeypatch):
+    """A portal-saved URL with env credentials would send the OLD store's
+    password to the NEW store; whichever source supplies the URL supplies
+    the auth pair, empty included."""
+    from app import main
+
+    monkeypatch.setattr(main, "LOKI_PUSH_URL", "http://old:3100/loki/api/v1/push")
+    monkeypatch.setattr(main, "LOKI_USERNAME", "old-user")
+    monkeypatch.setattr(main, "LOKI_PASSWORD", "old-pass")
+
+    # No DB store: env URL with env creds, exactly as ever.
+    assert main._effective_log_push() == (
+        "http://old:3100/loki/api/v1/push", "old-user", "old-pass")
+
+    # DB store without creds: no creds, not the env ones.
+    _put(log_store_url="http://new:3100")
+    assert main._effective_log_push() == (
+        "http://new:3100/loki/api/v1/push", "", "")
+
+    # DB store with its own pair.
+    _put(log_store_username="123456", log_store_password="glc_token")
+    assert main._effective_log_push() == (
+        "http://new:3100/loki/api/v1/push", "123456", "glc_token")
+
+
+def test_classic_mode_resolution_is_the_env(monkeypatch):
+    from app import main
+
+    monkeypatch.setattr(main, "LOKI_PUSH_URL", "http://env:3100/loki/api/v1/push")
+    assert main._effective_log_push()[0] == "http://env:3100/loki/api/v1/push"
+
+
+def test_alertmanager_follows_the_same_rule(managed, monkeypatch):
+    from app import main
+
+    monkeypatch.setattr(main, "ALERTMANAGER_URL", "http://env-am:9093")
+    assert main._effective_alertmanager() == "http://env-am:9093"
+    _put(alertmanager_url="http://portal-am:9093")
+    assert main._effective_alertmanager() == "http://portal-am:9093"
+    _put(alertmanager_url=None)
+    assert main._effective_alertmanager() == "http://env-am:9093"
+
+
+# ------------------------------------------------------------- the secret --
+
+
+def test_the_password_is_never_echoed_by_the_settings_view(managed):
+    _put(log_store_password="glc_hunter2")
+    out = client.get("/admin/settings", headers=ADMIN).json()["settings"]
+    assert out["log_store_password"] == {"set": True, "source": "db"}
+    # Nowhere in the whole response, under any key.
+    assert "glc_hunter2" not in client.get(
+        "/admin/settings", headers=ADMIN).text
+
+
+def test_the_secrets_route_is_the_one_place_the_plaintext_exists(managed):
+    _put(log_store_url="http://loki:3100", log_store_username="u",
+         log_store_password="glc_hunter2")
+    out = client.get("/admin/settings/secrets", headers=ADMIN).json()
+    assert out == {"log_store_url": "http://loki:3100",
+                   "log_store_push_url": "",
+                   "log_store_username": "u",
+                   "log_store_password": "glc_hunter2"}
+    assert client.get("/admin/settings/secrets").status_code == 401
+
+
+def test_the_secret_value_never_reaches_the_event_log(managed):
+    _put(log_store_password="glc_hunter2")
+    rows = [r["detail"] for r in managed._db.execute("SELECT detail FROM events")]
+    assert all("glc_hunter2" not in d for d in rows)
+
+
+def test_url_settings_must_be_urls(managed):
+    assert _put(log_store_url="loki:3100").status_code == 422
+    assert _put(grafana_url="not a url").status_code == 422
+    assert _put(alertmanager_url="ftp://am:9093").status_code == 422
+
+
+# ------------------------------------------------------------- push test --
+
+
+def test_the_push_test_names_the_write_only_token_trap(managed, monkeypatch):
+    """The failure this button exists for: a 403 store where every finding
+    is accepted with a 200 and never stored."""
+    import httpx
+
+    _put(log_store_url="http://loki:3100")
+
+    class FakeResp:
+        status_code = 403
+
+    async def fake_post(self, url, **kw):
+        return FakeResp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    out = client.post("/admin/test/log-store-push", headers=ADMIN).json()
+    assert out["ok"] is False
+    assert "403" in out["detail"]
+    assert "write access" in out["hint"]
+
+
+def test_the_push_test_succeeds_and_redacts(managed, monkeypatch):
+    import httpx
+
+    _put(log_store_url="http://user:secretpw@loki:3100")
+
+    class FakeResp:
+        status_code = 204
+
+    async def fake_post(self, url, **kw):
+        return FakeResp()
+
+    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    out = client.post("/admin/test/log-store-push", headers=ADMIN).json()
+    assert out["ok"] is True
+    assert "secretpw" not in out["url"]
+
+
+def test_the_push_test_with_nothing_configured_is_a_400(managed):
+    resp = client.post("/admin/test/log-store-push", headers=ADMIN)
+    assert resp.status_code == 400
+    assert "no log store" in resp.json()["detail"]

--- a/receiver/tests/test_smoke.py
+++ b/receiver/tests/test_smoke.py
@@ -264,14 +264,12 @@ def test_a_rejected_push_is_counted_and_says_why():
 
     original = httpx.AsyncClient.post
     httpx.AsyncClient.post = boom
-    main.LOKI_PUSH_URL = "http://example.invalid/"
     try:
         class F:
             surface, severity, os = "cli", "warn", "linux"
-        asyncio.run(main._push_loki(F(), "{}"))
+        asyncio.run(main._push_loki(F(), "{}", "http://example.invalid/", "", ""))
     finally:
         httpx.AsyncClient.post = original
-        main.LOKI_PUSH_URL = ""
 
     metrics = generate_latest().decode()
     assert 'aiguard_loki_push_failures_total{reason="http_404"}' in metrics


### PR DESCRIPTION
First increment of v0.9.8 ("the one-command install", design agreed today): the backend that lets the wizard configure everything install-time used to own. UI lands in increment 2.

**New settings** (same DB-wins-when-set / null-deletes rules): `receiver_public_url`, `log_store_url` (base), `log_store_push_url` (advanced override), `log_store_username`, `log_store_password`, `alertmanager_url`, `grafana_url`/`grafana_panels`/`grafana_dashboard_uid`/`overview_widgets`. URL keys validate http(s) at the edge.

**Resolution at use time, not boot:**
- Receiver derives the push endpoint from the saved base (`<base>/loki/api/v1/push`) — the base-vs-push footgun becomes impossible to make in the portal — and resolves per finding, so a store saved in the wizard takes effect with no restart. Whichever source supplies the URL supplies the credentials: env creds never go to a portal-saved store. Alertmanager same rule.
- Portal `_findings` resolves the read config via a new `GET /admin/settings/secrets` (server-side only, 30s cache, invalidated instantly on any settings write; a receiver that can't answer is a loud 502, never a silent env fallback that could read a different store than the receiver writes). `/api/config` resolves Grafana embedding, overview widgets and the artifact public URL settings-first; the CSP frame-src follows the cached setting. Artifacts bake the saved public URL.

**The first recoverable secret**, stated honestly: the log-store password is masked everywhere (`{set, source}`, never the value), plaintext on exactly one admin route the portal never relays; the settings event log never carries it. SECURITY.md, the receiver README and the state.py docstring all now distinguish fleet credentials (hash-only, unchanged) from integration secrets, and name the env/Secret path for anyone who declines the trade.

**Connection tests**: `POST /admin/test/log-store-push` (one synthetic line, hints shared with the real push path — catches the write-only-token trap at setup), `POST /api/test/log-store-read` (hints at missing logs:read), `POST /api/test/receiver-url` (server-side /healthz probe that warns on dotless hosts — the tailscale short-name trap — before an artifact bakes it; admin-gated, http(s) only).

Verified: 95 receiver + 306 portal tests (12 + 16 new), plus a live E2E with a portal started with **no Loki env at all**: 503 naming Settings → save one base URL through the API → graph reads findings immediately, both connection tests pass, the short-name probe warns, and a generated artifact bakes the saved public URL.