### PR TITLE
portal: per-day trends, weekly digest, service-credential reads, new proxies

### DIFF
--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -29,6 +29,7 @@ useful without a name on it.
 import csv
 import io
 import json
+import math
 import os
 import re
 import sys
@@ -36,6 +37,7 @@ import time
 import urllib.parse
 import urllib.request
 from collections import defaultdict
+from datetime import datetime, timedelta, timezone
 
 from app import governance
 
@@ -741,7 +743,72 @@ def mcp_from(findings):
     return out
 
 
-def graph_from(findings, domain_map=None, identity_map=None):
+def trends_from(findings, domain_map=None, hours=168):
+    """Per-day activity across the window: the change dimension.
+
+    Every other number here is a total over the window, which answers "how
+    much" and never "which way is it going" - 23 personal accounts reads
+    the same whether it was 12 last week or 40. These series are bucketed
+    by UTC calendar day from the same findings, so the overview can draw
+    the shape of the week instead of one number.
+
+    Per-tool activity counts distinct devices per day; a cloud-only tool
+    (no device on any finding) falls back to findings per day rather than
+    flatlining at zero. tool_first_seen is kept so a tool that appeared two
+    days ago can be labelled new - a thing no total can show.
+    """
+    domain_map = domain_map or {}
+    ndays = max(2, math.ceil(hours / 24))
+    today = datetime.now(timezone.utc).date()
+    days = [(today - timedelta(days=i)).isoformat()
+            for i in range(ndays - 1, -1, -1)]
+    idx = {d: i for i, d in enumerate(days)}
+
+    devices_daily = [set() for _ in days]
+    personal_daily = [0] * ndays
+    tool_devices = defaultdict(lambda: [set() for _ in days])
+    tool_events = defaultdict(lambda: [0] * ndays)
+    tool_first = {}
+
+    for f in findings:
+        ts = f.get("reported_at") or ""
+        i = idx.get(ts[:10])
+        if i is None:
+            continue
+        device = (f.get("device") or "").strip()
+        if device:
+            devices_daily[i].add(device)
+        tool = f.get("tool") or ""
+        if not tool or tool in NOT_A_TOOL:
+            continue
+        if (f.get("source") or "") in BRIDGE_SOURCES:
+            continue
+        tool = normalise_tool(tool, domain_map)
+        tool_events[tool][i] += 1
+        if device:
+            tool_devices[tool][i].add(device)
+        if tool not in tool_first or ts < tool_first[tool]:
+            tool_first[tool] = ts
+        if ((f.get("severity") or "") == "warn"
+                and (f.get("account_domain") or "").strip()):
+            personal_daily[i] += 1
+
+    tools_out = {}
+    for tool, events in tool_events.items():
+        counts = ([len(s) for s in tool_devices[tool]]
+                  if tool in tool_devices else [])
+        tools_out[tool] = counts if any(counts) else events
+
+    return {
+        "days": days,
+        "devices": [len(s) for s in devices_daily],
+        "personal": personal_daily,
+        "tools": tools_out,
+        "tool_first_seen": tool_first,
+    }
+
+
+def graph_from(findings, domain_map=None, identity_map=None, hours=168):
     """Everything above, assembled into the shape the API and the UI read."""
     devices, identities, tools, bridges, unattributed = build(
         findings, domain_map, identity_map)
@@ -763,6 +830,7 @@ def graph_from(findings, domain_map=None, identity_map=None):
         "unattributed": unattributed,
         "personal_accounts": personal_accounts_from(findings, domain_map),
         "mcp_servers": mcp_from(findings),
+        "trends": trends_from(findings, domain_map, hours),
         "counts": {
             "findings": len(findings),
             "devices": len(devices),

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -44,6 +44,11 @@ encryption.
   LOKI_USERNAME     basic auth user, for Grafana Cloud and most hosted Loki
   LOKI_PASSWORD     basic auth password, _FILE supported
   LOOKBACK_HOURS    default window, default 168
+  DIGEST_WEBHOOK_URL  Slack-compatible webhook for the weekly digest;
+                    DIGEST_DAY (mon..sun) and DIGEST_HOUR (UTC) tune when
+  RECEIVER_ADMIN_TOKEN  the receiver's ADMIN_TOKEN, _FILE supported. Lets
+                    the digest task read the log store saved through the
+                    portal; without it the digest needs LOKI_URL
   REGISTRY_PATH     registry.yaml, for resolving domains to tool ids
   IDENTITY_MAP      CSV of key,identity for attaching people to devices
   GOVERNANCE_PATH   YAML of approval decisions, owners and review dates
@@ -76,6 +81,8 @@ import re
 import secrets
 import time
 import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
@@ -252,7 +259,7 @@ SESSION_COOKIE = "aiguard_session"
 # again. Bounds the revocation latency, and only the positive answer is
 # cached: a refused session is refused every time.
 SESSION_CACHE_TTL = 60
-_session_cache: dict[str, tuple[float, str]] = {}  # token -> (until, username)
+_session_cache: dict[str, tuple[float, str, str]] = {}  # token -> (until, username, role)
 
 # The receiver-stored settings, cached briefly so a page of API calls does
 # not re-fetch them. Two caches because they answer different callers: the
@@ -503,11 +510,15 @@ def _log_store(request):
     answer is a loud error, because silently falling back to env here
     could read a different store than the receiver is writing to.
     """
-    if LOGIN_MODE and request is not None:
+    # request=None is a background caller (the digest). It reads with the
+    # service credential when one is configured, and falls back to env
+    # below when not - the same precedence a session gets.
+    if LOGIN_MODE and (request is not None or RECEIVER_ADMIN_TOKEN):
         now = time.time()
         if (_log_store_cache["data"] is None
                 or now - _log_store_cache["at"] >= SETTINGS_CACHE_TTL):
-            token = request.cookies.get(SESSION_COOKIE, "")
+            token = (request.cookies.get(SESSION_COOKIE, "")
+                     if request is not None else RECEIVER_ADMIN_TOKEN)
             try:
                 _log_store_cache["data"] = managed.receiver_request(
                     RECEIVER_URL, "GET", "/admin/settings/secrets", token)
@@ -824,7 +835,7 @@ def graph(request: Request,
         findings = _findings(hours, request)
         domain_map = derive.load_domain_map_from(_registry(request))
         identity_map = derive.load_identity_map(IDENTITY_MAP) if IDENTITY_MAP else {}
-        return derive.graph_from(findings, domain_map, identity_map)
+        return derive.graph_from(findings, domain_map, identity_map, hours)
 
     value, at = _cached("graph", hours, build)
     return JSONResponse(dict(value, derived_at=at, hours=hours,
@@ -1093,7 +1104,8 @@ def _session_ok(token: str) -> bool:
         for k in [k for k, v in _session_cache.items() if v[0] <= now]:
             _session_cache.pop(k, None)
     _session_cache[token] = (now + SESSION_CACHE_TTL,
-                             str(who.get("username", "")))
+                             str(who.get("username", "")),
+                             str(who.get("role", "admin")))
     return True
 
 
@@ -1162,9 +1174,11 @@ def auth_state(request: Request):
             # A login screen that cannot say whether an account exists should
             # say why, not guess a form.
             raise HTTPException(e.status, e.detail)
+    hit = _session_cache.get(token) or (0, "", "admin")
     return {"mode": "login" if PORTAL_AUTH != "none" else "none",
             "authenticated": authenticated,
-            "username": (_session_cache.get(token) or (0, ""))[1],
+            "username": hit[1],
+            "role": hit[2] if authenticated else "",
             "setup_needed": setup_needed}
 
 
@@ -1389,6 +1403,190 @@ def api_settings_write(req: SettingsWrite, _=Depends(require_auth),
     # log store must be read from on the very next page, not in 30s.
     _invalidate_settings_caches()
     return out
+
+
+class FindingStatusWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    key: str = Field(min_length=1, max_length=500)
+    # Empty status means clear: back to open.
+    status: str = Field(default="", max_length=16)
+    reason: str = Field(default="", max_length=500)
+
+
+@app.get("/api/finding-status")
+def api_finding_status(_=Depends(require_auth),
+                       token: str = Depends(_admin_forward)):
+    """The recorded answers to derived findings (acknowledged / accepted).
+    The findings themselves come from /api/graph; the receiver holds only
+    the human's response, keyed on a string the portal composes."""
+    return _receiver("GET", "/admin/finding-status", token)
+
+
+@app.post("/api/finding-status")
+def api_finding_status_write(req: FindingStatusWrite, _=Depends(require_auth),
+                             token: str = Depends(_admin_forward)):
+    if not req.status:
+        return _receiver("POST", "/admin/finding-status/clear", token,
+                         {"key": req.key})
+    return _receiver("PUT", "/admin/finding-status", token,
+                     {"key": req.key, "status": req.status,
+                      "reason": req.reason})
+
+
+@app.get("/api/audit")
+def api_audit(limit: int = Query(default=200, ge=1, le=1000),
+              _=Depends(require_auth), token: str = Depends(_admin_forward)):
+    """The receiver's admin activity trail, relayed as-is."""
+    return _receiver("GET", "/admin/events?limit=%d" % limit, token)
+
+
+class UserCreate(BaseModel):
+    model_config = {"extra": "forbid"}
+    username: str = Field(min_length=2, max_length=64)
+    password: str = Field(min_length=12, max_length=256)
+    role: str = Field(min_length=1, max_length=16)
+
+
+class UserPasswordReset(BaseModel):
+    model_config = {"extra": "forbid"}
+    new: str = Field(min_length=12, max_length=256)
+
+
+_UID_RE = re.compile(r"^[0-9a-f]{16}$")
+
+
+@app.get("/api/users")
+def api_users(_=Depends(require_auth), token: str = Depends(_admin_forward)):
+    """The accounts, admin and viewer alike. The receiver owns them; the
+    portal relays, and the receiver's role gate decides who may change
+    what."""
+    return _receiver("GET", "/admin/users", token)
+
+
+@app.post("/api/users")
+def api_users_create(req: UserCreate, _=Depends(require_auth),
+                     token: str = Depends(_admin_forward)):
+    return _receiver("POST", "/admin/users", token, req.model_dump())
+
+
+@app.post("/api/users/{uid}/delete")
+def api_users_delete(uid: str, _=Depends(require_auth),
+                     token: str = Depends(_admin_forward)):
+    if not _UID_RE.match(uid):
+        raise HTTPException(422, "malformed user id")
+    return _receiver("POST", "/admin/users/%s/delete" % uid, token)
+
+
+@app.post("/api/users/{uid}/password")
+def api_users_reset(uid: str, req: UserPasswordReset, _=Depends(require_auth),
+                    token: str = Depends(_admin_forward)):
+    if not _UID_RE.match(uid):
+        raise HTTPException(422, "malformed user id")
+    return _receiver("POST", "/admin/users/%s/password" % uid, token,
+                     req.model_dump())
+
+
+# ---------------------------------------------------------------- digest ---
+# A weekly summary to a Slack-compatible webhook: the portal is a page
+# somebody must remember to open, and the digest is what keeps the estate
+# in front of them when they do not. Env-driven, because the task runs with
+# no operator session to read portal-saved settings with - the receiver's
+# own webhook_url setting covers the event-shaped notifications (a new
+# discovery candidate) instead.
+#
+# The task reads findings either from the env log store (LOKI_URL), or -
+# the managed-by-default path, where the log store was saved through the
+# wizard - via RECEIVER_ADMIN_TOKEN: the receiver's ADMIN_TOKEN credential,
+# which lets the background task read the saved log-store settings the way
+# a session would. Without either it declines at startup and says why,
+# rather than mailing a digest of an empty estate.
+DIGEST_WEBHOOK_URL = require_http_url(
+    "DIGEST_WEBHOOK_URL", os.environ.get("DIGEST_WEBHOOK_URL", ""))
+RECEIVER_ADMIN_TOKEN = _secret("RECEIVER_ADMIN_TOKEN")
+_DIGEST_DAYS = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+# `or` rather than a default arg: compose passes empty strings for unset
+# variables, and int("") is a crash at startup rather than a default.
+DIGEST_DAY = (os.environ.get("DIGEST_DAY") or "mon").lower()[:3]
+DIGEST_HOUR = min(23, max(0, int(os.environ.get("DIGEST_HOUR") or "8")))
+
+
+def next_digest(after, day=DIGEST_DAY, hour=DIGEST_HOUR):
+    """The next scheduled send strictly after `after` (UTC). Restart-safe by
+    construction: there is no cursor to lose, just the next slot."""
+    target = _DIGEST_DAYS.index(day if day in _DIGEST_DAYS else "mon")
+    cand = after.replace(hour=hour, minute=0, second=0, microsecond=0)
+    while cand <= after or cand.weekday() != target:
+        cand += timedelta(days=1)
+    return cand
+
+
+def digest_text(g, s, hours):
+    """The digest body, from the same derivations every page reads.
+
+    Slack mrkdwn, and deliberately short: the digest's job is to say
+    whether the estate needs someone this week, not to be the report.
+    """
+    pa = g.get("personal_accounts") or []
+    people = {r.get("user") or r.get("device")
+              for r in pa if r.get("user") or r.get("device")}
+    counts = g.get("counts") or {}
+    silent = [r for grp in (s or {}).get("groups", [])
+              for r in grp.get("sources", []) if not r.get("reporting")]
+    top = sorted(((k, len(v.get("devices") or []))
+                  for k, v in (g.get("tools") or {}).items()),
+                 key=lambda kv: (-kv[1], kv[0]))[:5]
+    n = len(pa)
+    lines = ["*ai-guard: the last %d days*" % round(hours / 24),
+             "• %d personal account%s across %d %s"
+             % (n, "" if n == 1 else "s", len(people),
+                "person" if len(people) == 1 else "people"),
+             "• %d tools in use on %d devices"
+             % (counts.get("tools", 0), counts.get("devices", 0))]
+    if top:
+        lines.append("• top tools: "
+                     + ", ".join("%s (%d)" % t for t in top))
+    if silent:
+        lines.append("• %d detection source%s silent"
+                     % (len(silent), "" if len(silent) == 1 else "s"))
+    return "\n".join(lines)
+
+
+@app.on_event("startup")
+async def _digest_task():
+    if not DIGEST_WEBHOOK_URL:
+        return
+    if LOGIN_MODE and not LOKI_URL and not RECEIVER_ADMIN_TOKEN:
+        log.warning("DIGEST_WEBHOOK_URL is set but the background task has "
+                    "no way to read findings: set RECEIVER_ADMIN_TOKEN (the "
+                    "receiver's ADMIN_TOKEN) so it can use the log store "
+                    "saved in the portal, or set LOKI_URL directly. No "
+                    "digest will be sent.")
+        return
+    import asyncio
+
+    def send():
+        findings = _findings(LOOKBACK_HOURS, None)
+        domain_map = derive.load_domain_map_from(_registry(None))
+        g = derive.graph_from(findings, domain_map, {}, LOOKBACK_HOURS)
+        s = derive.status_from(findings)
+        body = json.dumps({"text": digest_text(g, s, LOOKBACK_HOURS)}).encode()
+        req = urllib.request.Request(
+            DIGEST_WEBHOOK_URL, data=body,
+            headers={"Content-Type": "application/json"})
+        urllib.request.urlopen(req, timeout=10).read()
+
+    async def loop():
+        while True:
+            now = datetime.now(timezone.utc)
+            await asyncio.sleep(
+                max(60.0, (next_digest(now) - now).total_seconds()))
+            try:
+                await asyncio.to_thread(send)
+                log.info("weekly digest sent")
+            except Exception as e:  # noqa: BLE001 - the log line is the story
+                log.warning("weekly digest failed: %s", e)
+
+    asyncio.get_running_loop().create_task(loop())
 
 
 @app.get("/api/governance-decisions")

--- a/portal/tests/test_digest.py
+++ b/portal/tests/test_digest.py
@@ -1,0 +1,72 @@
+"""The weekly digest: the schedule computation and the text it sends.
+
+The background loop itself is not under test - it is a sleep around these
+two functions. What can be quietly wrong is the arithmetic (a digest that
+fires on the wrong day, or twice) and the text (numbers that disagree with
+the pages the reader opens next), so those are what get pinned down.
+"""
+
+import os
+from datetime import datetime, timezone
+
+os.environ.setdefault("PORTAL_AUTH", "none")
+
+from app import main
+
+
+def dt(y, m, d, h=0):
+    return datetime(y, m, d, h, tzinfo=timezone.utc)
+
+
+# 2026-08-24 is a Monday.
+
+
+def test_next_digest_is_the_coming_slot():
+    # Sunday evening -> Monday 08:00.
+    assert main.next_digest(dt(2026, 8, 23, 20), "mon", 8) == dt(2026, 8, 24, 8)
+    # Monday 07:59 -> the same morning.
+    assert main.next_digest(dt(2026, 8, 24, 7), "mon", 8) == dt(2026, 8, 24, 8)
+
+
+def test_next_digest_never_returns_now_or_the_past():
+    # Exactly on the slot -> a week later, so a send at 08:00 cannot
+    # reschedule itself for the moment it just fired.
+    assert main.next_digest(dt(2026, 8, 24, 8), "mon", 8) == dt(2026, 8, 31, 8)
+    # Monday afternoon -> next Monday.
+    assert main.next_digest(dt(2026, 8, 24, 15), "mon", 8) == dt(2026, 8, 31, 8)
+
+
+def test_next_digest_unknown_day_falls_back_to_monday():
+    assert main.next_digest(dt(2026, 8, 22, 0), "someday", 8).weekday() == 0
+
+
+def test_digest_text_carries_the_numbers_the_pages_show():
+    g = {
+        "personal_accounts": [
+            {"user": "kaya", "device": "MAC-1", "tool": "chatgpt"},
+            {"user": "", "device": "WIN-2", "tool": "gemini"},
+        ],
+        "counts": {"tools": 9, "devices": 61},
+        "tools": {"chatgpt": {"devices": ["a", "b"]},
+                  "claude": {"devices": ["a"]}},
+    }
+    s = {"groups": [
+        {"group": "endpoint", "sources": [{"source": "x", "reporting": True}]},
+        {"group": "cloud", "sources": [{"source": "y", "reporting": False},
+                                       {"source": "z", "reporting": False}]},
+    ]}
+    text = main.digest_text(g, s, 168)
+    assert "last 7 days" in text
+    assert "2 personal accounts across 2 people" in text
+    assert "9 tools in use on 61 devices" in text
+    assert "chatgpt (2)" in text
+    assert "2 detection sources silent" in text
+
+
+def test_digest_text_singular_forms_and_empty_estate():
+    g = {"personal_accounts": [{"user": "kaya", "device": "", "tool": "t"}],
+         "counts": {"tools": 0, "devices": 0}, "tools": {}}
+    text = main.digest_text(g, {"groups": []}, 24)
+    assert "1 personal account across 1 person" in text
+    assert "top tools" not in text
+    assert "silent" not in text

--- a/portal/tests/test_login.py
+++ b/portal/tests/test_login.py
@@ -142,7 +142,7 @@ def test_auth_state_in_classic_mode_names_the_mode_and_calls_nothing(monkeypatch
 def test_auth_state_offers_create_account_on_a_fresh_receiver(login_mode):
     out = main.auth_state(_request())
     assert out == {"mode": "login", "authenticated": False, "username": "",
-                   "setup_needed": True}
+                   "role": "", "setup_needed": True}
     # It asked the receiver's unauthenticated one-bit probe, nothing else.
     assert [c["path"] for c in login_mode] == ["/admin/setup"]
 

--- a/portal/tests/test_trends.py
+++ b/portal/tests/test_trends.py
@@ -1,0 +1,104 @@
+"""Tests for trends_from: the per-day series behind the overview's sparklines
+and deltas.
+
+The rest of the portal is totals over the window; this is the one derivation
+that keeps time. The properties that matter: findings land in the right UTC
+day bucket, per-tool activity counts distinct devices rather than findings, a
+cloud-only tool does not flatline at zero, and the excluded classes (the
+platform's own agents, bridge targets) stay excluded here as everywhere else.
+"""
+
+import os
+from datetime import datetime, timedelta, timezone
+
+os.environ.setdefault("PORTAL_AUTH", "none")
+
+from app import derive
+
+
+def day(offset=0, hour=12):
+    """An ISO timestamp `offset` days before now, inside the current day."""
+    t = datetime.now(timezone.utc) - timedelta(days=offset)
+    return t.replace(hour=hour, minute=0, second=0, microsecond=0) \
+            .strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def finding(**kw):
+    f = {
+        "tool": "claude-code", "surface": "cli", "os": "macos",
+        "account_domain": "", "device": "MAC-1", "user": "sam",
+        "severity": "info", "source": "collector-macos",
+        "reported_at": day(0),
+    }
+    f.update(kw)
+    return f
+
+
+def test_window_shape_and_day_order():
+    t = derive.trends_from([], hours=168)
+    assert len(t["days"]) == 7
+    assert t["days"] == sorted(t["days"])          # oldest first
+    assert t["days"][-1] == datetime.now(timezone.utc).date().isoformat()
+    assert t["devices"] == [0] * 7
+    assert t["personal"] == [0] * 7
+
+
+def test_findings_land_in_their_day_and_devices_are_distinct():
+    fs = [
+        finding(reported_at=day(2)),
+        finding(reported_at=day(2), surface="ide"),   # same device, same day
+        finding(reported_at=day(2), device="MAC-2"),
+        finding(reported_at=day(0)),
+    ]
+    t = derive.trends_from(fs, hours=168)
+    assert t["devices"][-3] == 2      # two distinct devices two days ago
+    assert t["devices"][-1] == 1
+    assert t["tools"]["claude-code"][-3] == 2
+    assert t["tools"]["claude-code"][-1] == 1
+
+
+def test_personal_series_counts_warn_with_account_only():
+    fs = [
+        finding(severity="warn", account_domain="gmail.com"),
+        finding(severity="warn", account_domain=""),      # no account: not personal
+        finding(severity="info", account_domain="gmail.com"),
+    ]
+    t = derive.trends_from(fs, hours=168)
+    assert t["personal"][-1] == 1
+
+
+def test_cloud_only_tool_falls_back_to_findings_per_day():
+    fs = [finding(tool="fireflies", surface="cloud", device="",
+                  source="entra_sign_in"),
+          finding(tool="fireflies", surface="cloud", device="",
+                  source="entra_sign_in")]
+    t = derive.trends_from(fs, hours=168)
+    assert t["tools"]["fireflies"][-1] == 2
+
+
+def test_agents_and_bridges_are_not_tools_here_either():
+    fs = [finding(tool="paste-guard"),
+          finding(tool="slack", source="sentinelone_bridge")]
+    t = derive.trends_from(fs, hours=168)
+    assert "paste-guard" not in t["tools"]
+    assert "slack" not in t["tools"]
+    # ...but the machine still counts as active: the agent ran on it.
+    assert t["devices"][-1] == 1
+
+
+def test_tool_first_seen_is_the_oldest_timestamp():
+    fs = [finding(reported_at=day(1)), finding(reported_at=day(5))]
+    t = derive.trends_from(fs, hours=168)
+    assert t["tool_first_seen"]["claude-code"] == day(5)
+
+
+def test_out_of_window_findings_are_ignored():
+    t = derive.trends_from([finding(reported_at="2020-01-01T00:00:00Z")],
+                           hours=168)
+    assert sum(t["devices"]) == 0
+
+
+def test_graph_carries_trends():
+    g = derive.graph_from([finding()], hours=48)
+    assert len(g["trends"]["days"]) == 2
+    assert sum(g["trends"]["devices"]) == 1


### PR DESCRIPTION
The backend half of the portal's next release. Merge after #148 (the proxies talk to its routes); the current UI simply ignores the extra data until the redesign lands.

- **trends_from**: the change dimension. Every other number is a total over the window, which answers "how much" and never "which way" — this buckets the same findings by UTC day: per-tool distinct devices per day (findings per day for cloud-only tools), personal findings per day, active devices per day, per-tool first_seen.
- **Weekly digest** to a Slack-compatible webhook (`DIGEST_WEBHOOK_URL`, `DIGEST_DAY`/`DIGEST_HOUR`): personal accounts, tools in use, top tools, silent sources. Short on purpose — its job is to say whether the estate needs someone this week. Restart-safe by construction: no cursor, just the next slot.
- **`RECEIVER_ADMIN_TOKEN`** (`_FILE` supported): lets the background task read the log store saved through the wizard — the managed-by-default path, where `LOKI_URL` env is typically unset. Without either the task declines at startup and says why.
- **Proxies** for the receiver's new surface: finding-status, the audit trail, account management. `/api/auth` now carries the session's role so the UI can label a read-only account.

New test suites for the trends bucketing and the digest schedule/text. 366 portal tests pass.