### PR TITLE
Release v0.10.0

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.10.1
+version: 0.10.2
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.9.9"
+appVersion: "0.10.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -94,14 +94,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.9
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.10.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.9
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.10.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -135,7 +135,7 @@ On the compose route it is already there, on port 8091. Otherwise:
 docker run --rm -p 8091:8091 \
   -e LOKI_URL=http://your-loki:3100 \
   -e PORTAL_USER=admin -e PORTAL_PASSWORD=... \
-  ghcr.io/amansk5/shadow-ai-guard/portal:0.9.9
+  ghcr.io/amansk5/shadow-ai-guard/portal:0.10.0
 ```
 
 It refuses to start without authentication, because it names who runs what on

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.9.9
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.10.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Version bumps for the v0.10.0 release: chart `0.10.1 -> 0.10.2`, `appVersion 0.10.0`, and the three image pins (docs/getting-started.md, docs/deployment/kubernetes.md, receiver/deploy/receiver.yaml) to `0.10.0`.

On merge I'll tag `v0.10.0`, which builds and pushes the images and publishes chart `0.10.2` to the OCI registry.

Draft release notes (published on the tag):

---

# v0.10.0 — the review queue replaces the pipeline

New AI tools found in your estate now flow into the portal on their own and wait for one click: define or dismiss. No repo edit, no rebuild, no merge request, no forge.

## The candidates queue (#135)

- The receiver grows a **candidates queue**: tools observed in the estate that nobody has defined. Reporting credentials can suggest; only an admin can define. Every field is re-validated server-side.
- The **discovery service posts there by default** — same DNS-telemetry → registry-filter → LLM-classify pipeline, new destination. (GitLab config still selects the original MR mode for teams whose registry review lives in a forge.)
- The portal review queue shows **"New AI tools found"** — name, domains, device count, confidence — with **Add to registry** (prefilled editor; saving the entry resolves the candidate) and **Dismiss** (a stored decision later runs cannot reopen).
- Setup gains a pre-configured **discovery CronJob** download: enrollment token minted per download, telemetry/classification credentials named as comments for your own Secret.

## Unknown MCP servers join the queue (#136)

The endpoint collectors' one raw signal — MCP server names from machines' config files — feeds the same queue at ingest: an unknown server appears as an "MCP server" candidate with a distinct-device count (a re-scan is not a second machine). Servers matching a registry tool are recognised as known. Resolution: add an entry whose id is the server's slug — exactly what the prefill produces.

## Paste guard as a setting; the Firefox artifact matrix (#137)

- **`paste_guard_mode`** (off/warn/block) and **`classification_markings`** are now central Settings, baked into every generated extension policy — the only channel the extension reads. An explicitly saved empty markings list is honoured as a choice.
- The extension deploy downloads now cover the full matrix, each minting its own revocable enrollment token: **Chromium policy (macOS)**, **Chromium deploy script (Windows)**, **Firefox policy (macOS)** and **Firefox deploy script (Windows)**. Firefox artifacts are keyed on the gecko id and install the **Mozilla-signed .xpi** (its URL is a setting — no enterprise policy waives Mozilla signing; sign via addons.mozilla.org self-distribution).
- Wizard step 5 is now **"Browser extension & paste guard"** with everything in one place, and the Setup copy says plainly: the paste guard IS the accounts extension — one install, one policy.

## Upgrade notes

No breaking changes. New settings default sensibly (paste guard warns, the default marking set applies); existing extension policies keep working until regenerated. The discovery CronJob is opt-in via the Setup download; its DNS input is currently SentinelOne Deep Visibility (a generic DNS-log input is the planned fast-follow).

## Images & chart

- `ghcr.io/amansk5/shadow-ai-guard/receiver:0.10.0`
- `ghcr.io/amansk5/shadow-ai-guard/portal:0.10.0`
- Helm chart `0.10.2` — `oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard`