### PR TITLE
chart: default fsGroup 65532 so the managed-mode PVC is writable

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -247,6 +247,31 @@ keeps its current token, so nothing has to be redeployed.
 
 ---
 
+## The receiver crash-loops on `unable to open database file`
+
+```
+sqlite3.OperationalError: unable to open database file
+```
+
+Managed mode keeps its state DB on a PVC, and the PVC arrived owned by root.
+Most StorageClasses hand volumes over that way; it is `fsGroup` in the pod
+security context that makes the kubelet chown the mount to the pod's group.
+The chart runs the receiver as uid 65532, so without `fsGroup` that uid cannot
+create `/var/lib/ai-guard/state.db` and the pod dies before serving anything.
+
+Chart 0.10.5 sets `fsGroup: 65532` by default. On an older chart, or with a
+values file that replaces `podSecurityContext` wholesale, add it back:
+
+```yaml
+podSecurityContext:
+  fsGroup: 65532
+```
+
+and `helm upgrade`. The pod recovers on the next start; nothing on the volume
+needs repair.
+
+---
+
 ## `ImagePullBackOff`
 
 ```bash

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.10.4
+version: 0.10.5
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -314,6 +314,11 @@ podSecurityContext:
   runAsNonRoot: true
   runAsUser: 65532
   runAsGroup: 65532
+  # Managed mode mounts a PVC for the state DB. Most StorageClasses hand the
+  # volume over owned by root, and it is fsGroup that makes the kubelet chown
+  # it to something uid 65532 can write - without it the receiver crash-loops
+  # on "unable to open database file" before serving a single request.
+  fsGroup: 65532
   seccompProfile:
     type: RuntimeDefault
 


### PR DESCRIPTION
Managed mode keeps its state DB on a PVC, and most StorageClasses hand the volume over owned by root. `runAsUser: 65532` alone doesn't fix that - it's `fsGroup` that gets the kubelet to chown the mount to the pod's group - so a fresh install with managed mode on (the default since 0.9.9) crash-loops on `sqlite3.OperationalError: unable to open database file` anywhere the StorageClass isn't already permissive.

- `podSecurityContext` now defaults `fsGroup: 65532`
- chart bumped to 0.10.5
- troubleshooting entry for the symptom, for deployments on an older chart or with a values file that replaces `podSecurityContext` wholesale

`helm lint` clean.