### PR TITLE
Release v0.9.9

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.10.0
+version: 0.10.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.9.8"
+appVersion: "0.9.9"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -94,14 +94,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.8
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.9
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.8
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.9
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,7 +135,7 @@ On the compose route it is already there, on port 8091. Otherwise:
 docker run --rm -p 8091:8091 \
   -e LOKI_URL=http://your-loki:3100 \
   -e PORTAL_USER=admin -e PORTAL_PASSWORD=... \
-  ghcr.io/amansk5/shadow-ai-guard/portal:0.9.8
+  ghcr.io/amansk5/shadow-ai-guard/portal:0.9.9
 ```
 
 It refuses to start without authentication, because it names who runs what on

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.8
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.9
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Version bumps for the v0.9.9 release: chart `0.10.0 -> 0.10.1`, `appVersion 0.9.9`, and the three image pins (docs/getting-started.md, docs/deployment/kubernetes.md, receiver/deploy/receiver.yaml) to `0.9.9`.

On merge I'll tag `v0.9.9`, which builds and pushes the images and publishes chart `0.10.1` to the OCI registry.

Draft release notes (published on the tag):

---

# v0.9.9 — managed by default, and a discovery loop that closes itself

## ⚠ Breaking for upgraders: managed mode is now the DEFAULT

If you were running **classic** mode via the Helm chart or compose file, this release flips the default under you:

- **Helm**: `managed.enabled` now defaults to `true`. To stay classic, set `managed.enabled=false` explicitly.
- **Compose**: the base `docker-compose.yml` is now the managed stack; classic moved to an overlay: `docker compose -f docker-compose.yml -f docker-compose.classic.yml up`. (`docker-compose.managed.yml` is gone — it IS the base now.)

Existing managed deployments are unaffected. Classic remains fully supported as the full-control choice.

## The self-sustaining discovery loop

- **Portal-defined registry entries** — define a tool in the portal's Tool registry view (full schema parity), validated to the registry build's own rules, served merged into `/registry` and every collector surface list. The fleet detects it on its next run, no rebuild, no MR, no pipeline.
- **Retroactive normalization** — historical raw-hostname findings fold into the tool the moment you define it.
- **Suggest-entry** from unknown domains in the register; **review-queue widget** on the overview ("No new AI tools awaiting a decision").
- Additions-only: shipped ids/domains can't be redefined; portal entries carry `added_by: portal`, `approved` forced false until a human decides.

## Fixes

- **#104** — Loki reads paginate the full window instead of silently capping at 5,000; the safety cap (`LOKI_MAX_FINDINGS`, default 100,000) is reported in the UI, API, diagnostics, and evidence manifest when hit.
- **#106** — collectors pass the bearer to curl on stdin, keeping it out of `ps`; SECURITY.md now states the shared token's real exposure and the managed-mode mitigations.
- Evidence manifests count portal-recorded decisions, not just governance-file ones.

## Docs

- Setup pages link to exact files on GitHub, pinned to the release tag.
- Jamf/SentinelOne reframed as reference implementations of their surfaces — Kandji, Addigy, Intune, or any DNS log source slot into the same seams.
- Root README rewritten around the one-command managed install.