### PR TITLE
Fix #104 and #106, fold dependabot #117

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -791,7 +791,7 @@ jobs:
       # path gate means a component only builds when it changes.
       - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
         if: steps.gate.outputs.build == 'true'
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
         if: steps.gate.outputs.build == 'true'
 
       # Both architectures under one tag, so `docker pull` resolves correctly

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,7 +40,20 @@ should accept before deploying:
 - Any holder can read the registry via `/registry/collector`. The registry
   is not secret (it describes public products), but it does reveal what you
   detect.
-- Compromise of one endpoint reveals the same token every endpoint uses.
+- **A standard local user on any enrolled machine can read the token.** No
+  compromise required: it sits in a Jamf script parameter, an Intune script
+  body, or managed browser storage (a world-readable plist on macOS, HKLM
+  on Windows), all of which are readable without elevation on a default
+  install. Because it is the same token fleet-wide, any employee who looks
+  can then author findings about any colleague's machine - the register is
+  only as trustworthy as the least curious person in the fleet.
+- Historically the collectors also passed the token to `curl` as a
+  command-line argument, which publishes it to every local user via `ps`
+  for the duration of each request. Since 0.9.9 the collectors send the
+  `Authorization` header on curl's stdin (`-H @-`) so it never appears in
+  process arguments; the Windows collector uses `Invoke-RestMethod`, which
+  keeps it in-process. This narrows the exposure, but the storage locations
+  above still apply - argv hygiene does not make a shared secret per-device.
 
 If that is unacceptable in your threat model, use managed mode (the
 default since 0.9.9): the
@@ -49,9 +62,12 @@ be revoked without touching any other, and an enrollment token in an MDM
 artifact can create auditable device records but never submit findings. The
 shared token remains valid alongside (the browser extension and scanners
 still use it), so the consequences above shrink to those surfaces rather
-than disappearing. See the receiver README for the mechanics, including the
-separate `ADMIN_TOKEN` that mints credentials - separate precisely because
-the shared token is on every machine in the fleet.
+than disappearing - and `REQUIRE_DEVICE_CREDENTIALS=true` closes even that:
+the receiver then rejects the shared token on `/report` entirely, so a
+token read off a colleague's machine submits nothing. See the receiver
+README for the mechanics, including the separate `ADMIN_TOKEN` that mints
+credentials - separate precisely because the shared token is on every
+machine in the fleet.
 
 ### The portal
 

--- a/endpoint/linux/ai-guard-collector.sh
+++ b/endpoint/linux/ai-guard-collector.sh
@@ -51,6 +51,15 @@ set -u
 # ------------------------------------------------------------------ config --
 RECEIVER_BASE="${AIGUARD_RECEIVER_BASE:-}"
 TOKEN="${AIGUARD_TOKEN:-}"
+
+# Every authenticated request goes through this: the Authorization header
+# travels to curl on stdin (-H @-), never in argv. /proc/<pid>/cmdline is
+# readable by every local user unless hidepid is set, so a bearer token in
+# a command line is a bearer token published to the machine (issue #106).
+# Requires curl 7.55+ (2017).
+auth_curl() {
+  printf 'Authorization: Bearer %s\n' "$TOKEN" | curl -H @- "$@"
+}
 CORP_DOMAINS="${AIGUARD_CORP_DOMAINS:-}"
 
 ENDPOINT=""
@@ -296,8 +305,8 @@ report() {
     return
   fi
   local code
-  code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' \
-    -X POST -H "Authorization: Bearer $TOKEN" \
+  code=$(auth_curl -s -m 10 -o /dev/null -w '%{http_code}' \
+    -X POST \
     -H "X-AiGuard-Agent-Version: $COLLECTOR_VERSION" \
     -H 'Content-Type: application/json' \
     --data "$payload" "$ENDPOINT" 2>/dev/null || echo 000)
@@ -337,8 +346,7 @@ fetch_registry() {
   REG_TMP=$(mktemp /tmp/ai-guard-reg.XXXXXX) || return 1
   REG_FILE="$REG_TMP"
   local code
-  code=$(curl -s -m 15 -o "$REG_FILE" -w '%{http_code}' \
-    -H "Authorization: Bearer $TOKEN" \
+  code=$(auth_curl -s -m 15 -o "$REG_FILE" -w '%{http_code}' \
     "${RECEIVER_BASE%/}/registry/collector" 2>/dev/null || echo 000)
   [ "$code" = "200" ]
 }
@@ -407,8 +415,8 @@ case "$TOKEN" in
       ENROLL_BODY=$(printf '{"platform":"linux","serial":"%s","hostname":"%s","agent_version":"%s"}' \
         "$(json_escape "$DEVICE")" "$(json_escape "$DEVICE_NAME")" "$COLLECTOR_VERSION")
       ENROLL_RESP=$(mktemp /tmp/ai-guard-enroll.XXXXXX)
-      ENROLL_CODE=$(curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
-        -X POST -H "Authorization: Bearer $TOKEN" \
+      ENROLL_CODE=$(auth_curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
+        -X POST \
         -H 'Content-Type: application/json' \
         --data "$ENROLL_BODY" "${RECEIVER_BASE%/}/enroll" 2>/dev/null || echo 000)
       if [ "$ENROLL_CODE" = "200" ]; then

--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -45,6 +45,15 @@ RECEIVER_BASE="${4:-}"
 ENDPOINT=""
 [ -n "$RECEIVER_BASE" ] && ENDPOINT="${RECEIVER_BASE%/}/report"
 TOKEN="${5:-}"
+
+# Every authenticated request goes through this: the Authorization header
+# travels to curl on stdin (-H @-), never in argv. `ps` shows every
+# process's arguments to every local user for the life of the request, so
+# a bearer token in a command line is a bearer token published to the
+# machine (issue #106). Requires curl 7.55+ (2017); macOS ships far newer.
+auth_curl() {
+  /usr/bin/printf 'Authorization: Bearer %s\n' "$TOKEN" | /usr/bin/curl -H @- "$@"
+}
 CORP_DOMAINS="${6:-}"
 
 SUMMARY_DIR="/Library/Application Support/ai-guard"
@@ -217,8 +226,7 @@ report() {
   local delivered=false
   if [ -n "$ENDPOINT" ]; then
     local http_code
-    http_code=$(/usr/bin/curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "$ENDPOINT" \
-      -H "Authorization: Bearer $TOKEN" \
+    http_code=$(auth_curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "$ENDPOINT" \
       -H "X-AiGuard-Agent-Version: $COLLECTOR_VERSION" \
       -H "Content-Type: application/json" \
       -d "$payload" || echo "000")
@@ -288,8 +296,7 @@ fetch_registry() {
   REG_TMP=$(/usr/bin/mktemp /tmp/ai-guard-reg.XXXXXX) || return 1
   REG_FILE="$REG_TMP"
   local code
-  code=$(/usr/bin/curl -s -m 15 -o "$REG_FILE" -w '%{http_code}' \
-    -H "Authorization: Bearer $TOKEN" \
+  code=$(auth_curl -s -m 15 -o "$REG_FILE" -w '%{http_code}' \
     "${RECEIVER_BASE%/}/registry/collector" 2>/dev/null || echo "000")
   [ "$code" = "200" ]
 }
@@ -346,8 +353,8 @@ case "$TOKEN" in
       ENROLL_BODY=$(/usr/bin/printf '{"platform":"macos","serial":"%s","hostname":"%s","agent_version":"%s"}' \
         "$(json_escape "$SERIAL")" "$(json_escape "$DEVICE_NAME")" "$COLLECTOR_VERSION")
       ENROLL_RESP=$(/usr/bin/mktemp /tmp/ai-guard-enroll.XXXXXX)
-      ENROLL_CODE=$(/usr/bin/curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
-        -X POST -H "Authorization: Bearer $TOKEN" \
+      ENROLL_CODE=$(auth_curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
+        -X POST \
         -H "Content-Type: application/json" \
         -d "$ENROLL_BODY" "${RECEIVER_BASE%/}/enroll" 2>/dev/null || echo "000")
       if [ "$ENROLL_CODE" = "200" ]; then

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -68,58 +68,93 @@ COLLECTOR_SOURCES = {"collector-macos", "collector-linux", "collector-windows"}
 COLLECTOR_SURFACES = {"cli", "ide", "mcp", "endpoint"}
 
 
+class Findings(list):
+    """A list of findings that also says whether it is the WHOLE window.
+
+    truncated=True means the read stopped at the safety cap and older
+    findings in the window were not fetched - every count derived from it
+    is a floor, not a total, and the pages say so. A plain list (a test
+    double, say) reads as complete, which getattr callers get for free.
+    """
+
+    truncated = False
+
+
 def fetch_from_loki(base, hours, token=None, limit=5000, username=None,
-                    password=None):
-    """Pull findings from Loki. Returns a list of parsed finding dicts.
+                    password=None, max_findings=100_000):
+    """Pull findings from Loki, paginating until the window is exhausted.
+
+    Loki caps one query_range response at `limit` entries. The old single
+    request silently returned the newest 5,000 of a larger window, and
+    every portal number - the register, the status page, the evidence
+    manifest with its checksum - was then computed over a sample presented
+    as the whole (issue #104). Now the read walks backward page by page
+    until a page comes back short, or max_findings is hit - and hitting
+    the cap is REPORTED, not swallowed: the result's truncated flag rides
+    into the API responses and the evidence manifest.
+
+    The boundary between pages is oldest-seen minus one nanosecond, so a
+    finding sharing that exact nanosecond with the boundary entry could be
+    skipped; receiver timestamps are time_ns() at ingest, which makes that
+    collision effectively impossible.
 
     Two authentication shapes, because log stores disagree about which they
-    want. A bearer token covers self-hosted Loki behind a gateway; basic auth
-    is what Grafana Cloud and most hosted offerings use, where the username is
-    a numeric instance id.
-
-    Basic auth was missing here while the receiver already had it, and the
-    asymmetry was invisible until both ran against the same hosted Loki: the
-    receiver wrote successfully and the portal got a 401 reading back the
-    findings it had just stored. A deployment where writes work and reads do
-    not is not a working deployment, and nothing in the config named the gap.
-
-    Both may be set. They are not alternatives to each other in any protocol
-    sense, and a gateway that wants a bearer token in front of a Loki that
-    wants basic auth is a real arrangement.
+    want. A bearer token covers self-hosted Loki behind a gateway; basic
+    auth is what Grafana Cloud and most hosted offerings use, where the
+    username is a numeric instance id. Both may be set: a gateway that
+    wants a bearer in front of a Loki that wants basic auth is a real
+    arrangement. Built by hand rather than with HTTPBasicAuthHandler,
+    which only sends credentials after a 401 with a realm it recognises -
+    Grafana Cloud answers 401 without one, so the retry never carried the
+    header.
     """
     import base64
 
     end = int(time.time() * 1e9)
     start = end - int(hours * 3600 * 1e9)
-    params = urllib.parse.urlencode({
-        "query": '{app="ai-guard-receiver", kind="finding"}',
-        "start": start,
-        "end": end,
-        "limit": limit,
-        "direction": "backward",
-    })
-    req = urllib.request.Request(base.rstrip("/") + "/loki/api/v1/query_range?" + params)
-    if username:
-        # Built by hand rather than with HTTPBasicAuthHandler, which only
-        # sends credentials after a 401 and a realm it recognises. Grafana
-        # Cloud answers 401 without a realm the handler will act on, so the
-        # retry never carries the header and the request fails a second time.
-        creds = base64.b64encode(
-            ("%s:%s" % (username, password or "")).encode()).decode()
-        req.add_header("Authorization", "Basic " + creds)
-    elif token:
-        req.add_header("Authorization", "Bearer " + token)
 
-    with urllib.request.urlopen(req, timeout=30) as resp:
-        payload = json.load(resp)
+    def page(page_end):
+        params = urllib.parse.urlencode({
+            "query": '{app="ai-guard-receiver", kind="finding"}',
+            "start": start,
+            "end": page_end,
+            "limit": limit,
+            "direction": "backward",
+        })
+        req = urllib.request.Request(
+            base.rstrip("/") + "/loki/api/v1/query_range?" + params)
+        if username:
+            creds = base64.b64encode(
+                ("%s:%s" % (username, password or "")).encode()).decode()
+            req.add_header("Authorization", "Basic " + creds)
+        elif token:
+            req.add_header("Authorization", "Bearer " + token)
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.load(resp)
+        entries, raw = [], 0
+        for stream in payload.get("data", {}).get("result", []):
+            for ts, line in stream.get("values", []):
+                raw += 1
+                try:
+                    entries.append((int(ts), json.loads(line)))
+                except (json.JSONDecodeError, ValueError):
+                    continue
+        return entries, raw
 
-    out = []
-    for stream in payload.get("data", {}).get("result", []):
-        for _ts, line in stream.get("values", []):
-            try:
-                out.append(json.loads(line))
-            except json.JSONDecodeError:
-                continue
+    out = Findings()
+    page_end = end
+    while True:
+        entries, raw = page(page_end)
+        out.extend(e for _, e in entries)
+        if raw < limit:
+            break  # a short page: the window is exhausted
+        if len(out) >= max_findings:
+            out.truncated = True
+            break
+        oldest = min((ts for ts, _ in entries), default=None)
+        if oldest is None or oldest <= start:
+            break
+        page_end = oldest - 1
     return out
 
 

--- a/portal/app/evidence.py
+++ b/portal/app/evidence.py
@@ -120,7 +120,8 @@ def _due_soon(rows, days=REVIEW_SOON_DAYS, now=None):
 
 def evidence_from(register_rows, status, personal, mcp, paste,
                   registry_path="", governance_path="",
-                  app_version="", hours=0, now=None):
+                  app_version="", hours=0, now=None,
+                  findings_truncated=False):
     """A snapshot manifest, checksummed.
 
     Takes derivations already computed rather than findings, so a snapshot and
@@ -131,7 +132,11 @@ def evidence_from(register_rows, status, personal, mcp, paste,
     rows = list(register_rows or [])
     observed = [r for r in rows if r.get("observed")]
 
-    decided = [r for r in observed if r.get("status_source") == "governance"]
+    # "governance" is the file, "portal" the recorded decision - both are
+    # a human's decision and both count as one. Counting only the file made
+    # decisions_recorded lie the day the portal write path shipped.
+    decided = [r for r in observed
+               if r.get("status_source") in ("governance", "portal")]
     by_status = {}
     for r in decided:
         by_status[r["status"]] = by_status.get(r["status"], 0) + 1
@@ -148,6 +153,11 @@ def evidence_from(register_rows, status, personal, mcp, paste,
             "hours": int(hours) if float(hours or 0).is_integer() else hours,
         },
         "app_version": app_version,
+        # Whether the Loki read behind these numbers stopped at the safety
+        # cap. True means every count below is a floor computed over the
+        # newest findings, not a total - which an evidence artifact must
+        # say about itself or it is not evidence (issue #104).
+        "findings_truncated": bool(findings_truncated),
         "registry_sha256": file_sha256(registry_path),
         "governance_sha256": file_sha256(governance_path),
 

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -208,6 +208,10 @@ GRAFANA_URL = os.environ.get("GRAFANA_URL", "").rstrip("/")
 GRAFANA_PANELS = os.environ.get("GRAFANA_PANELS", "")
 GRAFANA_DASHBOARD_UID = os.environ.get("GRAFANA_DASHBOARD_UID", "")
 CACHE_TTL = int(os.environ.get("CACHE_TTL_SECONDS", "30"))
+# The pagination safety cap for one Loki read (issue #104): the read walks
+# the whole window page by page and stops early only here - and says so.
+# Raise it for a very large fleet rather than living with a floor.
+LOKI_MAX_FINDINGS = int(os.environ.get("LOKI_MAX_FINDINGS", "100000"))
 
 # Which widgets the overview shows, in order. A deployment decision rather than
 # a per-user one: the portal holds no state and has no users to hold it
@@ -422,6 +426,10 @@ STARTED_AT = time.time()
 # happening", and only this tells them apart.
 _last_loki_ok: float = 0.0
 _last_loki_error: str = ""
+# Whether the most recent Loki read stopped at LOKI_MAX_FINDINGS. Reported
+# on every derived response and in the evidence manifest, because a count
+# computed over a sample must never present itself as a total (issue #104).
+_last_read_truncated: bool = False
 
 
 def _redact_url(url):
@@ -574,15 +582,17 @@ def _findings(hours, request=None):
                    "Settings (managed mode), or set LOKI_URL - the same "
                    "store the receiver writes to.",
         )
-    global _last_loki_ok, _last_loki_error
+    global _last_loki_ok, _last_loki_error, _last_read_truncated
     try:
         out = derive.fetch_from_loki(
             # The bearer token is env configuration and belongs to the env
             # store; a portal-saved store authenticates with its own pair.
             url, hours, LOKI_TOKEN if source == "env" else None,
-            username=username or None, password=password or None)
+            username=username or None, password=password or None,
+            max_findings=LOKI_MAX_FINDINGS)
         _last_loki_ok = time.time()
         _last_loki_error = ""
+        _last_read_truncated = getattr(out, "truncated", False)
         return out
     except Exception as e:
         # The detail goes to the log, not to the caller. An exception message
@@ -753,6 +763,7 @@ def diagnostics(_=Depends(require_auth)):
             "loki_configured": bool(LOKI_URL),
             "loki_last_success": _last_loki_ok or None,
             "loki_last_error": _last_loki_error,
+            "loki_last_read_truncated": _last_read_truncated,
             "lookback_hours": LOOKBACK_HOURS,
             "cache_ttl_seconds": CACHE_TTL,
             "auth_mode": ("login" if LOGIN_MODE and PORTAL_AUTH != "none"
@@ -796,7 +807,8 @@ def graph(request: Request,
         return derive.graph_from(findings, domain_map, identity_map)
 
     value, at = _cached("graph", hours, build)
-    return JSONResponse(dict(value, derived_at=at, hours=hours))
+    return JSONResponse(dict(value, derived_at=at, hours=hours,
+                             findings_truncated=_last_read_truncated))
 
 
 @app.get("/api/status")
@@ -811,7 +823,8 @@ def status(request: Request,
         return derive.status_from(_findings(hours, request))
 
     value, at = _cached("status", hours, build)
-    return JSONResponse(dict(value, derived_at=at, hours=hours))
+    return JSONResponse(dict(value, derived_at=at, hours=hours,
+                             findings_truncated=_last_read_truncated))
 
 
 @app.get("/api/evidence")
@@ -845,6 +858,7 @@ def evidence_snapshot(request: Request,
         governance_path=GOVERNANCE_PATH,
         app_version=APP_VERSION,
         hours=hours,
+        findings_truncated=_last_read_truncated,
     )
 
     if download:
@@ -956,6 +970,7 @@ def register(request: Request,
         # portal: either means somebody is deciding, and the "nothing is
         # configured" note would be false.
         "governance_configured": bool(GOVERNANCE_PATH) or portal_decisions > 0,
+        "findings_truncated": _last_read_truncated,
         # Decisions naming a tool the registry does not know. Reported rather
         # than dropped: the likely cause is a typo, and a decision that
         # silently matches nothing is how an organisation believes it has

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -553,12 +553,21 @@ const WIDGETS = {
     to show.</p></div>`,
 };
 
+// The truncation banner (issue #104): a Loki read that stopped at the
+// safety cap means every count on screen is a floor. Saying so beats a
+// smaller number pretending to be the total.
+const truncNote = flag => flag ? `<div class="note">Only the newest findings
+  in this window were fetched (the read hit its safety cap): every count
+  here is a floor, not a total. Narrow the window, or raise
+  <span class="mono">LOKI_MAX_FINDINGS</span>.</div>` : '';
+
 function overview() {
   const ws = CFG.overview_widgets || [{kind:'stat_row'},{kind:'review_queue'},
     {kind:'top_tools'},{kind:'recent_personal_accounts'},{kind:'detection_coverage'}];
   const stat = ws.filter(w => w.kind === 'stat_row');
   const rest = ws.filter(w => w.kind !== 'stat_row');
   return `<h2>Overview</h2>
+  ${truncNote(G.findings_truncated)}
   <p class="lede">Which widgets appear is a deployment decision, set in
   <code>OVERVIEW_WIDGETS</code>, so an organisation shapes its own landing page
   and the portal keeps no state and needs no accounts.</p>
@@ -1131,6 +1140,7 @@ async function register() {
   };
 
   return `<h2>AI register</h2>
+  ${truncNote(REG.findings_truncated)}
   <p class="lede">The AI tools actually in use, from findings in the last
   ${esc(win)}. The registry is a watchlist rather than an inventory, so a tool
   it knows about and nothing has reported is counted below rather than listed.

--- a/portal/collector-scripts/collector-linux.sh
+++ b/portal/collector-scripts/collector-linux.sh
@@ -51,6 +51,15 @@ set -u
 # ------------------------------------------------------------------ config --
 RECEIVER_BASE="${AIGUARD_RECEIVER_BASE:-}"
 TOKEN="${AIGUARD_TOKEN:-}"
+
+# Every authenticated request goes through this: the Authorization header
+# travels to curl on stdin (-H @-), never in argv. /proc/<pid>/cmdline is
+# readable by every local user unless hidepid is set, so a bearer token in
+# a command line is a bearer token published to the machine (issue #106).
+# Requires curl 7.55+ (2017).
+auth_curl() {
+  printf 'Authorization: Bearer %s\n' "$TOKEN" | curl -H @- "$@"
+}
 CORP_DOMAINS="${AIGUARD_CORP_DOMAINS:-}"
 
 ENDPOINT=""
@@ -296,8 +305,8 @@ report() {
     return
   fi
   local code
-  code=$(curl -s -m 10 -o /dev/null -w '%{http_code}' \
-    -X POST -H "Authorization: Bearer $TOKEN" \
+  code=$(auth_curl -s -m 10 -o /dev/null -w '%{http_code}' \
+    -X POST \
     -H "X-AiGuard-Agent-Version: $COLLECTOR_VERSION" \
     -H 'Content-Type: application/json' \
     --data "$payload" "$ENDPOINT" 2>/dev/null || echo 000)
@@ -337,8 +346,7 @@ fetch_registry() {
   REG_TMP=$(mktemp /tmp/ai-guard-reg.XXXXXX) || return 1
   REG_FILE="$REG_TMP"
   local code
-  code=$(curl -s -m 15 -o "$REG_FILE" -w '%{http_code}' \
-    -H "Authorization: Bearer $TOKEN" \
+  code=$(auth_curl -s -m 15 -o "$REG_FILE" -w '%{http_code}' \
     "${RECEIVER_BASE%/}/registry/collector" 2>/dev/null || echo 000)
   [ "$code" = "200" ]
 }
@@ -407,8 +415,8 @@ case "$TOKEN" in
       ENROLL_BODY=$(printf '{"platform":"linux","serial":"%s","hostname":"%s","agent_version":"%s"}' \
         "$(json_escape "$DEVICE")" "$(json_escape "$DEVICE_NAME")" "$COLLECTOR_VERSION")
       ENROLL_RESP=$(mktemp /tmp/ai-guard-enroll.XXXXXX)
-      ENROLL_CODE=$(curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
-        -X POST -H "Authorization: Bearer $TOKEN" \
+      ENROLL_CODE=$(auth_curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
+        -X POST \
         -H 'Content-Type: application/json' \
         --data "$ENROLL_BODY" "${RECEIVER_BASE%/}/enroll" 2>/dev/null || echo 000)
       if [ "$ENROLL_CODE" = "200" ]; then

--- a/portal/collector-scripts/collector-macos.sh
+++ b/portal/collector-scripts/collector-macos.sh
@@ -45,6 +45,15 @@ RECEIVER_BASE="${4:-}"
 ENDPOINT=""
 [ -n "$RECEIVER_BASE" ] && ENDPOINT="${RECEIVER_BASE%/}/report"
 TOKEN="${5:-}"
+
+# Every authenticated request goes through this: the Authorization header
+# travels to curl on stdin (-H @-), never in argv. `ps` shows every
+# process's arguments to every local user for the life of the request, so
+# a bearer token in a command line is a bearer token published to the
+# machine (issue #106). Requires curl 7.55+ (2017); macOS ships far newer.
+auth_curl() {
+  /usr/bin/printf 'Authorization: Bearer %s\n' "$TOKEN" | /usr/bin/curl -H @- "$@"
+}
 CORP_DOMAINS="${6:-}"
 
 SUMMARY_DIR="/Library/Application Support/ai-guard"
@@ -217,8 +226,7 @@ report() {
   local delivered=false
   if [ -n "$ENDPOINT" ]; then
     local http_code
-    http_code=$(/usr/bin/curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "$ENDPOINT" \
-      -H "Authorization: Bearer $TOKEN" \
+    http_code=$(auth_curl -s -m 10 -o /dev/null -w '%{http_code}' -X POST "$ENDPOINT" \
       -H "X-AiGuard-Agent-Version: $COLLECTOR_VERSION" \
       -H "Content-Type: application/json" \
       -d "$payload" || echo "000")
@@ -288,8 +296,7 @@ fetch_registry() {
   REG_TMP=$(/usr/bin/mktemp /tmp/ai-guard-reg.XXXXXX) || return 1
   REG_FILE="$REG_TMP"
   local code
-  code=$(/usr/bin/curl -s -m 15 -o "$REG_FILE" -w '%{http_code}' \
-    -H "Authorization: Bearer $TOKEN" \
+  code=$(auth_curl -s -m 15 -o "$REG_FILE" -w '%{http_code}' \
     "${RECEIVER_BASE%/}/registry/collector" 2>/dev/null || echo "000")
   [ "$code" = "200" ]
 }
@@ -346,8 +353,8 @@ case "$TOKEN" in
       ENROLL_BODY=$(/usr/bin/printf '{"platform":"macos","serial":"%s","hostname":"%s","agent_version":"%s"}' \
         "$(json_escape "$SERIAL")" "$(json_escape "$DEVICE_NAME")" "$COLLECTOR_VERSION")
       ENROLL_RESP=$(/usr/bin/mktemp /tmp/ai-guard-enroll.XXXXXX)
-      ENROLL_CODE=$(/usr/bin/curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
-        -X POST -H "Authorization: Bearer $TOKEN" \
+      ENROLL_CODE=$(auth_curl -s -m 15 -o "$ENROLL_RESP" -w '%{http_code}' \
+        -X POST \
         -H "Content-Type: application/json" \
         -d "$ENROLL_BODY" "${RECEIVER_BASE%/}/enroll" 2>/dev/null || echo "000")
       if [ "$ENROLL_CODE" = "200" ]; then

--- a/portal/tests/test_loki_pagination.py
+++ b/portal/tests/test_loki_pagination.py
@@ -1,0 +1,134 @@
+"""The Loki read walks the whole window, and says so when it cannot.
+
+Loki caps one query_range response at `limit` entries. Before issue #104
+the portal made one request and presented the newest 5,000 findings as the
+whole estate - every register count, coverage number, and checksummed
+evidence manifest was silently computed over a sample. The properties that
+close that:
+
+- the read paginates backward until a page comes back short of the limit,
+- the safety cap (max_findings) stops a pathological window, and stopping
+  there is REPORTED via the result's truncated flag, never swallowed,
+- page boundaries do not skip or duplicate entries.
+"""
+
+import io
+import json
+import urllib.parse
+import urllib.request
+
+import pytest
+
+from app import derive
+
+
+def _loki_response(entries):
+    """One query_range payload: entries as (ts_ns, dict) pairs."""
+    values = [(str(ts), json.dumps(doc)) for ts, doc in entries]
+    body = json.dumps(
+        {"data": {"result": [{"stream": {}, "values": values}]}})
+    return io.BytesIO(body.encode())
+
+
+class _FakeLoki:
+    """Answers urlopen the way Loki answers query_range: the newest
+    `limit` entries at or before `end`, newest first."""
+
+    def __init__(self, findings):
+        # findings: list of (ts_ns, dict), any order
+        self.findings = sorted(findings, key=lambda p: p[0], reverse=True)
+        self.requests = []  # the (start, end, limit) each call asked for
+
+    def __call__(self, req, timeout=None):
+        q = urllib.parse.parse_qs(urllib.parse.urlparse(req.full_url).query)
+        start = int(q["start"][0])
+        end = int(q["end"][0])
+        limit = int(q["limit"][0])
+        self.requests.append((start, end, limit))
+        window = [(ts, doc) for ts, doc in self.findings
+                  if start <= ts <= end]
+        # BytesIO is already a context manager, which is all urlopen's
+        # caller needs from it.
+        return _loki_response(window[:limit])
+
+
+def _findings(n, newest_ts):
+    """n findings one second apart, newest first."""
+    step = 1_000_000_000
+    return [(newest_ts - i * step, {"tool": "tool-%d" % i, "device": "d"})
+            for i in range(n)]
+
+
+@pytest.fixture
+def loki(monkeypatch):
+    def install(findings):
+        fake = _FakeLoki(findings)
+        monkeypatch.setattr(urllib.request, "urlopen", fake)
+        return fake
+    return install
+
+
+def test_a_window_larger_than_one_page_is_fetched_completely(loki):
+    import time
+    now = int(time.time() * 1e9)
+    fake = loki(_findings(12, now))
+    out = derive.fetch_from_loki("http://loki", hours=1, limit=5)
+    assert len(out) == 12
+    assert out.truncated is False
+    # Three pages: 5 + 5 + 2, and the short page ended the walk.
+    assert len(fake.requests) == 3
+
+
+def test_every_finding_arrives_exactly_once(loki):
+    import time
+    now = int(time.time() * 1e9)
+    fake = loki(_findings(12, now))
+    out = derive.fetch_from_loki("http://loki", hours=1, limit=5)
+    tools = [f["tool"] for f in out]
+    assert sorted(tools) == sorted("tool-%d" % i for i in range(12))
+    # Each page asks for strictly older entries than the last: the next
+    # end is below the previous page's oldest timestamp, so the boundary
+    # entry cannot be served twice.
+    ends = [end for _, end, _ in fake.requests]
+    assert ends == sorted(ends, reverse=True) and len(set(ends)) == len(ends)
+
+
+def test_a_single_short_page_costs_one_request(loki):
+    import time
+    now = int(time.time() * 1e9)
+    fake = loki(_findings(3, now))
+    out = derive.fetch_from_loki("http://loki", hours=1, limit=5)
+    assert len(out) == 3
+    assert out.truncated is False
+    assert len(fake.requests) == 1
+
+
+def test_hitting_the_cap_stops_and_is_reported_not_swallowed(loki):
+    import time
+    now = int(time.time() * 1e9)
+    loki(_findings(30, now))
+    out = derive.fetch_from_loki("http://loki", hours=1, limit=5,
+                                 max_findings=10)
+    assert len(out) == 10
+    assert out.truncated is True
+
+
+def test_the_cap_flag_is_false_when_the_cap_was_merely_reached_exactly(loki):
+    """Exactly max_findings in the window, landing on a short final page:
+    the whole window WAS read, so nothing was truncated."""
+    import time
+    now = int(time.time() * 1e9)
+    loki(_findings(7, now))
+    out = derive.fetch_from_loki("http://loki", hours=1, limit=5,
+                                 max_findings=7)
+    # 5 + 2: the second page is short, the walk ends before the cap check
+    # ever fires with a full page in hand.
+    assert len(out) == 7
+    assert out.truncated is False
+
+
+def test_a_plain_list_reads_as_complete():
+    """Test doubles and old callers hand back plain lists; getattr
+    callers must read those as not-truncated rather than crash."""
+    assert getattr([], "truncated", False) is False
+    assert derive.Findings().truncated is False

--- a/portal/tests/test_runtime_log_store.py
+++ b/portal/tests/test_runtime_log_store.py
@@ -117,7 +117,7 @@ def test_findings_only_sends_the_env_bearer_to_the_env_store(login_mode,
     seen = {}
 
     def fake_fetch(url, hours, token=None, limit=5000, username=None,
-                   password=None):
+                   password=None, max_findings=100_000):
         seen.update(url=url, token=token, username=username)
         return []
     monkeypatch.setattr(main.derive, "fetch_from_loki", fake_fetch)


### PR DESCRIPTION
One combined fix round for everything open before the v0.9.9 release.

## #104 — Loki reads silently capped at 5,000 findings

`fetch_from_loki` made a single `query_range` request, and Loki caps one response at `limit` entries — so the portal presented the newest 5,000 findings as the whole estate. Every register count, coverage number, and checksummed evidence manifest was computed over a sample with nothing saying so.

- The read now **paginates backward** (`end = oldest_seen − 1ns`) until a page comes back short of the limit.
- A safety cap remains — `LOKI_MAX_FINDINGS`, default 100,000 — but hitting it is **reported, not swallowed**: the result carries a `truncated` flag that rides into the `graph`/`status`/`register` API responses, a visible banner on the overview and register views, the diagnostics page, and the evidence manifest itself (`findings_truncated`, inside the checksum — an evidence artifact must say this about itself or it is not evidence).
- New test file `test_loki_pagination.py`: multi-page fetch completeness, exactly-once delivery across page boundaries, single-request short window, cap-hit reporting, and the exact-cap-on-a-short-page edge.
- Bonus fix surfaced on the way: the evidence manifest counted only governance-**file** decisions, undercounting from the day the portal decision path shipped. Portal decisions now count.

## #106 — shared token readable by any local user; curl exposed it in argv

Two parts:

- **The fixable half, fixed**: all six `curl` call sites in the macOS and Linux collectors passed `-H "Authorization: Bearer $TOKEN"` as an argument, which publishes the token to every local user via `ps` for the life of each request. They now go through an `auth_curl` helper that feeds the header on **stdin** (`curl -H @-`), so it never appears in process arguments. Portal byte-copies re-synced (the byte-equality test enforces it). Windows already used `Invoke-RestMethod` (in-process).
- **The honest half, documented**: SECURITY.md now states plainly that a *standard local user* on any enrolled machine can read the shared token — no compromise required (Jamf script parameter, Intune script body, world-readable managed-storage plist, HKLM) — and that the same token fleet-wide means any employee who looks can author findings about a colleague's machine. It then names the managed-mode ladder that shrinks this: per-device credentials, per-machine revocation, and `REQUIRE_DEVICE_CREDENTIALS=true` as the shared token's off-switch.

## Dependabot #117

`docker/setup-buildx-action` v4.2.0 → v4.3.0 (`37fe6310`), same bump as the dependabot PR — folded here so #117 can be closed without a separate merge.

Both suites green: portal 319 passed, receiver 106 passed. `auth_curl` functionally verified against a local HTTP server (header arrives intact via stdin).

Fixes #104
Fixes #106
Closes #117