### PR TITLE
The review queue and the checkout-free Setup view (v0.9.9 increment 3)

### DIFF
--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -780,21 +780,27 @@ def status_from(findings):
     expected = [
         ("endpoint", "collector-macos", "macOS collector", "endpoint/macos/README.md",
          "Deploy ai-guard-collector.sh as a Jamf policy running as root on a "
-         "recurring check-in. Set AIGUARD_RECEIVER_BASE, AIGUARD_TOKEN and "
+         "recurring check-in. In managed mode, download the pre-configured "
+         "script below - receiver URL and enrollment token already baked. "
+         "Classically, set AIGUARD_RECEIVER_BASE, AIGUARD_TOKEN and "
          "AIGUARD_CORP_DOMAINS as script parameters."),
         ("endpoint", "collector-linux", "Linux collector", "endpoint/linux/README.md",
-         "Run ai-guard-collector.sh as root on a schedule: an RMM, a cron job "
-         "or a systemd timer. Same three environment variables as macOS."),
+         "Run ai-guard-collector.sh as root on a schedule: an RMM scheduled "
+         "job, cron, or a systemd timer. In managed mode the download below "
+         "is ready to paste in as-is; classically, same three environment "
+         "variables as macOS."),
         ("endpoint", "collector-windows", "Windows collector", "endpoint/windows/README.md",
-         "Deploy ai-guard-collector.ps1 as an Intune platform script. Same "
-         "three variables, set at the top of the script or as parameters."),
+         "Deploy ai-guard-collector.ps1 as an Intune platform script. In "
+         "managed mode the download below is upload-ready; classically, set "
+         "the same three variables at the top of the script."),
         ("browser", "browser_extension", "Browser extension: accounts",
          "extension/README.md",
-         "Push the extension by managed policy (Jamf for Chrome/Edge on macOS, "
-         "Intune ADMX on Windows) with the receiver URL and token in the "
-         "managed configuration - in managed mode an enrollment token, which "
-         "each browser profile exchanges once for its own credential. Reports "
-         "which account is signed into an AI tool in the browser."),
+         "Push the extension by managed policy (Jamf for Chrome/Edge on "
+         "macOS, the deploy script on Windows). In managed mode, download "
+         "the pre-configured managed-storage policy below - URL, enrollment "
+         "token and corporate domains baked; each browser profile exchanges "
+         "the token once for its own credential. Reports which account is "
+         "signed into an AI tool in the browser."),
         ("browser", "paste_guard", "Browser extension: paste guard",
          "extension/README.md",
          "Part of the same extension. Reports pastes it stopped or flagged, "

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -684,10 +684,11 @@ KNOWN_WIDGETS = {
     "detection_coverage": "How much of each surface is reporting",
     "source_health": "Sources reporting versus silent",
     "paste_guard": "Pastes warned, overridden and blocked",
+    "review_queue": "Observed tools awaiting a governance decision",
 }
 
-DEFAULT_WIDGETS = ["stat_row", "top_tools", "recent_personal_accounts",
-                   "detection_coverage"]
+DEFAULT_WIDGETS = ["stat_row", "review_queue", "top_tools",
+                   "recent_personal_accounts", "detection_coverage"]
 
 
 def _widgets(spec=None):

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -296,6 +296,11 @@ async function load(force) {
     // guard widget and a widget that fetches on render would flash empty.
     const pr = await fetch('/api/paste-guard' + q);
     if (pr.ok) PG = await pr.json();
+    // Same again for the review queue: it draws from the register.
+    if ((CFG.overview_widgets || []).some(w => w.kind === 'review_queue')) {
+      const rr = await fetch('/api/register' + q);
+      if (rr.ok) REG = await rr.json();
+    }
     loadError = '';
   } catch (e) {
     loadError = String(e.message || e);
@@ -482,6 +487,45 @@ const WIDGETS = {
            pasted nothing.`}</p></div>`;
   },
 
+  review_queue: () => {
+    // The queue that replaces a weekly review pipeline: observed tools no
+    // one has decided about. Recording the decision IS the acknowledgment,
+    // so an empty queue means exactly what it says. Not-in-registry rows
+    // first - they are the gap evidence - then newest first.
+    if (!REG || !REG.rows) return `<div class="wcard w6"><h3>Awaiting a decision</h3>
+      <p class="lede">No register data - open the AI register for the reason.</p></div>`;
+    const dayAgo = Date.now() - 86400000;
+    const isNew = r => r.first_seen && Date.parse(r.first_seen) > dayAgo;
+    const undecided = (REG.rows || [])
+      .filter(r => r.status_source !== 'governance' && r.status_source !== 'portal')
+      .sort((a, b) => ((a.in_registry ? 1 : 0) - (b.in_registry ? 1 : 0))
+        || ((Date.parse(b.first_seen || 0) || 0) - (Date.parse(a.first_seen || 0) || 0)));
+    if (!undecided.length) {
+      const ago = t => {
+        const m = Math.round((Date.now() - Date.parse(t)) / 60000);
+        return m < 90 ? m + 'm ago' : Math.round(m / 60) + 'h ago';
+      };
+      const srcs = ((S && S.groups) || []).flatMap(g => g.sources || [])
+        .filter(x => x.last_seen).sort((a, b) => a.last_seen < b.last_seen ? 1 : -1)
+        .slice(0, 2);
+      return `<div class="wcard w6"><h3>Awaiting a decision</h3>
+        <p class="lede">No new AI tools awaiting a decision.${srcs.length
+          ? ' Newest source data: ' + srcs.map(x =>
+              esc(x.label) + ' ' + ago(x.last_seen)).join(', ') + '.' : ''}</p></div>`;
+    }
+    return `<div class="wcard w6"><h3>Awaiting a decision
+      <span class="count">${undecided.length}</span></h3>
+    <table>${undecided.slice(0, 6).map(r => `<tr>
+      <td><a href="#register" style="color:var(--fg);text-decoration:none">${esc(r.name)}</a></td>
+      <td>${!r.in_registry ? '<span class="pill p-warn">not in registry</span>' : ''}
+          ${isNew(r) ? '<span class="pill p-acc">new today</span>' : ''}</td>
+      <td style="color:var(--mut)">${esc((r.first_seen || '').slice(0, 10))}</td>
+    </tr>`).join('')}</table>
+    <p class="src-note"><a href="#register" style="color:var(--pri)">Decide on
+    the AI register</a> - a decision is the acknowledgment, so deciding
+    clears the queue.</p></div>`;
+  },
+
   grafana: (w) => {
     const base = CFG.grafana_url;
     if (!base) return `<div class="wcard w4"><h3>${esc(w.ref)}</h3>
@@ -510,8 +554,8 @@ const WIDGETS = {
 };
 
 function overview() {
-  const ws = CFG.overview_widgets || [{kind:'stat_row'},{kind:'top_tools'},
-    {kind:'recent_personal_accounts'},{kind:'detection_coverage'}];
+  const ws = CFG.overview_widgets || [{kind:'stat_row'},{kind:'review_queue'},
+    {kind:'top_tools'},{kind:'recent_personal_accounts'},{kind:'detection_coverage'}];
   const stat = ws.filter(w => w.kind === 'stat_row');
   const rest = ws.filter(w => w.kind !== 'stat_row');
   return `<h2>Overview</h2>
@@ -971,6 +1015,13 @@ async function register() {
   }
   const rows = (REG.rows || []).filter(r =>
     match(r.name) || match(r.id) || match(r.vendor) || match(r.category));
+  // Queue order: undecided first (the register doubles as the review
+  // queue), keeping the server's exposure order within each half.
+  const _decided = r => (r.status_source === 'governance'
+    || r.status_source === 'portal') ? 1 : 0;
+  rows.sort((a, b) => _decided(a) - _decided(b));
+  const _newToday = r => r.first_seen
+    && Date.parse(r.first_seen) > Date.now() - 86400000;
 
   const win = REG.hours >= 24 ? Math.round(REG.hours / 24) + ' days'
                               : REG.hours + ' hours';
@@ -1132,7 +1183,8 @@ async function register() {
   ${rows.map(r => `<div class="card">
     <div class="card-top">
       <div style="min-width:0">
-        <div class="card-name">${esc(r.name)}</div>
+        <div class="card-name">${esc(r.name)}
+          ${_newToday(r) ? '<span class="pill p-acc">new today</span>' : ''}</div>
         <div class="card-meta">${r.vendor ? esc(r.vendor) + ' · ' : ''}${esc(r.id)}</div>
       </div>
       ${status(r)}
@@ -1716,6 +1768,13 @@ async function settings() {
   not set it leaves it empty rather than guessing.</p></div>`;
 }
 
+// Repo docs as real links, pinned to the release this portal runs - the
+// docs a reader lands on should match the version they run, and nobody
+// deploying from the OCI chart has a checkout to open files in.
+const docUrl = d => 'https://github.com/AmanSK5/shadow-ai-guard/blob/'
+  + (/^\d+\./.test(CFG.version || '') ? 'v' + CFG.version : 'main')
+  + '/' + d;
+
 function setup() {
   if (loadError) return `<h2>Setup</h2>
     <div class="note">Could not read findings: ${esc(loadError)}</div>
@@ -1746,7 +1805,9 @@ function setup() {
       <td>${esc(r.label)}<br><span class="mono" style="font-size:11px;color:var(--mut)">${esc(r.source)}</span>
         ${r.reporting ? '' : `<div style="margin-top:6px;font-family:inherit;font-size:12px;color:var(--mut);max-width:52ch;line-height:1.5">
           ${esc(r.needs || '')}
-          <br><span class="mono" style="font-size:11px">${esc(r.doc)}</span></div>`}
+          <br><a class="mono" style="font-size:11px;color:var(--acc)"
+            href="${esc(docUrl(r.doc))}" target="_blank"
+            rel="noopener noreferrer">${esc(r.doc)}</a></div>`}
         ${r.artifact && CFG.managed && CFG.managed.artifacts_ready ? `<div style="margin-top:6px">
           <button class="mini" data-act="artifact" data-key="${esc(r.artifact)}">Download pre-configured artifact</button></div>` : ''}</td>
       <td>${r.reporting ? '<span class="pill p-ok">reporting</span>'

--- a/portal/tests/test_wizard.py
+++ b/portal/tests/test_wizard.py
@@ -259,3 +259,22 @@ def test_the_js_category_list_matches_the_schema():
     js_list = html[start:html.index("];", start)]
     for value in enum:
         assert "'%s'" % value in js_list, value
+
+
+def test_every_setup_doc_reference_is_a_real_file():
+    """The Setup view renders these as GitHub links pinned to the running
+    release. A renamed or moved doc becomes a 404 on every deployment's
+    Setup page, so the paths are held to the repo here."""
+    from app.derive import status_from
+
+    repo = Path(__file__).parent.parent.parent
+    docs = {r["doc"] for g in status_from([])["groups"] for r in g["sources"]}
+    for d in sorted(docs):
+        assert (repo / d).is_file(), d
+
+
+def test_the_page_carries_the_review_queue():
+    html = (main.STATIC / "index.html").read_text()
+    for needle in ("review_queue", "Awaiting a decision", "new today",
+                   "docUrl", "github.com/AmanSK5/shadow-ai-guard/blob/"):
+        assert needle in html, needle


### PR DESCRIPTION
Third and final feature increment of v0.9.9.

- **`review_queue` widget** (in KNOWN_WIDGETS both sides of the sync test, and in the default overview): observed tools with no governance decision — not-in-registry first, newest first, "new today" badged — linking to the register, with the empty state that was the point: *"No new AI tools awaiting a decision. Newest source data: …"* (freshness is last-run derived, per the design). A decision is the acknowledgment; no new state, nothing to mark read. `load()` prefetches the register when the widget is configured, same as paste-guard.
- **Register as the queue's long form**: undecided rows sort first, tools first seen within 24h get a badge.
- **Setup view, checkout-free**: row copy leads with the pre-configured download where one exists (classic instructions retained after), and every `x/README.md` reference is now a GitHub link **pinned to the running release** (`blob/v<version>`, `main` for dev builds). A test walks every referenced path and asserts the file exists, so a doc rename can't 404 on every deployment's Setup page.

Verified: 313 portal + 106 receiver tests, and a click-through with a bonus finding: the queue showed the previously-unknown tool as **`mystery-ai-example`, in-registry** — the merged registry's domain map now folds even *historical* raw-hostname findings into the portal-defined tool at derivation time, which closes the discovery loop harder than designed. Queue walked 3 → 1 → empty state live.