### PR TITLE
The receiver-URL probe explains its vantage point

### DIFF
--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1352,9 +1352,21 @@ def test_receiver_url(_=Depends(require_auth),
         with _urlreq.urlopen(url + "/healthz", timeout=5) as resp:
             body = json.loads(resp.read() or b"{}")
     except Exception as e:
+        # This probe runs from the portal's own pod, which is a different
+        # network from the endpoints the URL is FOR. A URL only reachable
+        # over a VPN or tailnet (a .ts.net name, say) can be exactly right
+        # and still fail here - the pod cannot even resolve it. Say so,
+        # and name the check that actually settles it.
         return {"ok": False, "warnings": warnings,
-                "detail": "could not reach %s/healthz (%s)"
-                          % (_redact_url(url), type(e).__name__)}
+                "detail": "could not reach %s/healthz from inside the "
+                          "cluster (%s). That can be normal: if the URL is "
+                          "only reachable from your endpoints' network (a "
+                          "VPN or tailnet), confirm from one of those "
+                          "machines instead - curl %s/healthz - and if it "
+                          "answers, the saved URL is right and this result "
+                          "can be ignored."
+                          % (_redact_url(url), type(e).__name__,
+                             _redact_url(url))}
     if not body.get("ok"):
         return {"ok": False, "warnings": warnings,
                 "detail": "%s answered, but not like an ai-guard receiver"


### PR DESCRIPTION
Found live during the v0.9.8 homelab acceptance test: the probe runs from the portal pod, which is not on the tailnet, so it reported "could not reach" for `https://ai-guard.<tailnet>.ts.net` — a URL the endpoints (tailnet machines) reach fine; the pod cannot even resolve `.ts.net` names.

The URL was correct and the wizard flow worked; only the probe's verdict was misleading. Its failure message now says it probed from inside the cluster, names the VPN/tailnet case where that is normal, and gives the `curl <url>/healthz`-from-an-endpoint check that actually settles it. The dotless-host warning (the real footgun) is unchanged.

308 portal tests pass. Copy-only.