### PR TITLE
Release v0.9.8

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.8.13
+version: 0.9.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.9.7"
+appVersion: "0.9.8"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -91,14 +91,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.7
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.8
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.7
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.8
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,7 +135,7 @@ On the compose route it is already there, on port 8091. Otherwise:
 docker run --rm -p 8091:8091 \
   -e LOKI_URL=http://your-loki:3100 \
   -e PORTAL_USER=admin -e PORTAL_PASSWORD=... \
-  ghcr.io/amansk5/shadow-ai-guard/portal:0.9.7
+  ghcr.io/amansk5/shadow-ai-guard/portal:0.9.8
 ```
 
 It refuses to start without authentication, because it names who runs what on

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.7
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.8
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
v0.9.8: runtime log-store/alerting/URL settings (#123), wizard v2 (#124), OCI chart + one-command docs (#125).

- chart **0.9.0** (version jump marks the managed arc: login → settings → wizard → one-command install; no values changed meaning, 0.8.x upgrades clean), appVersion 0.9.8
- image pins bumped in all three checked places: docs/deployment/kubernetes.md, docs/getting-started.md, receiver/deploy/receiver.yaml

On merge: tag v0.9.8, publish the GitHub release (notes drafted) — **the tag build is the first real run of the publish-chart job**, so I'll watch it and verify `helm show chart oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard` resolves. Then the homelab acceptance test finally happens as designed: the documented one command plus Tailscale ingress values, everything else in the wizard.