### PR TITLE
Paste guard as a setting; the Firefox artifact matrix

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -63,15 +63,18 @@ packed extension (.crx) and an update manifest (updates.xml) on public
 HTTPS, plus two policies per browser delivered by your MDM or GPO: an
 install policy (forcelist) and a managed-storage config.
 
-With a managed-mode deployment, the portal generates the managed-storage
-config pre-configured (the onboarding wizard, or the Setup view's browser
-row): receiver URL, a fresh enrollment token, and your corporate domains
-baked into a ready-to-upload plist whose header names the per-browser
-preference domains and the Windows script invocation. Set the extension ID
-in the portal's Settings first - the id comes from packing (step 2 below)
-and the portal cannot derive it for you. Because this extension reads no
-central config, a corporate-domain change means regenerating and re-pushing
-that policy.
+With a managed-mode deployment, the portal generates the whole matrix
+pre-configured (the onboarding wizard, or the Setup view's browser row):
+the Chromium managed-storage plist for macOS, the Windows deploy scripts
+for Chromium and Firefox, and the Firefox install-and-configure plist for
+macOS - receiver URL, a fresh enrollment token per download, your
+corporate domains, and the paste guard settings (mode and classification
+markings, both editable in the portal) baked in. Set the extension IDs in
+the portal's Settings first - the Chromium id comes from packing (step 2
+below), the Firefox gecko id from the manifest - plus the update-manifest
+URL (Chromium) and the signed .xpi URL (Firefox), which the portal cannot
+derive for you. Because this extension reads no central config, changing
+any of those means regenerating and re-pushing the policies.
 
 ### 1. Customise the source
 

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -830,19 +830,23 @@ def status_from(findings):
          "the same three variables at the top of the script."),
         ("browser", "browser_extension", "Browser extension: accounts",
          "extension/README.md",
-         "Push the extension by managed policy (Jamf for Chrome/Edge on "
-         "macOS, the deploy script on Windows). In managed mode, download "
-         "the pre-configured managed-storage policy below - URL, enrollment "
-         "token and corporate domains baked; each browser profile exchanges "
-         "the token once for its own credential. Reports which account is "
-         "signed into an AI tool in the browser."),
+         "Push the extension by managed policy. In managed mode the portal "
+         "generates the full matrix pre-configured - Chromium policy for "
+         "macOS, deploy scripts for Windows, and Firefox equivalents (keyed "
+         "on the gecko id, installing the Mozilla-signed .xpi) - URL, "
+         "enrollment token, corporate domains and paste guard settings "
+         "baked; each browser profile exchanges the token once for its own "
+         "credential. Reports which account is signed into an AI tool in "
+         "the browser."),
         ("browser", "paste_guard", "Browser extension: paste guard",
          "extension/README.md",
-         "Part of the same extension. Reports pastes it stopped or flagged, "
-         "and a daily heartbeat proving the whole chain works on that device. "
-         "Silent while the accounts row reports means nobody has pasted "
-         "anything matching a detector, which is a different thing from not "
-         "being deployed."),
+         "The same extension, not a second install: its mode (off/warn/"
+         "block) and the classification markings it scans for are Settings "
+         "here, baked into the same policy artifacts. Reports pastes it "
+         "stopped or flagged, and a daily heartbeat proving the whole chain "
+         "works on that device. Silent while the accounts row reports means "
+         "nobody has pasted anything matching a detector, which is a "
+         "different thing from not being deployed."),
         ("cloud", "entra_sign_in", "Entra sign-ins", "scanner/README.md",
          "Register an app in Entra with AuditLog.Read.All and Directory.Read.All, "
          "then set AIGUARD_ENTRA_TENANT_ID, _CLIENT_ID and _CLIENT_SECRET."),

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1324,6 +1324,12 @@ class SettingsWrite(BaseModel):
     grafana_panels: str | None = Field(default=None, max_length=2000)
     grafana_dashboard_uid: str | None = Field(default=None, max_length=128)
     overview_widgets: str | None = Field(default=None, max_length=500)
+    extension_update_url: str | None = Field(default=None, max_length=500)
+    extension_xpi_url: str | None = Field(default=None, max_length=500)
+    paste_guard_mode: str | None = Field(default=None, max_length=8)
+    firefox_extension_id: str | None = Field(default=None, max_length=128)
+    classification_markings: list[str] | None = Field(default=None,
+                                                      max_length=50)
 
 
 class DecisionWrite(BaseModel):
@@ -1486,8 +1492,9 @@ def api_password(req: PasswordWrite, _=Depends(require_auth),
 
 # Artifacts generated from templates rather than substituted into script
 # copies. Same minting and download shape as the collector kinds.
-GENERATED_ARTIFACTS = ("extension-policy", "scanner-cronjob",
-                       "discovery-cronjob")
+GENERATED_ARTIFACTS = ("extension-policy", "extension-windows",
+                       "firefox-policy", "firefox-windows",
+                       "scanner-cronjob", "discovery-cronjob")
 
 
 @app.post("/api/artifacts/{kind}")
@@ -1522,14 +1529,40 @@ def artifact(kind: str, _=Depends(require_auth),
                  "set RECEIVER_PUBLIC_URL). It is not the portal's internal "
                  "RECEIVER_URL; see the portal README.")
 
-    extension_id, corp_domains = "", []
-    if kind == "extension-policy":
-        extension_id = (stored.get("extension_id") or {}).get("value") or ""
-        corp_domains = (stored.get("corp_domains") or {}).get("value") or []
-        if not extension_id:
+    def setting(key):
+        return (stored.get(key) or {}).get("value") or ""
+
+    extension_kinds = ("extension-policy", "extension-windows",
+                       "firefox-policy", "firefox-windows")
+    extension_id = corp_domains = mode = markings = None
+    if kind in extension_kinds:
+        corp_domains = setting("corp_domains") or []
+        mode = setting("paste_guard_mode") or "warn"
+        # value may be a stored empty list (a real choice: no markings);
+        # only an absent setting falls back to the default set.
+        raw = stored.get("classification_markings") or {}
+        markings = raw.get("value") if raw.get("source") == "db" else None
+        if kind in ("extension-policy", "extension-windows"):
+            extension_id = setting("extension_id")
+            if not extension_id:
+                raise HTTPException(
+                    409, "set the extension ID in Settings first: the "
+                         "policy is keyed on it")
+        else:
+            extension_id = setting("firefox_extension_id")
+            if not extension_id:
+                raise HTTPException(
+                    409, "set the Firefox extension ID (the gecko id) in "
+                         "Settings first: Firefox policy is keyed on it")
+        if kind == "extension-windows" and not setting("extension_update_url"):
             raise HTTPException(
-                409, "set the extension ID in Settings first: the policy "
-                     "names the per-browser upload domains with it")
+                409, "set the extension update URL in Settings first: "
+                     "Windows installs the extension from it")
+        if kind in ("firefox-policy", "firefox-windows") \
+                and not setting("extension_xpi_url"):
+            raise HTTPException(
+                409, "set the signed .xpi URL in Settings first: Firefox "
+                     "installs only the Mozilla-signed file, from that URL")
 
     minted = _receiver("POST", "/admin/enrollment-tokens", token,
                        {"note": "portal artifact: %s" % kind})
@@ -1537,7 +1570,21 @@ def artifact(kind: str, _=Depends(require_auth),
         if kind == "extension-policy":
             filename, content = managed.generate_extension_policy(
                 extension_id, public_url, minted["token"],
-                corp_domains)
+                corp_domains, mode, markings)
+        elif kind == "extension-windows":
+            filename, content = managed.generate_extension_windows(
+                COLLECTOR_SCRIPTS_DIR, extension_id,
+                setting("extension_update_url"), public_url,
+                minted["token"], corp_domains, mode, markings)
+        elif kind == "firefox-policy":
+            filename, content = managed.generate_firefox_policy(
+                extension_id, setting("extension_xpi_url"), public_url,
+                minted["token"], corp_domains, mode, markings)
+        elif kind == "firefox-windows":
+            filename, content = managed.generate_firefox_windows(
+                COLLECTOR_SCRIPTS_DIR, extension_id,
+                setting("extension_xpi_url"), public_url,
+                minted["token"], corp_domains, mode, markings)
         elif kind == "scanner-cronjob":
             # A release build's version is the image tag on ghcr; a dev
             # build has no matching image, and "latest" is the honest

--- a/portal/app/managed.py
+++ b/portal/app/managed.py
@@ -158,8 +158,43 @@ def _refuse_unembeddable(pairs):
                                % name)
 
 
+# The extension's own default set, baked when the operator has not chosen
+# their own in Settings. Mirrors extension/deploy/*'s hand-written files.
+DEFAULT_MARKINGS = (
+    "Client Confidential",
+    "Internal Confidential",
+    "Internal Use Only",
+    "Strictly Confidential",
+    "Commercial in Confidence",
+)
+
+
+def _checked_markings(markings):
+    """The markings list an artifact will carry, validated for every
+    context it lands in (XML text and PowerShell single-quoted strings).
+    Spaces are legitimate here - these are document classification phrases
+    - so this is a narrower refusal than _refuse_unembeddable."""
+    out = list(DEFAULT_MARKINGS) if markings is None else list(markings)
+    for m in out:
+        if not m or any(c in m for c in "'\"\\$`\n\r\t<>&"):
+            raise ArtifactError(
+                "a classification marking cannot be embedded in an artifact:"
+                " %r" % m[:60])
+    return out
+
+
+def _checked_mode(mode):
+    mode = mode or "warn"
+    if mode not in ("off", "warn", "block"):
+        raise ArtifactError("paste guard mode must be off, warn or block")
+    return mode
+
+
 def generate_extension_policy(extension_id: str, url: str, token: str,
-                              corp_domains: list[str]) -> tuple[str, str]:
+                              corp_domains: list[str],
+                              paste_guard_mode: str = "warn",
+                              markings: list[str] | None = None
+                              ) -> tuple[str, str]:
     """The browser extension's managed-storage policy, ready to deploy.
 
     One plist body serves every Chromium browser - the browser is chosen by
@@ -189,9 +224,12 @@ def generate_extension_policy(extension_id: str, url: str, token: str,
                             for d in corp_domains) or (
         "        <!-- no corporate domains set; every account will read as"
         " personal until Settings has them and this file is regenerated -->")
+    markings_xml = "\n".join("        <string>%s</string>" % _xml(m)
+                             for m in _checked_markings(markings))
     return "ai-guard-extension-policy.plist", _EXTENSION_POLICY_TEMPLATE % {
         "id": _xml(extension_id), "url": _xml(url), "token": _xml(token),
-        "domains": domains_xml,
+        "domains": domains_xml, "mode": _checked_mode(paste_guard_mode),
+        "markings": markings_xml,
     }
 
 
@@ -241,15 +279,232 @@ _EXTENSION_POLICY_TEMPLATE = """\
 %(domains)s
     </array>
     <key>pasteGuardMode</key>
-    <string>warn</string>
+    <string>%(mode)s</string>
     <key>classificationMarkings</key>
     <array>
-        <string>Client Confidential</string>
-        <string>Internal Confidential</string>
-        <string>Internal Use Only</string>
-        <string>Strictly Confidential</string>
-        <string>Commercial in Confidence</string>
+%(markings)s
     </array>
+</dict>
+</plist>
+"""
+
+
+def _ps_str(v: str) -> str:
+    """A PowerShell single-quoted literal. The only escape in single quotes
+    is doubling the quote itself, and quotes are refused upstream anyway -
+    this keeps the property even if a refusal is ever loosened."""
+    return "'" + v.replace("'", "''") + "'"
+
+
+def _ps_arr(values) -> str:
+    return "@(" + ", ".join(_ps_str(v) for v in values) + ")"
+
+
+# The config block both Windows deploy scripts carry verbatim (a test
+# asserts the copies match extension/deploy/windows/). Substituted as one
+# anchor each so a script that changes shape fails loudly at generate time.
+_PS_SHARED_ANCHORS = (
+    "$AllowedDomains = @('example.com')",
+    "$PasteGuardMode = 'warn'",
+    """$ClassificationMarkings = @(
+    'Client Confidential'
+    'Internal Confidential'
+    'Internal Use Only'
+    'Strictly Confidential'
+    'Commercial in Confidence'
+)""",
+)
+
+
+def _generate_ps_deploy(scripts_dir: str, script: str, download: str,
+                        head_anchors: list, url: str, token: str,
+                        corp_domains: list[str], mode: str,
+                        markings) -> tuple[str, str]:
+    """One pre-configured Windows deploy script: the head anchors are the
+    script's own REPLACE_WITH placeholders, the shared trio is domains,
+    paste guard mode and markings."""
+    for d in corp_domains:
+        _refuse_unembeddable(((d, "corp domain"),))
+    marks = _checked_markings(markings)
+    path = Path(scripts_dir) / script
+    try:
+        content = path.read_text()
+    except OSError as e:
+        raise ArtifactError("deploy script not readable: %s (%s)"
+                            % (path.name, type(e).__name__))
+
+    subs = list(head_anchors) + [
+        # An empty list bakes @() - every account reads as personal until
+        # Settings has domains and the script is regenerated. Leaving the
+        # placeholder would deploy example.com as a corporate domain.
+        (_PS_SHARED_ANCHORS[0],
+         "$AllowedDomains = %s" % _ps_arr(corp_domains)),
+        (_PS_SHARED_ANCHORS[1],
+         "$PasteGuardMode = %s" % _ps_str(_checked_mode(mode))),
+        (_PS_SHARED_ANCHORS[2],
+         "$ClassificationMarkings = %s" % _ps_arr(marks)),
+    ]
+    for anchor, repl in subs:
+        if content.count(anchor) != 1:
+            raise ArtifactError(
+                "substitution anchor not found exactly once in %s: %r - the "
+                "deploy script changed shape; update the anchors to match"
+                % (script, anchor.splitlines()[0]))
+        content = content.replace(anchor, repl)
+    return download, content
+
+
+def generate_extension_windows(scripts_dir: str, extension_id: str,
+                               update_url: str, url: str, token: str,
+                               corp_domains: list[str], mode: str = "warn",
+                               markings=None) -> tuple[str, str]:
+    """The Chromium Windows deploy script, pre-configured: Intune-ready,
+    same trust story as every artifact (fresh token, values baked as the
+    script's own config block)."""
+    _refuse_unembeddable(((url, "receiver URL"), (token, "token"),
+                          (update_url, "extension update URL")))
+    if not re.fullmatch(r"[a-p]{32}", extension_id or ""):
+        raise ArtifactError(
+            "the extension id does not look like a Chromium extension id"
+            " (32 letters a-p); check Settings")
+    head = [
+        ("$ExtensionId = 'REPLACE_WITH_EXTENSION_ID'",
+         "$ExtensionId = %s" % _ps_str(extension_id)),
+        ("$UpdatesXml  = 'https://REPLACE_WITH_HOST/updates.xml'",
+         "$UpdatesXml  = %s" % _ps_str(update_url)),
+        ("$Endpoint    = 'https://REPLACE_WITH_HOST/report'",
+         "$Endpoint    = %s" % _ps_str(url.rstrip("/") + "/report")),
+        ("$AuthToken   = 'REPLACE_WITH_TOKEN'",
+         "$AuthToken   = %s" % _ps_str(token)),
+    ]
+    return _generate_ps_deploy(scripts_dir, "extension-windows.ps1",
+                               "Deploy-AiGuardExtension.ps1", head, url,
+                               token, corp_domains, mode, markings)
+
+
+def generate_firefox_windows(scripts_dir: str, gecko_id: str, xpi_url: str,
+                             url: str, token: str, corp_domains: list[str],
+                             mode: str = "warn",
+                             markings=None) -> tuple[str, str]:
+    """The Firefox Windows deploy script, pre-configured. The .xpi it
+    installs must be the Mozilla-signed one - no policy can waive that -
+    which is why the signed file's URL is a setting the operator supplies
+    rather than something the portal can invent."""
+    _refuse_unembeddable(((url, "receiver URL"), (token, "token"),
+                          (xpi_url, "signed .xpi URL"),
+                          (gecko_id, "Firefox extension id")))
+    head = [
+        ("$GeckoId   = 'REPLACE_WITH_GECKO_ID'",
+         "$GeckoId   = %s" % _ps_str(gecko_id)),
+        ("$XpiUrl    = 'https://REPLACE_WITH_HOST/ai-guard-1.0.0.xpi'",
+         "$XpiUrl    = %s" % _ps_str(xpi_url)),
+        ("$Endpoint  = 'https://REPLACE_WITH_HOST/report'",
+         "$Endpoint  = %s" % _ps_str(url.rstrip("/") + "/report")),
+        ("$AuthToken = 'REPLACE_WITH_TOKEN'",
+         "$AuthToken = %s" % _ps_str(token)),
+    ]
+    return _generate_ps_deploy(scripts_dir, "firefox-windows.ps1",
+                               "Deploy-AiGuardExtensionFirefox.ps1", head,
+                               url, token, corp_domains, mode, markings)
+
+
+def generate_firefox_policy(gecko_id: str, xpi_url: str, url: str,
+                            token: str, corp_domains: list[str],
+                            mode: str = "warn",
+                            markings=None) -> tuple[str, str]:
+    """Firefox's install-and-configure payload for macOS, in one plist.
+
+    Mirrors extension/deploy/macos/firefox/managed-storage.plist: policy
+    lives under org.mozilla.firefox (not a per-extension domain), managed
+    storage under 3rdparty > Extensions > the gecko id, and install_url
+    (not update_url) pointing at the Mozilla-SIGNED .xpi - Firefox refuses
+    unsigned extensions on release builds and no enterprise policy changes
+    that, so the signed file's URL is an operator-supplied setting."""
+    _refuse_unembeddable(((url, "receiver URL"), (token, "token"),
+                          (xpi_url, "signed .xpi URL"),
+                          (gecko_id, "Firefox extension id")))
+    for d in corp_domains:
+        _refuse_unembeddable(((d, "corp domain"),))
+    domains_xml = "\n".join(
+        "                <string>%s</string>" % _xml(d)
+        for d in corp_domains) or (
+        "                <!-- no corporate domains set; every account will"
+        " read as personal until Settings has them and this file is"
+        " regenerated -->")
+    markings_xml = "\n".join(
+        "                <string>%s</string>" % _xml(m)
+        for m in _checked_markings(markings))
+    return "ai-guard-firefox-policy.plist", _FIREFOX_POLICY_TEMPLATE % {
+        "id": _xml(gecko_id), "xpi": _xml(xpi_url), "url": _xml(url),
+        "token": _xml(token), "domains": domains_xml,
+        "mode": _checked_mode(mode), "markings": markings_xml,
+    }
+
+
+_FIREFOX_POLICY_TEMPLATE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  ai-guard browser extension: Firefox install-and-configure payload,
+  generated by the portal with a fresh enrollment token baked in.
+
+  Upload as an "Application &amp; Custom Settings" payload under the
+  preference domain org.mozilla.firefox. Unlike the Chromium browsers,
+  Firefox reads install and configuration from this one payload.
+
+  install_url points at the Mozilla-SIGNED .xpi (Settings holds its URL).
+  Firefox refuses unsigned extensions on release builds, and no enterprise
+  policy changes that; sign by submitting to addons.mozilla.org as a
+  self-distributed add-on. See extension/README.md.
+
+  deviceIdentifier: $SERIALNUMBER is substituted per machine by Jamf;
+  other MDMs have equivalents. allowedDomains and the paste guard settings
+  are baked because the extension reads no central config - changing them
+  in the portal means regenerating and re-pushing this policy.
+-->
+<plist version="1.0">
+<dict>
+    <key>EnterprisePoliciesEnabled</key>
+    <true/>
+
+    <key>ExtensionSettings</key>
+    <dict>
+        <key>%(id)s</key>
+        <dict>
+            <key>installation_mode</key>
+            <string>force_installed</string>
+            <key>install_url</key>
+            <string>%(xpi)s</string>
+            <key>updates_disabled</key>
+            <false/>
+        </dict>
+    </dict>
+
+    <key>3rdparty</key>
+    <dict>
+        <key>Extensions</key>
+        <dict>
+            <key>%(id)s</key>
+            <dict>
+                <key>reportEndpoint</key>
+                <string>%(url)s/report</string>
+                <key>authToken</key>
+                <string>%(token)s</string>
+                <key>deviceIdentifier</key>
+                <string>$SERIALNUMBER</string>
+                <key>pasteGuardMode</key>
+                <string>%(mode)s</string>
+                <key>allowedDomains</key>
+                <array>
+%(domains)s
+                </array>
+                <key>classificationMarkings</key>
+                <array>
+%(markings)s
+                </array>
+            </dict>
+        </dict>
+    </dict>
 </dict>
 </plist>
 """

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -1449,6 +1449,52 @@ function settingRow(key, label, placeholder, note) {
     <div class="src-note">${esc(note)}${note ? ' ' : ''}${secretNote || src}</div></dd>`;
 }
 
+// The paste guard and extension-delivery settings, shared by the wizard
+// and the Settings view. The paste guard IS the browser extension - one
+// package, one policy - and these values are baked into every generated
+// policy artifact, so a change here means regenerate and re-push.
+function pasteGuardFields() {
+  const s = (SETTINGS && SETTINGS.settings) || {};
+  const mode = (s.paste_guard_mode || {}).value || '';
+  const marksSet = (s.classification_markings || {}).source === 'db';
+  const marks = marksSet ? ((s.classification_markings || {}).value || []) : null;
+  const opt = (v, label) => `<option value="${v}"${mode === v ? ' selected' : ''}>${label}</option>`;
+  return `
+    <dt>Paste guard mode</dt><dd>
+      <select id="set-paste_guard_mode" class="mfield">
+        <option value=""${mode ? '' : ' selected'}>warn (default)</option>
+        ${opt('off', 'off')}${opt('warn', 'warn')}${opt('block', 'block')}
+      </select>
+      <button class="mini" data-act="save-setting" data-key="paste_guard_mode">save</button>
+      <div class="src-note">What the guard does when a paste into an AI tool
+      matches a marking or detector: warn asks the person, block stops it.
+      Baked into every extension policy artifact below.</div></dd>
+    <dt>Classification markings</dt><dd>
+      <textarea id="set-classification_markings" class="mfield" rows="4"
+        style="min-width:340px;resize:vertical;font-family:inherit"
+        placeholder="one marking per line (empty = the default set)">${marks === null ? '' : esc(marks.join('\n'))}</textarea>
+      <button class="mini" data-act="save-markings">save</button>
+      ${marksSet ? '<button class="mini" data-act="clear-markings">clear (default set)</button>' : ''}
+      <div class="src-note">Document phrases the guard scans pastes for, one
+      per line. Saving an empty box records "no markings" as a real choice;
+      clear falls back to the default five. Content never leaves the device -
+      the guard reports detector ids only.</div></dd>
+    ${settingRow('firefox_extension_id', 'Firefox extension ID (gecko id)',
+      'ai-guard@your-org.example',
+      'From browser_specific_settings.gecko.id in the manifest - a different'
+      + ' string from the Chromium id, for the same extension. Unlocks the'
+      + ' Firefox artifacts.')}
+    ${settingRow('extension_update_url', 'Chromium update manifest URL',
+      'https://files.example.com/updates.xml',
+      'Where the packed extension update manifest is hosted. Unlocks the'
+      + ' Windows Chromium deploy script.')}
+    ${settingRow('extension_xpi_url', 'Signed .xpi URL (Firefox)',
+      'https://files.example.com/ai-guard-1.0.0.xpi',
+      'The Mozilla-SIGNED file (addons.mozilla.org self-distribution) -'
+      + ' Firefox refuses unsigned extensions on release builds, and no'
+      + ' enterprise policy changes that. Unlocks the Firefox artifacts.')}`;
+}
+
 // The last result of a connection test, rendered where its button lives.
 function testNote(which) {
   const t = TESTS[which];
@@ -1593,13 +1639,23 @@ async function wizard() {
   <table><tr><th>tool</th><th>vendor</th><th>decision</th><th></th></tr>
   ${REGTOOLS.map(toolRow).join('')}</table></div>
 
-  <div class="wcard" style="margin-bottom:10px"><h3>5 · Browser extension ID</h3>
-  <p class="lede" style="margin-bottom:10px">The packed extension's 32-letter
-  id (extension/README.md shows how to derive it). It unlocks the
-  pre-configured policy download below.</p>
-  <input id="set-extid" class="mfield" style="min-width:340px"
-    placeholder="the browser extension's ID" value="${esc(eid)}">
-  <button class="mini" data-act="save-extid">save</button></div>
+  <div class="wcard" style="margin-bottom:10px"><h3>5 · Browser extension &amp; paste guard</h3>
+  <p class="lede" style="margin-bottom:10px">One extension does both jobs:
+  reporting which account is signed into an AI tool, and the paste guard
+  that warns or blocks when marked content is pasted into one. Chrome, Edge
+  and Brave install it by Chromium policy; Firefox by Mozilla policy from a
+  signed .xpi. Everything here is baked into the policy downloads in
+  step 7.</p>
+  <dl class="kv">
+    <dt>Chromium extension ID</dt><dd>
+      <input id="set-extid" class="mfield" style="min-width:340px"
+        placeholder="the 32-letter id from chrome://extensions" value="${esc(eid)}">
+      <button class="mini" data-act="save-extid">save</button>
+      <div class="src-note">The packed extension's 32-letter id
+      (extension/README.md shows how to derive it). Unlocks the Chromium
+      policy downloads.</div></dd>
+    ${pasteGuardFields()}
+  </dl></div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>6 · Alerting and Grafana (optional)</h3>
   <dl class="kv">
@@ -1620,7 +1676,10 @@ async function wizard() {
     <button class="mini" data-act="artifact" data-key="collector-macos">macOS collector</button>
     <button class="mini" data-act="artifact" data-key="collector-linux">Linux collector</button>
     <button class="mini" data-act="artifact" data-key="collector-windows">Windows collector</button>
-    <button class="mini" data-act="artifact" data-key="extension-policy">extension policy${eid ? '' : ' (needs step 5)'}</button>
+    <button class="mini" data-act="artifact" data-key="extension-policy">extension policy · Chromium macOS${eid ? '' : ' (needs step 5)'}</button>
+    <button class="mini" data-act="artifact" data-key="extension-windows">extension deploy · Chromium Windows</button>
+    <button class="mini" data-act="artifact" data-key="firefox-policy">extension policy · Firefox macOS</button>
+    <button class="mini" data-act="artifact" data-key="firefox-windows">extension deploy · Firefox Windows</button>
     <button class="mini" data-act="artifact" data-key="scanner-cronjob">scanner CronJob</button>
     <button class="mini" data-act="artifact" data-key="discovery-cronjob">discovery CronJob</button>
   </div>` : `<div class="note">No public receiver URL yet, so downloads cannot
@@ -1671,6 +1730,7 @@ function managedSettings() {
       <button class="mini" data-act="save-extid">save</button>
       <div class="src-note">Used to generate the extension's managed-policy
       artifact. Empty clears it.</div></dd>
+    ${pasteGuardFields()}
   </dl></div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>Receiver</h3>
@@ -2253,6 +2313,17 @@ async function managedAction(act, el) {
       alert('Could not clear the decision: ' + d);
     }
     REG = null; EV = null; render(); return;
+  }
+  if (act === 'save-markings' || act === 'clear-markings') {
+    const marks = act === 'clear-markings' ? null
+      : _val('set-classification_markings').split('\n')
+          .map(x => x.trim()).filter(Boolean);
+    const r = await mfetch('/api/settings',
+      {method: 'POST', body: JSON.stringify({classification_markings: marks})});
+    if (r.ok) { SETTINGS = await r.json(); SETMSG = 'Saved. Regenerate the extension artifacts to roll it out.'; }
+    else if (r.status === 401) { sessionLost(); return; }
+    else { let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {} SETMSG = 'Not saved: ' + d; }
+    render(); return;
   }
   if (act === 'save-setting') {
     const key = el.getAttribute('data-key');

--- a/portal/collector-scripts/extension-windows.ps1
+++ b/portal/collector-scripts/extension-windows.ps1
@@ -1,0 +1,293 @@
+<#
+    ai-guard browser extension: install and configure on Windows.
+
+    Deploy as an Intune platform script (Devices > Scripts and remediations >
+    Platform scripts). Settings that matter:
+
+        Run this script using the logged on credentials   No
+        Enforce script signature check                    No
+        Run script in 64 bit PowerShell Host              Yes
+
+    The first must be No: every key here is under HKLM and a user context
+    cannot write them. The third should be Yes. HKLM\SOFTWARE\Policies is one
+    of the keys shared between the 32 and 64 bit registry views rather than
+    redirected, so a 32 bit host would probably work, and "probably" is not
+    worth carrying on a fleet-wide policy.
+
+    This does what two Jamf payloads do on macOS. Chromium browsers read the
+    install policy from the browser's own policy key and the managed config
+    from a 3rdparty subkey, and neither is expressible as an Intune ADMX
+    setting: the 3rdparty path is arbitrary registry defined by the
+    extension's own managed schema, not a Chrome policy. So it is a script.
+
+    A script is also the only way to get the device identifier right.
+    %COMPUTERNAME% in a .reg file is a literal string to Chrome, not an
+    environment variable, and even expanded it would be the hostname. Every
+    other source keys a device on its hardware serial, and one that sends a
+    hostname splits that machine into two on any view that groups by device.
+
+    Idempotent. Safe to re-run, and re-running is how a changed token reaches
+    a machine that was already configured.
+#>
+
+# SupportsShouldProcess on the script itself, so -WhatIf reaches the helpers
+# below: $WhatIfPreference propagates to functions called in the same session,
+# but only because the caller declared it. Run it before a fleet rollout:
+#
+#     .\Deploy-AiGuardExtension.ps1 -WhatIf
+#
+# and it prints every key it would write and writes none of them.
+[CmdletBinding(SupportsShouldProcess)]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------- config --
+# Replace all three. EXTENSION_ID is the 32 character id Chrome derives from
+# the manifest key: read it from chrome://extensions on a machine that already
+# has it, not from anywhere else.
+$ExtensionId = 'REPLACE_WITH_EXTENSION_ID'
+$UpdatesXml  = 'https://REPLACE_WITH_HOST/updates.xml'
+$Endpoint    = 'https://REPLACE_WITH_HOST/report'
+$AuthToken   = 'REPLACE_WITH_TOKEN'
+
+$AllowedDomains = @('example.com')
+$PasteGuardMode = 'warn'
+$ClassificationMarkings = @(
+    'Client Confidential'
+    'Internal Confidential'
+    'Internal Use Only'
+    'Strictly Confidential'
+    'Commercial in Confidence'
+)
+
+# Chromium browsers on Windows, by policy root. All three read the same
+# schema, so they differ only in where the policy lives.
+#
+# Writing policy for a browser that is not installed is harmless: the key sits
+# unread until someone installs it, at which point the extension arrives with
+# it. That is the right default for a fleet where any of the three might be
+# installed later.
+#
+# Firefox is not here. It does not read extension policy from these keys, it
+# needs the Mozilla-signed .xpi rather than a .crx, and its managed storage is
+# keyed on the gecko id rather than the 32 character Chrome id. See
+# Deploy-AiGuardExtensionFirefox.ps1.
+$Browsers = @{
+    'Chrome' = 'HKLM:\SOFTWARE\Policies\Google\Chrome'
+    'Edge'   = 'HKLM:\SOFTWARE\Policies\Microsoft\Edge'
+    'Brave'  = 'HKLM:\SOFTWARE\Policies\BraveSoftware\Brave'
+}
+
+# ------------------------------------------------------------ device id --
+# Serials that are not serials. OEMs ship these in the BIOS field on machines
+# that were never given one, and they are worse than a hostname: a hostname
+# splits one machine into two, whereas fifty machines all reporting
+# "To Be Filled By O.E.M." collapse into one device and the other forty nine
+# disappear from every count.
+$BogusSerials = @(
+    'to be filled by o.e.m.'
+    'to be filled by oem'
+    'default string'
+    'system serial number'
+    'not specified'
+    'not applicable'
+    'none'
+    'invalid'
+    'o.e.m.'
+    '0'
+    '123456789'
+)
+
+function Get-DeviceIdentifier {
+    $serial = ''
+    try {
+        $serial = (Get-CimInstance Win32_BIOS -ErrorAction Stop).SerialNumber
+        if ($null -ne $serial) { $serial = $serial.Trim() }
+    } catch {
+        Write-Host "ai-guard: serial lookup failed ($($_.Exception.Message))"
+    }
+
+    if (-not $serial -or $BogusSerials -contains $serial.ToLower()) {
+        # Said out loud, because this changes what every finding from this
+        # machine is keyed on. One device reporting a hostname where the rest
+        # report serials reads as a deliberate difference rather than a
+        # placeholder BIOS, and it is worth someone seeing in the Intune
+        # script output.
+        Write-Host "ai-guard: BIOS serial is '$serial', using COMPUTERNAME instead"
+        return $env:COMPUTERNAME
+    }
+    return $serial
+}
+
+# --------------------------------------------------------------- helpers --
+function Set-RegValue {
+    <#
+        SupportsShouldProcess so the script can be dry-run. This writes policy
+        that applies to every browser on the machine, and being able to see
+        what it would do before it does it is worth four lines:
+
+            .\Deploy-AiGuardExtension.ps1 -WhatIf
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param($Path, $Name, $Value)
+    if (-not $PSCmdlet.ShouldProcess("$Path\$Name", 'Set registry value')) { return }
+    if (-not (Test-Path $Path)) { New-Item -Path $Path -Force | Out-Null }
+    New-ItemProperty -Path $Path -Name $Name -Value $Value `
+        -PropertyType String -Force | Out-Null
+}
+
+function ConvertTo-Hashtable {
+    <#
+        A hashtable from either a PSCustomObject or a hashtable.
+
+        ConvertFrom-Json returns a PSCustomObject, whose properties are the JSON
+        keys. A freshly created @{} is a hashtable, whose .PSObject.Properties
+        are the .NET collection's own members: IsFixedSize, Count, Keys,
+        SyncRoot and the rest. Enumerating the second as though it were the
+        first copies all of them into the policy.
+    #>
+    param($Object)
+    $out = @{}
+    if ($null -eq $Object) { return $out }
+    if ($Object -is [System.Collections.IDictionary]) {
+        foreach ($k in $Object.Keys) { $out[$k] = $Object[$k] }
+        return $out
+    }
+    foreach ($p in $Object.PSObject.Properties) { $out[$p.Name] = $p.Value }
+    return $out
+}
+
+
+function Get-ExtensionSettings {
+    <#
+        The existing ExtensionSettings for a browser, as a hashtable.
+
+        Read-modify-write, for the same reason the Firefox script does it: this
+        one value holds every extension's configuration, so writing ours
+        wholesale removes anything another policy put there. The Firefox script
+        had this from the start because a real machine turned out to have
+        SentinelOne's extension in that value; the Chromium script did not, and
+        overwrote it.
+
+        Unparseable existing content stops the script rather than being
+        replaced, because silently discarding a policy we cannot read is the
+        failure this is meant to prevent.
+    #>
+    param($Root)
+    if (-not (Test-Path $Root)) { return @{} }
+    $raw = (Get-ItemProperty -Path $Root -Name 'ExtensionSettings' -ErrorAction SilentlyContinue).ExtensionSettings
+    if (-not $raw) { return @{} }
+    try {
+        return ConvertTo-Hashtable ($raw | ConvertFrom-Json -ErrorAction Stop)
+    } catch {
+        Write-Host "ai-guard: existing ExtensionSettings at $Root is not valid JSON, refusing to overwrite it"
+        throw
+    }
+}
+
+
+function ConvertTo-JsonArray {
+    <#
+        A JSON array, even when there is one element.
+
+        `@('a') | ConvertTo-Json` returns the string "a", not ["a"], because the
+        pipeline unwraps a single-element array before ConvertTo-Json ever sees
+        it. The managed schema declares allowedDomains as an array and the
+        extension checks Array.isArray, so a scalar is discarded and the
+        built-in fallback list is used instead.
+
+        That failure is silent and looks like success: one corporate domain
+        configured, and the extension quietly running on its own defaults. It
+        was found by reading the registry after a deployment, not by anything
+        going wrong.
+
+        The unary comma wraps the value in an outer array so the pipeline has
+        something to unwrap, and PowerShell 5.1 is what Intune runs, so -AsArray
+        is not available.
+    #>
+    param([string[]]$Items)
+    if ($null -eq $Items -or $Items.Count -eq 0) { return '[]' }
+    if ($Items.Count -eq 1) { return ConvertTo-Json @(, $Items[0]) -Compress }
+    return ConvertTo-Json $Items -Compress
+}
+
+
+function Get-ForcelistIndex {
+    <#
+        The index to write this extension's forcelist entry at.
+
+        The forcelist is a set of numbered values, and the numbers are just
+        slots. Hardcoding "1" is how a script evicts whatever another policy
+        already force-installed there, which on a managed fleet is somebody
+        else's extension disappearing with no error and no obvious cause.
+
+        Returns the existing index if this extension is already listed, so
+        re-running updates in place rather than adding a duplicate. Otherwise
+        the lowest free number.
+
+        Write-Host rather than Write-Output for the progress line.
+        PowerShell collects everything a function writes to the output
+        stream as its return value, so a message here would come back
+        alongside the value. A -WhatIf run caught exactly that: the
+        forcelist value name came out as
+        "ai-guard: forcelist indexes 1 in use, taking 2 2".
+    #>
+    param($Path)
+    if (-not (Test-Path $Path)) { return '1' }
+
+    $existing = Get-ItemProperty -Path $Path -ErrorAction SilentlyContinue
+    $used = @()
+    foreach ($prop in $existing.PSObject.Properties) {
+        if ($prop.Name -notmatch '^\d+$') { continue }   # PSPath and friends
+        if ($prop.Value -like "$ExtensionId;*" -or $prop.Value -eq $ExtensionId) {
+            Write-Host "ai-guard: already at forcelist index $($prop.Name), updating in place"
+            return $prop.Name
+        }
+        $used += [int]$prop.Name
+    }
+
+    $i = 1
+    while ($used -contains $i) { $i++ }
+    if ($i -ne 1) { Write-Host "ai-guard: forcelist indexes $($used -join ', ') in use, taking $i" }
+    return "$i"
+}
+
+
+$DeviceId = Get-DeviceIdentifier
+Write-Output "ai-guard: device identifier = $DeviceId"
+
+# ExtensionSettings is what makes a browser poll a self-hosted updates.xml for
+# NEW versions. The forcelist alone installs the extension and then never
+# updates it, which is a fleet frozen on whatever version it first received.
+
+foreach ($name in $Browsers.Keys) {
+    $root = $Browsers[$name]
+
+    # Install
+    Set-RegValue "$root\ExtensionInstallForcelist" `
+        (Get-ForcelistIndex "$root\ExtensionInstallForcelist") `
+        "$ExtensionId;$UpdatesXml"
+    $settings = Get-ExtensionSettings $root
+    $settings[$ExtensionId] = @{
+        installation_mode   = 'force_installed'
+        update_url          = $UpdatesXml
+        override_update_url = $true
+    }
+    Set-RegValue $root 'ExtensionSettings' ($settings | ConvertTo-Json -Compress -Depth 10)
+
+    # Config. Lists are JSON strings: the managed storage schema declares them
+    # as arrays and the registry has no array type Chrome will read here.
+    $policy = "$root\3rdparty\extensions\$ExtensionId\policy"
+    Set-RegValue $policy 'reportEndpoint'   $Endpoint
+    Set-RegValue $policy 'authToken'        $AuthToken
+    Set-RegValue $policy 'deviceIdentifier' $DeviceId
+    Set-RegValue $policy 'pasteGuardMode'   $PasteGuardMode
+    Set-RegValue $policy 'allowedDomains'         (ConvertTo-JsonArray $AllowedDomains)
+    Set-RegValue $policy 'classificationMarkings' (ConvertTo-JsonArray $ClassificationMarkings)
+
+    Write-Output "ai-guard: configured $name"
+}
+
+Write-Output "ai-guard: done. The extension appears after the browser restarts."
+exit 0

--- a/portal/collector-scripts/firefox-windows.ps1
+++ b/portal/collector-scripts/firefox-windows.ps1
@@ -1,0 +1,216 @@
+<#
+    ai-guard browser extension: install and configure on Firefox for Windows.
+
+    Separate from the Chromium script because almost nothing is shared. Firefox
+    needs the Mozilla-signed .xpi rather than a .crx, installs from the file
+    directly rather than polling an update manifest, keys managed storage on
+    the gecko id rather than the 32 character Chrome id, and stores policy as
+    JSON in a single registry value rather than as individual values.
+
+    Deploy as an Intune platform script alongside the Chromium one. Same
+    settings:
+
+        Run this script using the logged on credentials   No
+        Enforce script signature check                    No
+        Run script in 64 bit PowerShell Host              Yes
+
+    Firefox reads enterprise policy from one of three places, in order:
+    HKLM\SOFTWARE\Policies\Mozilla\Firefox, a policies.json next to the
+    binary, or the same key under HKCU. This writes the HKLM key, which
+    survives a Firefox reinstall where policies.json does not.
+
+    Idempotent, and deliberately a read-modify-write: another policy may
+    already own ExtensionSettings or 3rdparty, and clobbering it would silently
+    remove someone else's extension.
+#>
+
+# SupportsShouldProcess on the script itself, so -WhatIf reaches the helpers
+# below: $WhatIfPreference propagates to functions called in the same session,
+# but only because the caller declared it. Run it before a fleet rollout:
+#
+#     .\Deploy-AiGuardExtensionFirefox.ps1 -WhatIf
+#
+# and it prints every key it would write and writes none of them.
+[CmdletBinding(SupportsShouldProcess)]
+param()
+
+$ErrorActionPreference = 'Stop'
+
+# ---------------------------------------------------------------- config --
+# GeckoId must match browser_specific_settings.gecko.id in the manifest.
+# XpiUrl is the SIGNED .xpi returned by addons.mozilla.org, not the one you
+# built: Firefox refuses unsigned extensions on release builds.
+$GeckoId   = 'REPLACE_WITH_GECKO_ID'
+$XpiUrl    = 'https://REPLACE_WITH_HOST/ai-guard-1.0.0.xpi'
+$Endpoint  = 'https://REPLACE_WITH_HOST/report'
+$AuthToken = 'REPLACE_WITH_TOKEN'
+
+$AllowedDomains = @('example.com')
+$PasteGuardMode = 'warn'
+$ClassificationMarkings = @(
+    'Client Confidential'
+    'Internal Confidential'
+    'Internal Use Only'
+    'Strictly Confidential'
+    'Commercial in Confidence'
+)
+
+$FirefoxPolicies = 'HKLM:\SOFTWARE\Policies\Mozilla\Firefox'
+
+# ------------------------------------------------------------ device id --
+# Serials that are not serials. OEMs ship these in the BIOS field on machines
+# that were never given one, and they are worse than a hostname: a hostname
+# splits one machine into two, whereas fifty machines all reporting
+# "To Be Filled By O.E.M." collapse into one device and the other forty nine
+# disappear from every count.
+$BogusSerials = @(
+    'to be filled by o.e.m.'
+    'to be filled by oem'
+    'default string'
+    'system serial number'
+    'not specified'
+    'not applicable'
+    'none'
+    'invalid'
+    'o.e.m.'
+    '0'
+    '123456789'
+)
+
+function Get-DeviceIdentifier {
+    $serial = ''
+    try {
+        $serial = (Get-CimInstance Win32_BIOS -ErrorAction Stop).SerialNumber
+        if ($null -ne $serial) { $serial = $serial.Trim() }
+    } catch {
+        Write-Host "ai-guard: serial lookup failed ($($_.Exception.Message))"
+    }
+
+    if (-not $serial -or $BogusSerials -contains $serial.ToLower()) {
+        Write-Host "ai-guard: BIOS serial is '$serial', using COMPUTERNAME instead"
+        return $env:COMPUTERNAME
+    }
+    return $serial
+}
+
+# --------------------------------------------------------------- helpers --
+function ConvertTo-Hashtable {
+    <#
+        A hashtable from either a PSCustomObject or a hashtable.
+
+        This exists because the two arrive by different routes and only one of
+        them can be enumerated with .PSObject.Properties. ConvertFrom-Json
+        returns a PSCustomObject, whose properties are the JSON keys. A freshly
+        created @{} is a hashtable, whose .PSObject.Properties are the .NET
+        collection's own members: IsFixedSize, Count, IsSynchronized,
+        IsReadOnly, Keys, Values, SyncRoot.
+
+        Enumerating a hashtable that way copied all seven into the policy, so a
+        machine with no existing 3rdparty value ended up with an Extensions
+        object containing "Count": 0 alongside the real entry. It only happened
+        on first install, which is why a merge tested against existing JSON did
+        not show it.
+    #>
+    param($Object)
+    $out = @{}
+    if ($null -eq $Object) { return $out }
+    if ($Object -is [System.Collections.IDictionary]) {
+        foreach ($k in $Object.Keys) { $out[$k] = $Object[$k] }
+        return $out
+    }
+    foreach ($p in $Object.PSObject.Properties) { $out[$p.Name] = $p.Value }
+    return $out
+}
+
+
+function Get-JsonPolicy {
+    <#
+        The existing value of a JSON policy, as a hashtable, or an empty one.
+
+        Read-modify-write rather than overwrite. ExtensionSettings and 3rdparty
+        are single values holding every extension's configuration, so writing
+        ours wholesale would remove any other extension the organisation
+        deploys. Unparseable existing content is left alone and reported:
+        replacing something we cannot read is how a working policy disappears.
+
+        Write-Host rather than Write-Output for the progress line.
+        PowerShell collects everything a function writes to the output
+        stream as its return value, so a message here would come back
+        alongside the value. A -WhatIf run caught exactly that: the
+        forcelist value name came out as
+        "ai-guard: forcelist indexes 1 in use, taking 2 2".
+    #>
+    param($Path, $Name)
+    if (-not (Test-Path $Path)) { return @{} }
+    $raw = (Get-ItemProperty -Path $Path -Name $Name -ErrorAction SilentlyContinue).$Name
+    if (-not $raw) { return @{} }
+    try {
+        $obj = $raw | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        Write-Host "ai-guard: existing $Name is not valid JSON, refusing to overwrite it"
+        throw
+    }
+    return ConvertTo-Hashtable $obj
+}
+
+function Set-JsonPolicy {
+    <#
+        SupportsShouldProcess so the script can be dry-run. This rewrites a
+        policy value that holds every extension's configuration, so seeing what
+        it would write before it writes it is worth having:
+
+            .\Deploy-AiGuardExtensionFirefox.ps1 -WhatIf
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param($Path, $Name, $Value)
+    if (-not $PSCmdlet.ShouldProcess("$Path\$Name", 'Set policy value')) { return }
+    if (-not (Test-Path $Path)) { New-Item -Path $Path -Force | Out-Null }
+    New-ItemProperty -Path $Path -Name $Name `
+        -Value ($Value | ConvertTo-Json -Compress -Depth 10) `
+        -PropertyType String -Force | Out-Null
+}
+
+$DeviceId = Get-DeviceIdentifier
+Write-Output "ai-guard: device identifier = $DeviceId"
+
+# Policies must be switched on at all, or every setting below is ignored.
+if ($PSCmdlet.ShouldProcess($FirefoxPolicies, 'Enable enterprise policies')) {
+    if (-not (Test-Path $FirefoxPolicies)) {
+        New-Item -Path $FirefoxPolicies -Force | Out-Null
+    }
+    New-ItemProperty -Path $FirefoxPolicies -Name 'EnterprisePoliciesEnabled' `
+        -Value 1 -PropertyType DWord -Force | Out-Null
+}
+
+# ---- install ----
+# install_url, not update_url. Firefox installs from the .xpi and then polls
+# the manifest's own gecko.update_url for new versions, so there is no
+# override_update_url equivalent and none is needed.
+$settings = Get-JsonPolicy $FirefoxPolicies 'ExtensionSettings'
+$settings[$GeckoId] = @{
+    installation_mode = 'force_installed'
+    install_url       = $XpiUrl
+    updates_disabled  = $false
+}
+Set-JsonPolicy $FirefoxPolicies 'ExtensionSettings' $settings
+
+# ---- config ----
+# Managed storage lives under 3rdparty > Extensions > the GECKO id. The Chrome
+# 32 character id is a different string for the same extension and will not
+# work here.
+$thirdParty = Get-JsonPolicy $FirefoxPolicies '3rdparty'
+$extensions = ConvertTo-Hashtable $thirdParty['Extensions']
+$extensions[$GeckoId] = @{
+    reportEndpoint         = $Endpoint
+    authToken              = $AuthToken
+    deviceIdentifier       = $DeviceId
+    pasteGuardMode         = $PasteGuardMode
+    allowedDomains         = $AllowedDomains
+    classificationMarkings = $ClassificationMarkings
+}
+$thirdParty['Extensions'] = $extensions
+Set-JsonPolicy $FirefoxPolicies '3rdparty' $thirdParty
+
+Write-Output "ai-guard: configured Firefox"
+Write-Output "ai-guard: done. Check about:policies on the device after a restart."
+exit 0

--- a/portal/tests/test_extension_artifacts.py
+++ b/portal/tests/test_extension_artifacts.py
@@ -1,0 +1,163 @@
+"""The extension artifact matrix: one policy story, four downloads.
+
+The paste guard is the extension, and its settings (mode, markings) are
+central Settings baked into every generated artifact - so the properties
+under test are: the settings actually land in the files; absent settings
+fall back to the documented defaults (warn, the five markings); an
+explicitly saved empty markings list is honoured as a choice; Firefox
+artifacts are gated on the gecko id and the SIGNED .xpi URL because
+without them the policy is a no-op; and nothing that could escape its
+quoting context can be embedded.
+"""
+
+import os
+from pathlib import Path
+
+os.environ.setdefault("PORTAL_AUTH", "none")
+
+import pytest
+from fastapi import HTTPException
+
+from app import main, managed
+
+SCRIPTS = Path(__file__).parent.parent / "collector-scripts"
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setattr(main, "RECEIVER_URL", "http://receiver.internal:8080")
+    monkeypatch.setattr(main, "RECEIVER_PUBLIC_URL", "https://rx.example.com")
+    monkeypatch.setattr(main, "COLLECTOR_SCRIPTS_DIR", str(SCRIPTS))
+
+
+def _receiver_with(settings):
+    def fake(base, method, path, admin_token, body=None):
+        if path == "/admin/settings":
+            return {"settings": settings}
+        if method == "POST" and path == "/admin/enrollment-tokens":
+            return {"id": "tok1", "token": "aige_MINTED",
+                    "expires_at": "2027-01-01T00:00:00+00:00"}
+        return {}
+    return fake
+
+
+BASE_SETTINGS = {
+    "extension_id": {"value": "a" * 32, "source": "db"},
+    "firefox_extension_id": {"value": "ai-guard@corp.example", "source": "db"},
+    "extension_update_url": {"value": "https://files.corp.example/updates.xml",
+                             "source": "db"},
+    "extension_xpi_url": {"value": "https://files.corp.example/ai-guard.xpi",
+                          "source": "db"},
+    "corp_domains": {"value": ["corp.example"], "source": "db"},
+}
+
+
+@pytest.fixture
+def receiver(monkeypatch, configured):
+    def install(extra=None):
+        settings = {**BASE_SETTINGS, **(extra or {})}
+        monkeypatch.setattr(main.managed, "receiver_request",
+                            _receiver_with(settings))
+    install()
+    return install
+
+
+def _body(kind):
+    return main.artifact(kind, _=None, token="t").body.decode()
+
+
+# ------------------------------------------------- settings land in files --
+
+
+def test_defaults_when_nothing_is_saved(receiver):
+    plist = _body("extension-policy")
+    assert "<string>warn</string>" in plist
+    for m in managed.DEFAULT_MARKINGS:
+        assert m in plist
+
+
+def test_saved_mode_and_markings_reach_all_four_artifacts(receiver):
+    receiver({"paste_guard_mode": {"value": "block", "source": "db"},
+              "classification_markings": {"value": ["Top Secret"],
+                                          "source": "db"}})
+    plist = _body("extension-policy")
+    assert "<string>block</string>" in plist
+    assert "Top Secret" in plist and "Client Confidential" not in plist
+
+    ff = _body("firefox-policy")
+    assert "<key>ai-guard@corp.example</key>" in ff
+    assert "<string>block</string>" in ff and "Top Secret" in ff
+    assert "https://files.corp.example/ai-guard.xpi" in ff
+
+    win = _body("extension-windows")
+    assert "$PasteGuardMode = 'block'" in win
+    assert "$ClassificationMarkings = @('Top Secret')" in win
+    assert "$ExtensionId = '%s'" % ("a" * 32) in win
+    assert "$UpdatesXml  = 'https://files.corp.example/updates.xml'" in win
+    assert "$AuthToken   = 'aige_MINTED'" in win
+
+    ffwin = _body("firefox-windows")
+    assert "$GeckoId   = 'ai-guard@corp.example'" in ffwin
+    assert "$XpiUrl    = 'https://files.corp.example/ai-guard.xpi'" in ffwin
+    assert "$AllowedDomains = @('corp.example')" in ffwin
+
+
+def test_an_explicitly_empty_markings_list_is_a_choice_not_a_fallback(receiver):
+    receiver({"classification_markings": {"value": [], "source": "db"}})
+    plist = _body("extension-policy")
+    assert "Client Confidential" not in plist
+
+
+# --------------------------------------------------------------- the gates --
+
+
+def test_firefox_artifacts_are_gated_on_the_gecko_id(receiver):
+    receiver({"firefox_extension_id": {"value": "", "source": "unset"}})
+    for kind in ("firefox-policy", "firefox-windows"):
+        with pytest.raises(HTTPException) as e:
+            main.artifact(kind, _=None, token="t")
+        assert e.value.status_code == 409
+        assert "gecko" in e.value.detail
+
+
+def test_firefox_artifacts_are_gated_on_the_signed_xpi(receiver):
+    receiver({"extension_xpi_url": {"value": "", "source": "unset"}})
+    with pytest.raises(HTTPException) as e:
+        main.artifact("firefox-policy", _=None, token="t")
+    assert e.value.status_code == 409
+    assert "signed" in e.value.detail
+
+
+def test_the_windows_chromium_script_is_gated_on_the_update_url(receiver):
+    receiver({"extension_update_url": {"value": "", "source": "unset"}})
+    with pytest.raises(HTTPException) as e:
+        main.artifact("extension-windows", _=None, token="t")
+    assert e.value.status_code == 409
+    assert "update URL" in e.value.detail
+
+
+# ------------------------------------------------------------ embeddability --
+
+
+def test_a_marking_that_could_escape_its_quoting_is_refused():
+    for bad in ("it's secret", 'say "no"', "a`b", "a$b", "a<b>"):
+        with pytest.raises(managed.ArtifactError):
+            managed._checked_markings([bad])
+
+
+def test_markings_with_spaces_are_legitimate():
+    assert managed._checked_markings(["Commercial in Confidence"]) == [
+        "Commercial in Confidence"]
+
+
+def test_a_quote_in_a_powershell_value_cannot_break_out():
+    # Defence in depth behind the refusal: if it were ever loosened, the
+    # doubled quote keeps the literal a literal.
+    assert managed._ps_str("it's") == "'it''s'"
+
+
+def test_an_empty_domain_list_bakes_an_empty_array_not_the_placeholder(receiver):
+    receiver({"corp_domains": {"value": [], "source": "unset"}})
+    win = _body("firefox-windows")
+    assert "$AllowedDomains = @()" in win
+    assert "@('example.com')" not in win

--- a/portal/tests/test_managed_portal.py
+++ b/portal/tests/test_managed_portal.py
@@ -36,6 +36,10 @@ def test_the_script_copies_match_their_sources():
         ("collector-macos.sh", "endpoint/macos/ai-guard-collector.sh"),
         ("collector-linux.sh", "endpoint/linux/ai-guard-collector.sh"),
         ("collector-windows.ps1", "endpoint/windows/ai-guard-collector.ps1"),
+        ("extension-windows.ps1",
+         "extension/deploy/windows/Deploy-AiGuardExtension.ps1"),
+        ("firefox-windows.ps1",
+         "extension/deploy/windows/Deploy-AiGuardExtensionFirefox.ps1"),
     ]
     for copy, source in pairs:
         assert (SCRIPTS / copy).read_bytes() == (REPO / source).read_bytes(), (

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -997,7 +997,17 @@ _STR_SETTINGS = (
     ("grafana_panels", False, 2000),
     ("grafana_dashboard_uid", False, 128),
     ("overview_widgets", False, 500),
+    # Where the packed extension is served from: the Chromium update
+    # manifest, and the Mozilla-signed .xpi. The portal bakes these into
+    # the Windows deploy scripts and the Firefox policy.
+    ("extension_update_url", True, 500),
+    ("extension_xpi_url", True, 500),
 )
+
+# What the paste guard does when a marked document is pasted into an AI
+# tool. Baked into every extension policy artifact; "warn" is the default
+# when unset, matching the extension's own default.
+_PASTE_GUARD_MODES = ("off", "warn", "block")
 SECRET_SETTINGS = ("log_store_password",)
 
 
@@ -1018,6 +1028,12 @@ class SettingsUpdate(BaseModel):
     grafana_panels: str | None = Field(default=None, max_length=2000)
     grafana_dashboard_uid: str | None = Field(default=None, max_length=128)
     overview_widgets: str | None = Field(default=None, max_length=500)
+    extension_update_url: str | None = Field(default=None, max_length=500)
+    extension_xpi_url: str | None = Field(default=None, max_length=500)
+    paste_guard_mode: str | None = Field(default=None, max_length=8)
+    firefox_extension_id: str | None = Field(default=None, max_length=128)
+    classification_markings: list[str] | None = Field(default=None,
+                                                      max_length=50)
 
 
 @app.get("/admin/settings")
@@ -1074,6 +1090,15 @@ def get_settings(authorization: str = Header(default="")):
         "grafana_panels": plain("grafana_panels"),
         "grafana_dashboard_uid": plain("grafana_dashboard_uid"),
         "overview_widgets": plain("overview_widgets"),
+        "extension_update_url": plain("extension_update_url"),
+        "extension_xpi_url": plain("extension_xpi_url"),
+        "paste_guard_mode": plain("paste_guard_mode"),
+        "firefox_extension_id": plain("firefox_extension_id"),
+        "classification_markings": {
+            "value": stored.get("classification_markings"),
+            "source": ("db" if stored.get("classification_markings")
+                       is not None else "unset"),
+        },
     }}
 
 
@@ -1128,6 +1153,43 @@ def put_settings(req: SettingsUpdate, authorization: str = Header(default="")):
 
     if "onboarding_done" in req.model_fields_set:
         STATE.set_setting("onboarding_done", req.onboarding_done, by)
+
+    if "paste_guard_mode" in req.model_fields_set:
+        mode = (req.paste_guard_mode or "").strip()
+        if not mode:
+            STATE.set_setting("paste_guard_mode", None, by)
+        elif mode not in _PASTE_GUARD_MODES:
+            raise HTTPException(422, "paste_guard_mode must be one of: %s"
+                                % ", ".join(_PASTE_GUARD_MODES))
+        else:
+            STATE.set_setting("paste_guard_mode", mode, by)
+
+    if "firefox_extension_id" in req.model_fields_set:
+        fid = (req.firefox_extension_id or "").strip()
+        if not fid:
+            STATE.set_setting("firefox_extension_id", None, by)
+        else:
+            if any(c.isspace() or ord(c) < 32 for c in fid):
+                raise HTTPException(
+                    422, "firefox extension id cannot contain whitespace")
+            STATE.set_setting("firefox_extension_id", fid, by)
+
+    if "classification_markings" in req.model_fields_set:
+        if req.classification_markings is None:
+            STATE.set_setting("classification_markings", None, by)
+        else:
+            marks = [m.strip() for m in req.classification_markings
+                     if m and m.strip()]
+            for m in marks:
+                if len(m) > 120:
+                    raise HTTPException(422, "marking too long: %s" % m[:60])
+                if any(ord(c) < 32 for c in m):
+                    raise HTTPException(
+                        422, "marking cannot contain control characters")
+            # An explicit empty list is a real choice (no markings, guard
+            # only reports detector hits) and is stored as one; null
+            # deletes, falling back to the artifact default set.
+            STATE.set_setting("classification_markings", marks, by)
 
     for key, is_url, _max in _STR_SETTINGS:
         if key not in req.model_fields_set:

--- a/receiver/tests/test_settings.py
+++ b/receiver/tests/test_settings.py
@@ -237,3 +237,64 @@ def test_a_database_from_before_settings_gains_the_tables(tmp_path):
     assert st.get_settings() == {}
     assert st.list_decisions() == []
     assert st.list_tokens()[0]["id"] == "t1"
+
+
+# ------------------------------------- paste guard and extension delivery --
+# Settings baked into the portal's extension artifacts. The receiver only
+# stores and validates; what warrants tests is the validation - a mode
+# outside the enum or a marking that could carry control characters must
+# never reach an artifact generator.
+
+
+def test_paste_guard_mode_is_an_enum(managed):
+    ok = client.put("/admin/settings", headers=ADMIN,
+                    json={"paste_guard_mode": "block"})
+    assert ok.status_code == 200
+    got = client.get("/admin/settings", headers=ADMIN).json()["settings"]
+    assert got["paste_guard_mode"] == {"value": "block", "source": "db"}
+    bad = client.put("/admin/settings", headers=ADMIN,
+                     json={"paste_guard_mode": "loud"})
+    assert bad.status_code == 422
+    assert "off, warn, block" in bad.json()["detail"]
+
+
+def test_markings_store_as_a_list_and_empty_is_a_choice(managed):
+    client.put("/admin/settings", headers=ADMIN,
+               json={"classification_markings": [" Top Secret ", "", "Internal"]})
+    got = client.get("/admin/settings", headers=ADMIN).json()["settings"]
+    assert got["classification_markings"] == {
+        "value": ["Top Secret", "Internal"], "source": "db"}
+    # An explicit empty list is stored (no markings, on purpose); null
+    # deletes and the source goes back to unset.
+    client.put("/admin/settings", headers=ADMIN,
+               json={"classification_markings": []})
+    got = client.get("/admin/settings", headers=ADMIN).json()["settings"]
+    assert got["classification_markings"] == {"value": [], "source": "db"}
+    client.put("/admin/settings", headers=ADMIN,
+               json={"classification_markings": None})
+    got = client.get("/admin/settings", headers=ADMIN).json()["settings"]
+    assert got["classification_markings"]["source"] == "unset"
+
+
+def test_a_marking_with_control_characters_is_refused(managed):
+    bad = client.put("/admin/settings", headers=ADMIN,
+                     json={"classification_markings": ["a\nb"]})
+    assert bad.status_code == 422
+
+
+def test_the_firefox_id_refuses_whitespace(managed):
+    ok = client.put("/admin/settings", headers=ADMIN,
+                    json={"firefox_extension_id": "ai-guard@corp.example"})
+    assert ok.status_code == 200
+    bad = client.put("/admin/settings", headers=ADMIN,
+                     json={"firefox_extension_id": "ai guard@x"})
+    assert bad.status_code == 422
+
+
+def test_the_delivery_urls_must_be_urls(managed):
+    for key in ("extension_update_url", "extension_xpi_url"):
+        bad = client.put("/admin/settings", headers=ADMIN, json={key: "files/x"})
+        assert bad.status_code == 422, key
+        ok = client.put("/admin/settings", headers=ADMIN,
+                        json={key: "https://files.corp.example/x"})
+        assert ok.status_code == 200, key


### PR DESCRIPTION
Increment 3: the paste guard becomes portal-configurable, and the extension deploy story covers Firefox and Windows with generated artifacts — no more hand-editing REPLACE_WITH placeholders.

## Settings (receiver + portal)

- **`paste_guard_mode`** — off/warn/block, enum-validated at the receiver. Unset means warn, matching the extension's own default.
- **`classification_markings`** — a list; whitespace-trimmed, control characters refused. An explicitly saved **empty list is a recorded choice** ("no markings, on purpose"); null deletes and falls back to the default five at artifact time.
- **`firefox_extension_id`** (the gecko id — a different string from the Chromium id, for the same extension), **`extension_update_url`** (Chromium update manifest), **`extension_xpi_url`** (the Mozilla-signed .xpi) — the delivery URLs the portal cannot derive.

## The artifact matrix (each mints its own revocable enrollment token)

| Artifact | Platform | Notes |
|---|---|---|
| extension policy | Chromium · macOS | existing plist, now carrying the saved mode + markings instead of hardcodes |
| extension deploy script | Chromium · Windows | pre-configured `Deploy-AiGuardExtension.ps1`, gated on the update-manifest URL |
| Firefox policy | Firefox · macOS | install-and-configure plist under `org.mozilla.firefox`: force-install from the signed .xpi + managed storage under `3rdparty` keyed on the gecko id |
| Firefox deploy script | Firefox · Windows | pre-configured `Deploy-AiGuardExtensionFirefox.ps1` |

The Windows scripts are generated from **byte-verified copies** of `extension/deploy/windows/*` (the byte-equality test now covers them) by anchor substitution on the scripts' own config blocks — an anchor that stops matching fails loudly at generate time. PowerShell values are single-quote-escaped so nothing can break out of a literal; markings are validated for both contexts they land in (XML text, PS strings) while keeping spaces legitimate. An empty corp-domains list bakes `@()` rather than deploying the `example.com` placeholder.

Firefox artifacts are gated (409 with the reason) on the gecko id and the signed .xpi URL, because Firefox refuses unsigned extensions on release builds and no enterprise policy changes that — the artifact without them would be a no-op. Signing still goes through addons.mozilla.org self-distribution (documented in extension/README.md).

## UI + copy

- Wizard step 5 is now **"Browser extension & paste guard"**: Chromium id, gecko id, the two delivery URLs, a mode select, and a markings textarea — mirrored under Settings. Step 7 lists all four downloads plus the CronJobs.
- Setup rows now say plainly: the paste guard **is** the accounts extension, one install, its behaviour set here and baked into the same artifacts; and the browser row describes the full matrix including Firefox.
- extension/README.md's managed-mode paragraph rewritten to match.

## Tests

- Portal `test_extension_artifacts.py` (10): settings land in all four artifacts; defaults when unset; empty-markings-as-choice; the three 409 gates; embeddability refusals; PS quote-doubling; empty-domains `@()`.
- Receiver settings tests (5): mode enum, markings list semantics (trim/empty/null), control-character refusal, gecko-id whitespace refusal, URL-shape checks on the delivery URLs.
- Byte-equality pairs extended to the two deploy scripts.

Suites: receiver 128, portal 334, discovery 37 — all passing (rebased on main after #136).