### PR TITLE
receiver: finding lifecycle, audit read, discovery webhook, accounts with roles

### DIFF
--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -475,22 +475,29 @@ _MANAGED = ("/enroll", "/admin")
 _ADMIN_OPEN = ("/admin/setup", "/admin/login")
 
 
-def _admin_header_ok(header: str) -> bool:
-    """Is this Authorization header an admin?
+def _admin_role(header: str) -> str | None:
+    """Which trust level this Authorization header carries, or None.
 
     Two shapes: the optional API credential (ADMIN_TOKEN, for automation and
-    break-glass), or a live portal session minted by /admin/login. The
-    emptiness guard is not redundant: compare_digest holds two empty strings
-    equal, so without it a deployment with no ADMIN_TOKEN would let an empty
-    header in.
+    break-glass), which is always an admin because both of those are
+    operator acts; or a live portal session minted by /admin/login, which
+    carries its account's role. The emptiness guard is not redundant:
+    compare_digest holds two empty strings equal, so without it a
+    deployment with no ADMIN_TOKEN would let an empty header in.
     """
     if _EXPECTED_ADMIN and hmac.compare_digest(
         header.encode("latin-1"), _EXPECTED_ADMIN
     ):
-        return True
+        return "admin"
     if STATE is not None and header.startswith("Bearer " + _state.SESSION_PREFIX):
-        return STATE.session_user(header[len("Bearer "):]) is not None
-    return False
+        u = STATE.session_user(header[len("Bearer "):])
+        if u is not None:
+            return u.get("role") or "admin"
+    return None
+
+
+def _admin_header_ok(header: str) -> bool:
+    return _admin_role(header) is not None
 
 
 def _body_size_response(request: Request):
@@ -771,13 +778,20 @@ def _touch_device(request: Request):
         )
 
 
-def _admin_auth(authorization: str):
+def _admin_auth(authorization: str, write: bool = False):
     # Defence in depth for /admin/*, like _auth for ingest. 404 when managed
     # mode is off: routes that do not exist should not confirm they exist.
+    # write=True is the role gate: a viewer account reads everything and
+    # changes nothing, and the refusal names the reason rather than lying
+    # with a generic 401 to someone who IS authenticated.
     if STATE is None:
         raise HTTPException(404, "Not Found")
-    if not _admin_header_ok(authorization):
+    role = _admin_role(authorization)
+    if role is None:
         raise HTTPException(401, "bad token")
+    if write and role != "admin":
+        raise HTTPException(403, "this account is read-only: an admin "
+                                 "account has to make this change")
 
 
 # What can enroll. The three collector platforms, one browser profile
@@ -829,7 +843,7 @@ def enroll(req: EnrollRequest, authorization: str = Header(default="")):
 
 @app.post("/admin/enrollment-tokens")
 def mint_enrollment_token(req: MintRequest, authorization: str = Header(default="")):
-    _admin_auth(authorization)
+    _admin_auth(authorization, write=True)
     return STATE.mint_token(req.note, req.ttl_days)
 
 
@@ -843,7 +857,7 @@ def list_enrollment_tokens(authorization: str = Header(default="")):
 
 @app.post("/admin/enrollment-tokens/{tid}/revoke")
 def revoke_enrollment_token(tid: str, authorization: str = Header(default="")):
-    _admin_auth(authorization)
+    _admin_auth(authorization, write=True)
     if not STATE.revoke_token(tid):
         raise HTTPException(404, "no such active token")
     return {"ok": True}
@@ -857,7 +871,7 @@ def list_devices(authorization: str = Header(default="")):
 
 @app.post("/admin/devices/{did}/revoke")
 def revoke_device(did: str, authorization: str = Header(default="")):
-    _admin_auth(authorization)
+    _admin_auth(authorization, write=True)
     if not STATE.revoke_device(did):
         raise HTTPException(404, "no such active device")
     return {"ok": True}
@@ -961,8 +975,76 @@ def session_info(authorization: str = Header(default="")):
     if token.startswith(_state.SESSION_PREFIX):
         u = STATE.session_user(token)
         if u is not None:
-            return {"username": u["username"], "expires_at": u["expires_at"]}
-    return {"username": "", "expires_at": None}
+            return {"username": u["username"], "expires_at": u["expires_at"],
+                    "role": u.get("role") or "admin"}
+    return {"username": "", "expires_at": None, "role": "admin"}
+
+
+# -------------------------------------------------------------- accounts --
+# Admin runs the platform; viewer reads it and changes nothing - the
+# auditor, the exec, the person who needs the pages but must never be a
+# way in. Every action below lands in the audit trail with who did it.
+
+_USERNAME_RE = re.compile(r"^[a-zA-Z0-9._@-]{2,64}$")
+
+
+class UserCreate(BaseModel):
+    model_config = {"extra": "forbid"}
+    username: str = Field(min_length=2, max_length=64)
+    password: str = Field(min_length=12, max_length=256)
+    role: str = Field(min_length=1, max_length=16)
+
+
+class UserPasswordReset(BaseModel):
+    model_config = {"extra": "forbid"}
+    new: str = Field(min_length=12, max_length=256)
+
+
+@app.get("/admin/users")
+def get_users(authorization: str = Header(default="")):
+    _admin_auth(authorization)
+    return {"users": STATE.list_users()}
+
+
+@app.post("/admin/users")
+def post_user(req: UserCreate, authorization: str = Header(default="")):
+    _admin_auth(authorization, write=True)
+    if not _USERNAME_RE.match(req.username):
+        raise HTTPException(422, "usernames are 2-64 characters of letters, "
+                                 "digits, . _ @ -")
+    try:
+        return STATE.create_user(req.username, req.password, req.role,
+                                 _admin_actor(authorization))
+    except _state.AuthError as e:
+        raise HTTPException(e.status, e.detail)
+
+
+@app.post("/admin/users/{uid}/delete")
+def delete_user(uid: str, authorization: str = Header(default="")):
+    _admin_auth(authorization, write=True)
+    if not re.fullmatch(r"[0-9a-f]{16}", uid):
+        raise HTTPException(422, "malformed user id")
+    try:
+        if not STATE.delete_user(uid, _admin_actor(authorization)):
+            raise HTTPException(404, "no account with that id")
+    except _state.AuthError as e:
+        raise HTTPException(e.status, e.detail)
+    return {"deleted": uid}
+
+
+@app.post("/admin/users/{uid}/password")
+def reset_user_password(uid: str, req: UserPasswordReset,
+                        authorization: str = Header(default="")):
+    """An admin setting someone else's password - the forgotten-password
+    path. Changing your own goes through /admin/password, which proves the
+    current one."""
+    _admin_auth(authorization, write=True)
+    if not re.fullmatch(r"[0-9a-f]{16}", uid):
+        raise HTTPException(422, "malformed user id")
+    if not STATE.reset_user_password(uid, req.new,
+                                     _admin_actor(authorization)):
+        raise HTTPException(404, "no account with that id")
+    return {"reset": uid}
 
 
 # ------------------------------------------------------- central settings --
@@ -1004,6 +1086,10 @@ _STR_SETTINGS = (
     ("extension_update_url", True, 500),
     ("extension_crx_url", True, 500),
     ("extension_xpi_url", True, 500),
+    # Where event notifications go: a Slack-compatible incoming webhook.
+    # Fired on a NEW discovery candidate - the moment a human decision
+    # becomes needed - and never per finding, which would be a firehose.
+    ("webhook_url", True, 500),
 )
 
 # What the paste guard does when a marked document is pasted into an AI
@@ -1033,6 +1119,7 @@ class SettingsUpdate(BaseModel):
     extension_update_url: str | None = Field(default=None, max_length=500)
     extension_crx_url: str | None = Field(default=None, max_length=500)
     extension_xpi_url: str | None = Field(default=None, max_length=500)
+    webhook_url: str | None = Field(default=None, max_length=500)
     paste_guard_mode: str | None = Field(default=None, max_length=8)
     firefox_extension_id: str | None = Field(default=None, max_length=128)
     classification_markings: list[str] | None = Field(default=None,
@@ -1116,6 +1203,11 @@ def get_settings_secrets(authorization: str = Header(default="")):
     have SET the password, so it grants nothing they lack - but it is the
     honest statement of the property: integration secrets are recoverable
     by the admin API, unlike fleet credentials, which are hashes.
+
+    Deliberately NOT write-gated: the portal reads Loki on behalf of
+    whoever is signed in, so a viewer session reaches this hop too. What
+    the credential guards - the findings - is exactly what a viewer is
+    trusted to read, and the portal still never relays the value itself.
     """
     _admin_auth(authorization)
     s = STATE.get_settings()
@@ -1129,7 +1221,7 @@ def get_settings_secrets(authorization: str = Header(default="")):
 def put_settings(req: SettingsUpdate, authorization: str = Header(default="")):
     """Partial upsert: only the keys sent change. An explicit null deletes
     the row, which is how the environment value comes back into effect."""
-    _admin_auth(authorization)
+    _admin_auth(authorization, write=True)
     by = _admin_actor(authorization)
 
     if "corp_domains" in req.model_fields_set:
@@ -1222,7 +1314,7 @@ async def test_log_store_push(authorization: str = Header(default="")):
     collector and never stored. That is invisible until someone looks at a
     dashboard; here it is one button during setup.
     """
-    _admin_auth(authorization)
+    _admin_auth(authorization, write=True)
     url, username, password = _effective_log_push()
     if not url:
         raise HTTPException(
@@ -1361,7 +1453,7 @@ def put_registry_entries(req: RegistryEntriesUpdate,
     before anything is written, and the domain map refreshes on the way
     out, so a defined tool normalizes findings immediately and reaches
     collectors on their next check-in."""
-    _admin_auth(authorization)
+    _admin_auth(authorization, write=True)
     by = _admin_actor(authorization)
 
     shipped = _load_registry() or {"tools": []}
@@ -1443,6 +1535,29 @@ def _candidate_key(kind: str, name: str) -> str:
     return "%s:%s" % (kind, slug[:80])
 
 
+def _notify_webhook(text: str):
+    """Fire-and-forget to the operator's incoming webhook, if one is set.
+
+    A thread rather than the request: ingest must never wait on someone
+    else's Slack. Failures are logged and dropped, because a webhook outage
+    must not become a reason findings bounce. The payload is the plain
+    {"text": ...} shape Slack-compatible incoming webhooks accept.
+    """
+    if STATE is None:
+        return
+    url = STATE.get_setting("webhook_url")
+    if not url:
+        return
+
+    def post():
+        try:
+            httpx.post(url, json={"text": text}, timeout=5)
+        except Exception as e:  # noqa: BLE001 - a log line is the whole story
+            log.warning("webhook notification failed: %s", type(e).__name__)
+
+    threading.Thread(target=post, daemon=True).start()
+
+
 @app.post("/candidates")
 def post_candidates(req: CandidatesPost, request: Request,
                     authorization: str = Header(default="")):
@@ -1454,6 +1569,7 @@ def post_candidates(req: CandidatesPost, request: Request,
     source = device["serial"] if device else "shared-token"
 
     accepted = 0
+    new_names = []
     for c in req.candidates:
         if c.kind not in _CANDIDATE_KINDS:
             raise HTTPException(422, "unknown candidate kind: %s" % c.kind[:16])
@@ -1467,11 +1583,18 @@ def post_candidates(req: CandidatesPost, request: Request,
         for d in c.domains:
             if not _CANDIDATE_DOMAIN.match(d):
                 raise HTTPException(422, "bad domain: %s" % d[:60])
-        STATE.upsert_candidate(
+        fresh = STATE.upsert_candidate(
             _candidate_key(c.kind, c.name), c.kind, c.name, c.vendor,
             c.category, c.confidence, sorted(set(c.domains)), c.devices,
             c.evidence, source)
+        if fresh:
+            new_names.append(c.name)
         accepted += 1
+    if new_names:
+        _notify_webhook(
+            "ai-guard: %d new AI tool%s in the review queue: %s"
+            % (len(new_names), "" if len(new_names) == 1 else "s",
+               ", ".join(sorted(new_names)[:10])))
     return {"accepted": accepted}
 
 
@@ -1502,10 +1625,13 @@ def _note_mcp_candidates(f: Finding):
         key = _candidate_key("mcp_server", name)
         if key.split(":", 1)[1] in _REGISTRY_IDS:
             continue
-        STATE.observe_candidate(
-            key, "mcp_server", name,
-            "MCP server defined in %s config" % f.tool, "endpoint",
-            f.device if f.device != "unknown" else "")
+        if STATE.observe_candidate(
+                key, "mcp_server", name,
+                "MCP server defined in %s config" % f.tool, "endpoint",
+                f.device if f.device != "unknown" else ""):
+            _notify_webhook(
+                "ai-guard: unknown MCP server %r seen in a %s config - now"
+                " in the review queue" % (name, f.tool))
 
 
 @app.get("/admin/candidates")
@@ -1535,12 +1661,65 @@ def get_candidates(authorization: str = Header(default="")):
 
 @app.post("/admin/candidates/{key}/dismiss")
 def dismiss_candidate(key: str, authorization: str = Header(default="")):
-    _admin_auth(authorization)
+    _admin_auth(authorization, write=True)
     if not re.fullmatch(r"[a-z0-9_:-]{1,100}", key):
         raise HTTPException(422, "malformed candidate key")
     if not STATE.dismiss_candidate(key, _admin_actor(authorization)):
         raise HTTPException(404, "no undismissed candidate with that key")
     return {"dismissed": key}
+
+
+class FindingStatusWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    key: str = Field(min_length=1, max_length=500)
+    status: str = Field(min_length=1, max_length=16)
+    reason: str = Field(default="", max_length=500)
+
+
+class FindingStatusClear(BaseModel):
+    model_config = {"extra": "forbid"}
+    key: str = Field(min_length=1, max_length=500)
+
+
+@app.get("/admin/finding-status")
+def get_finding_statuses(authorization: str = Header(default="")):
+    """The human answers to derived findings: acknowledged, or accepted with
+    a reason. The findings themselves live in the log store and are
+    recomputed every load; only the answer is state, and only the answer
+    is here. The key is opaque to the receiver on purpose - the portal
+    composes it from the finding's identity, and a receiver that parsed it
+    would couple itself to a shape it does not own."""
+    _admin_auth(authorization)
+    return {"statuses": STATE.list_finding_statuses()}
+
+
+@app.put("/admin/finding-status")
+def put_finding_status(req: FindingStatusWrite,
+                       authorization: str = Header(default="")):
+    _admin_auth(authorization, write=True)
+    try:
+        STATE.set_finding_status(req.key, req.status, req.reason,
+                                 _admin_actor(authorization))
+    except ValueError as e:
+        raise HTTPException(422, str(e))
+    return {"key": req.key, "status": req.status}
+
+
+@app.post("/admin/finding-status/clear")
+def clear_finding_status(req: FindingStatusClear,
+                         authorization: str = Header(default="")):
+    _admin_auth(authorization, write=True)
+    if not STATE.clear_finding_status(req.key, _admin_actor(authorization)):
+        raise HTTPException(404, "no status recorded for that key")
+    return {"cleared": req.key}
+
+
+@app.get("/admin/events")
+def get_events(limit: int = 200, authorization: str = Header(default="")):
+    """The audit trail. Every admin write already records who did what and
+    when; this read is what turns that from a diary into accountability."""
+    _admin_auth(authorization)
+    return {"events": STATE.list_events(min(max(int(limit), 1), 1000))}
 
 
 @app.get("/admin/governance")
@@ -1556,7 +1735,7 @@ def put_governance(req: GovernanceUpdate, authorization: str = Header(default=""
     Validation happens for the whole batch before anything is written, so a
     422 means nothing changed rather than half a batch applied.
     """
-    _admin_auth(authorization)
+    _admin_auth(authorization, write=True)
     by = _admin_actor(authorization)
 
     for d in req.decisions:
@@ -1600,11 +1779,16 @@ def change_password(req: PasswordChangeRequest,
     _admin_auth(authorization)
     token = _bearer(authorization)
     is_session = token.startswith(_state.SESSION_PREFIX)
+    # A session changes its own account's password, whatever its role: a
+    # viewer owning their credential is not a write to the platform. The
+    # API credential path targets the oldest admin - break-glass.
+    user = STATE.session_user(token) if is_session else None
     try:
         STATE.change_password(
             req.new,
             current=req.current if is_session else None,
             keep_session=token if is_session else None,
+            user_id=user["user_id"] if user else None,
         )
     except _state.AuthError as e:
         raise HTTPException(e.status, e.detail)

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -95,7 +95,8 @@ CREATE TABLE IF NOT EXISTS admin_users (
   username      TEXT NOT NULL UNIQUE,
   password_hash TEXT NOT NULL,
   created_at    TEXT NOT NULL,
-  last_login_at TEXT
+  last_login_at TEXT,
+  role          TEXT NOT NULL DEFAULT 'admin'
 );
 CREATE TABLE IF NOT EXISTS sessions (
   token_hash BLOB NOT NULL UNIQUE,
@@ -148,6 +149,13 @@ CREATE TABLE IF NOT EXISTS candidates (
   dismissed_at TEXT,
   dismissed_by TEXT NOT NULL DEFAULT ''
 );
+CREATE TABLE IF NOT EXISTS finding_status (
+  key    TEXT PRIMARY KEY,
+  status TEXT NOT NULL,
+  reason TEXT NOT NULL DEFAULT '',
+  actor  TEXT NOT NULL DEFAULT '',
+  at     TEXT NOT NULL
+);
 """
 
 # Columns added after the first release, applied to databases that predate
@@ -159,6 +167,12 @@ _DEVICE_COLUMNS_ADDED = (
     # reimaged laptop, the stateless scanner - or a displaced device).
     ("reenrolled_at", "TEXT"),
     ("enrollments", "INTEGER NOT NULL DEFAULT 1"),
+)
+
+# Accounts predate roles; a database from before the column gets every
+# existing account as admin, which is exactly what those accounts were.
+_ADMIN_COLUMNS_ADDED = (
+    ("role", "TEXT NOT NULL DEFAULT 'admin'"),
 )
 
 
@@ -242,6 +256,12 @@ class State:
             for name, decl in _DEVICE_COLUMNS_ADDED:
                 if name not in have:
                     self._db.execute(f"ALTER TABLE devices ADD COLUMN {name} {decl}")
+            have = {r["name"]
+                    for r in self._db.execute("PRAGMA table_info(admin_users)")}
+            for name, decl in _ADMIN_COLUMNS_ADDED:
+                if name not in have:
+                    self._db.execute(
+                        f"ALTER TABLE admin_users ADD COLUMN {name} {decl}")
             self._db.commit()
 
     def _event(self, kind: str, detail: dict):
@@ -418,20 +438,21 @@ class State:
         return row is not None
 
     def create_admin(self, username: str, password: str) -> dict:
-        """The first (and for now only) admin account.
+        """The first account, always an admin.
 
-        Refuses once any account exists: creating an account is what the
-        one-time setup code authorizes, and after that the door is shut.
-        More accounts, when they come, will be minted by an admin from
-        inside, not by anyone holding a boot log.
+        Refuses once any account exists: creating the first account is what
+        the one-time setup code authorizes, and after that the door is
+        shut. Further accounts are minted by an admin from inside
+        (create_user below), not by anyone holding a boot log.
         """
         uid = secrets.token_hex(8)
         with self._lock:
             if self._db.execute("SELECT 1 FROM admin_users LIMIT 1").fetchone():
                 raise AuthError(409, "an admin account already exists")
             self._db.execute(
-                "INSERT INTO admin_users (id, username, password_hash, created_at)"
-                " VALUES (?, ?, ?, ?)",
+                "INSERT INTO admin_users"
+                " (id, username, password_hash, created_at, role)"
+                " VALUES (?, ?, ?, ?, 'admin')",
                 (uid, username, _hash_password(password), _now()),
             )
             self._event("admin_created", {"user": uid, "username": username})
@@ -479,16 +500,103 @@ class State:
         return {"token": token, "expires_at": expires, "username": username}
 
     def session_user(self, token: str) -> dict | None:
-        """Who this session belongs to, or None if it is not a live one."""
+        """Who this session belongs to (and as what role), or None if it is
+        not a live one."""
         with self._lock:
             row = self._db.execute(
-                "SELECT s.user_id, s.expires_at, u.username"
+                "SELECT s.user_id, s.expires_at, u.username, u.role"
                 " FROM sessions s JOIN admin_users u ON u.id = s.user_id"
                 " WHERE s.token_hash = ? AND s.revoked_at IS NULL"
                 " AND s.expires_at > ?",
                 (_hash(token), _now()),
             ).fetchone()
         return dict(row) if row else None
+
+    # ------------------------------------------------- account management --
+    # More than one pair of eyes, without more than one level of trust being
+    # implicit: an admin runs the platform, a viewer reads it. Viewer exists
+    # for the auditor and the exec - people who need the pages and must not
+    # be able to change what the pages say. Roles are fixed at creation;
+    # changing someone's trust level is delete-and-recreate, which leaves a
+    # cleaner audit trail than an edit ever would.
+
+    ROLES = ("admin", "viewer")
+
+    def list_users(self) -> list[dict]:
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT id, username, role, created_at, last_login_at"
+                " FROM admin_users ORDER BY created_at"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def create_user(self, username: str, password: str, role: str,
+                    by: str = "") -> dict:
+        if role not in self.ROLES:
+            raise AuthError(422, "role must be admin or viewer")
+        uid = secrets.token_hex(8)
+        with self._lock:
+            if self._db.execute(
+                "SELECT 1 FROM admin_users WHERE username = ?", (username,)
+            ).fetchone():
+                raise AuthError(409, "that username already exists")
+            self._db.execute(
+                "INSERT INTO admin_users"
+                " (id, username, password_hash, created_at, role)"
+                " VALUES (?, ?, ?, ?, ?)",
+                (uid, username, _hash_password(password), _now(), role),
+            )
+            self._event("user_created",
+                        {"user": uid, "username": username, "role": role,
+                         "by": by})
+            self._db.commit()
+        return {"id": uid, "username": username, "role": role}
+
+    def delete_user(self, uid: str, by: str = "") -> bool:
+        """Remove an account and kill its sessions. The last admin cannot be
+        deleted: a deployment with accounts and no admin is locked out of
+        its own account management, and the API credential that could fix
+        it is optional."""
+        with self._lock:
+            row = self._db.execute(
+                "SELECT role FROM admin_users WHERE id = ?", (uid,)
+            ).fetchone()
+            if row is None:
+                return False
+            if row["role"] == "admin":
+                admins = self._db.execute(
+                    "SELECT COUNT(*) AS n FROM admin_users WHERE role = 'admin'"
+                ).fetchone()["n"]
+                if admins <= 1:
+                    raise AuthError(409, "cannot delete the last admin")
+            # Sessions reference the account (FK), and a deleted account's
+            # sessions have nothing left to say - remove rather than revoke.
+            self._db.execute("DELETE FROM sessions WHERE user_id = ?", (uid,))
+            self._db.execute("DELETE FROM admin_users WHERE id = ?", (uid,))
+            self._event("user_deleted", {"user": uid, "by": by})
+            self._db.commit()
+        return True
+
+    def reset_user_password(self, uid: str, new_password: str,
+                            by: str = "") -> bool:
+        """An admin setting someone else's password. Every session that user
+        holds dies with the old one - the reset exists because the old
+        credential can no longer be trusted, and that distrust extends to
+        anything it minted."""
+        with self._lock:
+            if self._db.execute(
+                "SELECT 1 FROM admin_users WHERE id = ?", (uid,)
+            ).fetchone() is None:
+                return False
+            self._db.execute(
+                "UPDATE admin_users SET password_hash = ? WHERE id = ?",
+                (_hash_password(new_password), uid))
+            self._db.execute(
+                "UPDATE sessions SET revoked_at = ? WHERE user_id = ?"
+                " AND revoked_at IS NULL", (_now(), uid))
+            self._event("password_reset", {"user": uid, "by": by})
+            self._db.commit()
+        return True
 
     def logout(self, token: str) -> bool:
         with self._lock:
@@ -670,9 +778,13 @@ class State:
                          devices: int, evidence: str, source: str):
         """New key inserts; a known key refreshes what a rerun can know
         better (device count, confidence, last_seen) and keeps what it
-        cannot (first_seen, and any dismissal)."""
+        cannot (first_seen, and any dismissal). Returns whether the key was
+        new, so the caller can notify on a discovery exactly once."""
         now = _now()
         with self._lock:
+            fresh = self._db.execute(
+                "SELECT 1 FROM candidates WHERE key = ?", (key,)
+            ).fetchone() is None
             self._db.execute(
                 "INSERT INTO candidates (key, kind, name, vendor, category,"
                 " confidence, domains, devices, evidence, source,"
@@ -688,6 +800,7 @@ class State:
             )
             self._event("candidate_reported", {"key": key, "source": source})
             self._db.commit()
+        return fresh
 
     def observe_candidate(self, key: str, kind: str, name: str,
                           evidence: str, source: str, device: str = ""):
@@ -730,6 +843,72 @@ class State:
                 self._event("candidate_observed", {"key": key,
                                                    "source": source})
             self._db.commit()
+        return fresh
+
+    # ------------------------------------------------- finding lifecycle --
+    # A finding the portal derives (a personal account, say) has no row of
+    # its own here - it is recomputed from the log store every load. What
+    # DOES belong here is the human's answer to it: spoken to, accepted
+    # with a reason, or back to open. Keyed on an opaque string the portal
+    # composes, so the receiver never needs to understand the finding shape.
+
+    FINDING_STATUSES = ("acknowledged", "accepted")
+
+    def list_finding_statuses(self) -> list[dict]:
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT key, status, reason, actor, at FROM finding_status"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def set_finding_status(self, key: str, status: str, reason: str = "",
+                           by: str = ""):
+        if status not in self.FINDING_STATUSES:
+            raise ValueError("status must be one of %s"
+                             % ", ".join(self.FINDING_STATUSES))
+        with self._lock:
+            self._db.execute(
+                "INSERT INTO finding_status (key, status, reason, actor, at)"
+                " VALUES (?, ?, ?, ?, ?)"
+                " ON CONFLICT(key) DO UPDATE SET status = excluded.status,"
+                " reason = excluded.reason, actor = excluded.actor,"
+                " at = excluded.at",
+                (key, status, reason, by, _now()),
+            )
+            self._event("finding_status_set",
+                        {"key": key[:200], "status": status, "by": by})
+            self._db.commit()
+
+    def clear_finding_status(self, key: str, by: str = "") -> bool:
+        with self._lock:
+            cur = self._db.execute(
+                "DELETE FROM finding_status WHERE key = ?", (key,))
+            if cur.rowcount:
+                self._event("finding_status_cleared",
+                            {"key": key[:200], "by": by})
+            self._db.commit()
+        return bool(cur.rowcount)
+
+    # ---------------------------------------------------------- audit -----
+
+    def list_events(self, limit: int = 200) -> list[dict]:
+        """The admin activity trail, newest first. Every write above already
+        records itself here; this is the read that makes it an audit log
+        rather than a diary nobody opens."""
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT rowid, at, kind, detail FROM events"
+                " ORDER BY rowid DESC LIMIT ?", (int(limit),)
+            ).fetchall()
+        out = []
+        for r in rows:
+            d = dict(r)
+            try:
+                d["detail"] = json.loads(d["detail"])
+            except (json.JSONDecodeError, TypeError):
+                d["detail"] = {}
+            out.append(d)
+        return out
 
     def dismiss_candidate(self, key: str, by: str = "") -> bool:
         with self._lock:
@@ -744,19 +923,29 @@ class State:
         return bool(cur.rowcount)
 
     def change_password(self, new_password: str, current: str | None = None,
-                        keep_session: str | None = None):
-        """Set the sole admin's password, optionally proving the current one.
+                        keep_session: str | None = None,
+                        user_id: str | None = None):
+        """Set a user's own password, optionally proving the current one.
 
-        current=None is the break-glass path, reached only with the API
-        credential (the operator who can set the receiver's environment
-        already owns the box). Every session except keep_session dies with
-        the old password - a stolen session must not outlive the password
-        change that was made because of it.
+        user_id names whose - the session's own user in the normal path.
+        current=None with no user_id is the break-glass path, reached only
+        with the API credential (the operator who can set the receiver's
+        environment already owns the box); it targets the oldest admin,
+        which is the account the setup code created. Every session except
+        keep_session dies with the old password - a stolen session must not
+        outlive the password change that was made because of it.
         """
         with self._lock:
-            row = self._db.execute(
-                "SELECT id, password_hash FROM admin_users LIMIT 1"
-            ).fetchone()
+            if user_id is not None:
+                row = self._db.execute(
+                    "SELECT id, password_hash FROM admin_users WHERE id = ?",
+                    (user_id,),
+                ).fetchone()
+            else:
+                row = self._db.execute(
+                    "SELECT id, password_hash FROM admin_users"
+                    " WHERE role = 'admin' ORDER BY created_at LIMIT 1"
+                ).fetchone()
             if row is None:
                 raise AuthError(409, "no admin account exists")
             if current is not None and not _verify_password(

--- a/receiver/tests/test_auth.py
+++ b/receiver/tests/test_auth.py
@@ -226,7 +226,7 @@ def test_the_api_credential_is_break_glass(managed, monkeypatch):
     assert _login(password="recovered-long-password").status_code == 200
     # The credential is not a person: the probe says so.
     who = client.get("/admin/session", headers=API_ADMIN).json()
-    assert who == {"username": "", "expires_at": None}
+    assert who == {"username": "", "expires_at": None, "role": "admin"}
 
 
 def test_password_change_with_no_account_is_409(managed, monkeypatch):

--- a/receiver/tests/test_lifecycle_audit_webhook.py
+++ b/receiver/tests/test_lifecycle_audit_webhook.py
@@ -1,0 +1,157 @@
+"""Finding lifecycle, the audit read, and the discovery webhook.
+
+Three small features with one shape: the receiver stores the human's answer
+(a finding status, an admin action, a webhook URL) and never re-derives the
+question. The properties under test: statuses are validated and auditable,
+the audit read returns what the writes recorded, and the webhook fires
+exactly once per new candidate - never on a rerun, never when unset, and
+never in a way that can fail the ingest request.
+"""
+
+import os
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import main
+from app import state as state_mod
+from app.main import app
+
+client = TestClient(app)
+
+AUTH = {"Authorization": "Bearer test-token-for-ci"}
+ADMIN = {"Authorization": "Bearer admin-test-token"}
+
+CANDIDATE = {
+    "kind": "domain", "name": "Mystery AI", "vendor": "Mystery Labs",
+    "category": "assistant", "confidence": "high",
+    "domains": ["mystery-ai.example"], "devices": 3,
+    "evidence": "seen in fleet DNS over 7d",
+}
+
+
+@pytest.fixture
+def managed(tmp_path, monkeypatch):
+    st = state_mod.State(str(tmp_path / "state.db"))
+    monkeypatch.setattr(main, "STATE", st)
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"Bearer admin-test-token")
+    yield st
+
+
+@pytest.fixture
+def webhook(managed, monkeypatch):
+    """Point the webhook at a recorder, and run the notify thread inline so
+    the test can assert on it."""
+    managed.set_setting("webhook_url", "https://hooks.example/T/B/x")
+    sent = []
+    monkeypatch.setattr(main.httpx, "post",
+                        lambda url, json=None, timeout=None:
+                        sent.append((url, json)))
+
+    class InlineThread:
+        def __init__(self, target=None, daemon=None):
+            self._target = target
+        def start(self):
+            self._target()
+
+    monkeypatch.setattr(main.threading, "Thread", InlineThread)
+    yield sent
+
+
+# ------------------------------------------------------- finding lifecycle --
+
+
+def test_status_round_trip_with_actor_and_reason(managed):
+    r = client.put("/admin/finding-status", headers=ADMIN, json={
+        "key": '["sam","gmail.com","chatgpt","MAC-1"]',
+        "status": "accepted", "reason": "migrating to the work account"})
+    assert r.status_code == 200
+    (s,) = client.get("/admin/finding-status",
+                      headers=ADMIN).json()["statuses"]
+    assert s["status"] == "accepted"
+    assert s["reason"] == "migrating to the work account"
+    assert s["actor"] == "api"          # the API credential, not a person
+    assert s["at"]
+
+
+def test_status_must_be_a_known_one(managed):
+    r = client.put("/admin/finding-status", headers=ADMIN,
+                   json={"key": "k", "status": "ignored"})
+    assert r.status_code == 422
+
+
+def test_clear_removes_and_404s_when_nothing_stood(managed):
+    client.put("/admin/finding-status", headers=ADMIN,
+               json={"key": "k", "status": "acknowledged"})
+    assert client.post("/admin/finding-status/clear", headers=ADMIN,
+                       json={"key": "k"}).status_code == 200
+    assert client.get("/admin/finding-status",
+                      headers=ADMIN).json()["statuses"] == []
+    assert client.post("/admin/finding-status/clear", headers=ADMIN,
+                       json={"key": "k"}).status_code == 404
+
+
+def test_lifecycle_routes_need_admin(managed):
+    assert client.get("/admin/finding-status",
+                      headers=AUTH).status_code == 401
+    assert client.put("/admin/finding-status", headers=AUTH,
+                      json={"key": "k", "status": "acknowledged"}).status_code == 401
+
+
+# ------------------------------------------------------------------ audit --
+
+
+def test_the_audit_read_returns_what_writes_recorded(managed):
+    client.put("/admin/finding-status", headers=ADMIN,
+               json={"key": "k", "status": "acknowledged"})
+    events = client.get("/admin/events", headers=ADMIN).json()["events"]
+    kinds = [e["kind"] for e in events]
+    assert "finding_status_set" in kinds
+    e = next(x for x in events if x["kind"] == "finding_status_set")
+    assert e["detail"]["status"] == "acknowledged"
+    assert e["at"]
+
+
+def test_events_newest_first_and_capped(managed):
+    for i in range(5):
+        client.put("/admin/finding-status", headers=ADMIN,
+                   json={"key": "k%d" % i, "status": "acknowledged"})
+    events = client.get("/admin/events?limit=3", headers=ADMIN).json()["events"]
+    assert len(events) == 3
+    assert events[0]["detail"]["key"] == "k4"     # newest first
+
+
+# ---------------------------------------------------------------- webhook --
+
+
+def test_new_candidate_fires_the_webhook_once(webhook):
+    client.post("/candidates", headers=AUTH,
+                json={"candidates": [CANDIDATE]})
+    assert len(webhook) == 1
+    url, payload = webhook[0]
+    assert url == "https://hooks.example/T/B/x"
+    assert "Mystery AI" in payload["text"]
+    # A rerun of the same discovery is not a new decision to make.
+    client.post("/candidates", headers=AUTH,
+                json={"candidates": [CANDIDATE]})
+    assert len(webhook) == 1
+
+
+def test_no_webhook_url_means_no_call(managed, monkeypatch):
+    called = []
+    monkeypatch.setattr(main.httpx, "post",
+                        lambda *a, **k: called.append(1))
+    client.post("/candidates", headers=AUTH,
+                json={"candidates": [CANDIDATE]})
+    assert called == []
+
+
+def test_webhook_failure_never_fails_the_ingest(webhook, monkeypatch):
+    def boom(*a, **k):
+        raise OSError("connection refused")
+    monkeypatch.setattr(main.httpx, "post", boom)
+    r = client.post("/candidates", headers=AUTH,
+                    json={"candidates": [CANDIDATE]})
+    assert r.status_code == 200

--- a/receiver/tests/test_roles.py
+++ b/receiver/tests/test_roles.py
@@ -1,0 +1,161 @@
+"""Accounts and roles: admin runs the platform, viewer reads it.
+
+The properties under test: a viewer session passes every read gate and is
+refused by every write gate with a 403 that says why; the last admin cannot
+be deleted; a password reset kills the sessions the old password minted;
+a viewer still owns their own password; and the whole trail lands in the
+audit log with the acting username on it.
+"""
+
+import os
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import main
+from app import state as state_mod
+from app.main import app
+
+client = TestClient(app)
+
+API_ADMIN = {"Authorization": "Bearer admin-test-token"}
+
+
+@pytest.fixture
+def managed(tmp_path, monkeypatch):
+    st = state_mod.State(str(tmp_path / "state.db"))
+    monkeypatch.setattr(main, "STATE", st)
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"Bearer admin-test-token")
+    yield st
+
+
+def _mk(managed, username, role, password="a-long-enough-password"):
+    return managed.create_user(username, password, role, by="test")
+
+
+def _session(managed, username, password="a-long-enough-password"):
+    tok = managed.login(username, password)["token"]
+    return {"Authorization": "Bearer " + tok}
+
+
+@pytest.fixture
+def viewer(managed):
+    managed.create_admin("root", "a-long-enough-password")
+    _mk(managed, "auditor", "viewer")
+    return _session(managed, "auditor")
+
+
+@pytest.fixture
+def admin(managed):
+    # created by the viewer fixture's create_admin when both are used;
+    # standalone tests create their own.
+    if not managed.has_admin():
+        managed.create_admin("root", "a-long-enough-password")
+    return _session(managed, "root")
+
+
+# ------------------------------------------------------------ the gate ----
+
+
+def test_viewer_reads_everything(viewer):
+    for path in ("/admin/settings", "/admin/devices", "/admin/candidates",
+                 "/admin/governance", "/admin/events", "/admin/users",
+                 "/admin/finding-status", "/admin/settings/secrets"):
+        assert client.get(path, headers=viewer).status_code == 200, path
+
+
+def test_viewer_writes_nothing_and_is_told_why(viewer):
+    refusals = [
+        client.put("/admin/settings", headers=viewer,
+                   json={"corp_domains": ["example.com"]}),
+        client.post("/admin/enrollment-tokens", headers=viewer,
+                    json={"note": "x"}),
+        client.put("/admin/finding-status", headers=viewer,
+                   json={"key": "k", "status": "acknowledged"}),
+        client.post("/admin/users", headers=viewer,
+                    json={"username": "sneaky", "role": "admin",
+                          "password": "a-long-enough-password"}),
+    ]
+    for r in refusals:
+        assert r.status_code == 403
+        assert "read-only" in r.json()["detail"]
+
+
+def test_the_session_probe_names_the_role(viewer, admin):
+    assert client.get("/admin/session", headers=viewer).json()["role"] == "viewer"
+    assert client.get("/admin/session", headers=admin).json()["role"] == "admin"
+
+
+# ------------------------------------------------------- account management --
+
+
+def test_admin_creates_lists_and_deletes_accounts(managed, admin):
+    r = client.post("/admin/users", headers=admin,
+                    json={"username": "auditor", "role": "viewer",
+                          "password": "a-long-enough-password"})
+    assert r.status_code == 200 and r.json()["role"] == "viewer"
+    users = client.get("/admin/users", headers=admin).json()["users"]
+    assert [(u["username"], u["role"]) for u in users] == \
+        [("root", "admin"), ("auditor", "viewer")]
+    uid = users[1]["id"]
+    assert client.post(f"/admin/users/{uid}/delete",
+                       headers=admin).status_code == 200
+    users = client.get("/admin/users", headers=admin).json()["users"]
+    assert len(users) == 1
+
+
+def test_duplicate_usernames_and_odd_roles_are_refused(managed, admin):
+    body = {"username": "root", "role": "viewer",
+            "password": "a-long-enough-password"}
+    assert client.post("/admin/users", headers=admin, json=body).status_code == 409
+    body = {"username": "ok.name", "role": "superuser",
+            "password": "a-long-enough-password"}
+    assert client.post("/admin/users", headers=admin, json=body).status_code == 422
+
+
+def test_the_last_admin_cannot_be_deleted(managed, admin):
+    uid = client.get("/admin/users", headers=admin).json()["users"][0]["id"]
+    r = client.post(f"/admin/users/{uid}/delete", headers=admin)
+    assert r.status_code == 409
+    assert "last admin" in r.json()["detail"]
+
+
+def test_deleting_an_account_kills_its_sessions(managed, admin):
+    _mk(managed, "temp", "viewer")
+    sess = _session(managed, "temp")
+    uid = next(u["id"] for u in managed.list_users() if u["username"] == "temp")
+    client.post(f"/admin/users/{uid}/delete", headers=admin)
+    assert client.get("/admin/settings", headers=sess).status_code == 401
+
+
+def test_password_reset_revokes_the_old_sessions(managed, admin):
+    _mk(managed, "temp", "viewer")
+    old = _session(managed, "temp")
+    uid = next(u["id"] for u in managed.list_users() if u["username"] == "temp")
+    r = client.post(f"/admin/users/{uid}/password", headers=admin,
+                    json={"new": "a-different-long-password"})
+    assert r.status_code == 200
+    assert client.get("/admin/settings", headers=old).status_code == 401
+    assert _session(managed, "temp", "a-different-long-password")
+
+
+def test_a_viewer_owns_their_own_password(managed, viewer):
+    r = client.post("/admin/password", headers=viewer,
+                    json={"current": "a-long-enough-password",
+                          "new": "my-new-viewer-password"})
+    assert r.status_code == 200
+    # ...and it changed THEIR password, not the admin's.
+    assert _session(managed, "auditor", "my-new-viewer-password")
+    assert _session(managed, "root")
+
+
+def test_account_actions_land_in_the_audit_trail(managed, admin):
+    client.post("/admin/users", headers=admin,
+                json={"username": "auditor", "role": "viewer",
+                      "password": "a-long-enough-password"})
+    events = client.get("/admin/events", headers=admin).json()["events"]
+    e = next(x for x in events if x["kind"] == "user_created")
+    assert e["detail"]["username"] == "auditor"
+    assert e["detail"]["by"] == "root"


### PR DESCRIPTION
Four managed-mode features with one shape: the receiver stores the human side of the platform and never re-derives the findings themselves.

- **Finding lifecycle**: a `finding_status` table holding the recorded answer to a derived finding — acknowledged, or accepted with a reason — keyed on an opaque string the portal composes, so the receiver never couples to a finding shape it does not own. `/admin/finding-status` to read, set and clear.
- **Audit read**: `/admin/events` exposes the trail every admin write was already recording — newest first, capped — turning a diary nobody opened into an audit log.
- **Discovery webhook**: a `webhook_url` central setting. The receiver posts a Slack-compatible message when discovery puts a *new* tool or MCP server in the review queue — once per candidate lifetime, never per finding, fired from a thread so a webhook outage can never bounce ingest.
- **Accounts and roles**: admin runs the platform; viewer reads everything and changes nothing, refused by every write route with a 403 that says so. `/admin/users` CRUD with a last-admin guard; per-user password change; admin resets revoke the old sessions. Existing databases migrate in place — every pre-existing account becomes admin, which is what it was.

10 new tests for the lifecycle/audit/webhook (including "fires exactly once per discovery" and "webhook failure never fails ingest") and 10 for roles. 147 receiver tests pass.