### PR TITLE
Hosting notes on the extension guide

### DIFF
--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -1658,7 +1658,11 @@ async function extSetup() {
     and an update manifest (<span class="mono">updates.xml</span>) that
     points at it. Any static host or artifact pipeline your org already
     trusts works; serve the .crx as
-    <span class="mono">application/x-chrome-extension</span>.</p>
+    <span class="mono">application/x-chrome-extension</span>. Two habits
+    save a later outage: if your host grants read access per file, grant it
+    by prefix instead, or every new release starts life private; and keep
+    the previous .crx up when you upload a new one - re-pointing updates.xml
+    at it is your rollback.</p>
     <dl class="kv">
       ${settingRow('extension_crx_url', 'Packed .crx URL',
         'https://files.example.com/' + crxName,


### PR DESCRIPTION
Two lines on the guide's hosting page, both learned the hard way and previously only in extension/README.md: hosts that grant read access per file leave every new release private until someone notices (grant by prefix), and keeping the previous .crx hosted is the rollback - re-point updates.xml at it. The page is written for someone without a checkout, so the page carries them.