### PR TITLE
OCI chart publishing and the one-command docs (v0.9.8 increment 3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -819,3 +819,32 @@ jobs:
           echo "$got"
           echo "$got" | grep -qx 'linux/amd64' || { echo "::error::amd64 missing"; exit 1; }
           echo "$got" | grep -qx 'linux/arm64' || { echo "::error::arm64 missing"; exit 1; }
+  publish-chart:
+    # Tags only: the chart is a release artifact, versioned by its own
+    # chart version and published beside the images it deploys, so
+    #   helm install ai-guard oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard
+    # works with no clone. Runs after the images so a freshly published
+    # chart never points at tags that do not exist yet.
+    if: github.ref_type == 'tag'
+    permissions:
+      contents: read
+      packages: write
+    needs: [build-images]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: package and push the chart as OCI
+        run: |
+          REPO="ghcr.io/${{ github.repository }}"
+          REPO="${REPO,,}"   # ghcr requires lowercase
+          echo '${{ secrets.GITHUB_TOKEN }}' | helm registry login ghcr.io \
+            -u '${{ github.actor }}' --password-stdin
+          helm package charts/ai-guard
+          TGZ=$(ls ai-guard-*.tgz)
+          helm push "$TGZ" "oci://$REPO/charts"
+      - name: confirm the published chart resolves
+        run: |
+          REPO="ghcr.io/${{ github.repository }}"
+          REPO="${REPO,,}"
+          VER=$(awk '/^version:/{print $2}' charts/ai-guard/Chart.yaml)
+          helm show chart "oci://$REPO/charts/ai-guard" --version "$VER"

--- a/README.md
+++ b/README.md
@@ -270,6 +270,15 @@ that can run a container on a schedule.
 
 ## Deployment order
 
+In managed mode the order is one step and then the portal: `helm install`
+from the published OCI chart with `managed.enabled=true` (plus ingress
+values), create the admin account from the boot-printed setup code, and the
+first-run wizard handles the rest - log store, domains, governance, and
+pre-configured downloads for every surface. See
+[Kubernetes](docs/deployment/kubernetes.md).
+
+Classically, or by hand:
+
 1. Deploy the receiver and publish the registry:
    [Docker Compose](deploy/compose/README.md) or
    [Kubernetes](docs/deployment/kubernetes.md).

--- a/charts/ai-guard/README.md
+++ b/charts/ai-guard/README.md
@@ -6,9 +6,32 @@ with nothing to build first.
 
 ## Install
 
+The chart is published as an OCI artifact on every release, beside the
+images, so no clone is needed:
+
 ```bash
-helm install ai-guard charts/ai-guard \
+helm install ai-guard oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard \
+  --set managed.enabled=true \
+  --set ingress.enabled=true \
+  --set ingress.host=ai-guard.example.com \
+  --set portal.ingress.enabled=true \
+  --set portal.ingress.host=ai-guard-portal.example.com
+```
+
+With `managed.enabled` that is the whole install: the receiver prints a
+one-time setup code to its log, the portal turns it into the admin account,
+and the first-run wizard configures everything else (log store, public
+receiver URL, corporate domains, governance, deployment downloads) at
+runtime. See
+[../../docs/deployment/kubernetes.md](../../docs/deployment/kubernetes.md).
+
+Classic mode instead configures by values, as ever (from a checkout,
+`charts/ai-guard` in place of the OCI reference works the same):
+
+```bash
+helm install ai-guard oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard \
   --set loki.pushUrl=http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push \
+  --set portal.lokiUrl=http://loki.monitoring.svc.cluster.local:3100 \
   --set ingress.enabled=true \
   --set ingress.host=ai-guard.example.com
 ```

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -17,18 +17,57 @@ If you have no cluster, you do not need one: see [the routes](README.md).
   network, so the receiver has to be reachable, with TLS and a real
   certificate.
 
-## The short way
+## The short way: managed mode
 
-The chart does everything below in one command, with the compiled registry
-already inside it:
+One command, no clone - the chart is published as an OCI artifact beside the
+images. Only what creates cluster objects goes on the command line (the
+ingresses); everything else is configured in the portal afterwards:
 
 ```bash
-helm install ai-guard charts/ai-guard \
+helm install ai-guard oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard \
+  --namespace ai-guard --create-namespace \
+  --set managed.enabled=true \
+  --set ingress.enabled=true \
+  --set ingress.host=ai-guard.example.com \
+  --set portal.ingress.enabled=true \
+  --set portal.ingress.host=ai-guard-portal.example.com
+```
+
+(On a Tailscale-operator cluster: `ingress.className=tailscale` and
+`portal.ingress.className=tailscale` with short hostnames like `ai-guard` -
+the operator serves them at `https://<host>.<tailnet>.ts.net`.)
+
+Then read the one-time setup code the receiver printed:
+
+```bash
+kubectl -n ai-guard logs deploy/ai-guard | grep setup_code
+```
+
+Open the portal, enter the code, create the admin account, and the first-run
+wizard takes it from there: the public receiver URL (with a probe that warns
+about names other machines cannot resolve - on Tailscale it must be the full
+`.ts.net` address, not the short ingress name), the log store (self-hosted or
+Grafana Cloud, with connection tests both ways), corporate domains, a
+governance baseline, the extension ID, and pre-configured deployment
+downloads for every surface. Nothing after `helm install` touches a values
+file, and everything the wizard sets is editable later under Settings.
+
+## The short way: classic mode
+
+The same install without managed mode is entirely environment-driven, as it
+always was:
+
+```bash
+helm install ai-guard oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard \
   --namespace ai-guard --create-namespace \
   --set loki.pushUrl=http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push \
+  --set portal.lokiUrl=http://loki.monitoring.svc.cluster.local:3100 \
   --set ingress.enabled=true \
   --set ingress.host=ai-guard.example.com
 ```
+
+(A checked-out repo installs the same chart from `charts/ai-guard` instead of
+the OCI reference.)
 
 Read the token it generated:
 
@@ -198,16 +237,22 @@ arrive is that failure.
 
 ### Authentication
 
-The portal names who runs what on which machine, so it refuses to start without
-credentials. The chart generates a password on first install and keeps it
-across upgrades:
+The portal names who runs what on which machine, so it refuses to start
+without credentials. What those are depends on the mode.
+
+**Managed mode** replaces all of this with a real login: the admin account
+created from the boot-printed setup code (see the short way above). No portal
+password Secret exists, and `portal.auth.*` is moot unless set to `none`.
+
+**Classic mode** is basic auth. The chart generates a password on first
+install and keeps it across upgrades:
 
     kubectl -n "$NS" get secret ai-guard-portal \
       -o jsonpath='{.data.password}' | base64 -d; echo
 
-If your ingress can do OIDC or mTLS, do it there and set
-`portal.auth.mode=none` behind it. That is the better arrangement: basic auth
-is one shared credential with no per-user trail.
+Either way, if your ingress can do OIDC or mTLS, do it there and set
+`portal.auth.mode=none` behind it - one shared credential with no per-user
+trail is a floor, not a ceiling.
 
 ### Governance and identity
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,6 +37,13 @@ get started. Add those once the basic thread works.
 You also need the **bearer token** your receiver was deployed with. Every
 source authenticates with it. The route you followed says where to find it.
 
+**Managed mode shortcut:** if you deployed with `managed.enabled`, the
+portal's first-run wizard replaces most of this page - it configures the log
+store and corporate domains centrally, and its deployment downloads are the
+collector scripts below with the receiver URL and a fresh enrollment token
+already baked in, so there is no token to find and nothing to edit. Download,
+run as root/admin (or push through your MDM), and skip to step 2.
+
 ## 1. Roll out one collector
 
 Pick the OS of your test machine and follow its README:


### PR DESCRIPTION
Third increment of v0.9.8, closing the loop from #123/#124.

**CI**: a `publish-chart` job on release tags packages `charts/ai-guard` and pushes it to `oci://ghcr.io/amansk5/shadow-ai-guard/charts` (then verifies it resolves with `helm show chart`). It runs after `build-images`, so a freshly published chart never references image tags that don't exist yet. Chart artifacts are versioned by chart version, as OCI charts are.

**Docs**:
- `docs/deployment/kubernetes.md`: the short way is now two sections. **Managed** leads — `helm install` from the OCI reference with `managed.enabled` + ingress values only, the setup-code one-liner, and what the wizard takes from there (including the probe's warning about names other machines can't resolve, with the Tailscale `.ts.net` guidance finally in the doc rather than lore). **Classic** keeps the env-driven command, now with `portal.lokiUrl` included (a long-standing omission).
- The Authentication section says which mode it describes: managed = the login, no portal password Secret; classic = basic auth as before.
- `charts/ai-guard/README.md` install section: OCI-first, managed one-command, classic beneath.
- `docs/getting-started.md`: a managed-mode shortcut note — the wizard's downloads are these collector scripts with URL + enrollment token baked, so no token hunting.
- `README.md` deployment order: managed is one step and then the portal; the classic five-step list stays.

Verified: 95 receiver + 308 portal tests (docs-pin checks included), helm lint, workflow YAML parses. The publish job itself can only prove out on the next release tag — v0.9.8 will be its first run.