### PR TITLE
Extension setup as a guided flow

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -72,18 +72,23 @@ through enterprise browser policy. The one-time work is:
 After that, everything day-to-day (mode changes, domain changes, new
 enrollment tokens) is a policy push, and releases are pack-upload-done.
 
-With a managed-mode deployment, the portal generates the whole matrix
-pre-configured (the onboarding wizard, or the Setup view's browser row):
-the Chromium managed-storage plist for macOS, the Windows deploy scripts
-for Chromium and Firefox, and the Firefox install-and-configure plist for
-macOS - receiver URL, a fresh enrollment token per download, your
-corporate domains, and the paste guard settings (mode and classification
-markings, both editable in the portal) baked in. Set the extension IDs in
-the portal's Settings first - the Chromium id comes from packing (step 2
-below), the Firefox gecko id from the manifest - plus the update-manifest
-URL (Chromium) and the signed .xpi URL (Firefox), which the portal cannot
-derive for you. Because this extension reads no central config, changing
-any of those means regenerating and re-pushing the policies.
+With a managed-mode deployment, the portal walks all of this: the wizard's
+extension step opens a guided setup that serves the source pre-configured
+(this repo's `src/`, with the receiver origin already in the manifest - so
+none of it needs a checkout), carries the packing instructions from this
+README, generates `updates.xml` and `firefox-updates.json` from what you
+save, and probes the hosted URLs - including whether the .xpi you hosted
+is actually the Mozilla-signed one. The portal also generates the whole
+policy matrix pre-configured: the Chromium managed-storage plist for
+macOS, the Windows deploy scripts for Chromium and Firefox, and the
+Firefox install-and-configure plist for macOS - receiver URL, a fresh
+enrollment token per download, your corporate domains, and the paste
+guard settings (mode and classification markings, both editable in the
+portal) baked in. What the portal cannot derive for you it asks for: the
+Chromium id from packing (step 2 below), the Firefox gecko id from the
+manifest, and the hosting URLs. Because this extension reads no central
+config, changing any of those means regenerating and re-pushing the
+policies.
 
 ### 1. Customise the source
 

--- a/portal/Dockerfile
+++ b/portal/Dockerfile
@@ -26,6 +26,9 @@ COPY app/ app/
 # asserts these are byte-identical to the sources, the same pattern as the
 # chart's bundled registry.
 COPY collector-scripts/ collector-scripts/
+# Verified copies of extension/src, same reasoning: the extension-source
+# download serves these with the receiver origin substituted in.
+COPY extension-src/ extension-src/
 
 # Passed by CI from the release tag, or the commit for a build off main. A
 # local build leaves it as "dev", which is honest: a hardcoded version drifts,

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -79,7 +79,8 @@ import urllib.parse
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
-from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
+from fastapi.responses import (FileResponse, JSONResponse, PlainTextResponse,
+                               Response)
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel, Field
 
@@ -302,6 +303,12 @@ elif not (PORTAL_USER and PORTAL_PASSWORD):
 # chart's bundled registry; a test asserts byte equality with the sources).
 COLLECTOR_SCRIPTS_DIR = os.environ.get(
     "COLLECTOR_SCRIPTS_DIR", str(Path(__file__).parent.parent / "collector-scripts"))
+
+# Verified copies of extension/src, same pattern: the extension-source
+# download serves these with the receiver origin substituted in, so packing
+# the extension no longer needs a checkout.
+EXTENSION_SRC_DIR = os.environ.get(
+    "EXTENSION_SRC_DIR", str(Path(__file__).parent.parent / "extension-src"))
 
 STATIC = Path(__file__).parent / "static"
 
@@ -678,8 +685,21 @@ def config(request: Request, _=Depends(require_auth)):
             "enabled": bool(RECEIVER_URL),
             "artifacts_ready": bool(RECEIVER_URL and public_url),
             "receiver_public_url_default": public_url,
+            # The bundled extension source's version: the setup guide names
+            # files with it and the generated update manifests carry it.
+            "extension_version": _extension_version_or_blank(),
         },
     }
+
+
+def _extension_version_or_blank() -> str:
+    """Config must render even if the bundled source is unreadable - the
+    guide then says VERSION where it would say a number, and the download
+    itself reports the real error."""
+    try:
+        return managed.extension_version(EXTENSION_SRC_DIR)
+    except managed.ArtifactError:
+        return ""
 
 
 # The widgets the overview knows how to draw. A name not in here is a typo or
@@ -1480,6 +1500,125 @@ def test_log_store_push(_=Depends(require_auth),
     return _receiver("POST", "/admin/test/log-store-push", token)
 
 
+def _fetch_hosted(url: str, cap: int):
+    """(status, content-type, first `cap` bytes) of a saved hosting URL.
+
+    Server-side like the receiver-url probe, and reading at most `cap`
+    bytes: the .xpi check needs the file, but a probe must not be a way to
+    pull something huge through the portal pod.
+    """
+    import urllib.request as _urlreq
+
+    req = _urlreq.Request(url, headers={"User-Agent": "ai-guard-portal"})
+    with _urlreq.urlopen(req, timeout=10) as resp:
+        return (resp.status, resp.headers.get("Content-Type", ""),
+                resp.read(cap))
+
+
+_HOSTING_CAVEAT = ("could not reach %s from inside the cluster (%s). These "
+                   "files must be reachable by every browser in the fleet, "
+                   "so unlike the receiver probe this usually IS a problem - "
+                   "but if your artifact host is only visible from the "
+                   "corporate network, confirm from a fleet machine instead.")
+
+
+@app.post("/api/test/extension-updates")
+def test_extension_updates(_=Depends(require_auth),
+                           token: str = Depends(_admin_forward)):
+    """Fetch the saved Chromium update manifest URL and check it against
+    the saved extension id: the failure this catches is a hosted file that
+    answers 200 and quietly describes some other id or version, which
+    browsers treat as 'no update for you', forever."""
+    stored = _receiver("GET", "/admin/settings", token).get("settings", {})
+    url = ((stored.get("extension_update_url") or {}).get("value") or "").strip()
+    if not url:
+        raise HTTPException(
+            400, "no update manifest URL to probe: save one first")
+    try:
+        status, ctype, body = _fetch_hosted(url, 64 * 1024)
+    except Exception as e:
+        return {"ok": False,
+                "detail": _HOSTING_CAVEAT % (_redact_url(url),
+                                             type(e).__name__)}
+    warnings = []
+    try:
+        import xml.etree.ElementTree as ET
+        root = ET.fromstring(body.decode("utf-8", "replace"))
+        ns = "{http://www.google.com/update2/response}"
+        apps = root.findall(ns + "app") or root.findall("app")
+        appids = [a.get("appid", "") for a in apps]
+        saved_id = ((stored.get("extension_id") or {}).get("value") or "")
+        if saved_id and saved_id not in appids:
+            return {"ok": False, "url": url,
+                    "detail": "the hosted manifest describes %s, not the "
+                              "saved extension id - browsers pointed at it "
+                              "will never install or update this extension"
+                              % (", ".join(appids) or "no extension")}
+        checks = [u for a in apps
+                  for u in a.findall(ns + "updatecheck") + a.findall("updatecheck")]
+        versions = sorted({c.get("version", "?") for c in checks})
+        try:
+            bundled = managed.extension_version(EXTENSION_SRC_DIR)
+            if bundled not in versions:
+                warnings.append(
+                    "the hosted manifest says version %s; the source this "
+                    "portal serves is %s. Fine if you packed a different "
+                    "version on purpose."
+                    % (", ".join(versions) or "?", bundled))
+        except managed.ArtifactError:
+            pass
+    except ET.ParseError:
+        return {"ok": False, "url": url,
+                "detail": "%s answered, but not with XML an update manifest "
+                          "could parse as" % _redact_url(url)}
+    return {"ok": True, "url": url, "warnings": warnings,
+            "detail": "the hosted manifest matches the saved extension id"}
+
+
+@app.post("/api/test/extension-xpi")
+def test_extension_xpi(_=Depends(require_auth),
+                       token: str = Depends(_admin_forward)):
+    """Fetch the saved .xpi URL and check it is the SIGNED file.
+
+    The trap this exists for: hosting the .xpi you built instead of the one
+    AMO returned. Both are valid zips, both download fine, and Firefox
+    refuses one of them on every machine in the fleet. A signed .xpi
+    contains META-INF/mozilla.rsa; an unsigned one does not."""
+    import io
+    import zipfile
+
+    stored = _receiver("GET", "/admin/settings", token).get("settings", {})
+    url = ((stored.get("extension_xpi_url") or {}).get("value") or "").strip()
+    if not url:
+        raise HTTPException(400, "no signed .xpi URL to probe: save one first")
+    try:
+        status, ctype, body = _fetch_hosted(url, 32 * 1024 * 1024)
+    except Exception as e:
+        return {"ok": False,
+                "detail": _HOSTING_CAVEAT % (_redact_url(url),
+                                             type(e).__name__)}
+    warnings = []
+    if ctype and "xpinstall" not in ctype and "octet-stream" not in ctype:
+        warnings.append(
+            "served as %s; Firefox expects application/x-xpinstall "
+            "(some hosts need the content type set per file)" % ctype)
+    try:
+        names = zipfile.ZipFile(io.BytesIO(body)).namelist()
+    except zipfile.BadZipFile:
+        return {"ok": False, "url": url,
+                "detail": "%s answered, but the file is not a zip (an .xpi "
+                          "is one), or is larger than this probe reads"
+                          % _redact_url(url)}
+    if "META-INF/mozilla.rsa" not in names:
+        return {"ok": False, "url": url,
+                "detail": "the hosted .xpi is not Mozilla-signed (no "
+                          "META-INF/mozilla.rsa) - this is your own build; "
+                          "Firefox will refuse it. Host the file AMO "
+                          "returned after signing."}
+    return {"ok": True, "url": url, "warnings": warnings,
+            "detail": "the hosted .xpi is Mozilla-signed"}
+
+
 @app.post("/api/password")
 def api_password(req: PasswordWrite, _=Depends(require_auth),
                  token: str = Depends(_admin_forward)):
@@ -1494,7 +1633,16 @@ def api_password(req: PasswordWrite, _=Depends(require_auth),
 # copies. Same minting and download shape as the collector kinds.
 GENERATED_ARTIFACTS = ("extension-policy", "extension-windows",
                        "firefox-policy", "firefox-windows",
-                       "scanner-cronjob", "discovery-cronjob")
+                       "scanner-cronjob", "discovery-cronjob",
+                       "extension-source", "extension-updates-xml",
+                       "firefox-updates-json")
+
+# The extension-hosting downloads carry no credential - the source zip and
+# the update manifests bake URLs and ids, never a token - so generating one
+# must not mint. A minted-but-unused token in the list reads as a rollout
+# that never happened.
+TOKENLESS_ARTIFACTS = ("extension-source", "extension-updates-xml",
+                       "firefox-updates-json")
 
 
 @app.post("/api/artifacts/{kind}")
@@ -1531,6 +1679,45 @@ def artifact(kind: str, _=Depends(require_auth),
 
     def setting(key):
         return (stored.get(key) or {}).get("value") or ""
+
+    if kind in TOKENLESS_ARTIFACTS:
+        try:
+            if kind == "extension-source":
+                filename, content = managed.generate_extension_source(
+                    EXTENSION_SRC_DIR, public_url)
+                return Response(content, media_type="application/zip",
+                                headers={"Content-Disposition":
+                                         'attachment; filename="%s"' % filename})
+            if kind == "extension-updates-xml":
+                if not setting("extension_id"):
+                    raise HTTPException(
+                        409, "set the extension ID in Settings first: the "
+                             "update manifest is keyed on it")
+                if not setting("extension_crx_url"):
+                    raise HTTPException(
+                        409, "set the packed .crx URL in Settings first: "
+                             "the update manifest points browsers at it")
+                filename, content = managed.generate_updates_xml(
+                    setting("extension_id"), setting("extension_crx_url"),
+                    managed.extension_version(EXTENSION_SRC_DIR))
+            else:
+                if not setting("firefox_extension_id"):
+                    raise HTTPException(
+                        409, "set the Firefox extension ID (the gecko id) "
+                             "in Settings first: the update manifest is "
+                             "keyed on it")
+                if not setting("extension_xpi_url"):
+                    raise HTTPException(
+                        409, "set the signed .xpi URL in Settings first: "
+                             "the update manifest points Firefox at it")
+                filename, content = managed.generate_firefox_updates_json(
+                    setting("firefox_extension_id"),
+                    setting("extension_xpi_url"),
+                    managed.extension_version(EXTENSION_SRC_DIR))
+        except managed.ArtifactError as e:
+            raise HTTPException(500, str(e))
+        return PlainTextResponse(content, headers={
+            "Content-Disposition": 'attachment; filename="%s"' % filename})
 
     extension_kinds = ("extension-policy", "extension-windows",
                        "firefox-policy", "firefox-windows")

--- a/portal/app/managed.py
+++ b/portal/app/managed.py
@@ -21,6 +21,7 @@ the portal image cannot see the endpoint/ tree at build time.
 import json
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from xml.sax.saxutils import escape as _xml
@@ -651,3 +652,149 @@ spec:
                 - name: AIGUARD_SCANNER_ID
                   value: "scanner"
 """
+
+
+# ------------------------------------------------- extension source & hosting
+
+# Verified copies of extension/src (the same byte-equality test as the
+# collector scripts), so an operator without a checkout can download the
+# source, pack it, and host it - the whole of extension/README.md's setup
+# without the repo. The zip does README step 1 for them: the receiver
+# origin substituted into manifest.json's host_permissions.
+EXTENSION_SOURCE_FILES = ("manifest.json", "background.js", "content.js",
+                          "guard.js", "managed-schema.json")
+
+# The shipped manifest's placeholder receiver origin. Substituted as a
+# byte-exact anchor, like the collector scripts: a manifest edit that
+# reshapes this line must fail loudly at generation, not produce a zip
+# whose report POSTs die on CORS.
+_MANIFEST_ORIGIN_ANCHOR = '"https://ai-guard.example.com/*"'
+
+
+def extension_version(src_dir: str) -> str:
+    """The version of the bundled extension source.
+
+    The generated update manifests carry it, because the version in an
+    update manifest MUST match the packed extension's own, and the packed
+    extension is (for anyone using the guided setup) exactly this source.
+    """
+    try:
+        manifest = json.loads((Path(src_dir) / "manifest.json").read_text())
+    except (OSError, ValueError) as e:
+        raise ArtifactError("bundled extension manifest not readable (%s)"
+                            % type(e).__name__)
+    version = str(manifest.get("version", ""))
+    if not re.fullmatch(r"[0-9]+(\.[0-9]+){0,3}", version):
+        raise ArtifactError("the bundled extension manifest has no usable"
+                            " version")
+    return version
+
+
+def generate_extension_source(src_dir: str, url: str) -> tuple[str, bytes]:
+    """A zip of the extension source, pointed at this deployment's receiver.
+
+    Everything ships byte-identical except manifest.json, where the
+    placeholder origin in host_permissions becomes the receiver's - the one
+    edit the README requires before packing. Deterministic timestamps, so
+    two downloads of the same release are the same bytes.
+    """
+    import io
+    import zipfile
+
+    _refuse_unembeddable(((url, "receiver URL"),))
+    parts = urllib.parse.urlsplit(url)
+    if parts.scheme not in ("http", "https") or not parts.netloc:
+        raise ArtifactError("the receiver URL does not parse as a URL")
+    origin = "%s://%s" % (parts.scheme, parts.netloc)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        for name in EXTENSION_SOURCE_FILES:
+            path = Path(src_dir) / name
+            try:
+                data = path.read_bytes()
+            except OSError as e:
+                raise ArtifactError("bundled extension source not readable:"
+                                    " %s (%s)" % (name, type(e).__name__))
+            if name == "manifest.json":
+                text = data.decode()
+                if text.count(_MANIFEST_ORIGIN_ANCHOR) != 1:
+                    raise ArtifactError(
+                        "substitution anchor not found exactly once in"
+                        " manifest.json - the extension manifest changed"
+                        " shape; update _MANIFEST_ORIGIN_ANCHOR to match")
+                data = text.replace(_MANIFEST_ORIGIN_ANCHOR,
+                                    '"%s/*"' % origin).encode()
+            info = zipfile.ZipInfo("ai-guard-extension/" + name,
+                                   date_time=(1980, 1, 1, 0, 0, 0))
+            info.external_attr = 0o644 << 16
+            z.writestr(info, data)
+    return "ai-guard-extension-source.zip", buf.getvalue()
+
+
+def generate_updates_xml(extension_id: str, crx_url: str,
+                         version: str) -> tuple[str, str]:
+    """The Chromium update manifest, filled in from Settings.
+
+    Mirrors extension/updates.xml.template; the operator hosts this next to
+    the .crx instead of hand-editing the template. The version is the
+    bundled source's own - see extension_version().
+    """
+    if not re.fullmatch(r"[a-p]{32}", extension_id or ""):
+        raise ArtifactError(
+            "the extension id does not look like a Chromium extension id"
+            " (32 letters a-p); check Settings")
+    _refuse_unembeddable(((crx_url, "packed .crx URL"),))
+    return "updates.xml", _UPDATES_XML_TEMPLATE % {
+        "id": _xml(extension_id), "crx": _xml(crx_url),
+        "version": _xml(version),
+    }
+
+
+_UPDATES_XML_TEMPLATE = """\
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+  ai-guard extension update manifest, generated by the portal. Host this
+  file at the update manifest URL saved in Settings, next to the packed
+  .crx. On every release: pack the new source with the SAME .pem, upload
+  the versioned .crx, and download this file again - the version below
+  must always match the packed manifest's.
+-->
+<gupdate xmlns='http://www.google.com/update2/response' protocol='2.0'>
+  <app appid='%(id)s'>
+    <updatecheck
+      codebase='%(crx)s'
+      version='%(version)s' />
+  </app>
+</gupdate>
+"""
+
+
+def generate_firefox_updates_json(gecko_id: str, xpi_url: str,
+                                  version: str) -> tuple[str, str]:
+    """The Firefox update manifest, filled in from Settings.
+
+    Mirrors extension/firefox-updates.json.template. Serialized with
+    json.dumps rather than formatted into a string: the gecko id is
+    operator-supplied and lands as a JSON key.
+    """
+    _refuse_unembeddable(((xpi_url, "signed .xpi URL"),
+                          (gecko_id, "Firefox extension id")))
+    body = {
+        "_comment": [
+            "ai-guard Firefox update manifest, generated by the portal.",
+            "Host this file at the URL named in the extension manifest's",
+            "browser_specific_settings.gecko.update_url, next to the",
+            "SIGNED .xpi. On every release: rebuild the .xpi, have AMO",
+            "sign it, upload the signed file, and download this file",
+            "again - the version below must match the packed manifest's.",
+        ],
+        "addons": {
+            gecko_id: {
+                "updates": [
+                    {"version": version, "update_link": xpi_url}
+                ]
+            }
+        },
+    }
+    return "firefox-updates.json", json.dumps(body, indent=2) + "\n"

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -374,7 +374,8 @@ const NAV = [
 // not recognised. Two lists that must agree, with nothing enforcing it.
 // 'wizard' is reachable by fragment but absent from the nav: it is a door
 // you walk through once, not a place to live.
-const VIEWS = NAV.flatMap(sec => sec.items.map(([id]) => id)).concat(['wizard']);
+const VIEWS = NAV.flatMap(sec => sec.items.map(([id]) => id))
+  .concat(['wizard', 'extsetup']);
 const fromHash = () => {
   const h = (location.hash || '').replace(/^#/, '');
   return VIEWS.includes(h) ? h : 'setup';
@@ -1433,11 +1434,14 @@ function settingRow(key, label, placeholder, note) {
     <div class="src-note">${esc(note)}${note ? ' ' : ''}${secretNote || src}</div></dd>`;
 }
 
-// The paste guard and extension-delivery settings, shared by the wizard
-// and the Settings view. The paste guard IS the browser extension - one
-// package, one policy - and these values are baked into every generated
-// policy artifact, so a change here means regenerate and re-push.
-function pasteGuardFields() {
+// The paste guard and extension-delivery settings, shared by the Settings
+// view and the extension setup guide. The paste guard IS the browser
+// extension - one package, one policy - and these values are baked into
+// every generated policy artifact, so a change here means regenerate and
+// re-push. Split in two: behaviour (what the guard does) and delivery
+// (where the packed extension lives), because the guide puts them on
+// different pages while Settings shows everything flat.
+function pasteGuardBehaviourFields() {
   const s = (SETTINGS && SETTINGS.settings) || {};
   const mode = (s.paste_guard_mode || {}).value || '';
   const marksSet = (s.classification_markings || {}).source === 'db';
@@ -1462,12 +1466,20 @@ function pasteGuardFields() {
       <div class="src-note">Document phrases the guard looks for in pastes,
       one per line. Save an empty box to use no markings; clear to go back
       to the default five. What people paste never leaves their device -
-      only which detector matched gets reported.</div></dd>
+      only which detector matched gets reported.</div></dd>`;
+}
+
+function extensionDeliveryFields() {
+  return `
     ${settingRow('firefox_extension_id', 'Firefox extension ID (gecko id)',
       'ai-guard@your-org.example',
       'The id you set in the manifest (browser_specific_settings.gecko.id).'
       + ' Not the same as the Chromium id. Needed for the Firefox'
       + ' downloads.')}
+    ${settingRow('extension_crx_url', 'Packed .crx URL (Chromium)',
+      'https://files.example.com/ai-guard-1.0.0.crx',
+      'Where you host the packed .crx. The generated updates.xml points'
+      + ' browsers at it.')}
     ${settingRow('extension_update_url', 'Chromium update manifest URL',
       'https://files.example.com/updates.xml',
       'Where you host the packed extension update manifest (updates.xml).'
@@ -1476,8 +1488,12 @@ function pasteGuardFields() {
       'https://files.example.com/ai-guard-1.0.0.xpi',
       'Where you host the SIGNED .xpi from addons.mozilla.org'
       + ' (self-distribution). Firefox only installs Mozilla-signed'
-      + ' extensions - extension/README.md explains the one-time signing'
-      + ' step. Needed for the Firefox downloads.')}`;
+      + ' extensions - the extension setup guide covers the one-time'
+      + ' signing step. Needed for the Firefox downloads.')}`;
+}
+
+function pasteGuardFields() {
+  return pasteGuardBehaviourFields() + extensionDeliveryFields();
 }
 
 // The last result of a connection test, rendered where its button lives.
@@ -1512,6 +1528,218 @@ const logStoreTests = () => `<div style="margin-top:8px">
   <button class="mini" data-act="run-test" data-key="log-store-push">test: receiver can write</button>
   <button class="mini" data-act="run-test" data-key="log-store-read">test: portal can read</button>
 </div>${testNote('log-store-push')}${testNote('log-store-read')}`;
+
+// ------------------------------------------------- extension setup guide --
+// The pack-and-host workflow from extension/README.md as six short pages,
+// so setting the extension up needs neither a checkout nor the README:
+// the source download is pre-configured, the update manifests are
+// generated, and the hosting URLs are probed. Reachable from the wizard's
+// step 5 and from Settings; every value it saves is the same central
+// setting the flat Settings rows edit.
+let EXTPAGE = 1;
+
+function extSettingsState() {
+  const s = (SETTINGS && SETTINGS.settings) || {};
+  const v = k => ((s[k] || {}).value || '');
+  return {
+    id: v('extension_id'), crx: v('extension_crx_url'),
+    upd: v('extension_update_url'), gecko: v('firefox_extension_id'),
+    xpi: v('extension_xpi_url'), mode: v('paste_guard_mode'),
+  };
+}
+
+// The wizard step-5 summary: where extension setup stands, at a glance.
+function extStatusRows() {
+  const st = extSettingsState();
+  const pill = val => val
+    ? `<span class="pill p-ok">set</span> <span class="mono" style="font-size:11px">${esc(val)}</span>`
+    : '<span class="none">not set</span>';
+  return `<dl class="kv">
+    <dt>Chromium extension ID</dt><dd>${pill(st.id)}</dd>
+    <dt>Chromium hosting</dt><dd>${pill(st.crx && st.upd ? 'crx + updates.xml URLs' : st.crx || st.upd)}</dd>
+    <dt>Firefox (optional)</dt><dd>${pill(st.gecko && st.xpi ? st.gecko : st.gecko || st.xpi)}</dd>
+    <dt>Paste guard mode</dt><dd><span class="pill ${st.mode === 'block' ? 'p-warn' : 'p-ok'}">${esc(st.mode || 'warn (default)')}</span></dd>
+  </dl>`;
+}
+
+const extCmd = c => `<div style="display:flex;gap:8px;align-items:flex-start;margin:8px 0">
+  <pre class="mono" style="margin:0;padding:8px 10px;background:var(--sf2);border:1px solid var(--bd);border-radius:6px;overflow-x:auto;flex:1;font-size:12px">${esc(c)}</pre>
+  <button class="mini" data-act="copy" data-copy="${esc(c)}">copy</button></div>`;
+
+async function extSetup() {
+  const gate = CFG.managed && CFG.managed.enabled
+    ? '' : (managedGate('Extension setup') || '<h2>Extension setup</h2>');
+  if (gate) return gate;
+  const st = extSettingsState();
+  const ver = (CFG.managed && CFG.managed.extension_version) || '';
+  const rx = (CFG.managed && CFG.managed.receiver_public_url_default) || '';
+  const ready = CFG.managed && CFG.managed.artifacts_ready;
+  const crxName = 'ai-guard-' + (ver || 'VERSION') + '.crx';
+  const xpiName = 'ai-guard-' + (ver || 'VERSION') + '.xpi';
+
+  const PAGES = [
+    ['Download', !!ready],
+    ['Pack', null],
+    ['Identity', !!st.id],
+    ['Host it', !!(st.crx && st.upd)],
+    ['Firefox', !!(st.gecko && st.xpi)],
+    ['Behaviour', null],
+  ];
+  const chips = PAGES.map(([t, done], i) => `<button class="mini"
+    ${EXTPAGE === i + 1 ? 'style="border-color:var(--pri);color:var(--pri)"' : ''}
+    data-act="ext-page" data-key="${i + 1}">${i + 1} · ${t}${done === true ? ' ✓' : ''}</button>`).join(' ');
+
+  const dlBtn = (kind, label) => `<button class="mini" style="padding:6px 14px"
+    data-act="artifact" data-key="${kind}">${label}</button>`;
+
+  let body = '';
+  if (EXTPAGE === 1) body = `
+    <h3>Download the pre-configured source</h3>
+    <p class="lede">The extension is not on a web store: you pack it once and
+    your browsers install it from where you host it. This download is the
+    extension source shipped with this portal${ver ? ` (version ${esc(ver)})` : ''},
+    with its manifest already pointed at
+    <span class="mono">${esc(rx || 'your receiver')}</span> - the one edit
+    packing needs. Unzip it somewhere you will keep: repacking a later
+    release must use the same folder name and the same key.</p>
+    ${ready ? dlBtn('extension-source', 'download the extension source (zip)')
+      : '<div class="note">No public receiver URL yet - the manifest bakes the origin your browsers report to. Save one in the wizard\'s step 1 (or Settings) and this download appears.</div>'}
+    <p class="src-note">If the receiver URL ever changes, download again and
+    repack - the extension reads no central config, so the origin lives in
+    the package. Trimming the covered AI sites is possible too (edit
+    host_permissions and both content_scripts match lists together), but the
+    default set is the registry's browser surface and most deployments ship
+    it as is.</p>`;
+  if (EXTPAGE === 2) body = `
+    <h3>Pack it, and keep the key</h3>
+    <p class="lede">Packing happens in any Chromium browser on your own
+    machine and produces two files: the extension package (.crx) and its
+    signing key (.pem).</p>
+    <ol class="lede" style="line-height:2">
+      <li>Open <span class="mono">chrome://extensions</span>, switch on
+        <b>Developer mode</b> (top right).</li>
+      <li><b>Pack extension</b> → root directory = the unzipped
+        <span class="mono">ai-guard-extension</span> folder. Leave the key
+        field blank the first time.</li>
+      <li>You get <span class="mono">ai-guard-extension.crx</span> and
+        <span class="mono">ai-guard-extension.pem</span>.</li>
+    </ol>
+    <div class="note">The .pem is the signing key. Store it in your password
+    manager and never commit it: losing it changes the extension id and
+    forces a full redeployment through your MDM.</div>
+    <p class="lede" style="margin-top:10px">Derive the 32-letter extension id
+    (you will save it on the next page):</p>
+    ${extCmd("openssl rsa -in ai-guard-extension.pem -pubout -outform DER 2>/dev/null | shasum -a 256 | cut -c1-32 | tr '0-9a-f' 'a-p'")}
+    <p class="lede">Then pin the identity so every future repack keeps the
+    same id: derive the public key,</p>
+    ${extCmd('openssl rsa -in ai-guard-extension.pem -pubout -outform DER 2>/dev/null | openssl base64 -A; echo')}
+    <p class="lede">add it to <span class="mono">manifest.json</span> as a
+    top-level <span class="mono">"key": "&lt;that value&gt;"</span>, and pack
+    again - this time supplying the .pem. Rename the result to a versioned
+    name: <span class="mono">${esc(crxName)}</span>.</p>`;
+  if (EXTPAGE === 3) body = `
+    <h3>Save the Chromium identity</h3>
+    <p class="lede">The id from the previous page's first command (or from
+    <span class="mono">chrome://extensions</span> on any machine with the
+    packed extension loaded). Every Chromium policy artifact is keyed on it -
+    without it the browser installs nothing.</p>
+    <dl class="kv">
+      <dt>Chromium extension ID</dt><dd>
+        <input id="set-extid" class="mfield" style="min-width:340px"
+          placeholder="the 32-letter id, a-p only" value="${esc(st.id)}">
+        <button class="mini" data-act="save-extid">save</button>
+        <div class="src-note">32 letters a-p. Anything else means the id was
+        read from the wrong place - it is not the key, and not a hash.</div></dd>
+    </dl>`;
+  if (EXTPAGE === 4) body = `
+    <h3>Host the package</h3>
+    <p class="lede">Two small files go on HTTPS anywhere every browser in
+    the fleet can fetch: the packed <span class="mono">${esc(crxName)}</span>
+    and an update manifest (<span class="mono">updates.xml</span>) that
+    points at it. Any static host or artifact pipeline your org already
+    trusts works; serve the .crx as
+    <span class="mono">application/x-chrome-extension</span>.</p>
+    <dl class="kv">
+      ${settingRow('extension_crx_url', 'Packed .crx URL',
+        'https://files.example.com/' + crxName,
+        'The public URL of the versioned .crx. Save it first; the update manifest below is generated from it.')}
+    </dl>
+    <p class="lede" style="margin:10px 0 0">${st.crx && st.id
+      ? 'Download the generated update manifest and host it next to the .crx:'
+      : 'Save the .crx URL (and the id on the previous page) and the generated update manifest appears here:'}</p>
+    ${st.crx && st.id ? dlBtn('extension-updates-xml', 'download updates.xml') : ''}
+    <dl class="kv" style="margin-top:10px">
+      ${settingRow('extension_update_url', 'Update manifest URL',
+        'https://files.example.com/updates.xml',
+        'Where you put updates.xml. The install policies point every browser at this URL, and it is how future releases roll out - pack, upload, replace updates.xml, done.')}
+    </dl>
+    ${st.upd ? `<div style="margin-top:8px">
+      <button class="mini" data-act="run-test" data-key="extension-updates">probe the hosted manifest</button>
+    </div>${testNote('extension-updates')}` : ''}`;
+  if (EXTPAGE === 5) body = `
+    <h3>Firefox (skip if you do not deploy it)</h3>
+    <p class="lede">Firefox refuses unsigned extensions on release builds,
+    with no enterprise override, so it takes three extra one-time steps:
+    give the extension a Firefox identity, have Mozilla sign it, and host
+    the signed file.</p>
+    <p class="lede"><b>1 · Identity.</b> In your unzipped source, edit
+    <span class="mono">manifest.json</span> →
+    <span class="mono">browser_specific_settings.gecko</span>: set
+    <span class="mono">id</span> to an address-shaped id you own (e.g.
+    <span class="mono">ai-guard@your-org.example</span>) and
+    <span class="mono">update_url</span> to where you will host
+    <span class="mono">firefox-updates.json</span>. Then build the .xpi -
+    an .xpi is a zip of the files themselves, not of the folder:</p>
+    ${extCmd('cd ai-guard-extension && zip -r -FS ../' + xpiName + ' manifest.json background.js content.js guard.js managed-schema.json')}
+    <p class="lede"><b>2 · Signing.</b> Submit that file to
+    addons.mozilla.org as a <b>self-distributed</b> add-on ("On your own
+    site" at submission). Mozilla signs it without listing it publicly,
+    usually in minutes. The file you host is the one AMO returns, not the
+    one you built - a signed .xpi contains
+    <span class="mono">META-INF/mozilla.rsa</span>.</p>
+    <p class="lede"><b>3 · Host.</b> The signed .xpi and the generated
+    <span class="mono">firefox-updates.json</span> go next to the Chromium
+    files (serve the .xpi as
+    <span class="mono">application/x-xpinstall</span>).</p>
+    <dl class="kv">
+      ${settingRow('firefox_extension_id', 'Firefox extension ID (gecko id)',
+        'ai-guard@your-org.example',
+        'The id you set in the manifest. Not the 32-letter Chromium id.')}
+      ${settingRow('extension_xpi_url', 'Signed .xpi URL',
+        'https://files.example.com/' + xpiName,
+        'The public URL of the SIGNED file from AMO.')}
+    </dl>
+    ${st.gecko && st.xpi ? `<p class="lede" style="margin:10px 0 0">Host this
+      next to it, at the update_url you put in the manifest:</p>
+      ${dlBtn('firefox-updates-json', 'download firefox-updates.json')}
+      <div style="margin-top:8px">
+        <button class="mini" data-act="run-test" data-key="extension-xpi">probe the hosted .xpi (checks the Mozilla signature)</button>
+      </div>${testNote('extension-xpi')}` : ''}`;
+  if (EXTPAGE === 6) body = `
+    <h3>What the guard does</h3>
+    <p class="lede">Both values are baked into every policy download, so a
+    later change here means regenerate and re-push. The usual path is warn
+    for a couple of weeks, then block once the override count has had its
+    policy conversation.</p>
+    <dl class="kv">${pasteGuardBehaviourFields()}</dl>
+    <p class="lede" style="margin-top:14px">That is the one-time work done.
+    The policy downloads - pre-filled with all of this plus a fresh
+    enrollment token each - are in the wizard's step 7, and pushing those
+    through your MDM is the actual rollout.</p>
+    <button class="mini" style="padding:6px 14px" data-act="open-wizard">back to the setup wizard</button>`;
+
+  return `<h2>Extension setup</h2>
+  <p class="lede">The browser extension, from source to hosted package, one
+  step at a time. Nothing here needs a checkout, and every saved value stays
+  editable under Settings.</p>
+  ${SETMSG ? `<div class="note">${esc(SETMSG)}</div>` : ''}
+  <div style="margin:12px 0">${chips}</div>
+  <div class="wcard" style="margin-bottom:10px">${body}</div>
+  <div style="margin:14px 0">
+    ${EXTPAGE > 1 ? `<button class="mini" data-act="ext-page" data-key="${EXTPAGE - 1}">← back</button>` : ''}
+    ${EXTPAGE < 6 ? `<button class="mini" data-act="ext-page" data-key="${EXTPAGE + 1}">next →</button>` : ''}
+  </div>`;
+}
 
 // The first-run wizard: everything a fresh managed install needs, in
 // order, on one page. Every step is skippable and everything here is
@@ -1628,19 +1856,18 @@ async function wizard() {
   <div class="wcard" style="margin-bottom:10px"><h3>5 · Browser extension &amp; paste guard</h3>
   <p class="lede" style="margin-bottom:10px">One extension does both jobs:
   it reports which account is signed into each AI site, and its paste guard
-  warns or blocks risky pastes. You pack it once (extension/README.md), then
-  everything you set here gets baked into the ready-made policy downloads in
-  step 7. Fine to skip on a first pass and come back.</p>
-  <dl class="kv">
-    <dt>Chromium extension ID</dt><dd>
-      <input id="set-extid" class="mfield" style="min-width:340px"
-        placeholder="the 32-letter id from chrome://extensions" value="${esc(eid)}">
-      <button class="mini" data-act="save-extid">save</button>
-      <div class="src-note">The 32-letter id Chrome gives the packed
-      extension - read it from chrome://extensions on a machine that has it.
-      Needed for the Chromium downloads.</div></dd>
-    ${pasteGuardFields()}
-  </dl></div>
+  warns or blocks risky pastes. It is a one-time pack-and-host, and the
+  guided setup walks it one step at a time - download the pre-configured
+  source here, no checkout needed. Everything it saves gets baked into the
+  ready-made policy downloads in step 7. Fine to skip on a first pass and
+  come back.</p>
+  ${extStatusRows()}
+  <div style="margin-top:10px">
+    <button class="mini" style="padding:6px 14px" data-act="ext-open">open the extension setup</button>
+    <span class="src-note" style="margin-left:8px">Six short steps: download,
+    pack, identity, hosting, Firefox, behaviour. Each value is also editable
+    flat under Settings.</span>
+  </div></div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>6 · Alerting and Grafana (optional)</h3>
   <dl class="kv">
@@ -1718,7 +1945,12 @@ function managedSettings() {
       <div class="src-note">Used to generate the extension's managed-policy
       artifact. Empty clears it.</div></dd>
     ${pasteGuardFields()}
-  </dl></div>
+  </dl>
+  <div style="margin-top:10px">
+    <button class="mini" data-act="ext-open">open the extension setup</button>
+    <span class="src-note" style="margin-left:8px">The guided version of
+    these fields: pack, host and sign, one step at a time.</span>
+  </div></div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>Receiver</h3>
   <dl class="kv">
@@ -2373,6 +2605,16 @@ async function managedAction(act, el) {
     history.replaceState(null, '', '#wizard');
     drawNav(); render(); return;
   }
+  if (act === 'ext-open') {
+    view = 'extsetup'; detail = null;
+    history.replaceState(null, '', '#extsetup');
+    drawNav(); render(); return;
+  }
+  if (act === 'ext-page') {
+    EXTPAGE = Math.min(6, Math.max(1, parseInt(el.getAttribute('data-key'), 10) || 1));
+    SETMSG = '';
+    render(); return;
+  }
   if (act === 'save-domains' || act === 'clear-domains' || act === 'save-extid') {
     const body = act === 'save-domains'
       ? {corp_domains: _val('set-domains').split(',').map(s => s.trim()).filter(Boolean)}
@@ -2499,6 +2741,7 @@ async function render() {
   if (view === 'fleet') { app.innerHTML = await fleet(); return; }
   if (view === 'tokens') { app.innerHTML = await tokens(); return; }
   if (view === 'wizard') { app.innerHTML = await wizard(); return; }
+  if (view === 'extsetup') { app.innerHTML = await extSetup(); return; }
   if (view === 'registry') { app.innerHTML = await registryView(); return; }
   app.innerHTML = ({setup, overview, devices, people, tools, coverage,
                     dashboard, personal, mcp})[view]();

--- a/portal/extension-src/background.js
+++ b/portal/extension-src/background.js
@@ -1,0 +1,386 @@
+// AI Guard - background service worker
+// Receives domain-only account flags and content-free paste-guard events,
+// dedupes them, attaches the MDM-stamped device id, and POSTs to the
+// configured endpoint.
+// v1.1.0: Slack webhook support removed; the receiver is the only sink.
+
+// Firefox exposes the extension APIs as browser.* returning promises, and also
+// as chrome.* returning callbacks. Chrome has no browser.* at all, and its
+// chrome.* returns promises under MV3. So chrome.* is the namespace that exists
+// in both and the one that behaves differently in each: every await in this
+// file would resolve to undefined in Firefox. Resolve the namespace once and
+// use that.
+const api = globalThis.browser ?? globalThis.chrome;
+
+const FALLBACK_ENDPOINT = ""; // leave blank; set via managed config in production
+const FALLBACK_DEVICE = "";   // optional: set a label for LOCAL testing only
+const FALLBACK_AUTH_TOKEN = ""; // optional: set for LOCAL testing only
+const DEDUPE_WINDOW_MS = 6 * 60 * 60 * 1000; // one flag per tool+domain per 6h
+
+// Managed mode. authToken in the policy may be an enrollment token (aige_...)
+// instead of the shared token: this profile then exchanges it once at /enroll
+// for its own device credential (aigd_...), kept in storage.local, and reports
+// with that. The prefix is the switch - the same contract as the endpoint
+// collectors, so an operator flips one policy value when ready.
+const ENROLL_PREFIX = "aige_";
+const ENROLLMENT_KEY = "enrollment";
+const AGENT_VERSION = api.runtime.getManifest().version;
+
+// Dedupe state for personal-account flags. This was a module-level Map, which
+// lives exactly as long as the service worker does: Chrome stops an MV3
+// worker after roughly thirty seconds idle and content.js checks every five
+// minutes, so the six-hour window was in practice one flag per check. The
+// receiver's alert TTL hid it from Slack, which is why nobody noticed, but
+// every repeat was a Loki line, a skewed occurrence count and a slice of the
+// portal's read budget.
+//
+// storage.session survives worker restarts, is cleared when the browser
+// exits and is never written to disk, which is the right lifetime for "we
+// already said this today". storage.local is the fallback for a browser
+// without it: the same fix the heartbeat already uses for lastHeartbeat.
+const SEEN_KEY = "personalAccountSeen";
+
+function seenStore() {
+  return api.storage.session || api.storage.local;
+}
+
+// True if this tool+domain was reported inside the window. Otherwise records
+// it and returns false. Entries past the window are dropped on the way
+// through so the object cannot grow without bound.
+async function alreadyReported(key, now) {
+  const store = seenStore();
+  let seen = {};
+  try {
+    const state = await store.get(SEEN_KEY);
+    seen = (state && state[SEEN_KEY]) || {};
+  } catch (e) { /* unreadable state is an empty state: report rather than lose */ }
+
+  if (seen[key] && now - seen[key] < DEDUPE_WINDOW_MS) return true;
+
+  for (const k of Object.keys(seen)) {
+    if (now - seen[k] >= DEDUPE_WINDOW_MS) delete seen[k];
+  }
+  seen[key] = now;
+  try {
+    await store.set({ [SEEN_KEY]: seen });
+  } catch (e) { /* a write that fails costs one duplicate, not a finding */ }
+  return false;
+}
+
+async function onPersonalAccount(msg) {
+  const key = msg.tool + ":" + msg.domain;
+  if (await alreadyReported(key, Date.now())) return;
+  await report({
+    tool: msg.tool,
+    // Absent until 1.2.0. The receiver defaults surface to "browser" and
+    // severity to "warn", so these findings looked right while carrying no
+    // source at all: on one fleet that was thousands a week that could not
+    // be traced to a detector. Defaults that happen to be correct are not
+    // the same as fields that are set.
+    surface: "browser",
+    source: "browser_extension",
+    severity: "warn",
+    account_domain: msg.domain,
+    reported_at: msg.ts,
+  });
+}
+
+api.runtime.onMessage.addListener((msg) => {
+  if (!msg) return;
+
+  if (msg.type === "personal-account") {
+    // Not returned. A listener that returns a promise tells Firefox a reply is
+    // coming, and content.js is not waiting for one.
+    onPersonalAccount(msg)
+      .catch((e) => console.warn("[ai-account-guard] report failed", e));
+    return;
+  }
+
+  if (msg.type === "paste-guard") {
+    // Content-side already dedupes. Mapped onto the receiver's existing
+    // Finding schema so no receiver change is needed: source identifies the
+    // guard, evidence carries "<action>: <detector ids>". The matched text
+    // never reaches this worker.
+    report({
+      tool: msg.tool,
+      surface: "browser",
+      source: "paste_guard",
+      severity: "warn",
+      evidence: "paste " + msg.action + ": " + msg.detectors.join(","),
+      reported_at: msg.ts,
+    }).catch((e) => console.warn("[ai-account-guard] report failed", e));
+  }
+});
+
+// ---- heartbeat: proves the whole chain works per device ----
+// Sent on browser startup, install/update, and daily via api.alarms.
+// Traverses extension -> managed config -> token -> receiver -> Loki, so one
+// heartbeat in the last 24h means the paste guard on that device WORKS, not
+// just that the MDM delivered a profile. Carries version and mode only.
+
+const HEARTBEAT_MIN_INTERVAL_MS = 20 * 60 * 60 * 1000; // at most ~once a day
+const HEARTBEAT_ALARM = "ai-guard-heartbeat";
+const HEARTBEAT_RETRY_ALARM = "ai-guard-heartbeat-retry";
+const HEARTBEAT_RETRY_MINUTES = 60;
+
+async function heartbeat(reason) {
+  try {
+    const state = await api.storage.local.get("lastHeartbeat");
+    const now = Date.now();
+    if (state.lastHeartbeat && now - state.lastHeartbeat < HEARTBEAT_MIN_INTERVAL_MS) return;
+    let mode = "warn";
+    try {
+      const cfg = await api.storage.managed.get("pasteGuardMode");
+      if (cfg && ["off", "warn", "block"].includes(cfg.pasteGuardMode)) mode = cfg.pasteGuardMode;
+    } catch (e) { /* unmanaged: fallback mode stands */ }
+
+    // Independent of whether the heartbeat lands. A device that cannot reach
+    // the receiver is exactly the one that might need a newer version to get
+    // out of that state, so the update check does not wait on delivery.
+    //
+    // Chrome only. Firefox has no requestUpdateCheck and polls its own update
+    // manifest on its own schedule, so there is nothing to ask for and calling
+    // it would throw inside the heartbeat.
+    if (api.runtime.requestUpdateCheck) api.runtime.requestUpdateCheck(() => {});
+
+    const delivered = await report({
+      tool: "paste-guard",
+      surface: "browser",
+      source: "paste_guard",
+      severity: "info",
+      evidence: "heartbeat version=" + AGENT_VERSION +
+                " mode=" + mode + " reason=" + reason,
+      reported_at: new Date().toISOString(),
+    });
+
+    // Only now. Writing the timestamp before delivery was confirmed meant a
+    // failed POST still counted as done, so the device went quiet for the
+    // whole interval and looked like a broken install on the dashboard for a
+    // day. delivered is false in print-only mode, where there is nothing to
+    // confirm and nothing to remember.
+    if (delivered) await api.storage.local.set({ lastHeartbeat: now });
+  } catch (e) {
+    console.warn("[ai-account-guard] heartbeat failed", e);
+    // Try again in an hour rather than waiting for tomorrow's alarm. Creating
+    // an alarm with an existing name replaces it, so repeated failures do not
+    // stack up.
+    api.alarms.create(HEARTBEAT_RETRY_ALARM, { delayInMinutes: HEARTBEAT_RETRY_MINUTES });
+  }
+}
+
+api.runtime.onStartup.addListener(() => heartbeat("startup"));
+api.runtime.onInstalled.addListener(() => heartbeat("installed"));
+api.alarms.create(HEARTBEAT_ALARM, { periodInMinutes: 60 * 24 });
+api.alarms.onAlarm.addListener((a) => {
+  if (a.name === HEARTBEAT_ALARM) heartbeat("alarm");
+  if (a.name === HEARTBEAT_RETRY_ALARM) heartbeat("retry");
+});
+
+async function getConfig() {
+  try {
+    const cfg = await api.storage.managed.get([
+      "reportEndpoint",
+      "deviceIdentifier",
+      "authToken",
+    ]);
+    return {
+      endpoint: (cfg && cfg.reportEndpoint) || FALLBACK_ENDPOINT,
+      device: (cfg && cfg.deviceIdentifier) || FALLBACK_DEVICE || "unknown",
+      authToken: (cfg && cfg.authToken) || FALLBACK_AUTH_TOKEN || "",
+    };
+  } catch (e) {
+    return {
+      endpoint: FALLBACK_ENDPOINT,
+      device: FALLBACK_DEVICE || "unknown",
+      authToken: FALLBACK_AUTH_TOKEN || "",
+    };
+  }
+}
+
+// Returns true when the receiver accepted the finding, false when there is no
+// endpoint to send it to, and throws when delivery failed. Callers that record
+// state need to know the difference: a POST that returned 401 or never left
+// the machine is not a delivered finding, and treating it as one is how a
+// device goes quiet without anything noticing.
+// api.runtime.getPlatformInfo returns "mac", "win", "linux", "cros",
+// "android", "openbsd". The receiver's vocabulary is macos, windows, linux,
+// unknown, and it coerces anything else to unknown - so ChromeOS reports
+// honestly as unknown rather than being forced into one of the three.
+const OS_NAMES = { mac: "macos", win: "windows", linux: "linux" };
+let osPromise = null;
+
+function detectOs() {
+  // Resolved once and reused. getPlatformInfo is async and cheap, but a
+  // service worker can be woken hundreds of times a day.
+  if (!osPromise) {
+    osPromise = api.runtime.getPlatformInfo()
+      .then((info) => OS_NAMES[info.os] || "unknown")
+      .catch(() => "unknown");
+  }
+  return osPromise;
+}
+
+// ---- enrollment (managed mode) ----
+
+// The receiver base is the report endpoint minus its path. The policy carries
+// the full endpoint, as it always has, so nothing new is configured.
+function receiverBase(endpoint) {
+  // A query string on the endpoint is allowed and dropped; the path must
+  // end in /report (or the legacy /flag) for /enroll to be derivable.
+  const m = /^(.*)\/(report|flag)\/?(\?.*)?$/.exec(endpoint);
+  return m ? m[1] : null;
+}
+
+// Eight hex characters, made once per browser profile. It is part of this
+// profile's serial, not a secret: uniqueness is all it provides, and the
+// fallback exists for a runtime without crypto.
+function newInstallId() {
+  const bytes = new Uint8Array(4);
+  try { crypto.getRandomValues(bytes); } catch (e) {
+    for (let i = 0; i < 4; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+async function storedEnrollment() {
+  try {
+    const state = await api.storage.local.get(ENROLLMENT_KEY);
+    return (state && state[ENROLLMENT_KEY]) || null;
+  } catch (e) { return null; }
+}
+
+// One in-flight enrollment at a time. A worker that wakes to a startup
+// heartbeat and a content-script flag at once would otherwise enroll twice,
+// and the second would displace the first.
+let enrollPromise = null;
+
+function enrollOnce(cfg, prior) {
+  if (!enrollPromise) {
+    enrollPromise = enroll(cfg, prior).finally(() => { enrollPromise = null; });
+  }
+  return enrollPromise;
+}
+
+async function enroll(cfg, prior) {
+  const base = receiverBase(cfg.endpoint);
+  if (!base) {
+    throw new Error("cannot enroll: reportEndpoint must end in /report to derive /enroll");
+  }
+  // The serial is the MDM-stamped device id plus a per-profile id. One
+  // machine legitimately runs several managed profiles (Chrome and Edge, two
+  // Chrome profiles); with the bare device id they would take turns
+  // displacing each other on the receiver. The id is kept across
+  // re-enrollments so the receiver sees the same profile, not a new one.
+  const installId = (prior && prior.installId) || newInstallId();
+  const serial = cfg.device + "/" + installId;
+  const response = await fetch(base + "/enroll", {
+    method: "POST",
+    headers: { "Content-Type": "application/json",
+               "Authorization": "Bearer " + cfg.authToken },
+    body: JSON.stringify({ platform: "browser", serial: serial, hostname: "",
+                           agent_version: AGENT_VERSION }),
+  });
+  if (!response.ok) {
+    // An expired or revoked enrollment token is an operations task, and the
+    // console is the only log this worker has; the heartbeat retry keeps
+    // asking hourly, so a fixed policy takes effect without a restart.
+    throw new Error("enrollment failed: receiver returned HTTP " + response.status);
+  }
+  let body = null;
+  try { body = await response.json(); } catch (e) { /* handled below */ }
+  if (!body || typeof body.device_token !== "string" || !body.device_token.startsWith("aigd_")) {
+    // A 200 from something that is not the receiver (a captive portal, a
+    // default backend) must not become an empty credential that then reads
+    // as "revoked" on every report.
+    throw new Error("enrollment failed: the response carried no device credential");
+  }
+  // "with" records which enrollment token issued this credential. A refused
+  // credential is re-enrolled only once the policy carries a different token
+  // (see report), so revoking a profile sticks until an operator rotates it.
+  const enrollment = { cred: body.device_token, installId: installId, with: cfg.authToken };
+  await api.storage.local.set({ [ENROLLMENT_KEY]: enrollment });
+  console.log("[ai-account-guard] enrolled as " + serial);
+  return enrollment;
+}
+
+// The bearer for this report, and the enrollment it came from (null when the
+// policy carries a shared token and there is nothing to re-enroll).
+async function resolveBearer(cfg) {
+  if (!cfg.authToken.startsWith(ENROLL_PREFIX)) {
+    return { bearer: cfg.authToken, enrollment: null };
+  }
+  let enrollment = await storedEnrollment();
+  if (!enrollment || !enrollment.cred) enrollment = await enrollOnce(cfg, enrollment);
+  return { bearer: enrollment.cred, enrollment: enrollment };
+}
+
+// After a 401 on a device credential. Another caller may already have
+// re-enrolled between our read and our refusal, so storage is read again
+// first: a credential that differs from the refused one is the answer.
+async function reenroll(cfg, refusedCred) {
+  const current = await storedEnrollment();
+  if (current && current.cred && current.cred !== refusedCred) return current;
+  return enrollOnce(cfg, current);
+}
+
+function post(endpoint, bearer, payload) {
+  const headers = { "Content-Type": "application/json",
+                    "X-AiGuard-Agent-Version": AGENT_VERSION };
+  if (bearer) headers["Authorization"] = "Bearer " + bearer;
+  return fetch(endpoint, { method: "POST", headers: headers, body: JSON.stringify(payload) });
+}
+
+async function report(payload) {
+  const cfg = await getConfig();
+  payload.device = cfg.device;
+
+  // Set here rather than at each call site: three callers had three chances
+  // to forget it, and all three did. The receiver coerced the missing field
+  // to "unknown", so every browser finding was unattributable to an OS and
+  // nothing said why.
+  if (!payload.os) payload.os = await detectOs();
+
+  if (!cfg.endpoint) {
+    // No endpoint set (e.g. loaded unpacked with no MDM config). Surface the
+    // flag in the service worker console so local testing is visible.
+    console.log("[ai-account-guard] FLAG (no endpoint set):", payload);
+    return false;
+  }
+
+  let { bearer, enrollment } = await resolveBearer(cfg);
+  let response = await post(cfg.endpoint, bearer, payload);
+
+  if (response.status === 401 && enrollment) {
+    // This profile's own credential was refused: revoked on the receiver, or
+    // reissued to another enrollment of the same serial. It re-enrolls only
+    // if the policy now carries a different enrollment token than the one
+    // this credential came from - the browser analogue of the collector's
+    // "delete device.cred": revoking a profile sticks until an operator
+    // rotates the token, rather than being undone by the next heartbeat.
+    if (cfg.authToken === enrollment.with) {
+      throw new Error("receiver refused this profile's device credential (revoked?);"
+                      + " it re-enrolls when the policy carries a new enrollment token");
+    }
+    console.warn("[ai-account-guard] device credential refused and the enrollment token"
+                 + " has changed: re-enrolling");
+    enrollment = await reenroll(cfg, bearer);
+    response = await post(cfg.endpoint, enrollment.cred, payload);
+  }
+
+  // fetch only rejects on a network-level failure, so a 401 or a 500 arrives
+  // here looking like success unless the status is checked.
+  if (!response.ok) {
+    throw new Error("receiver returned HTTP " + response.status);
+  }
+
+  // The policy token rotated (the 180-day TTL makes that routine) while
+  // this credential kept working: record the current token as the one this
+  // credential stands under. Otherwise a rotation months before a revoke
+  // would count as the rotation *after* it, and the revoke would not stick.
+  if (enrollment && enrollment.with !== cfg.authToken) {
+    try {
+      await api.storage.local.set({ [ENROLLMENT_KEY]: { ...enrollment, with: cfg.authToken } });
+    } catch (e) { /* next success tries again */ }
+  }
+  return true;
+}

--- a/portal/extension-src/content.js
+++ b/portal/extension-src/content.js
@@ -1,0 +1,162 @@
+// AI Guard - content script
+// Runs on each supported AI tool, resolves the signed-in account,
+// discards the local part immediately, and flags if the domain is not allowed.
+
+// Firefox exposes the extension APIs as browser.* returning promises, and also
+// as chrome.* returning callbacks. Chrome has no browser.* at all, and its
+// chrome.* returns promises under MV3. So chrome.* is the namespace that exists
+// in both and the one that behaves differently in each: every await in this
+// file would resolve to undefined in Firefox. Resolve the namespace once and
+// use that.
+const api = globalThis.browser ?? globalThis.chrome;
+
+const FALLBACK_ALLOWED = ["example.com"];
+
+// Per-tool resolvers. Each returns an email string or null.
+// IMPORTANT: these hit undocumented internal endpoints / DOM. Confirm each
+// one in devtools per tool and re-check after any vendor UI change.
+const RESOLVERS = {
+  "chatgpt.com": resolveChatGPT,
+  "chat.openai.com": resolveChatGPT,
+  "claude.ai": resolveClaude,
+  "gemini.google.com": resolveGemini,
+  "otter.ai": resolveOtter,
+  "www.otter.ai": resolveOtter,
+  "fireflies.ai": resolveFireflies,
+  "app.fireflies.ai": resolveFireflies,
+  "copilot.microsoft.com": resolveMsCopilot,
+};
+
+async function resolveChatGPT() {
+  // NextAuth session endpoint, same-origin so the page cookies attach.
+  const res = await fetch("/api/auth/session", { credentials: "include" });
+  if (!res.ok) return null;
+  const data = await res.json();
+  return (data && data.user && data.user.email) || null;
+}
+
+async function resolveClaude() {
+  // VERIFY: confirm the current-account endpoint and field name in devtools.
+  // If the endpoint shape changes, the DOM fallback below picks it up.
+  try {
+    const res = await fetch("/api/auth/current_account", { credentials: "include" });
+    if (res.ok) {
+      const data = await res.json();
+      if (data && data.email) return data.email;
+    }
+  } catch (e) { /* fall through to DOM */ }
+  return resolveFromAnyElement('[data-testid*="email"], [class*="email"]');
+}
+
+function resolveGemini() {
+  // Google one-bar exposes the account in an aria-label such as
+  // "Google Account: Name (name@domain)". Network-layer enforcement via
+  // X-GoogApps-Allowed-Domains is cleaner for Google, but this catches it too.
+  return resolveFromAnyElement('a[aria-label*="@"], [aria-label*="@"]');
+}
+
+function resolveOtter() {
+  // CONFIRMED: Otter renders the account email in the sidebar account switcher
+  // as a standalone leaf element. It is only visually truncated via the
+  // "truncate" CSS class; textContent holds the full address. Its classes are
+  // generic Tailwind utilities, so match on shape (a leaf whose entire text is
+  // an email) rather than class names.
+  return resolveExactEmailLeaf();
+}
+
+function resolveFireflies() {
+  // VERIFY: try the account/settings selectors first, then fall back to the
+  // shape-based leaf match (same approach confirmed working for Otter).
+  return (
+    resolveFromAnyElement(
+      '[class*="email"], [class*="account"], [class*="user"], [aria-label*="@"]'
+    ) || resolveExactEmailLeaf()
+  );
+}
+
+function resolveMsCopilot() {
+  // VERIFY: catches the CONSUMER Copilot (copilot.microsoft.com) signed in with
+  // a personal Microsoft account. The work M365 Copilot is Entra-based and runs
+  // in-app, so it is not covered here. Selectors first, then shape-based leaf.
+  return (
+    resolveFromAnyElement(
+      '[aria-label*="@"], [class*="account"], [class*="email"], [data-testid*="account"]'
+    ) || resolveExactEmailLeaf()
+  );
+}
+
+function resolveFromAnyElement(selector) {
+  const nodes = document.querySelectorAll(selector);
+  for (const node of nodes) {
+    const hay = (node.getAttribute("aria-label") || "") + " " + (node.textContent || "");
+    const m = hay.match(/[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/);
+    if (m) return m[0];
+  }
+  return null;
+}
+
+// Shape-based resolver: find a leaf element whose ENTIRE trimmed text is an
+// email. Account/profile fields hold the address on its own; an address inside
+// a transcript or chat body is embedded in a longer string and is ignored.
+// Independent of class names, so it survives vendor UI churn.
+function resolveExactEmailLeaf() {
+  const exact = /^[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}$/;
+  const nodes = document.querySelectorAll("div, span, p, a, button, li");
+  for (const node of nodes) {
+    if (node.childElementCount) continue;
+    const txt = (node.textContent || "").trim();
+    if (exact.test(txt)) return txt;
+  }
+  return null;
+}
+
+function domainOf(email) {
+  const at = email.lastIndexOf("@");
+  return at === -1 ? null : email.slice(at + 1).toLowerCase();
+}
+
+async function getAllowedDomains() {
+  try {
+    const cfg = await api.storage.managed.get("allowedDomains");
+    if (cfg && Array.isArray(cfg.allowedDomains) && cfg.allowedDomains.length) {
+      return cfg.allowedDomains.map((d) => d.toLowerCase());
+    }
+  } catch (e) { /* managed storage not set, use fallback */ }
+  return FALLBACK_ALLOWED;
+}
+
+async function check() {
+  const host = location.hostname;
+  const resolver = RESOLVERS[host];
+  if (!resolver) return;
+
+  let email = null;
+  try { email = await resolver(); } catch (e) { return; }
+  if (!email) return;
+
+  const domain = domainOf(email); // local part is dropped here and never leaves the page
+  if (!domain) return;
+
+  const allowed = await getAllowedDomains();
+  if (allowed.includes(domain)) return;
+
+  // Firefox returns a promise here and rejects it when the background page is
+  // not yet awake to receive. Chrome MV3 does the same. Nothing is waiting on
+  // the result, so an uncaught rejection would surface in the page console of
+  // a user's browser for no reason. Dedupe lives in background.js, keyed on
+  // tool+domain in storage.session, so a message dropped here is retried at
+  // the next check rather than lost: this check runs every five minutes and
+  // the window is six hours.
+  api.runtime.sendMessage({
+    type: "personal-account",
+    tool: host,
+    domain: domain,            // e.g. "gmail.com" for context, no name
+    ts: new Date().toISOString(),
+  }).catch(() => {});
+}
+
+// SPAs swap accounts without a full reload, so check on load and on an interval.
+// The early staggered checks catch SPA hydration so a live test fires in seconds.
+check();
+[3000, 10000, 30000].forEach((d) => setTimeout(check, d));
+setInterval(check, 5 * 60 * 1000);

--- a/portal/extension-src/guard.js
+++ b/portal/extension-src/guard.js
@@ -1,0 +1,324 @@
+// AI Guard - paste guard content script
+// Intercepts paste/drop into AI tools, scans the text locally for secret
+// patterns, and warns or blocks BEFORE the content reaches the page.
+// The matched text NEVER leaves the page: reports carry detector ids only.
+
+// Firefox exposes the extension APIs as browser.* returning promises, and also
+// as chrome.* returning callbacks. Chrome has no browser.* at all, and its
+// chrome.* returns promises under MV3. So chrome.* is the namespace that exists
+// in both and the one that behaves differently in each: every await in this
+// file would resolve to undefined in Firefox. Resolve the namespace once and
+// use that.
+const api = globalThis.browser ?? globalThis.chrome;
+
+const FALLBACK_PASTE_MODE = "warn"; // off | warn | block (managed config wins)
+const REPORT_DEDUPE_MS = 5 * 60 * 1000; // one report per tool+detector per 5m
+const reported = new Map();
+
+// Detector set, v1.1.0. Two shapes: { re } for pattern matches, { test } for
+// detectors needing logic (checksums, counting). Entropy scanning and the
+// org/client term list are deferred to v1.2 behind managed config.
+//
+// Deliberately excluded (false-positive rate would train people to ignore
+// the overlay): UK sort codes (collide with dd-mm-yy dates), dates of birth,
+// passport and driving licence numbers, single email addresses.
+
+const BULK_EMAIL_THRESHOLD = 10;
+const EMAIL_RE = /[\w.+-]+@[\w.-]+\.[A-Za-z]{2,}/g;
+
+function luhnOk(digits) {
+  let sum = 0, dbl = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    let d = digits.charCodeAt(i) - 48;
+    if (dbl) { d *= 2; if (d > 9) d -= 9; }
+    sum += d; dbl = !dbl;
+  }
+  return sum % 10 === 0;
+}
+
+// A card is written either as one unbroken run of digits, or in the groupings
+// the industry actually uses, with the SAME separator throughout: 4-4-4-4 for
+// most issuers, 4-6-5 for Amex, 4-6-4 for Diners, 4-4-4-4-3 for 19-digit PANs.
+//
+// The previous pattern allowed a separator after EVERY digit, which made any
+// run of space-separated numbers a candidate. SVG path and polygon data is
+// exactly that, and Luhn passes 10% of arbitrary digit runs, so it was not a
+// filter. Measured over 50,000 generated samples of path data, phone numbers,
+// timestamps and reference numbers: 5.97% flagged before, 0% after, with every
+// real card format from 13 to 19 digits still detected.
+const CARD_RE = /(?<![\d-])(?:\d{4}([ -])\d{4}\1\d{4}\1\d{1,4}(?:\1\d{1,3})?|\d{4}([ -])\d{6}\2\d{4,5}|\d{13,19})(?![\d-])/g;
+
+function hasPaymentCard(text) {
+  CARD_RE.lastIndex = 0; // the regex is module-level and /g carries state
+  let m;
+  while ((m = CARD_RE.exec(text)) !== null) {
+    const digits = m[0].replace(/[ -]/g, "");
+    if (digits.length >= 13 && digits.length <= 19 && luhnOk(digits)) return true;
+  }
+  return false;
+}
+
+const FALLBACK_MARKINGS = [
+  "client confidential",
+  "internal confidential",
+  "confidential internal",
+  "internal use only",
+  "strictly confidential",
+  "commercial in confidence",
+];
+// Compound labels match case-insensitively; bare CONFIDENTIAL only in full
+// caps (how classification stamps render), so prose and email disclaimer
+// footers ("this email is confidential...") stay silent. Bare "internal" is
+// undetectable by marking: it is everyday prose. The org term list planned
+// for v1.2 covers that tier from the content side.
+let markingRe = buildMarkingRe(FALLBACK_MARKINGS);
+let markingCapsRe = /\bCONFIDENTIAL\b/;
+
+function buildMarkingRe(labels) {
+  const esc = labels
+    .filter((l) => typeof l === "string" && l.trim())
+    .map((l) => l.trim().replace(/[.*+?^${}()|[\]\\]/g, "\\$&").replace(/\s+/g, "\\s+"));
+  return esc.length ? new RegExp("\\b(?:" + esc.join("|") + ")\\b", "i") : null;
+}
+
+function hasClassificationMarking(text) {
+  if (markingRe && markingRe.test(text)) return true;
+  return markingCapsRe.test(text);
+}
+
+async function refreshMarkings() {
+  try {
+    const cfg = await api.storage.managed.get("classificationMarkings");
+    if (cfg && Array.isArray(cfg.classificationMarkings) && cfg.classificationMarkings.length) {
+      markingRe = buildMarkingRe(cfg.classificationMarkings);
+    }
+  } catch (e) { /* managed storage not set, fallback list stays */ }
+}
+refreshMarkings();
+setInterval(refreshMarkings, 5 * 60 * 1000);
+
+function hasBulkEmails(text) {
+  const m = text.match(EMAIL_RE);
+  if (!m) return false;
+  return new Set(m.map((e) => e.toLowerCase())).size >= BULK_EMAIL_THRESHOLD;
+}
+
+const DETECTORS = [
+  // --- developer credentials ---
+  { id: "aws_access_key", label: "AWS access key",
+    re: /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/ },
+  { id: "private_key", label: "private key",
+    re: /-----BEGIN [A-Z ]*PRIVATE KEY-----/ },
+  { id: "gitlab_pat", label: "GitLab personal access token",
+    re: /\bglpat-[A-Za-z0-9_-]{20,}\b/ },
+  { id: "github_token", label: "GitHub token",
+    re: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{36,}\b|\bgithub_pat_[A-Za-z0-9_]{22,}\b/ },
+  { id: "anthropic_key", label: "Anthropic API key",
+    re: /\bsk-ant-[A-Za-z0-9-]{20,}\b/ },
+  { id: "openai_key", label: "OpenAI API key",
+    re: /\bsk-[A-Za-z0-9_-]*T3BlbkFJ[A-Za-z0-9_-]{10,}\b|\bsk-[A-Za-z0-9]{48}\b/ },
+  { id: "slack_token", label: "Slack token",
+    re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
+  { id: "jwt", label: "JWT",
+    re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{5,}\b/ },
+  { id: "google_api_key", label: "Google API key",
+    re: /\bAIza[0-9A-Za-z_-]{35}\b/ },
+  { id: "azure_storage_secret", label: "Azure storage secret",
+    re: /\b(?:AccountKey|SharedAccessSignature)=[A-Za-z0-9+/=%]{20,}/ },
+
+  // --- marketing / SaaS platform credentials ---
+  { id: "stripe_live_key", label: "Stripe live secret key",
+    re: /\b[sr]k_live_[A-Za-z0-9]{16,}\b/ },
+  { id: "mailchimp_key", label: "Mailchimp API key",
+    re: /\b[0-9a-f]{32}-us\d{1,2}\b/ },
+  { id: "hubspot_token", label: "HubSpot access token",
+    re: /\bpat-(?:na|eu)\d+-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/ },
+  { id: "sendgrid_key", label: "SendGrid API key",
+    re: /\bSG\.[A-Za-z0-9_-]{16,32}\.[A-Za-z0-9_-]{16,64}\b/ },
+  { id: "meta_access_token", label: "Meta access token",
+    re: /\bEAA[A-Za-z0-9]{30,}\b/ },
+
+  // --- shared credentials ---
+  { id: "password_assignment", label: "password",
+    re: /(?:password|passwd|pwd|passcode)\s*[:=]\s*\S{4,}/i },
+
+  // --- personal and financial data ---
+  { id: "payment_card", label: "payment card number", test: hasPaymentCard },
+  { id: "uk_nino", label: "National Insurance number",
+    re: /\b[A-CEGHJ-PR-TW-Z]{2}\s?\d{2}\s?\d{2}\s?\d{2}\s?[A-D]\b/ },
+  { id: "iban", label: "IBAN",
+    re: /\b(?:GB|IE|FR|DE|ES|IT|NL|BE|CH|PT|SE|DK|NO|PL|AT|FI|LU)\d{2}[A-Z0-9]{10,30}\b/ },
+  { id: "bulk_emails", label: "bulk email list", test: hasBulkEmails },
+  { id: "classification_marking", label: "classification marking",
+    test: hasClassificationMarking },
+];
+
+function scan(text) {
+  const hits = [];
+  for (const d of DETECTORS) {
+    const hit = d.re ? d.re.test(text) : d.test(text);
+    if (hit) hits.push(d);
+  }
+  return hits;
+}
+
+async function getPasteMode() {
+  try {
+    const cfg = await api.storage.managed.get("pasteGuardMode");
+    if (cfg && typeof cfg.pasteGuardMode === "string" &&
+        ["off", "warn", "block"].includes(cfg.pasteGuardMode)) {
+      return cfg.pasteGuardMode;
+    }
+  } catch (e) { /* managed storage not set, use fallback */ }
+  return FALLBACK_PASTE_MODE;
+}
+
+// Cache the mode so the paste handler can act synchronously. preventDefault
+// only works inside the event turn, so the decision cannot await anything.
+let pasteMode = FALLBACK_PASTE_MODE;
+getPasteMode().then((m) => { pasteMode = m; });
+setInterval(() => { getPasteMode().then((m) => { pasteMode = m; }); }, 5 * 60 * 1000);
+
+function isEditable(el) {
+  if (!el) return false;
+  if (el.isContentEditable) return true;
+  const tag = (el.tagName || "").toLowerCase();
+  return tag === "textarea" || tag === "input";
+}
+
+function handleCapture(event) {
+  if (!event.isTrusted) return; // ignore synthetic events from page scripts
+  if (pasteMode === "off") return;
+
+  const dt = event.clipboardData || event.dataTransfer;
+  if (!dt) return;
+  const text = dt.getData("text/plain");
+  if (!text) return; // image or file paste: out of scope for the text guard
+
+  const target = event.target;
+  if (!isEditable(target) && !isEditable(document.activeElement)) return;
+
+  const hits = scan(text);
+  if (!hits.length) return;
+
+  // Stop the content reaching the page in both warn and block mode. Warn mode
+  // then offers reinsertion; block mode does not.
+  event.preventDefault();
+  event.stopImmediatePropagation();
+
+  const action = pasteMode === "block" ? "blocked" : "warned";
+  showOverlay(hits, action, action === "warned" ? () => {
+    reinsert(target, text);
+    report(hits, "overridden");
+  } : null);
+  report(hits, action);
+}
+
+document.addEventListener("paste", handleCapture, true);
+document.addEventListener("drop", handleCapture, true);
+
+function reinsert(target, text) {
+  const el = isEditable(target) ? target : document.activeElement;
+  if (!el) return;
+  el.focus();
+  if (el.isContentEditable) {
+    // If the click cost us the selection, put a caret at the end of the
+    // editor so insertText has somewhere to insert.
+    const sel = window.getSelection();
+    if (!sel.rangeCount || !el.contains(sel.anchorNode)) {
+      const range = document.createRange();
+      range.selectNodeContents(el);
+      range.collapse(false);
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+    document.execCommand("insertText", false, text);
+  } else if ("value" in el) {
+    const start = el.selectionStart != null ? el.selectionStart : el.value.length;
+    if (el.setRangeText) {
+      el.setRangeText(text, start, start, "end");
+    } else {
+      el.value += text;
+    }
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+}
+
+function report(hits, action) {
+  const key = location.hostname + ":" + action + ":" +
+    hits.map((h) => h.id).sort().join(",");
+  const now = Date.now();
+  if (reported.has(key) && now - reported.get(key) < REPORT_DEDUPE_MS) return;
+  reported.set(key, now);
+
+  // Firefox returns a promise here and rejects it when the background page is
+  // not yet awake to receive. Chrome MV3 does the same. Nothing is waiting on
+  // the result, so an uncaught rejection would surface in the page console of
+  // a user's browser for no reason. The dedupe map has already recorded this
+  // one, so a dropped message is a lost finding rather than a repeated one,
+  // which is the right way round: the guard has already acted on screen and
+  // the report is the record of it.
+  api.runtime.sendMessage({
+    type: "paste-guard",
+    tool: location.hostname,
+    action: action,                       // warned | blocked | overridden
+    detectors: hits.map((h) => h.id),     // ids only, never the matched text
+    ts: new Date().toISOString(),
+  }).catch(() => {});
+}
+
+// Minimal overlay: inline-styled, high z-index, auto-dismiss. Deliberately
+// framework-free so it cannot clash with the host page.
+function showOverlay(hits, action, onOverride) {
+  const existing = document.getElementById("taag-paste-overlay");
+  if (existing) existing.remove();
+
+  const labels = hits.map((h) => h.label).join(", ");
+  const box = document.createElement("div");
+  box.id = "taag-paste-overlay";
+  box.style.cssText =
+    "position:fixed;top:16px;right:16px;z-index:2147483647;max-width:340px;" +
+    "background:#1f2430;color:#fff;border-left:4px solid " +
+    (action === "blocked" ? "#e5484d" : "#f5a524") + ";" +
+    "border-radius:6px;padding:12px 14px;font:13px/1.45 -apple-system," +
+    "'Segoe UI',sans-serif;box-shadow:0 4px 14px rgba(0,0,0,.35);";
+
+  const title = document.createElement("div");
+  title.style.cssText = "font-weight:600;margin-bottom:4px;";
+  title.textContent = action === "blocked" ? "Paste blocked" : "Sensitive content detected";
+  box.appendChild(title);
+
+  const body = document.createElement("div");
+  body.textContent = "Detected: " + labels + ". This looks like something " +
+    "that should not go into an AI tool. (AI Guard)";
+  box.appendChild(body);
+
+  const row = document.createElement("div");
+  row.style.cssText = "margin-top:10px;display:flex;gap:8px;";
+
+  if (onOverride) {
+    const go = document.createElement("button");
+    go.textContent = "Paste anyway";
+    go.style.cssText =
+      "background:#f5a524;border:0;border-radius:4px;padding:5px 10px;" +
+      "color:#1f2430;font-weight:600;cursor:pointer;font:inherit;";
+    // preventDefault on mousedown so the click does not move focus and
+    // selection out of the editor; the insert then lands where the paste
+    // was headed.
+    go.addEventListener("mousedown", (e) => e.preventDefault());
+    go.addEventListener("click", () => { box.remove(); onOverride(); });
+    row.appendChild(go);
+  }
+
+  const dismiss = document.createElement("button");
+  dismiss.textContent = "Dismiss";
+  dismiss.style.cssText =
+    "background:transparent;border:1px solid #555;border-radius:4px;" +
+    "padding:5px 10px;color:#ddd;cursor:pointer;font:inherit;";
+  dismiss.addEventListener("click", () => box.remove());
+  row.appendChild(dismiss);
+
+  box.appendChild(row);
+  document.documentElement.appendChild(box);
+  setTimeout(() => { if (box.isConnected && !onOverride) box.remove(); }, 8000);
+}

--- a/portal/extension-src/managed-schema.json
+++ b/portal/extension-src/managed-schema.json
@@ -1,0 +1,38 @@
+{
+  "type": "object",
+  "properties": {
+    "allowedDomains": {
+      "title": "Allowed email domains",
+      "description": "Account domains that are NOT flagged, e.g. example.com",
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "reportEndpoint": {
+      "title": "Report endpoint",
+      "description": "HTTPS URL that receives flag events as JSON POST",
+      "type": "string"
+    },
+    "deviceIdentifier": {
+      "title": "Device identifier",
+      "description": "Value the MDM stamps in so flags can be attributed to a device or enrolled user",
+      "type": "string"
+    },
+    "authToken": {
+      "title": "Auth token",
+      "description": "Bearer token sent to the report endpoint: the receiver's shared AUTH_TOKEN, or an enrollment token (aige_...) from a managed-mode receiver, which this browser profile exchanges once for its own device credential",
+      "type": "string"
+    },
+    "pasteGuardMode": {
+      "title": "Paste guard mode",
+      "description": "off, warn (intercept with a paste-anyway override), or block. Unset behaves as warn.",
+      "type": "string",
+      "enum": ["off", "warn", "block"]
+    },
+    "classificationMarkings": {
+      "title": "Classification markings",
+      "description": "Document classification labels the paste guard flags, matched case-insensitively as phrases (e.g. Client Confidential). Bare CONFIDENTIAL in caps is always flagged. Unset uses the built-in defaults in guard.js.",
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/portal/extension-src/manifest.json
+++ b/portal/extension-src/manifest.json
@@ -1,0 +1,80 @@
+{
+  "manifest_version": 3,
+  "name": "AI Guard",
+  "version": "1.4.0",
+  "description": "Flags AI tools signed in with a non-corporate account and stops secrets being pasted into them. Reports detector ids and account domains only, never content.",
+  "permissions": [
+    "storage",
+    "alarms"
+  ],
+  "host_permissions": [
+    "https://chatgpt.com/*",
+    "https://chat.openai.com/*",
+    "https://claude.ai/*",
+    "https://gemini.google.com/*",
+    "https://otter.ai/*",
+    "https://*.otter.ai/*",
+    "https://fireflies.ai/*",
+    "https://app.fireflies.ai/*",
+    "https://copilot.microsoft.com/*",
+    "https://ai-guard.example.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js",
+    "scripts": [
+      "background.js"
+    ]
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://chatgpt.com/*",
+        "https://chat.openai.com/*",
+        "https://claude.ai/*",
+        "https://gemini.google.com/*",
+        "https://otter.ai/*",
+        "https://*.otter.ai/*",
+        "https://fireflies.ai/*",
+        "https://app.fireflies.ai/*",
+        "https://copilot.microsoft.com/*"
+      ],
+      "js": [
+        "guard.js"
+      ],
+      "run_at": "document_start"
+    },
+    {
+      "matches": [
+        "https://chatgpt.com/*",
+        "https://chat.openai.com/*",
+        "https://claude.ai/*",
+        "https://gemini.google.com/*",
+        "https://otter.ai/*",
+        "https://*.otter.ai/*",
+        "https://fireflies.ai/*",
+        "https://app.fireflies.ai/*",
+        "https://copilot.microsoft.com/*"
+      ],
+      "js": [
+        "content.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ],
+  "storage": {
+    "managed_schema": "managed-schema.json"
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "ai-guard@example.com",
+      "strict_min_version": "140.0",
+      "update_url": "https://YOUR_HOST/firefox-updates.json",
+      "data_collection_permissions": {
+        "required": [
+          "websiteActivity",
+          "personallyIdentifyingInfo"
+        ]
+      }
+    }
+  }
+}

--- a/portal/tests/test_extension_setup.py
+++ b/portal/tests/test_extension_setup.py
@@ -1,0 +1,276 @@
+"""The extension setup guide's server half: source zip, update manifests,
+hosting probes.
+
+The properties: the source download is the shipped source with exactly one
+change (the receiver origin), because a second silent difference would make
+"pack what you downloaded" a lie; the update manifests are generated from
+Settings and carry the bundled source's version, since a version mismatch
+is the failure browsers report as nothing at all; none of these downloads
+mints an enrollment token, because they carry no credential and a minted-
+but-unused token reads as a rollout that never happened; and the probes
+catch the two hosted-file failures that answer 200 and still break every
+machine - a manifest describing some other id, and an unsigned .xpi.
+"""
+
+import io
+import json
+import os
+import xml.etree.ElementTree as ET
+import zipfile
+from pathlib import Path
+
+os.environ.setdefault("PORTAL_AUTH", "none")
+
+import pytest
+from fastapi import HTTPException
+
+from app import main, managed
+
+PORTAL = Path(__file__).parent.parent
+SRC = PORTAL / "extension-src"
+BUNDLED_VERSION = managed.extension_version(str(SRC))
+
+
+@pytest.fixture
+def configured(monkeypatch):
+    monkeypatch.setattr(main, "RECEIVER_URL", "http://receiver.internal:8080")
+    monkeypatch.setattr(main, "RECEIVER_PUBLIC_URL", "https://rx.example.com")
+    monkeypatch.setattr(main, "EXTENSION_SRC_DIR", str(SRC))
+
+
+def _receiver_with(settings, minted):
+    def fake(base, method, path, admin_token, body=None):
+        if path == "/admin/settings":
+            return {"settings": settings}
+        if method == "POST" and path == "/admin/enrollment-tokens":
+            minted.append(body)
+            return {"id": "tok1", "token": "aige_MINTED",
+                    "expires_at": "2027-01-01T00:00:00+00:00"}
+        return {}
+    return fake
+
+
+BASE_SETTINGS = {
+    "extension_id": {"value": "a" * 32, "source": "db"},
+    "firefox_extension_id": {"value": "ai-guard@corp.example", "source": "db"},
+    "extension_crx_url": {"value": "https://files.corp.example/ai-guard.crx",
+                          "source": "db"},
+    "extension_update_url": {"value": "https://files.corp.example/updates.xml",
+                             "source": "db"},
+    "extension_xpi_url": {"value": "https://files.corp.example/ai-guard.xpi",
+                          "source": "db"},
+}
+
+
+@pytest.fixture
+def receiver(monkeypatch, configured):
+    minted = []
+
+    def install(extra=None, drop=()):
+        settings = {k: v for k, v in {**BASE_SETTINGS, **(extra or {})}.items()
+                    if k not in drop}
+        monkeypatch.setattr(main.managed, "receiver_request",
+                            _receiver_with(settings, minted))
+    install()
+    return install, minted
+
+
+# ------------------------------------------------------------- source zip --
+
+
+def test_the_zip_is_the_source_with_exactly_one_change(receiver):
+    resp = main.artifact("extension-source", _=None, token="t")
+    z = zipfile.ZipFile(io.BytesIO(resp.body))
+    names = {n.rsplit("/", 1)[1] for n in z.namelist()}
+    assert names == set(managed.EXTENSION_SOURCE_FILES)
+
+    manifest = z.read("ai-guard-extension/manifest.json").decode()
+    assert '"https://rx.example.com/*"' in manifest
+    assert "ai-guard.example.com" not in manifest
+    for name in managed.EXTENSION_SOURCE_FILES:
+        if name == "manifest.json":
+            continue
+        assert (z.read("ai-guard-extension/" + name)
+                == (SRC / name).read_bytes()), name
+
+
+def test_the_origin_is_the_origin_not_the_whole_url(configured):
+    """A receiver URL saved with a path must not put the path into
+    host_permissions - a match pattern with a path component narrows the
+    permission and the report POST dies on CORS."""
+    _, content = managed.generate_extension_source(
+        str(SRC), "https://rx.example.com/some/path")
+    manifest = zipfile.ZipFile(io.BytesIO(content)).read(
+        "ai-guard-extension/manifest.json").decode()
+    assert '"https://rx.example.com/*"' in manifest
+
+
+def test_two_downloads_are_the_same_bytes(configured):
+    a = managed.generate_extension_source(str(SRC), "https://rx.example.com")
+    b = managed.generate_extension_source(str(SRC), "https://rx.example.com")
+    assert a == b
+
+
+def test_a_reshaped_manifest_fails_loudly(tmp_path):
+    """Same contract as the collector-script anchors: if the shipped
+    manifest no longer contains the placeholder exactly once, generation
+    must refuse rather than serve a zip that reports nowhere."""
+    for name in managed.EXTENSION_SOURCE_FILES:
+        (tmp_path / name).write_bytes((SRC / name).read_bytes())
+    (tmp_path / "manifest.json").write_text("{\"host_permissions\": []}")
+    with pytest.raises(managed.ArtifactError, match="anchor"):
+        managed.generate_extension_source(str(tmp_path), "https://rx.example.com")
+
+
+# -------------------------------------------------------- update manifests --
+
+
+def test_updates_xml_carries_the_settings_and_the_bundled_version(receiver):
+    resp = main.artifact("extension-updates-xml", _=None, token="t")
+    root = ET.fromstring(resp.body.decode())
+    ns = "{http://www.google.com/update2/response}"
+    app = root.find(ns + "app")
+    assert app.get("appid") == "a" * 32
+    check = app.find(ns + "updatecheck")
+    assert check.get("codebase") == "https://files.corp.example/ai-guard.crx"
+    assert check.get("version") == BUNDLED_VERSION
+
+
+def test_firefox_updates_json_is_keyed_on_the_gecko_id(receiver):
+    resp = main.artifact("firefox-updates-json", _=None, token="t")
+    body = json.loads(resp.body.decode())
+    (update,) = body["addons"]["ai-guard@corp.example"]["updates"]
+    assert update == {"version": BUNDLED_VERSION,
+                      "update_link": "https://files.corp.example/ai-guard.xpi"}
+
+
+def test_each_manifest_names_the_setting_it_is_missing(receiver):
+    install, _ = receiver
+    for kind, missing, said in (
+            ("extension-updates-xml", "extension_id", "extension ID"),
+            ("extension-updates-xml", "extension_crx_url", ".crx URL"),
+            ("firefox-updates-json", "firefox_extension_id", "gecko id"),
+            ("firefox-updates-json", "extension_xpi_url", ".xpi URL")):
+        install(drop=(missing,))
+        with pytest.raises(HTTPException) as e:
+            main.artifact(kind, _=None, token="t")
+        assert e.value.status_code == 409
+        assert said in e.value.detail
+
+
+def test_an_id_that_is_not_an_id_is_refused(configured):
+    with pytest.raises(managed.ArtifactError, match="Chromium extension id"):
+        managed.generate_updates_xml("not-an-id", "https://x.example/e.crx",
+                                     "1.0.0")
+
+
+def test_a_gecko_id_that_could_escape_json_is_refused(configured):
+    with pytest.raises(managed.ArtifactError):
+        managed.generate_firefox_updates_json(
+            'ai"guard@corp.example', "https://x.example/e.xpi", "1.0.0")
+
+
+# ------------------------------------------------------------- no minting --
+
+
+def test_the_hosting_downloads_mint_nothing(receiver):
+    """A collector artifact mints (that is its credential); these carry
+    none, so a token minted for one would sit in the list looking like a
+    rollout that never happened."""
+    _, minted = receiver
+    for kind in main.TOKENLESS_ARTIFACTS:
+        main.artifact(kind, _=None, token="t")
+    assert minted == []
+    main.artifact("scanner-cronjob", _=None, token="t")
+    assert len(minted) == 1  # the control: minting still works
+
+
+# ----------------------------------------------------------------- probes --
+
+
+def _updates_xml(appid, version):
+    return ("<?xml version='1.0' encoding='UTF-8'?>"
+            "<gupdate xmlns='http://www.google.com/update2/response'"
+            " protocol='2.0'><app appid='%s'><updatecheck"
+            " codebase='https://h/e.crx' version='%s' /></app></gupdate>"
+            % (appid, version)).encode()
+
+
+def _hosted(monkeypatch, body, ctype="application/xml"):
+    monkeypatch.setattr(main, "_fetch_hosted",
+                        lambda url, cap: (200, ctype, body[:cap]))
+
+
+def test_the_updates_probe_accepts_a_matching_manifest(receiver, monkeypatch):
+    _hosted(monkeypatch, _updates_xml("a" * 32, BUNDLED_VERSION))
+    out = main.test_extension_updates(_=None, token="t")
+    assert out["ok"] and not out["warnings"]
+
+
+def test_the_updates_probe_catches_somebody_elses_manifest(receiver, monkeypatch):
+    """The failure that looks fine everywhere: the URL answers 200, the XML
+    parses, and every browser polls it forever without installing anything,
+    because it describes a different extension."""
+    _hosted(monkeypatch, _updates_xml("b" * 32, BUNDLED_VERSION))
+    out = main.test_extension_updates(_=None, token="t")
+    assert not out["ok"]
+    assert "b" * 32 in out["detail"]
+
+
+def test_the_updates_probe_warns_on_a_version_behind_the_bundle(receiver, monkeypatch):
+    _hosted(monkeypatch, _updates_xml("a" * 32, "0.0.1"))
+    out = main.test_extension_updates(_=None, token="t")
+    assert out["ok"] and any("0.0.1" in w for w in out["warnings"])
+
+
+def test_the_updates_probe_says_when_the_answer_is_not_xml(receiver, monkeypatch):
+    _hosted(monkeypatch, b"<html>bucket listing</html")
+    out = main.test_extension_updates(_=None, token="t")
+    assert not out["ok"]
+
+
+def test_the_updates_probe_requires_a_saved_url(receiver, monkeypatch):
+    install, _ = receiver
+    install(drop=("extension_update_url",))
+    with pytest.raises(HTTPException) as e:
+        main.test_extension_updates(_=None, token="t")
+    assert e.value.status_code == 400
+
+
+def _xpi(names):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for n in names:
+            z.writestr(n, b"x")
+    return buf.getvalue()
+
+
+def test_the_xpi_probe_accepts_a_signed_file(receiver, monkeypatch):
+    _hosted(monkeypatch, _xpi(["manifest.json", "META-INF/mozilla.rsa"]),
+            "application/x-xpinstall")
+    out = main.test_extension_xpi(_=None, token="t")
+    assert out["ok"] and not out["warnings"]
+
+
+def test_the_xpi_probe_catches_the_unsigned_build(receiver, monkeypatch):
+    """The trap the probe exists for: your own build and the signed one are
+    both valid zips at valid URLs, and Firefox refuses one of them on every
+    machine in the fleet."""
+    _hosted(monkeypatch, _xpi(["manifest.json"]), "application/x-xpinstall")
+    out = main.test_extension_xpi(_=None, token="t")
+    assert not out["ok"]
+    assert "mozilla.rsa" in out["detail"]
+
+
+def test_the_xpi_probe_warns_on_the_wrong_content_type(receiver, monkeypatch):
+    _hosted(monkeypatch, _xpi(["manifest.json", "META-INF/mozilla.rsa"]),
+            "text/plain")
+    out = main.test_extension_xpi(_=None, token="t")
+    assert out["ok"] and any("content type" in w or "text/plain" in w
+                             for w in out["warnings"])
+
+
+def test_the_xpi_probe_says_when_the_file_is_not_a_zip(receiver, monkeypatch):
+    _hosted(monkeypatch, b"not a zip", "application/x-xpinstall")
+    out = main.test_extension_xpi(_=None, token="t")
+    assert not out["ok"]

--- a/portal/tests/test_managed_portal.py
+++ b/portal/tests/test_managed_portal.py
@@ -41,6 +41,8 @@ def test_the_script_copies_match_their_sources():
         ("firefox-windows.ps1",
          "extension/deploy/windows/Deploy-AiGuardExtensionFirefox.ps1"),
     ]
+    pairs += [("../extension-src/%s" % name, "extension/src/%s" % name)
+              for name in managed.EXTENSION_SOURCE_FILES]
     for copy, source in pairs:
         assert (SCRIPTS / copy).read_bytes() == (REPO / source).read_bytes(), (
             "portal/collector-scripts/%s no longer matches %s - re-copy it"
@@ -249,7 +251,8 @@ def test_config_names_which_managed_flag_is_missing(monkeypatch):
     monkeypatch.setattr(main, "RECEIVER_PUBLIC_URL", "")
     assert main.config(None, _=None)["managed"] == {
         "enabled": True, "artifacts_ready": False,
-        "receiver_public_url_default": ""}
+        "receiver_public_url_default": "",
+        "extension_version": managed.extension_version(main.EXTENSION_SRC_DIR)}
 
 
 # --------------------------------------------------------- receiver client --

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -998,9 +998,11 @@ _STR_SETTINGS = (
     ("grafana_dashboard_uid", False, 128),
     ("overview_widgets", False, 500),
     # Where the packed extension is served from: the Chromium update
-    # manifest, and the Mozilla-signed .xpi. The portal bakes these into
-    # the Windows deploy scripts and the Firefox policy.
+    # manifest, the packed .crx it points at, and the Mozilla-signed .xpi.
+    # The portal bakes these into the Windows deploy scripts, the Firefox
+    # policy, and the generated update manifests.
     ("extension_update_url", True, 500),
+    ("extension_crx_url", True, 500),
     ("extension_xpi_url", True, 500),
 )
 
@@ -1029,6 +1031,7 @@ class SettingsUpdate(BaseModel):
     grafana_dashboard_uid: str | None = Field(default=None, max_length=128)
     overview_widgets: str | None = Field(default=None, max_length=500)
     extension_update_url: str | None = Field(default=None, max_length=500)
+    extension_crx_url: str | None = Field(default=None, max_length=500)
     extension_xpi_url: str | None = Field(default=None, max_length=500)
     paste_guard_mode: str | None = Field(default=None, max_length=8)
     firefox_extension_id: str | None = Field(default=None, max_length=128)
@@ -1091,6 +1094,7 @@ def get_settings(authorization: str = Header(default="")):
         "grafana_dashboard_uid": plain("grafana_dashboard_uid"),
         "overview_widgets": plain("overview_widgets"),
         "extension_update_url": plain("extension_update_url"),
+        "extension_crx_url": plain("extension_crx_url"),
         "extension_xpi_url": plain("extension_xpi_url"),
         "paste_guard_mode": plain("paste_guard_mode"),
         "firefox_extension_id": plain("firefox_extension_id"),

--- a/receiver/tests/test_settings.py
+++ b/receiver/tests/test_settings.py
@@ -292,7 +292,8 @@ def test_the_firefox_id_refuses_whitespace(managed):
 
 
 def test_the_delivery_urls_must_be_urls(managed):
-    for key in ("extension_update_url", "extension_xpi_url"):
+    for key in ("extension_update_url", "extension_crx_url",
+                "extension_xpi_url"):
         bad = client.put("/admin/settings", headers=ADMIN, json={key: "files/x"})
         assert bad.status_code == 422, key
         ok = client.put("/admin/settings", headers=ADMIN,


### PR DESCRIPTION
The wizard's browser-extension step was six flat fields and a pointer at extension/README.md, which only helps if you have a checkout. This turns it into a six-page guided setup (wizard step 5 and Settings both open it) and moves the parts the portal can do itself into the portal:

- **Pre-configured source download**: the portal ships verified copies of extension/src (same byte-equality test as the collector scripts) and serves them as a zip with the receiver origin already substituted into the manifest's host_permissions - the one edit packing needs, and no checkout anywhere.
- **Generated update manifests**: updates.xml and firefox-updates.json are generated from Settings (extension id, hosting URLs, the bundled source's version) instead of hand-edited from the repo templates. New central setting: extension_crx_url. These downloads mint no enrollment token - they carry no credential.
- **Hosting probes**: server-side checks of the saved URLs. The Chromium probe catches a hosted manifest that answers 200 but describes a different id or version (browsers treat that as "no update", forever). The Firefox probe downloads the .xpi and checks for META-INF/mozilla.rsa, i.e. that the hosted file is the Mozilla-signed one and not your own build.
- **The guide pages** carry the README's packing walkthrough: the chrome://extensions steps, the two openssl commands as copyable blocks, the keep-the-pem warning, the key-pinning repack, and the AMO self-distribution signing path for Firefox. Hosting copy stays vendor-neutral - any HTTPS the fleet can reach.

Wizard step 5 is now a status summary (what's set, what isn't) plus the entry button; Settings keeps every field flat as before, with the new .crx URL row.

Tests: byte-equality for the new source copies, zip content and determinism, the one-change guarantee on the manifest, 409s naming the missing setting per manifest, no-minting on the hosting downloads, and probe verdicts for the matching / foreign / unparseable manifest and the signed / unsigned / non-zip .xpi cases. Portal 353 passed, receiver 128 passed.