### PR TITLE
Tidy up the docs and portal wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Shadow AI Guard detects AI usage across the places it actually appears, then
 correlates the findings so you can see the tools, accounts, users, devices and
 sources behind it.
 
-It is self-hosted, runs on infrastructure you probably already have for roughly
-the cost of nothing, and keeps AI governance close to the evidence rather than
-behind another SaaS platform.
+It is self-hosted and free. If you already run Docker or Kubernetes and a log
+stack, you have everything it needs. There is no SaaS platform behind it and
+nothing leaves your infrastructure.
 
 ## Contents
 
@@ -102,14 +102,13 @@ into the same downstream pipeline.
 
 ## Know your coverage
 
-A quiet source is not the same thing as a clean source.
+A source that reports nothing might be clean, or it might be broken. Those look
+identical on a dashboard, so the portal tells you the difference: which
+detection sources are reporting, which are set up but silent, and which you
+have not enabled yet.
 
-The portal shows which detection sources are reporting, which are configured
-but silent, and what still needs to be enabled. That matters because a green
-dashboard is only useful if you know what it can actually see.
-
-From the same findings, the portal derives relationships that are awkward to
-answer from a flat log stream:
+From the same findings, the portal also answers questions that are hard to get
+out of a flat log stream:
 
 - which tools a device has
 - which devices a person uses
@@ -206,13 +205,13 @@ MCP scanner ───────┘       │
 - **endpoint**: collectors for macOS, Windows and Linux. These read local AI
   tool configuration to report which account each tool is signed into. This is
   the data most API-level products do not have.
-- **discovery**: a scheduled job that classifies unrecognised AI-looking
-  domains from DNS telemetry and posts them to the portal's review queue as
-  candidates - "new AI tool found on N devices" - where defining or
-  dismissing each one is a human decision. Deployable from the portal as a
-  pre-configured CronJob. (With GitLab configured it opens merge requests
-  against the registry instead, for teams whose registry review lives in a
-  forge.)
+- **discovery**: a scheduled job that looks at your fleet's DNS activity,
+  filters out domains the registry already knows, and asks an LLM whether the
+  rest look like AI services. Anything that does shows up in the portal's
+  review queue as "new AI tool found on N devices". You then add it to the
+  registry with one click, or dismiss it. Nothing is detected until a person
+  decides. The portal generates a ready-to-apply CronJob for it. (If you set
+  the GitLab variables it opens merge requests against the registry instead.)
 - **portal**: the governance and relationship view. Findings arrive as isolated
   events; the portal correlates them into people, devices, tools and
   detection-source health. It reads from Loki, holds no database and is not in
@@ -271,35 +270,49 @@ that can run a container on a schedule.
 
 ## Two ways to run it
 
-**Managed (the default).** Zero-touch: one install command, a setup code,
-and everything else in the portal - the log store, corporate domains,
-governance decisions, registry additions for tools upstream does not know,
-per-device credentials with one-click revocation, and pre-configured
-deployment downloads for every surface. Configuration lives in the
-receiver's small state database and reaches the fleet at runtime; nobody
-needs this repository for anything but reading.
+**Managed (the default).** You install it once, log into the portal, and do
+everything else there: connect the log store, set your corporate domains,
+approve tools, add new tools to detection, enroll and revoke devices, and
+download pre-configured deployment files for every surface. You never need to
+touch this repository again after the install.
 
-**Classic (`managed.enabled=false`, or the compose classic overlay).** The
-file-and-environment deployment for teams that want full edit control and
-a review trail in their own repo: clone, and everything is a file or an
-env var - `governance.yaml` for decisions, `registry/registry.yaml` for
-detection identifiers, `CORP_DOMAINS` and friends for config, basic auth
-(or your reverse proxy's SSO) on the portal, one shared token, and **no
-server-side state at all** - losing any component loses nothing. Every
-managed feature has a file or env equivalent, and a merge request is a
-signed, reviewable audit log that most governance portals only imitate.
+**Classic (`managed.enabled=false`, or the compose classic overlay).** For
+teams that would rather manage everything as files in their own repo. Every
+setting is a file or an environment variable: `governance.yaml` for approval
+decisions, `registry/registry.yaml` for what gets detected, `CORP_DOMAINS`
+and friends for config. The receiver keeps no state at all, so there is
+nothing to back up and nothing to lose. Changes go through your normal merge
+request review, which some teams prefer as their audit trail.
 
-The two share one codebase and one finding schema; managed is classic plus
-a state file, not a fork.
+Both modes are the same codebase and the same finding schema. Managed is
+classic plus a small state database, not a fork. If you are not sure which
+you want, start with managed.
 
 ## Deployment order
 
-Managed mode is the default, and the order is one step and then the portal:
-`helm install` from the published OCI chart (plus ingress values), create
-the admin account from the boot-printed setup code, and the first-run
-wizard handles the rest - log store, domains, governance, registry
-additions, and pre-configured downloads for every surface. See
-[Kubernetes](docs/deployment/kubernetes.md).
+In managed mode (the default) the whole install is one command plus the
+portal:
+
+```bash
+helm install ai-guard oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard \
+  --namespace ai-guard --create-namespace \
+  --set ingress.enabled=true --set ingress.host=ai-guard.your.domain \
+  --set portal.ingress.enabled=true --set portal.ingress.host=ai-guard-portal.your.domain
+```
+
+Then:
+
+1. Get the one-time setup code from the receiver's log:
+   `kubectl logs deploy/ai-guard -n ai-guard | grep setup`
+2. Open the portal, create your admin account with that code.
+3. Follow the first-run wizard. It walks you through the log store, your
+   corporate domains, tool approvals, and gives you pre-configured downloads
+   for the collectors, the browser extension and the scanners.
+
+Docker Compose works the same way: `docker compose up` in `deploy/compose/`,
+then the same setup code and wizard. Details for both are in
+[Kubernetes](docs/deployment/kubernetes.md) and
+[Compose](deploy/compose/README.md).
 
 In classic mode, or by hand:
 
@@ -372,12 +385,12 @@ monitoring in most jurisdictions and usually warrants a DPIA.
 
 ## Status and known limitations
 
-This is an alpha, released early on purpose. It runs in production in one
-environment, and the rough edges are labelled rather than hidden.
+This is an alpha. It runs in production in one environment, and the rough
+edges are listed here rather than hidden.
 
-The list has changed since the first release: registry fallback drift, the
-Entra scanner counting failed sign-ins as usage, ongoing delegated access going
-unreported, and browser extension inventory have all been fixed and tested.
+The list keeps shrinking: registry fallback drift, the Entra scanner counting
+failed sign-ins as usage, unreported delegated access, and browser extension
+inventory have all been fixed and tested since the first release.
 
 Current known limitations:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -91,19 +91,17 @@ before; the wizard step is optional and the env path is unchanged.
 Classically it is HTTP basic auth: one shared credential, no per-user trail,
 and plaintext without TLS in front of it. That is a floor, not a ceiling.
 
-It refuses to start without it. Coming up open because a variable was missed is
-the failure that matters for this component: it is reachable, it looks like it
-works, and nothing says the door is off. `PORTAL_AUTH=none` exists for
-localhost and for running behind a proxy that authenticates instead, and it
-logs a warning on every start so an unauthenticated deployment is never
-something nobody noticed.
+It refuses to start without auth configured, so it can't come up open just
+because a variable was missed. `PORTAL_AUTH=none` exists for localhost and
+for running behind a proxy that authenticates instead, and it logs a warning
+on every start so an unauthenticated deployment is always a visible choice.
 
 If you already run a reverse proxy, authenticate there. It can do OIDC, mTLS
 or an allowlist against whatever you already have, which is better than what
 the portal can offer on its own.
 
-`/healthz` is unauthenticated deliberately: a liveness probe that needs a
-credential fails for the wrong reason, and it returns nothing about the estate.
+`/healthz` is unauthenticated on purpose: liveness probes shouldn't need
+credentials, and it reveals nothing about the estate.
 
 ## Rotating the bearer token
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -28,12 +28,11 @@ docker compose down -v
 
 ## The portal
 
-Open http://localhost:8091. It lands on a setup view showing which sources
-are reporting, derived from the findings themselves rather than from
-configuration being present: a source that has never reported is either not
-set up or genuinely has nothing to say, and those are identical from a
-dashboard, so each is listed with what it would need. In the demo most are
-not reporting, which is what a partly-configured deployment looks like.
+Open http://localhost:8091. It lands on a setup view showing which detection
+sources are reporting and what each silent one would need. In the demo most
+are not reporting - that's what a partly-configured deployment looks like,
+and the page exists so you can always tell "not set up" apart from "nothing
+to report".
 
 The other tabs are the part Grafana cannot do. Findings are a flat stream of
 isolated rows; the portal derives the relationships between them, so a device

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,10 +121,9 @@ Only the left-hand side does.
 The browser surface reports under two sources, because it answers two
 questions. `browser_extension` says which account is signed into an AI tool.
 `paste_guard` says what was stopped or flagged on the way into one, plus a
-daily heartbeat proving the chain works on that device. Both are the same
-extension; keeping them apart means "nobody has pasted anything matching a
-detector" is legible as a different state from "the extension is not
-deployed".
+daily heartbeat proving the chain works on that device. Both come from the same
+extension; keeping the sources separate is what lets you tell "nobody pasted
+anything risky" apart from "the extension isn't deployed".
 
 The paste guard is also the one place the platform prevents rather than
 observes: it scans pastes into AI tools on-device and warns or blocks before
@@ -221,28 +220,20 @@ telemetry are one laptop. The portal derives those relationships on request
 and holds no database, so like the dashboard it is a view rather than a store,
 and losing it loses nothing.
 
-The AI register is that view pointed at governance: the AI tools actually in
-use, with what the registry knows about each. The registry itself is a
-watchlist rather than an inventory, so a tool it knows about and nothing has
-reported is reported as a count rather than a row. A register padded with
-tools nobody in the organisation uses is a worse record of what that
-organisation does, not a more complete one, and it puts vendor defaults in
-front of a management review as though someone had taken a position on them.
-Coverage is a different question with its own answer in Setup and Uncovered
-devices. A tool observed and absent from the registry does get a row, flagged,
-because something in use that governance has never considered is worth acting
-on. Owner, review date and risk decision are organisational records rather
-than observations, so the register shows them as not set rather than leaving
-the columns blank. Owner, review date and the decision itself come from an optional governance
-file, described in [governance.md](governance.md), and the portal holds no
-governance state of its own: it reads the file and joins it at request time,
-the same way it joins findings.
+The AI register is that view pointed at governance: the tools actually in
+use, joined to what your organisation has decided about each. Tools the
+registry watches for but nobody uses show as a count, not a row - padding the
+register with unused tools would put vendor defaults in front of a management
+review as if someone had taken a position on them. A tool in use that the
+registry doesn't know does get a row, flagged, because that's the one worth
+acting on. Decisions (status, owner, review date) come from what you record
+in the portal or an optional governance file, described in
+[governance.md](governance.md).
 
-That file is deliberately not the registry. The registry answers what a tool is
-and how to detect it, and it ships with the project; governance answers what an
-organisation decided, which is nobody else's to ship. The separation is also
-physical, because approval used to be compiled into the browser extension's and
-the scanner's own config, neither of which had any use for it.
+Governance is kept separate from the registry on purpose. The registry
+answers "what is this tool and how do we detect it", and ships with the
+project. Governance answers "what did our organisation decide", which nobody
+else can ship for you.
 
 Approval records a position and does not change severity. Severity is decided
 at the point of detection and depends on the account domain, so an approved
@@ -250,40 +241,30 @@ tool signed into a personal account is still a warn, and an unapproved tool on
 a corporate account is still info. Those are independent dimensions and the
 portal keeps them that way: approval must never come to mean safe.
 
-An approval past its review date reports as reviewing, with the previous
-decision alongside, and the stored record is never rewritten. That is the same
-rule the platform applies to a source that has stopped reporting, turned on the
-decision instead: an approval nobody has revisited is not evidence a tool is
-safe, it is evidence that nobody looked.
+An approval past its review date shows as "reviewing" with the old decision
+alongside; the stored record is never rewritten. An approval nobody has
+revisited isn't evidence the tool is safe - it's evidence nobody looked.
 
-Evidence is that same idea pointed outwards. A snapshot states what was observed
-for a stated window, identifies the registry and governance files by hash rather
-than by version, and carries a digest of itself with that field omitted so it
-can be checked against itself later. It is neither reproducible nor
-tamper-evident, and both limits are worth stating plainly because the document
-is offered as evidence. Log retention means the same window may return less
-next year, so it cannot be recreated. And the digest is unkeyed with its rule
-published in the document, so it detects corruption and a careless edit rather
-than deliberate alteration: anyone changing a count recomputes the hash. Making
-it tamper-evident means signing the digest with a key the reader can verify and
-the editor cannot use, which is a piece of work rather than a stronger word. Every
-count that could flatter has its denominator beside it, because a snapshot
-reporting sources_reporting without sources_known would let a half-blind estate
-look complete on paper. See [evidence.md](evidence.md).
+The evidence snapshot is the same data packaged for an auditor: what was
+observed in a stated window, with the registry and governance files
+identified by hash, and a checksum over the whole document. Two limits are
+stated in the document itself because they matter for anything offered as
+evidence: it can't be regenerated identically later (log retention), and the
+checksum catches corruption and careless edits, not deliberate alteration
+(anyone changing a count can recompute it). Every count comes with its
+denominator - "8 sources reporting" always sits next to "of 12 known" -
+so a half-blind estate can't look complete on paper. See
+[evidence.md](evidence.md).
 
-Its entry points differ because the sources do. Endpoint findings carry a
-device and a local username, and the username is a hint rather than a key: it
-is firstname.lastname on one enrolment, a local account on another, whatever
-the person chose on an unmanaged machine. The device is reliable, because
-every fleet tool keys on the serial. Cloud findings carry an identity and no
-device, because Entra and Exchange know people, not machines. The two meet at
-the person, and that join is a lookup the deployer owns against whatever they
-run: an MDM, an RMM, a CMDB, a spreadsheet. The portal proposes a mapping and
-will not apply one, because a mapping the platform invented and then acted on
-is how the wrong name ends up on a report. A device with no mapping stays
-unattributed, which is a legitimate answer rather than a failure: a small team
-with no MDM still learns that three machines are running Ollama on personal
-accounts.
+Identity works in two halves. Endpoint findings know the machine (the
+serial is reliable - every fleet tool keys on it) but only a local username,
+which varies by how the machine was set up. Cloud findings know the person
+but not the machine. Joining them needs a lookup only the deployer has: an
+MDM, an RMM, a CMDB, a spreadsheet. The portal proposes a mapping from
+string matches but never applies one itself - a wrong guess acted on is how
+the wrong name ends up on a report. Devices with no mapping show as
+unattributed, which is fine: a small team with no MDM still learns that
+three machines are running Ollama on personal accounts.
 
 ## Why these choices
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,175 +1,160 @@
 # Getting started
 
-From a running receiver to your first finding on a dashboard. Once that thread
-works end to end, adding the other surfaces is repetition rather than new
-concepts.
+This page takes you from nothing to your first finding in the portal. Once one
+machine is reporting, every other surface is the same pattern: turn it on,
+watch it show up.
 
-If you just want to see what any of this looks like without deploying
-anything, skip to the demo at the end.
+If you just want to see what the project looks like before deploying anything,
+run the [demo](../demo/README.md) instead: `docker compose up` in `demo/`, no
+cluster, no credentials, fake data.
 
-## What you are building
+## The short version
 
-```
-one collector ──► receiver ──► logs (Loki) ──► Grafana dashboard
-                     │                            or the portal
-              registry (served to the collector at runtime)
-```
+1. Install the receiver and portal (one command).
+2. Get the one-time setup code from the receiver's log and create your admin
+   account.
+3. Follow the first-run wizard in the portal.
+4. Download a pre-configured collector from the wizard and run it on one
+   machine.
+5. Watch the finding appear.
 
-Everything else in the project is more sources feeding the same receiver. Get
-one source working first.
+That's the whole thing. The rest of this page is those five steps in detail.
 
-## Prerequisites
+## 1. Install
 
-- **A running receiver.** Two routes, both producing the same thing:
-  [Docker Compose](../deploy/compose/README.md) on a host, or
-  [Kubernetes](deployment/kubernetes.md). See
-  [the routes](deployment/README.md) if you are not sure which.
-- **A log pipeline that ingests container stdout.** The dashboard assumes
-  Loki, but the receiver's only output is JSON lines, so anything that scrapes
-  stdout works.
-- **Grafana**, to import the dashboard. Optional if you only want the portal.
-- **One macOS, Windows or Linux machine** you can run a script on as
-  root or admin, to be your first endpoint.
-
-You do not need Alertmanager, the cloud scanners or the browser extension to
-get started. Add those once the basic thread works.
-
-You also need the **bearer token** your receiver was deployed with. Every
-source authenticates with it. The route you followed says where to find it.
-
-**Managed mode shortcut (the default deployment):** the
-portal's first-run wizard replaces most of this page - it configures the log
-store and corporate domains centrally, and its deployment downloads are the
-collector scripts below with the receiver URL and a fresh enrollment token
-already baked in, so there is no token to find and nothing to edit. Download,
-run as root/admin (or push through your MDM), and skip to step 2.
-
-## 1. Roll out one collector
-
-Pick the OS of your test machine and follow its README:
-
-- macOS: [`endpoint/macos/README.md`](../endpoint/macos/README.md) (Jamf, or
-  run the script directly)
-- Windows: [`endpoint/windows/README.md`](../endpoint/windows/README.md)
-  (Intune)
-- Linux: [`endpoint/linux/README.md`](../endpoint/linux/README.md) (any RMM,
-  cron, or config management)
-
-Each needs the same three values:
-
-- the receiver base URL
-- the bearer token
-- your corporate domains, comma separated. Accounts on these are "work";
-  everything else is a personal-account finding.
-
-**How you pass them differs per platform**, because each matches its delivery
-mechanism, and this is the thing most likely to stop a first run:
-
-- **macOS** takes them as positional parameters, because that is how Jamf
-  passes script parameters. Environment variables are ignored. Running it by
-  hand means passing three empty strings first, since `$1`-`$3` are Jamf's own:
-
-      sudo ./ai-guard-collector.sh "" "" "" \
-        https://receiver.example.com <token> example.com
-
-- **Linux** takes environment variables: `AIGUARD_RECEIVER_BASE`,
-  `AIGUARD_TOKEN`, `AIGUARD_CORP_DOMAINS`.
-- **Windows** takes them at the top of the script or as Intune script
-  parameters.
-
-You can run any of them directly as root or admin with no MDM at all, which is
-the fastest way to see a finding.
-
-Run it once. The collector reads the AI tool config files in the user's home
-directory and POSTs findings to the receiver.
-
-## 2. See the finding
-
-Check the receiver's logs. Every finding it accepts is a JSON line on stdout,
-whether or not it also pushes to a log store:
+**Kubernetes:**
 
 ```bash
-# Docker Compose
-docker compose logs receiver --since 5m
+helm install ai-guard oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard \
+  --namespace ai-guard --create-namespace \
+  --set ingress.enabled=true --set ingress.host=ai-guard.your.domain \
+  --set portal.ingress.enabled=true --set portal.ingress.host=ai-guard-portal.your.domain
+```
 
+The two hosts are the URLs your machines will reach the receiver on and you
+will reach the portal on. Anything that gives those two services a hostname
+works: an ingress controller, Tailscale, a reverse proxy.
+
+**Docker Compose:**
+
+```bash
+git clone https://github.com/AmanSK5/shadow-ai-guard.git
+cd shadow-ai-guard/deploy/compose
+docker compose up -d
+```
+
+Both routes need a log store for findings. If you already run Loki, you will
+connect it in step 3 and nothing needs configuring up front. If you don't, the
+compose file includes one.
+
+## 2. Create your admin account
+
+The receiver prints a one-time setup code when it starts with no admin
+account:
+
+```bash
 # Kubernetes
-kubectl -n ai-guard logs deploy/ai-guard-receiver --since=5m
+kubectl logs deploy/ai-guard -n ai-guard | grep -i setup
+
+# Compose
+docker compose logs receiver | grep -i setup
 ```
 
-You should see a line carrying the tool, surface, account domain, device and
-user. That is the whole pipeline working: a config file on a machine became a
-structured finding in your log store.
+Open the portal, enter the code, pick a username and password. The code works
+exactly once and only for creating the first account.
 
-**If the collector reported success and you see nothing**, the collector never
-reached the receiver: check the URL and token it was given. **If you see the
-finding here but not in Grafana or the portal**, the push to the log store is
-failing rather than the collector - look for `"kind": "error"` in the same
-logs, which names the URL and the likely cause.
+## 3. Follow the wizard
 
-Nothing there? [Troubleshooting](../TROUBLESHOOTING.md) covers the usual
-reasons: a collector that printed nothing because the throttle suppressed a
-repeat, a receiver that accepted the finding but could not write it to Loki,
-and the parameters the macOS and Windows collectors need when you run them by
-hand rather than through Jamf or Intune.
+The portal opens on a first-run wizard. Work through it top to bottom:
 
-## 3. Import the dashboard
+1. **Public receiver URL** - the URL your laptops and servers can reach the
+   receiver on from outside the cluster. This gets baked into every download,
+   so the "save" button probes it and tells you if it's wrong.
+2. **Log store** - where findings are stored and read from. For an in-cluster
+   Loki this is one URL. For Grafana Cloud it's the URL, your numeric instance
+   ID as the username, and an access token with logs read *and* write. There
+   are test buttons for both directions; use them.
+3. **Corporate domains** - your work email domains. An AI tool signed into one
+   of these is a work account; anything else is flagged as personal.
+4. **Governance baseline** - which tools your organisation has approved or
+   banned. Only set the ones you have a position on; the rest stay undecided.
+5. **Browser extension and paste guard** - skip this on a first pass. Come
+   back to it once a collector is reporting (the extension needs packing
+   first; its [README](../extension/README.md) explains).
+6. **Alerting and Grafana** - optional, also fine to skip for now.
+7. **Deployment downloads** - this is the step that matters today. Download
+   the collector for whatever OS your test machine runs.
 
-In Grafana, import `dashboards/ai-guard.json`. Set the datasource variables to
-your Loki (and Prometheus, if used), and set the corporate domains variable to
-your domains.
+## 4. Run a collector on one machine
 
-The finding from step 2 should appear in the "who is running what" table,
-coloured by whether the account is personal or work.
-
-## 4. Optional: the portal
-
-Grafana answers how much and when. The portal answers what belongs to what:
-which tools a device has, which devices a person uses, and which of your
-sources are reporting versus silent. It reads the same logs, writes nothing,
-and is not in the ingest path, so it can be added or removed without touching
-anything above.
-
-On the compose route it is already there, on port 8091. Otherwise:
+The download from step 7 is ready to run: the receiver URL and an enrollment
+token are already inside it. Nothing to edit.
 
 ```bash
-docker run --rm -p 8091:8091 \
-  -e LOKI_URL=http://your-loki:3100 \
-  -e PORTAL_USER=admin -e PORTAL_PASSWORD=... \
-  ghcr.io/amansk5/shadow-ai-guard/portal:0.10.0
+# macOS / Linux, on the test machine
+sudo ./ai-guard-collector.sh
 ```
 
-It refuses to start without authentication, because it names who runs what on
-which machine.
+On Windows, run the `.ps1` as administrator.
 
-It opens on a setup view showing which sources are reporting and what each
-silent one needs, derived from findings rather than from configuration being
-present. Straight after step 2 that view is mostly empty, which is the honest
-picture rather than a broken one: one collector reporting and everything else
-not yet configured.
+The script reads the AI tool config files on that machine (which CLIs are
+installed, which accounts they're signed into, which IDE extensions and MCP
+servers exist) and reports what it finds. It also enrolls the machine, so it
+shows up under Fleet in the portal with its own credential you can revoke.
 
-[`portal/README.md`](../portal/README.md) covers attaching people to devices,
-embedding Grafana panels, and why basic auth is a floor rather than a ceiling.
+For a real rollout you push the same file through your MDM or RMM - Jamf,
+Intune, anything that can run a script as root/admin on a schedule. Each OS
+README ([macOS](../endpoint/macos/README.md),
+[Windows](../endpoint/windows/README.md),
+[Linux](../endpoint/linux/README.md)) has the exact steps for that. Pilot on
+one machine first.
+
+## 5. See the finding
+
+Open the portal. The overview should now show the tools found on your test
+machine, and Setup shows the collector as reporting.
+
+If nothing appears within a minute:
+
+- **The collector printed an error about the receiver URL or token** - it
+  never reached the receiver. Re-download the script (each download carries a
+  fresh token) and check the URL is reachable from that machine.
+- **The collector said it reported, but the portal is empty** - the receiver
+  got the finding but couldn't push it to the log store. Check the receiver's
+  logs for lines with `"kind": "error"`; they name the URL it tried and the
+  likely fix. The Diagnostics view in the portal shows the same thing.
+- Anything else: [Troubleshooting](../TROUBLESHOOTING.md).
 
 ## Where to go next
 
-- Add the other two collectors by repeating step 1.
-- Add cloud and network detection:
-  [`scanner/README.md`](../scanner/README.md) covers the Entra, Exchange,
-  Intune, Jamf and SentinelOne scanners, each optional.
-- Add the browser surface:
-  [`extension/README.md`](../extension/README.md) covers packing, hosting and
-  MDM deployment, including the paste guard.
-- Turn on alerting: set `ALERTMANAGER_URL` on the receiver so personal-account
-  findings page you.
-- Understand the design before extending it:
-  [`docs/architecture.md`](architecture.md).
-- Before deploying for real, read
-  [`docs/deployment-privacy.md`](deployment-privacy.md). This is workplace
-  monitoring and usually warrants a DPIA.
+Everything below is optional and independent. Add them in any order.
 
-## Just want to see it?
+- **More machines**: push the collector through your MDM/RMM.
+- **The browser extension and paste guard**: shows which accounts are signed
+  into AI sites, and warns or blocks when marked documents are pasted into
+  them. [extension/README.md](../extension/README.md) - it needs packing and
+  hosting once, then the portal generates the deployment files.
+- **Cloud and network scanners**: Entra sign-ins, OAuth grants, Exchange
+  signup evidence, Intune/Jamf inventory, SentinelOne DNS.
+  [scanner/README.md](../scanner/README.md). The portal generates the CronJob.
+- **Discovery**: a daily job that spots AI domains in your fleet's DNS that
+  the registry doesn't know yet, and queues them in the portal for you to
+  approve or dismiss. The portal generates this CronJob too.
+- **Grafana**: import `dashboards/ai-guard.json` for trends and history. The
+  portal can embed the panels.
+- **Alerting**: set the Alertmanager URL in Settings and personal-account
+  findings will page you.
 
-The demo in [`demo/`](../demo/README.md) needs no cluster, no real data and no
-credentials. `docker compose up` brings up the receiver, Loki, Grafana, the
-portal and a seeder, with both populated in a few minutes. Grafana is on 3000
-and the portal on 8091.
+Before deploying to real users' machines, read
+[deployment-privacy.md](deployment-privacy.md). This is workplace monitoring
+in most jurisdictions and usually needs a DPIA.
+
+## Running it classic (files instead of the portal)
+
+If you'd rather manage everything as files and environment variables in your
+own repo, with no server-side state, deploy with `managed.enabled=false` (or
+the compose classic overlay). You then edit `governance.yaml` and
+`registry/registry.yaml` by hand, set config through environment variables,
+and pass the receiver URL and shared token to collectors yourself - each OS
+README documents the values it needs. The
+[deployment docs](deployment/README.md) compare the two modes.

--- a/extension/README.md
+++ b/extension/README.md
@@ -57,11 +57,20 @@ warn to block is a policy push, not a release.
 
 ## Setup
 
-The extension is deployed as a force-installed managed extension through
-enterprise browser policy, not from a store listing. The moving parts:
-packed extension (.crx) and an update manifest (updates.xml) on public
-HTTPS, plus two policies per browser delivered by your MDM or GPO: an
-install policy (forcelist) and a managed-storage config.
+The extension is not on a web store - you pack it and deploy it yourself
+through enterprise browser policy. The one-time work is:
+
+1. Point the source at your receiver (a one-line manifest edit).
+2. Pack it, which gives you the extension's id and signing key.
+3. Host the packed file and its update manifest anywhere on HTTPS.
+   (Firefox: also submit to Mozilla for signing - covered below.)
+4. Deploy the policies through your MDM/GPO. In managed mode the portal
+   generates these pre-configured; classic mode uses the templates in
+   `deploy/`.
+5. Verify on one machine.
+
+After that, everything day-to-day (mode changes, domain changes, new
+enrollment tokens) is a policy push, and releases are pack-upload-done.
 
 With a managed-mode deployment, the portal generates the whole matrix
 pre-configured (the onboarding wizard, or the Setup view's browser row):

--- a/portal/README.md
+++ b/portal/README.md
@@ -3,19 +3,20 @@
 A governance view over the findings the receiver already collects. Devices,
 identities, tools, and the relationships between them.
 
-It reads Loki on request and derives entities. It writes nothing, holds no
-database, and is not in the path of anything that already works: if the portal
-falls over, collection carries on.
+It reads findings from Loki when you open a page. It writes nothing and holds
+no database, and it sits outside the collection path, so if the portal goes
+down, collection keeps working.
 
 ## Why it exists
 
-Findings are a flat stream. Each one is an isolated row, and Loki can filter
-and count them but cannot say that these forty rows are the same twelve
-machines. Every governance question is a relationship: which tools a device
-has, which devices a person uses, who is signed into what.
+Findings arrive as a flat stream of rows. Loki can filter and count them, but
+it can't tell you that forty rows are really twelve machines. The questions
+you actually ask are about relationships: which tools does this device have,
+which devices does this person use, who is signed into what. That's what the
+portal answers.
 
-Grafana is better at graphs. This is better at relationships. Both are
-optional and neither replaces the other.
+Grafana is better at graphs and history. The portal is better at
+relationships and current state. Run either or both.
 
 ## Deployment
 
@@ -32,10 +33,9 @@ The receiver stays one stateless container in all three.
 
 **Required.** The portal refuses to start without it.
 
-This page names who runs what on which machine, which is the most sensitive
-thing the platform produces. Coming up open because a variable was missed is
-the failure that matters: the portal is reachable, it looks like it works, and
-nothing says the door is off. So it fails closed and says why.
+The portal shows who runs what on which machine - the most sensitive thing
+this platform produces - so it will not start unauthenticated by accident. If
+no auth is configured, it stops and tells you.
 
 In **managed mode** (`RECEIVER_URL` set) none of the below applies: the
 portal has a real login backed by the receiver's admin account, and the
@@ -45,25 +45,22 @@ Classic mode:
     PORTAL_USER=admin
     PORTAL_PASSWORD=...
 
-Basic auth is a floor rather than a ceiling: one shared credential, no
-per-user trail, and plaintext without TLS in front of it. **If you already run
-a reverse proxy, authenticate there instead** - it can do OIDC, mTLS or an
-allowlist against whatever you already have - and run the portal behind it
-with:
+Basic auth is the minimum, not a recommendation: it's one shared credential,
+no per-user trail, and plaintext unless TLS sits in front. **If you already
+run a reverse proxy, authenticate there instead** (OIDC, mTLS, an allowlist -
+whatever you already have) and run the portal behind it with:
 
     PORTAL_AUTH=none
 
-That opt-out logs a warning on every start, because an unauthenticated
-deployment should never be something nobody noticed. It is the right setting
-for localhost and for a proxy that authenticates for you, and the wrong one for
-anything reachable.
+That setting logs a warning on every start so an unauthenticated deployment
+is never an accident. Use it for localhost and behind an authenticating
+proxy; don't use it for anything directly reachable.
 
-OIDC in the portal itself is deliberately out of scope: correct, but heavy, and
-a lot of configuration surface for something that reads a log store.
+The portal doesn't do OIDC itself - a reverse proxy does it better with less
+configuration.
 
-`/healthz` is unauthenticated on purpose. A liveness probe that needs a
-credential is a probe that fails for the wrong reason, and it returns nothing
-about the estate.
+`/healthz` is unauthenticated on purpose: liveness probes shouldn't need
+credentials, and it reveals nothing about your estate.
 
 ## Configuration
 
@@ -180,18 +177,17 @@ So the two halves meet at the person, and joining them is a lookup you own.
 Supply `IDENTITY_MAP` as a CSV of `key,identity` where the key is a device or a
 local username, from your MDM, your RMM, a CMDB, or a spreadsheet.
 
-**A device with no mapping stays unattributed, and that is a legitimate answer
-rather than a failure.** A small team with no MDM still gets "these three
-machines are running Ollama on personal accounts", which is useful without a
-name attached.
+**A device with no mapping just shows as unattributed, and that's fine.** A
+small team with no MDM still gets "these three machines are running Ollama on
+personal accounts", which is useful without a name attached.
 
 To start a map, `GET /api/suggest-identities?fmt=csv` returns proposals built
 by comparing normalised local usernames against the identities cloud sources
 report.
 
-The portal will not apply those proposals itself. They are string matches, and
-a mapping this platform invented and then acted on is how the wrong name ends
-up on a report.
+The portal never applies those proposals automatically. They're string
+matches, and you should check every line - a wrong match puts the wrong
+person's name on a report.
 
 ### Where the file goes
 
@@ -255,21 +251,21 @@ effect within `CACHE_TTL_SECONDS` (default 30) without a restart.
 The tools actually in use, from findings in the lookback window, joined to what
 the registry knows and what your organisation has decided.
 
-The registry is a watchlist rather than an inventory, so a tool it knows about
-and nothing has reported is a count rather than a row. A register padded with
-tools nobody here uses is a worse record of what an organisation does, not a
-more complete one. A tool observed and absent from the registry does get a row,
-flagged, because something in use that governance has never considered is the
-anomaly worth acting on.
+Tools the registry watches for but nobody uses show as a count, not a row -
+padding the register with unused tools would make it a worse record, not a
+more complete one. A tool in use that the registry doesn't know does get a
+row, flagged, because something in use that nobody has considered is the
+thing worth acting on.
 
-Status, owner and review date come from an optional governance file. Without
-one, everything reads as undecided, which is honest: every tool ships
-`approved: false` and presenting that as a refusal would assert a decision
-nobody made. See [docs/governance.md](../docs/governance.md).
+Status, owner and review date come from your recorded decisions (in the
+portal, or an optional governance file). Without any, everything shows as
+undecided - every tool ships `approved: false`, and showing that as "banned"
+would claim a decision nobody made. See
+[docs/governance.md](../docs/governance.md).
 
-An approval past its review date reports as reviewing, says how long ago it
-expired, and shows the previous decision. The record is not rewritten: a clock
-ticking over is not a decision.
+An approval past its review date shows as "reviewing", says how long ago it
+expired, and keeps the previous decision visible. The record itself isn't
+rewritten - a date passing is not a decision.
 
 `GET /api/register?fmt=csv` exports the same rows the page shows, with the
 timestamp and lookback window in the filename. It is a convenience export
@@ -281,19 +277,17 @@ What the guard stopped, on which tool, and how often. Metadata only: it inspects
 clipboard content on the device and reports detector identifiers, so what was
 nearly pasted is not here and is not stored anywhere.
 
-Overrides sort first. Somebody shown the detector by name who pasted anyway is
-the row to follow up, and sorting by event count would bury one override under
-twenty warnings that worked.
+Overrides sort first: someone who was shown a warning and pasted anyway is
+the row worth following up.
 
-The page also reports how many devices the guard checked in from, and which
-versions and modes they are running. Without that, "0 pastes stopped" means both
-an estate where nobody pasted a secret and one where the extension was never
-deployed. More than one version is a rollout that stalled; a device in warn mode
-where policy says block is a policy not in force.
+The page also shows how many devices the guard is running on, and which
+versions and modes. That's what makes "0 pastes stopped" trustworthy - without
+it, zero could just mean the extension was never deployed. Multiple versions
+means a rollout stalled somewhere; a device in warn mode when your policy says
+block means the policy isn't in force there.
 
-Heartbeats are excluded from the event counts. They share the same source, and
-counting them would report every device's daily check-in as a paste somebody
-tried to make.
+Daily heartbeats are excluded from the event counts, so a check-in never
+counts as a paste.
 
 ## ISO 42001 evidence
 
@@ -322,88 +316,63 @@ OVERVIEW_WIDGETS=stat_row,top_tools,recent_personal_accounts,detection_coverage
 | `paste_guard` | pastes warned, overridden and blocked |
 | `grafana:<panel title>` | a panel named in `GRAFANA_PANELS` |
 
-Prefer a native widget to a `grafana:` one where both exist. An embedded panel
-renders cross-origin, so it arrives in Grafana's typography with a title the
-portal cannot restyle, and it sits visibly apart from the cards beside it.
-`paste_guard` used to be a panel for this reason and no longer needs to be: the
-portal derives those counts itself.
+Prefer a native widget over a `grafana:` one where both exist - embedded
+panels arrive in Grafana's styling and look out of place next to the cards.
 
-Unset gives a sensible default rather than an empty page. An unknown name
-renders an error card naming what is valid, because a widget that silently does
-not appear looks identical to one that appeared with nothing to show, and that
-sends someone off debugging their data instead of their config.
-
-This is a deployment decision rather than a per-user one. The portal holds no
-state and has no users to hold it against, so an organisation shapes its landing
-page here and the portal stays something that can be deleted and reinstalled
-with nothing lost.
+Leaving it unset gives you a sensible default. A typo in a widget name shows
+an error card listing the valid names, so you find out immediately instead of
+wondering where your widget went.
 
 ## Personal accounts
 
-Its own section rather than a number on a summary page, because an approved
-tool signed into a personal account is still unmanaged data flow and an
-offboarding gap.
+Personal accounts get their own page because even an approved tool on a
+personal account is unmanaged data flow and an offboarding gap.
 
-"Personal" is the reporting source's judgement, not the portal's: the collector
-and the extension are told the corporate domains and decide at the point of
-detection. The portal does not re-derive it, because it may not hold the same
-list, and two definitions that disagree is worse than one that is occasionally
-coarse.
-
-Rows are keyed on the full tuple of person, account, tool and device. The same
-person signing into two tools is two things to follow up, not one account with
-a longer attribute list.
+"Personal" is decided at the point of detection: the collector and extension
+know your corporate domains and judge each account against them. Each row is
+one person + account + tool + device combination, so the same person on two
+tools is two rows - two things to follow up.
 
 ## MCP servers
 
-Counted by server rather than by tool. An MCP server is a standing integration
-rather than an application someone opens: it holds its own credentials and can
-reach whatever it was pointed at whether or not the tool that configured it is
-in use.
+Counted by server, not by tool. An MCP server is an integration with its own
+credentials - it can reach whatever it was pointed at even when the tool that
+configured it isn't open, which makes the server the interesting unit.
 
-Server names come from the finding evidence. Two formats are read, because a
-Loki window holds both for a while: the current `mcpServers: figma,context7`,
-and the older form that folded the list into the tool name. That older form is
-why this exists at all, since every distinct combination of servers became a
-separate tool, and a machine with two servers looked unrelated to a machine
-with one of them.
-
-What a server can actually do wherever it points depends on the credentials it
-holds, which are not visible from here. The device count is reach, not risk.
+What a server can actually do depends on the credentials it holds, which
+aren't visible from here. The device count tells you reach, not risk.
 
 ## Settings and diagnostics
 
 Read only, and split in two on purpose.
 
-Everything under Application, Loki, Registry and Access is something the portal
-verified about itself: it either reached Loki or it did not, loaded the registry
-or it did not. Anything it was merely told is grouped separately and labelled
-"Provided by deployment configuration", so a chart version nobody updated is
-never presented as a fact something checked. A Compose deployment leaves those
-fields empty rather than guessing.
+Everything under Application, Loki, Registry and Access is something the
+portal actually checked: it reached Loki or it didn't, loaded the registry or
+it didn't. Values it was merely told (like a chart version) are grouped
+separately and labelled "Provided by deployment configuration", so nothing
+unverified reads as a fact.
 
-Credential values are never shown. Whether one is configured is useful; what it
-is, is not.
+Credential values are never shown - only whether one is configured.
 
 ## Setup view
 
 The view the portal opens on. It shows which sources are reporting and which
 are silent, derived from findings rather than from configuration being present.
 
-A source that has never reported is either not set up or genuinely has nothing
-to say, and from a dashboard those are identical. Listing them turns "I
-deployed this and see an empty screen" into "the Entra scanner has never
-reported". It stays useful afterwards as an is-it-still-working view.
+A source that has never reported might not be set up, or might genuinely have
+nothing to say - a dashboard can't tell those apart, so this page lists each
+one and what it needs. It turns "I deployed this and the screen is empty"
+into "the Entra scanner has never reported". Afterwards it stays useful as an
+is-it-still-working view.
 
 ## Embedding Grafana
 
 The Grafana tab embeds Grafana panels, so the portal can be the one place
 someone looks. It is optional, and everything else works without it.
 
-Grafana refuses to be framed by default, deliberately: framing a session
-someone is logged into is how clickjacking works. Turning that off is a
-decision for the deployer, not something this portal can do on their behalf.
-It needs, on the Grafana side:
+Grafana refuses to be embedded in another page by default (that's a
+clickjacking protection). Allowing it is your call to make on the Grafana
+side:
 
     GF_SECURITY_ALLOW_EMBEDDING=true
     GF_SECURITY_COOKIE_SAMESITE=none

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -814,60 +814,57 @@ def status_from(findings):
     # where they were.
     expected = [
         ("endpoint", "collector-macos", "macOS collector", "endpoint/macos/README.md",
-         "Deploy ai-guard-collector.sh as a Jamf policy running as root on a "
-         "recurring check-in. In managed mode, download the pre-configured "
-         "script below - receiver URL and enrollment token already baked. "
-         "Classically, set AIGUARD_RECEIVER_BASE, AIGUARD_TOKEN and "
-         "AIGUARD_CORP_DOMAINS as script parameters."),
+         "Download the pre-configured script below and run it as a Jamf "
+         "policy (root, recurring check-in) - the receiver URL and an "
+         "enrollment token are already inside it. In classic mode, pass "
+         "AIGUARD_RECEIVER_BASE, AIGUARD_TOKEN and AIGUARD_CORP_DOMAINS as "
+         "script parameters instead."),
         ("endpoint", "collector-linux", "Linux collector", "endpoint/linux/README.md",
-         "Run ai-guard-collector.sh as root on a schedule: an RMM scheduled "
-         "job, cron, or a systemd timer. In managed mode the download below "
-         "is ready to paste in as-is; classically, same three environment "
-         "variables as macOS."),
+         "Download the script below and run it as root on a schedule - an "
+         "RMM job, cron, or a systemd timer. It's ready to run as-is. In "
+         "classic mode, set the same three environment variables as macOS."),
         ("endpoint", "collector-windows", "Windows collector", "endpoint/windows/README.md",
-         "Deploy ai-guard-collector.ps1 as an Intune platform script. In "
-         "managed mode the download below is upload-ready; classically, set "
-         "the same three variables at the top of the script."),
+         "Download the script below and upload it as an Intune platform "
+         "script - it's ready as-is. In classic mode, set the same three "
+         "values at the top of the script first."),
         ("browser", "browser_extension", "Browser extension: accounts",
          "extension/README.md",
-         "Push the extension by managed policy. In managed mode the portal "
-         "generates the full matrix pre-configured - Chromium policy for "
-         "macOS, deploy scripts for Windows, and Firefox equivalents (keyed "
-         "on the gecko id, installing the Mozilla-signed .xpi) - URL, "
-         "enrollment token, corporate domains and paste guard settings "
-         "baked; each browser profile exchanges the token once for its own "
-         "credential. Reports which account is signed into an AI tool in "
-         "the browser."),
+         "Shows which account is signed into each AI site in the browser. "
+         "Pack the extension once (extension/README.md), then download the "
+         "pre-configured policy for your platform below: Chromium policy "
+         "for macOS, deploy scripts for Windows, and Firefox versions of "
+         "both. Everything is baked in - URL, enrollment token, your "
+         "domains, paste guard settings."),
         ("browser", "paste_guard", "Browser extension: paste guard",
          "extension/README.md",
-         "The same extension, not a second install: its mode (off/warn/"
-         "block) and the classification markings it scans for are Settings "
-         "here, baked into the same policy artifacts. Reports pastes it "
-         "stopped or flagged, and a daily heartbeat proving the whole chain "
-         "works on that device. Silent while the accounts row reports means "
-         "nobody has pasted anything matching a detector, which is a "
-         "different thing from not being deployed."),
+         "Part of the same extension - no second install. It warns or "
+         "blocks when marked documents are pasted into AI tools; set the "
+         "mode and markings under Settings. If the accounts row above is "
+         "reporting but this one is quiet, the guard is working and nobody "
+         "has pasted anything risky."),
         ("cloud", "entra_sign_in", "Entra sign-ins", "scanner/README.md",
-         "Register an app in Entra with AuditLog.Read.All and Directory.Read.All, "
-         "then set AIGUARD_ENTRA_TENANT_ID, _CLIENT_ID and _CLIENT_SECRET."),
+         "Register an app in Entra with AuditLog.Read.All and "
+         "Directory.Read.All, then give the scanner AIGUARD_ENTRA_TENANT_ID, "
+         "_CLIENT_ID and _CLIENT_SECRET."),
         ("cloud", "entra_delegated_access", "Entra delegated access", "scanner/README.md",
-         "Same app registration as sign-ins. Covers non-interactive use that "
-         "sign-in logs miss."),
+         "Same Entra app as sign-ins. Catches background/API use that "
+         "interactive sign-in logs miss."),
         ("cloud", "entra_consent_grant", "Entra consent grants", "scanner/README.md",
          "Same app registration. Reports OAuth grants users have given to "
          "third-party applications."),
         ("cloud", "entra_service_principal", "Entra service principals", "scanner/README.md",
-         "Same app registration. Reports non-human identities, which are how "
-         "hidden agents usually appear."),
+         "Same Entra app. Reports non-human identities - service accounts "
+         "and app registrations, which is where hidden AI agents tend to "
+         "live."),
         ("cloud", "exchange_email", "Exchange signup evidence", "scanner/README.md",
-         "Add Mail.Read to the Entra app registration. Finds accounts created "
-         "with a work email outside SSO, which disabling Entra does not close."),
+         "Add Mail.Read to the Entra app. Finds AI accounts people created "
+         "with their work email directly (outside SSO) - blocking sign-in "
+         "in Entra doesn't close that path."),
         ("fleet", "jamf_app", "Jamf applications", "scanner/README.md",
          "A Jamf Pro API client with read access to computer inventory. Set "
-         "AIGUARD_JAMF_URL, _CLIENT_ID and _CLIENT_SECRET. Jamf is the "
-         "reference implementation of this surface - on Kandji, Addigy or "
-         "another MDM, any source that emits the finding shape fills this "
-         "row; see docs/writing-a-scanner.md."),
+         "AIGUARD_JAMF_URL, _CLIENT_ID and _CLIENT_SECRET. On Kandji, "
+         "Addigy or another MDM: anything that emits the finding shape "
+         "fills this row - see docs/writing-a-scanner.md."),
         ("fleet", "jamf_extension", "Jamf browser extensions", "scanner/README.md",
          "Same Jamf credentials. Reports AI browser extensions from inventory."),
         ("fleet", "intune_app", "Intune applications", "scanner/README.md",
@@ -878,20 +875,19 @@ def status_from(findings):
          "Same Intune permissions. Not yet emitted by any scanner."),
         ("network", "sentinelone_dns", "SentinelOne DNS", "scanner/README.md",
          "A SentinelOne API token with Deep Visibility read access. Set "
-         "AIGUARD_S1_URL and AIGUARD_S1_TOKEN. SentinelOne is the reference "
-         "implementation of the network surface - a dedicated DNS or "
-         "network-security service works the same way: any source emitting "
-         "the finding shape fills this row; see docs/writing-a-scanner.md."),
+         "AIGUARD_S1_URL and AIGUARD_S1_TOKEN. Using a different DNS or "
+         "network-security product? Anything that emits the finding shape "
+         "fills this row - see docs/writing-a-scanner.md."),
         ("network", "sentinelone_network", "SentinelOne network", "scanner/README.md",
-         "Same SentinelOne token. Catches local process bridges that never "
-         "touch a browser."),
+         "Same SentinelOne token. Catches AI traffic from local processes "
+         "that never touch a browser."),
         ("network", "sentinelone_bridge", "SentinelOne bridge targets", "scanner/README.md",
-         "Same SentinelOne token. Reports where an AI tool reached, not tools "
-         "someone installed."),
+         "Same SentinelOne token. Shows where AI tools connected to - "
+         "destinations, not installed software."),
         ("mcp", "mcp_scan", "MCP integration scan", "scanner/README.md",
-         "Produced by the endpoint collectors reading AI tool config files. If "
-         "a collector is reporting and this is not, nobody has wired up an MCP "
-         "server yet."),
+         "Comes from the endpoint collectors reading AI tool config files - "
+         "no separate setup. If a collector is reporting and this is quiet, "
+         "nobody has configured an MCP server yet."),
     ]
     # Sources the portal can generate a pre-configured deployment artifact
     # for, when managed mode is on. The value is the API path segment

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -243,11 +243,11 @@ function showLogin(msg) {
     <h2>${create ? 'Create the admin account' : 'Sign in'}</h2>
     <p class="lede">${create
       ? `No admin account exists yet. The receiver printed a one-time setup
-         code to its log at boot — <code>kubectl logs deploy/&lt;release&gt;-ai-guard
-         | grep setup_code</code>, or <code>docker compose logs receiver</code>.
-         Enter it here; it is consumed on use and a restart mints a fresh one.`
-      : `The portal signs in against the receiver's admin account. The session
-         is an HttpOnly cookie: nothing is stored where page script can read it.`}</p>
+         code to its log when it started - find it with
+         <code>kubectl logs deploy/&lt;release&gt;-ai-guard | grep setup_code</code>
+         or <code>docker compose logs receiver</code>. The code works once;
+         if you lose it, restart the receiver for a fresh one.`
+      : `Sign in with the admin account you created during setup.`}</p>
     ${msg ? `<div class="note">${esc(msg)}</div>` : ''}
     ${create ? `<p><input id="li-code" class="mfield" style="width:100%"
       placeholder="setup code (aigs_…)" autocomplete="off"></p>` : ''}
@@ -487,11 +487,11 @@ const WIDGETS = {
         <div><dt${over ? ' style="color:var(--dstr)"' : ''}>${over}</dt><dd>overridden</dd></div>
       </dl>
       <p class="src-note">${live
-        ? `Checked in from ${live} device${live === 1 ? '' : 's'}${
-             versions > 1 ? ` across ${versions} versions` : ''}, so a low
-           count of stopped pastes means what it says.`
-        : `No device checked in, so nothing here can be read as an estate that
-           pasted nothing.`}</p></div>`;
+        ? `The guard is running on ${live} device${live === 1 ? '' : 's'}${
+             versions > 1 ? ` (${versions} versions)` : ''}, so low numbers
+           here genuinely mean few risky pastes.`
+        : `No device has checked in yet, so zero here means "not deployed",
+           not "nobody pasted anything".`}</p></div>`;
   },
 
   review_queue: () => {
@@ -537,7 +537,7 @@ const WIDGETS = {
         .slice(0, 2);
       return `<div class="wcard w6"><h3>Awaiting a decision</h3>
         <p class="lede">No new AI tools awaiting a decision.${srcs.length
-          ? ' Newest source data: ' + srcs.map(x =>
+          ? ' Latest data: ' + srcs.map(x =>
               esc(x.label) + ' ' + ago(x.last_seen)).join(', ') + '.' : ''}</p></div>`;
     }
     return `<div class="wcard w6"><h3>Awaiting a decision
@@ -552,8 +552,8 @@ const WIDGETS = {
       <td style="color:var(--mut)">${esc((r.first_seen || '').slice(0, 10))}</td>
     </tr>`).join('')}</table>`}
     <p class="src-note"><a href="#register" style="color:var(--pri)">Decide on
-    the AI register</a> - a decision is the acknowledgment, so deciding
-    clears the queue.</p></div>`;
+    the AI register</a> - recording a decision clears the tool from this
+    queue.</p></div>`;
   },
 
   grafana: (w) => {
@@ -578,9 +578,8 @@ const WIDGETS = {
 
   error: (w) => `<div class="wcard w12"><h3>Widget not drawn</h3>
     <div class="note" style="margin:0">${esc(w.error)}</div>
-    <p class="src-note">Said out loud rather than skipped: a widget that
-    silently does not appear looks identical to one that appeared with nothing
-    to show.</p></div>`,
+    <p class="src-note">Shown so you know this widget failed, instead of it
+    quietly not appearing.</p></div>`,
 };
 
 // The truncation banner (issue #104): a Loki read that stopped at the
@@ -598,9 +597,8 @@ function overview() {
   const rest = ws.filter(w => w.kind !== 'stat_row');
   return `<h2>Overview</h2>
   ${truncNote(G.findings_truncated)}
-  <p class="lede">Which widgets appear is a deployment decision, set in
-  <code>OVERVIEW_WIDGETS</code>, so an organisation shapes its own landing page
-  and the portal keeps no state and needs no accounts.</p>
+  <p class="lede">You can choose which widgets appear here: the overview
+  widgets setting takes a comma-separated list.</p>
   ${stat.map(w => WIDGETS.stat_row(w)).join('')}
   <div class="grid">${rest.map(w =>
     (WIDGETS[w.kind] ? WIDGETS[w.kind](w) : WIDGETS.error({error:'no renderer for '+w.kind}))
@@ -663,10 +661,9 @@ function tools() {
 
 function coverage() {
   const gaps = ents(G.devices).filter(([,d]) => d.scanner_seen && !d.collector_seen);
-  return `<h2>Coverage</h2><p class="lede">An inventory or telemetry source knows
-  these machines, but no endpoint collector reports from them. An empty collector
-  result and an undeployed collector look identical on a dashboard, which is why
-  they are listed rather than counted.</p>
+  return `<h2>Coverage</h2><p class="lede">These machines are known to an inventory or
+  telemetry source, but no endpoint collector has reported from them. Usually
+  that means the collector isn't installed there yet.</p>
   ${gaps.length ? `<table><tr><th>device</th><th>sources</th><th>tools seen</th></tr>
   ${gaps.map(([k,d])=>`<tr><td>${esc(label(k,d))}</td>
     <td>${(d.sources||[]).map(s=>`<span class="pill p-mut">${esc(s)}</span>`).join('')}</td>
@@ -718,10 +715,10 @@ function mcp() {
   const tools = ents(G.tools).filter(([,t]) => (t.surfaces||[]).includes('mcp'));
   const devs = new Set(rows.flatMap(r => r.devices || []));
   return `<h2>MCP servers</h2>
-  <p class="lede">An MCP server is a standing integration rather than an
-  application someone opens. It holds its own credentials and can reach
-  whatever it was pointed at whether or not the tool that configured it is in
-  use, which makes the server the thing worth counting rather than the tool.</p>
+  <p class="lede">MCP servers are integrations AI tools are configured to use.
+  They hold their own credentials and can reach whatever they were pointed at,
+  even when the tool that configured them isn't open. That's why they get
+  their own page.</p>
 
   <dl class="stats">
     <div><dt>${rows.length}</dt><dd>servers</dd></div>
@@ -739,15 +736,11 @@ function mcp() {
     <td style="color:var(--mut)">${esc((r.first_seen||'').slice(0,10) || '—')}</td>
     <td style="color:var(--mut)">${esc((r.last_seen||'').slice(0,10) || '—')}</td>
   </tr>`).join('')}</table>
-  <p class="src-note">Click a server for the machines it is configured on. A
-  server on twenty machines is a different problem from one on a single laptop,
-  so the widest reach is listed first. The server names
-  come from the finding evidence rather than the tool name: folding the list
-  into the name made every distinct combination look like a separate tool.</p>`
-  : `<p class="lede">No MCP servers found. That is only meaningful if the
-  endpoint collectors are reporting, which the Setup page will tell you: the
-  MCP scan is produced by them reading AI tool config files, so a silent
-  collector and an estate with no MCP servers look identical from here.</p>`}`;
+  <p class="src-note">Click a server to see which machines it's configured on.
+  Widest reach is listed first.</p>`
+  : `<p class="lede">No MCP servers found. Check the Setup page first: MCP
+  findings come from the endpoint collectors, so if no collector is reporting,
+  this page can't see anything either.</p>`}`;
 }
 
 function mcpDetail(k) {
@@ -776,11 +769,11 @@ function personal() {
     match(r.user) || match(r.account_domain) || match(r.tool) ||
     match(r.device) || match(r.device_name));
   return `<h2>Personal accounts</h2>
-  <p class="lede">An approved tool signed into a personal account is still
-  unmanaged data flow and an offboarding gap, so this is its own section rather
-  than a number on a summary page. Personal means the reporting source judged
-  the account domain to be outside your corporate list, decided where that list
-  actually lives. These are leads to follow up, not verdicts.</p>
+  <p class="lede">AI tools signed into personal accounts. Even an approved
+  tool on a personal account means company data flowing somewhere you don't
+  manage, and access that survives offboarding. "Personal" means the account
+  domain isn't in your corporate domains list. Treat these as leads to follow
+  up, not verdicts.</p>
   ${rows.length ? `<table>
   <tr><th>who</th><th>account domain</th><th>tool</th><th>device</th>
   <th>surface</th><th>first seen</th><th>last seen</th><th>source</th></tr>
@@ -795,8 +788,7 @@ function personal() {
     <td style="color:var(--mut)">${esc((r.sources||[]).join(', ')) || '—'}</td>
   </tr>`).join('')}</table>`
   : `<p class="lede">None seen in the last ${CFG.lookback_hours || '?'} hours.
-  That is a result rather than an absence of one, provided the sources on the
-  Setup page are reporting.</p>`}`;
+  Worth trusting only if the sources on the Setup page are reporting.</p>`}`;
 }
 
 
@@ -1172,10 +1164,9 @@ async function register() {
   return `<h2>AI register</h2>
   ${truncNote(REG.findings_truncated)}
   <p class="lede">The AI tools actually in use, from findings in the last
-  ${esc(win)}. The registry is a watchlist rather than an inventory, so a tool
-  it knows about and nothing has reported is counted below rather than listed.
-  A tool observed and absent from the registry is the row worth acting on, and
-  is flagged as such.</p>
+  ${esc(win)}. Tools the registry watches for but nobody uses are counted
+  below, not listed. Tools in use that the registry doesn't know are flagged -
+  those are the ones to act on.</p>
 
   <dl class="stats">
     <div><dt>${REG.tools_observed}</dt><dd>in use</dd></div>
@@ -1185,16 +1176,14 @@ async function register() {
   </dl>
 
   ${!REG.governance_configured ? (CFG.managed && CFG.managed.enabled
-    ? `<p class="lede">No decisions recorded yet, so status falls back to the
-    registry's own flag - a shipped default rather than a decision anyone
-    made. Record one with <b>edit</b> on any card; it is stored centrally
-    and a governance file (<span class="mono">GOVERNANCE_PATH</span>) still
-    works alongside.</p>`
-    : `<p class="lede">No governance file is
-  configured, so status falls back to the registry's own flag and every tool
-  reads as not approved. That is a shipped default rather than a decision
-  anyone made. Set <span class="mono">GOVERNANCE_PATH</span> to record
-  approvals, owners and review dates.</p>`) : ''}
+    ? `<p class="lede">No decisions recorded yet, so every tool shows the
+    registry's shipped default (not approved). That's a default, not a
+    decision anyone made. Click <b>edit</b> on any card to record a real
+    one.</p>`
+    : `<p class="lede">No governance file is configured, so every tool
+  shows the registry's shipped default (not approved). That's a default, not
+  a decision anyone made. Set <span class="mono">GOVERNANCE_PATH</span> to
+  record approvals, owners and review dates.</p>`) : ''}
 
   ${((REG.governance_unmatched || []).length
      || (REG.exceptions_unmatched || []).length) ? `<div class="note">
@@ -1207,16 +1196,13 @@ async function register() {
         the registry does not know:</b>
         ${names.map(t => `<span class="pill p-warn">${esc(t)}</span>`).join('')}`;
     })()}
-    <div style="margin-top:6px">That is fine for a deliberate record about
-    something not yet registered, and it is also what a typo looks like. Either
-    way it is not being applied to anything, so it is shown rather than
-    dropped.</div>
+    <div style="margin-top:6px">This is fine if you recorded a decision
+    ahead of registering the tool - but it's also what a typo looks like.
+    Either way the record isn't being applied to anything right now.</div>
   </div>` : ''}
 
-  <p class="lede">One card per tool: what it is, how it is used, and what was
-  decided about it. First seen is in the CSV rather than here, because inside a
-  lookback window it is usually the same as last seen and Overview already
-  answers what is new this week.
+  <p class="lede">One card per tool: what it is, how it's used, and what was
+  decided about it.
   <a href="/api/register?fmt=csv" style="color:var(--pri)">Download CSV</a></p>
 
   ${rows.length ? `<div class="cards">
@@ -1390,11 +1376,11 @@ async function iso() {
   ].filter(([count]) => count > 0);
 
   return `<h2>ISO/IEC 42001 evidence</h2>
-  <p class="lede">Evidence Shadow AI Guard can provide to support an AI
-  management system. An index of what the platform can currently say and where
-  each record lives, not an assessment: nothing here is a compliance score, a
-  clause mapping, or a claim that a control is satisfied. The gaps are shown
-  beside the totals because a gap is the more useful finding.</p>
+  <p class="lede">What Shadow AI Guard can currently say, and where each
+  record lives, as evidence for an AI management system. This is an index,
+  not an assessment: no compliance score, no clause mapping, no claim that a
+  control is satisfied. Gaps are shown next to totals on purpose - the gap is
+  usually the useful part.</p>
 
   <table>
   <tr><th>Theme</th><th>What Shadow AI Guard can say</th><th>Evidence source</th></tr>
@@ -1407,23 +1393,21 @@ async function iso() {
   </table>
 
   <h3 style="margin-top:26px;font-size:14px">Review inputs</h3>
-  <p class="lede">Things a person may need to look at. These are inputs to a
-  review rather than conclusions: the platform can say a tool has no recorded
-  decision, and cannot say whether that is a problem.</p>
+  <p class="lede">Things a person may need to look at. The platform can tell
+  you a tool has no recorded decision; whether that matters is your call.</p>
   ${inputs.length ? `<ul class="inputs">
     ${inputs.map(([, text, target]) =>
       `<li><a href="#${target}">${esc(text)}</a></li>`).join('')}
-  </ul>` : `<p class="lede">Nothing outstanding in this window. That is a real
-  answer for a small estate, and it is also what an estate with no collectors
-  reporting looks like: ${e.sources_reporting} of ${e.sources_known} expected
-  sources are reporting.</p>`}
+  </ul>` : `<p class="lede">Nothing outstanding in this window. Sanity check:
+  ${e.sources_reporting} of ${e.sources_known} expected sources are reporting -
+  an estate with nothing reporting looks "clean" too.</p>`}
 
   <h3 style="margin-top:26px;font-size:14px">Evidence snapshot</h3>
-  <p class="lede">A checksummed statement of the counts above, for the stated
-  window, with the registry and governance files identified by hash. Generated
-  on demand and not stored. Not reproducible, because log retention may mean
-  the same window returns less later; tamper-evident, because the manifest
-  carries a digest of itself with that field omitted.
+  <p class="lede">A checksummed JSON file of the counts above for this window,
+  with the registry and governance files identified by hash. Generated on
+  demand, not stored. Note it can't be regenerated identically later (log
+  retention), and the checksum detects accidental changes, not deliberate
+  ones.
   <a href="/api/evidence?download=true" style="color:var(--pri)">Download JSON</a></p>`;
 }
 
@@ -1435,8 +1419,8 @@ function settingRow(key, label, placeholder, note) {
   const s = (SETTINGS && SETTINGS.settings || {})[key] || {value: '', source: 'unset'};
   const secret = !('value' in s);
   const src = s.source === 'db'
-    ? (s.env ? `Saved in the portal, shadowing the deployment's value; clearing falls back to it.` : 'Saved in the portal.')
-    : s.source === 'env' ? `From the deployment; saving here overrides it without touching the deployment.` : '';
+    ? (s.env ? `Saved in the portal (overriding the deployment's value; clear to fall back to it).` : 'Saved in the portal.')
+    : s.source === 'env' ? `Currently from the deployment's environment; saving here overrides it.` : '';
   const secretNote = secret
     ? (s.set ? 'A value is set (never shown). Leave blank and save to CLEAR it; type and save to replace it.' : 'Not set.')
     : '';
@@ -1466,33 +1450,34 @@ function pasteGuardFields() {
         ${opt('off', 'off')}${opt('warn', 'warn')}${opt('block', 'block')}
       </select>
       <button class="mini" data-act="save-setting" data-key="paste_guard_mode">save</button>
-      <div class="src-note">What the guard does when a paste into an AI tool
-      matches a marking or detector: warn asks the person, block stops it.
-      Baked into every extension policy artifact below.</div></dd>
+      <div class="src-note">What happens when someone pastes marked content
+      into an AI tool: warn asks them first, block stops it. Baked into the
+      policy downloads.</div></dd>
     <dt>Classification markings</dt><dd>
       <textarea id="set-classification_markings" class="mfield" rows="4"
         style="min-width:340px;resize:vertical;font-family:inherit"
         placeholder="one marking per line (empty = the default set)">${marks === null ? '' : esc(marks.join('\n'))}</textarea>
       <button class="mini" data-act="save-markings">save</button>
       ${marksSet ? '<button class="mini" data-act="clear-markings">clear (default set)</button>' : ''}
-      <div class="src-note">Document phrases the guard scans pastes for, one
-      per line. Saving an empty box records "no markings" as a real choice;
-      clear falls back to the default five. Content never leaves the device -
-      the guard reports detector ids only.</div></dd>
+      <div class="src-note">Document phrases the guard looks for in pastes,
+      one per line. Save an empty box to use no markings; clear to go back
+      to the default five. What people paste never leaves their device -
+      only which detector matched gets reported.</div></dd>
     ${settingRow('firefox_extension_id', 'Firefox extension ID (gecko id)',
       'ai-guard@your-org.example',
-      'From browser_specific_settings.gecko.id in the manifest - a different'
-      + ' string from the Chromium id, for the same extension. Unlocks the'
-      + ' Firefox artifacts.')}
+      'The id you set in the manifest (browser_specific_settings.gecko.id).'
+      + ' Not the same as the Chromium id. Needed for the Firefox'
+      + ' downloads.')}
     ${settingRow('extension_update_url', 'Chromium update manifest URL',
       'https://files.example.com/updates.xml',
-      'Where the packed extension update manifest is hosted. Unlocks the'
-      + ' Windows Chromium deploy script.')}
+      'Where you host the packed extension update manifest (updates.xml).'
+      + ' Needed for the Windows Chromium deploy script.')}
     ${settingRow('extension_xpi_url', 'Signed .xpi URL (Firefox)',
       'https://files.example.com/ai-guard-1.0.0.xpi',
-      'The Mozilla-SIGNED file (addons.mozilla.org self-distribution) -'
-      + ' Firefox refuses unsigned extensions on release builds, and no'
-      + ' enterprise policy changes that. Unlocks the Firefox artifacts.')}`;
+      'Where you host the SIGNED .xpi from addons.mozilla.org'
+      + ' (self-distribution). Firefox only installs Mozilla-signed'
+      + ' extensions - extension/README.md explains the one-time signing'
+      + ' step. Needed for the Firefox downloads.')}`;
 }
 
 // The last result of a connection test, rendered where its button lives.
@@ -1572,15 +1557,16 @@ async function wizard() {
     data-act="wiz-store" data-key="${k}">${lbl}</button>`;
 
   return `<h2>Welcome — set up your deployment</h2>
-  <p class="lede">Everything below is optional, editable later under
-  Settings, and stored centrally: it takes effect at runtime, so nothing
-  needs a redeploy afterwards.</p>
+  <p class="lede">Work through the steps top to bottom. Everything here can
+  be changed later under Settings, and changes take effect immediately - no
+  redeploys.</p>
   ${SETMSG ? `<div class="note">${esc(SETMSG)}</div>` : ''}
 
-  <div class="wcard" style="margin-bottom:10px"><h3>1 · Where endpoints reach the receiver</h3>
-  <p class="lede" style="margin-bottom:10px">The public URL baked into every
-  downloaded artifact. It must resolve from the machines being enrolled -
-  not from inside the cluster, and not only from this one. Save, then probe.</p>
+  <div class="wcard" style="margin-bottom:10px"><h3>1 · Where your machines reach the receiver</h3>
+  <p class="lede" style="margin-bottom:10px">The URL your laptops and servers
+  will send findings to. It gets baked into every download below, so it has
+  to work from those machines - not just from inside the cluster. Save it,
+  then hit probe to check.</p>
   <dl class="kv">
     ${settingRow('receiver_public_url', 'Public receiver URL',
       'https://ai-guard.your-tailnet.ts.net', '')}
@@ -1590,45 +1576,45 @@ async function wizard() {
   </div>${testNote('receiver-url')}</div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>2 · The log store</h3>
-  <p class="lede" style="margin-bottom:10px">Findings are JSON lines the
-  receiver pushes to a Loki-compatible store and the portal reads back.
-  Where is yours?</p>
+  <p class="lede" style="margin-bottom:10px">Findings are stored in a
+  Loki-compatible log store: the receiver writes to it, this portal reads
+  from it. Where is yours?</p>
   <div style="margin-bottom:10px">
     ${storeBtn('self', 'self-hosted / in-cluster')}
     ${storeBtn('cloud', 'hosted (Grafana Cloud)')}
     ${storeBtn('none', 'none yet')}
   </div>
-  ${WIZSTORE === 'none' ? `<p class="lede">Fine: findings still land on the
-    receiver's stdout, so anything scraping container logs keeps them.
-    The estate views here stay empty until a store is configured - add one
-    later under Settings.</p>`
-  : `${WIZSTORE === 'self' ? `<p class="lede">Find the in-cluster service -
-    <span class="mono">kubectl get svc -A | grep -i loki</span> - and use
-    its base URL, typically
+  ${WIZSTORE === 'none' ? `<p class="lede">That's fine - findings still land
+    in the receiver's container logs, so nothing is lost. The pages here
+    stay empty until you add a store later under Settings.</p>`
+  : `${WIZSTORE === 'self' ? `<p class="lede">Find your Loki service -
+    <span class="mono">kubectl get svc -A | grep -i loki</span> - and paste
+    its base URL, usually
     <span class="mono">http://loki.&lt;namespace&gt;.svc.cluster.local:3100</span>.
-    No credentials needed for a typical in-cluster Loki.</p>`
-  : `<p class="lede">From Grafana Cloud's Loki details page: the URL, the
-    numeric instance id as username, and an access-policy token with
-    <b>logs:write AND logs:read</b> - a write-only token stores nothing and
-    tells nobody, which is exactly what the tests below catch.</p>`}
+    An in-cluster Loki normally needs no credentials.</p>`
+  : `<p class="lede">From Grafana Cloud's Loki details page you need three
+    things: the URL, your numeric instance ID (that's the username), and an
+    access-policy token with <b>both logs:write and logs:read</b>. A
+    write-only token is the classic mistake - the test buttons below will
+    catch it.</p>`}
   <dl class="kv">${logStoreFields(WIZSTORE === 'cloud')}</dl>
   ${logStoreTests()}`}</div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>3 · Corporate domains</h3>
-  <p class="lede" style="margin-bottom:10px">Accounts on these domains are
-  work accounts; everything else reads as personal. Served to the collectors
-  on every check-in.</p>
+  <p class="lede" style="margin-bottom:10px">Your work email domains. An AI
+  tool signed into one of these counts as a work account; anything else gets
+  flagged as personal. Collectors pick this up automatically on their next
+  run.</p>
   <input id="set-domains" class="mfield" style="min-width:340px"
     placeholder="example.com, example.co.uk"
     value="${esc((cd.value || []).join(', '))}">
   <button class="mini" data-act="save-domains">save</button></div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>4 · Governance baseline</h3>
-  <p class="lede" style="margin-bottom:10px">What your organisation has
-  decided about the tools the registry watches for. Touch only the ones you
-  have a position on - the rest stay undecided, which is the honest state.
-  Approvals carry the review date below; refine any decision later on the
-  AI register.</p>
+  <p class="lede" style="margin-bottom:10px">Which AI tools your organisation
+  has approved or banned. Only set the ones you actually have a position on -
+  leaving the rest undecided is fine. You can refine any of this later on
+  the AI register.</p>
   ${GOVERR ? `<div class="note">${esc(GOVERR)}</div>` : ''}
   <div style="margin-bottom:10px">
     <input id="wiz-owner" class="mfield" value="${esc(WIZOWNER)}"
@@ -1641,19 +1627,18 @@ async function wizard() {
 
   <div class="wcard" style="margin-bottom:10px"><h3>5 · Browser extension &amp; paste guard</h3>
   <p class="lede" style="margin-bottom:10px">One extension does both jobs:
-  reporting which account is signed into an AI tool, and the paste guard
-  that warns or blocks when marked content is pasted into one. Chrome, Edge
-  and Brave install it by Chromium policy; Firefox by Mozilla policy from a
-  signed .xpi. Everything here is baked into the policy downloads in
-  step 7.</p>
+  it reports which account is signed into each AI site, and its paste guard
+  warns or blocks risky pastes. You pack it once (extension/README.md), then
+  everything you set here gets baked into the ready-made policy downloads in
+  step 7. Fine to skip on a first pass and come back.</p>
   <dl class="kv">
     <dt>Chromium extension ID</dt><dd>
       <input id="set-extid" class="mfield" style="min-width:340px"
         placeholder="the 32-letter id from chrome://extensions" value="${esc(eid)}">
       <button class="mini" data-act="save-extid">save</button>
-      <div class="src-note">The packed extension's 32-letter id
-      (extension/README.md shows how to derive it). Unlocks the Chromium
-      policy downloads.</div></dd>
+      <div class="src-note">The 32-letter id Chrome gives the packed
+      extension - read it from chrome://extensions on a machine that has it.
+      Needed for the Chromium downloads.</div></dd>
     ${pasteGuardFields()}
   </dl></div>
 
@@ -1668,10 +1653,11 @@ async function wizard() {
   </dl></div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>7 · Deployment downloads</h3>
-  <p class="lede" style="margin-bottom:10px">Each download mints its own
-  enrollment token (revocable on its own under Enrollment tokens) and bakes
-  the receiver URL, so what you upload to the MDM works as-is. Machines
-  enroll themselves and appear under Fleet.</p>
+  <p class="lede" style="margin-bottom:10px">Ready-to-deploy files with the
+  receiver URL and a fresh enrollment token already inside - push them
+  through your MDM or run them as-is. Machines enroll themselves and appear
+  under Fleet. Each download gets its own token, so you can revoke one
+  rollout without touching the others.</p>
   ${CFG.managed && CFG.managed.artifacts_ready ? `<div style="display:flex;gap:8px;flex-wrap:wrap">
     <button class="mini" data-act="artifact" data-key="collector-macos">macOS collector</button>
     <button class="mini" data-act="artifact" data-key="collector-linux">Linux collector</button>
@@ -1687,8 +1673,9 @@ async function wizard() {
 
   <div style="margin:18px 0">
     <button class="mini" style="padding:8px 18px" data-act="wiz-finish">Finish setup</button>
-    <span class="src-note" style="margin-left:10px">Opens the Setup view;
-    everything above stays editable under Settings and the AI register.</span>
+    <span class="src-note" style="margin-left:10px">You can come back:
+    everything above stays editable under Settings, and Settings can reopen
+    this wizard.</span>
   </div>`;
 }
 
@@ -1710,10 +1697,10 @@ function managedSettings() {
          saving here overrides it without touching the deployment.`
       : 'Not set anywhere yet.';
   return `<div class="wcard" style="margin-bottom:10px"><h3>Central settings</h3>
-  <p class="lede" style="margin-bottom:10px">Stored in the receiver and served
-  to the fleet at runtime: collectors pick a change up on their next check-in,
-  no MDM re-push. A value saved here wins over the matching environment
-  variable.</p>
+  <p class="lede" style="margin-bottom:10px">Saved in the receiver and picked
+  up by the fleet automatically - collectors get changes on their next
+  check-in, nothing needs re-pushing through the MDM. A value saved here
+  overrides the matching environment variable.</p>
   ${SETMSG ? `<div class="note">${esc(SETMSG)}</div>` : ''}
   <dl class="kv">
     <dt>Corporate domains</dt><dd>
@@ -1885,18 +1872,17 @@ function setup() {
 
   const g = S.groups || [];
   return `<h2>Setup</h2>
-  <p class="lede">What is reporting, derived from findings rather than from
-  configuration being present. A source that has never reported is either not
-  set up or genuinely has nothing to say, and those look identical from a
-  dashboard — so they are listed rather than counted.</p>
+  <p class="lede">What's reporting and what isn't, worked out from actual
+  findings - not from whether something is configured. Each silent source
+  below tells you what it needs to start reporting.</p>
 
   <dl class="stats">
     ${g.map(x => `<div><dt>${x.reporting}/${x.total}</dt><dd>${esc(x.group)}</dd></div>`).join('')}
   </dl>
 
   ${S.reporting === 0 ? `<div class="note">Nothing has reported in the last
-  ${esc(S.hours)} hours. If you have just deployed the receiver that is
-  expected: roll one collector or enable one scanner and it appears here.</div>` : ''}
+  ${esc(S.hours)} hours. If you've just installed, that's expected - run one
+  collector (Getting started walks through it) and it will appear here.</div>` : ''}
 
   ${g.map(x => `
     <h2 style="margin-top:22px;font-size:16px">${esc(x.group)}
@@ -1920,37 +1906,34 @@ function setup() {
   <h2 style="margin-top:28px;font-size:16px">Attaching people to devices
     <span class="pill ${CFG.identity_map_configured ? 'p-ok' : 'p-mut'}">${
       CFG.identity_map_configured ? 'map configured' : 'no map'}</span></h2>
-  <p class="lede">This platform does not resolve identity itself. Endpoint
-  findings carry a device and a local username, and that username is a hint
-  rather than a key: it is firstname.lastname on one enrolment, a local account
-  on another, and whatever the person chose on an unmanaged machine. Cloud
-  findings carry an identity and no device. The two meet at the person, and
-  that join is a lookup you own against whatever you run — an MDM, an RMM, a
-  CMDB, or a spreadsheet.</p>
+  <p class="lede">Endpoint findings know the machine but only a local
+  username; cloud findings know the person but not the machine. Joining the
+  two - "this laptop belongs to this person" - needs a lookup only you have:
+  your MDM, RMM, CMDB, or a spreadsheet. The portal helps you build that
+  file below.</p>
   ${CFG.identity_map_configured ? `<p class="lede">A map is configured.
-  Devices it does not cover stay unattributed, which is a legitimate answer.</p>`
+  Devices it doesn't cover show as unattributed, which is fine.</p>`
   : `<ol class="lede" style="padding-left:18px;line-height:2">
     <li><a href="/api/suggest-identities?fmt=csv" style="color:var(--pri)">Download
-      a proposed map</a>. It matches local usernames against the identities your
-      cloud sources report, and lists everything it could not match for you to
-      fill in.</li>
-    <li>Review every line. These are string matches, not authoritative: a wrong
-      line puts the wrong person's name against someone else's activity.</li>
-    <li>Save it outside this repository. It associates named people with
-      machines, so it is personal data and belongs wherever you keep deployment
-      configuration, not in git.</li>
+      a proposed map</a>. It matches local usernames against identities from
+      your cloud sources, and lists what it couldn't match for you to fill
+      in.</li>
+    <li>Check every line. These are string matches, and a wrong one puts the
+      wrong person's name against someone else's activity.</li>
+    <li>Keep the file outside this repository. It links named people to
+      machines, so it's personal data - store it with your deployment
+      config, not in git.</li>
     <li>Set <code>IDENTITY_MAP</code> to its path. In Docker, mount it read-only;
       in Kubernetes, a ConfigMap or Secret mounted as a file.</li>
   </ol>
-  <p class="lede">The file is re-read whenever the graph rebuilds, so an edit
-  takes effect within ${esc(CFG.cache_ttl_seconds || 300)} seconds without a
-  restart. Devices with no mapping stay unattributed and everything else keeps
-  working.</p>`}
+  <p class="lede">The file is re-read automatically, so edits take effect
+  within ${esc(CFG.cache_ttl_seconds || 300)} seconds, no restart needed.
+  Devices with no mapping just show as unattributed.</p>`}
 
   ${(S.unexpected || []).length ? `<h2 style="margin-top:26px;font-size:16px">Unrecognised sources</h2>
-  <p class="lede">Reporting, but not a source this build knows about. Either
-  something newer than this portal, or a source string that does not match what
-  the scanners emit — both worth chasing rather than ignoring.</p>
+  <p class="lede">These are reporting, but this portal build doesn't know
+  them. Either something newer than this portal, or a custom scanner with its
+  own source name. Worth checking either way.</p>
   <table><tr><th>source</th></tr>${S.unexpected.map(u =>
     `<tr><td>${esc(u)}</td></tr>`).join('')}</table>` : ''}`;
 }
@@ -1977,9 +1960,8 @@ function dashboard() {
     about how the frame authenticates — anonymous access on a locked-down
     Grafana, or an auth proxy. Those are yours to make; the portal cannot make
     them for you.</div>
-    <p class="lede">Nothing else here depends on this. Grafana is better at
-    graphs and this is better at relationships, so charts are enrichment rather
-    than a dependency.</p>`;
+    <p class="lede">Everything else in the portal works without Grafana -
+    this page just adds charts and history.</p>`;
 
   const base = CFG.grafana_url, panels = CFG.grafana_panels || [];
   const q = 'orgId=1&theme=dark&from=now-7d&to=now&kiosk';
@@ -2003,8 +1985,8 @@ function dashboard() {
   return `<h2>Grafana</h2>
   ${openIn(base)}
   <p class="lede">Panels embedded from ${esc(base)}. If a frame stays blank,
-  Grafana is refusing to be framed rather than the panel being wrong — check
-  <code>allow_embedding</code> and the cookie <code>SameSite</code> setting.</p>
+  Grafana is refusing to be embedded - check <code>allow_embedding</code> and
+  the cookie <code>SameSite</code> setting on the Grafana side.</p>
   ${bad.length ? `<div class="note">${bad.map(b => esc(b.error)).join('<br>')}</div>` : ''}
   <div style="display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(420px,1fr))">
   ${panels.filter(p => !p.error).map(p => `
@@ -2053,12 +2035,11 @@ async function fleet() {
   }
   const ds = FLEET.devices || [];
   return `<h2>Fleet</h2>
-  <p class="lede">Enrolled devices, from the receiver's registry — who holds a
-  credential, rather than who has reported lately (the Devices view derives
-  that from findings). Revoking stops that one credential on its next
-  request and touches nothing else. A device that re-enrolled (a reimaged
-  laptop, a scanner that enrolls every run — or a serial someone else
-  enrolled while it was silent) keeps its row and says so under "enrolled".</p>
+  <p class="lede">Every device holding a credential. (The Devices view is
+  different: it shows who has actually reported findings.) Revoke cuts off
+  that one device and nothing else. Re-enrollments - a reimaged laptop, a
+  scanner that enrolls every run - keep their row and are noted under
+  "enrolled".</p>
   ${ds.length ? `<table><tr><th>device</th><th>platform</th><th>serial</th>
     <th>enrolled</th><th>last seen</th><th>agent</th><th>status</th><th></th></tr>
   ${ds.map(d => `<tr>
@@ -2087,11 +2068,11 @@ async function tokens() {
   const state = t => t.revoked_at ? ['revoked', 'p-mut']
     : t.expires_at <= nowIso ? ['expired', 'p-mut'] : ['active', 'p-ok'];
   return `<h2>Enrollment tokens</h2>
-  <p class="lede">An enrollment token goes where the shared token goes today —
-  a Jamf parameter, the Intune script, an RMM variable — and machines exchange
-  it once for their own credential. It can create auditable device records and
-  nothing else, which is why a long life inside an MDM artifact is
-  acceptable; revoke it here the moment it is not.</p>
+  <p class="lede">An enrollment token goes into your MDM or RMM (a Jamf
+  parameter, the Intune script, an RMM variable). Each machine exchanges it
+  once for its own credential. The token itself can only enroll devices - it
+  can't submit findings - so a long expiry inside an MDM artifact is fine.
+  Revoke it here when a rollout is done or a token leaks.</p>
   ${MINTED ? (MINTED.error
     ? `<div class="note">${esc(MINTED.error)}
        <button class="mini" data-act="dismiss-minted">dismiss</button></div>`
@@ -2099,7 +2080,7 @@ async function tokens() {
        This is the only time it is shown — the receiver stores a hash.
        <br><code>${esc(MINTED.token)}</code><br>
        <button class="mini" data-act="copy" data-copy="${esc(MINTED.token)}">copy</button>
-       <button class="mini" data-act="dismiss-minted">done, it is saved</button>
+       <button class="mini" data-act="dismiss-minted">done, I've saved it</button>
        </div>`) : ''}
   <div style="margin:10px 0 16px">
     <input id="mint-note" class="mfield" placeholder="note, e.g. macOS Jamf rollout">

--- a/portal/tests/test_runtime_log_store.py
+++ b/portal/tests/test_runtime_log_store.py
@@ -276,7 +276,7 @@ def test_the_page_carries_the_new_settings_ui():
                    "settingRow('alertmanager_url'",
                    "settingRow('grafana_url'",
                    "settingRow('log_store_password'",
-                   "logs:write AND logs:read", "kubectl get svc"):
+                   "logs:write and logs:read", "kubectl get svc"):
         assert needle in html, needle
 
 


### PR DESCRIPTION
Wording-only pass over the docs and the portal UI. The goal: someone who has never seen the project can land on the README or the portal and know what to do next.

- getting-started.md is restructured around the default install: five steps from nothing to a finding. Classic mode moved to its own section at the end.
- README gets the actual install command and the steps after it, and a few sections are shortened.
- Portal on-screen text tightened everywhere: wizard, setup rows, settings notes, empty states. Silent sources on Setup now say plainly what they need.
- extension/README gets a short overview of the setup order before the detail.
- portal/README, architecture.md, SECURITY.md, demo/README: shortened the wordier sections.

No behaviour changes. One test needle updated to match new copy.