### PR TITLE
chart, compose, demo: digest wiring; the demo runs managed mode

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.10.5
+version: 0.10.6
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #

--- a/charts/ai-guard/templates/portal-deployment.yaml
+++ b/charts/ai-guard/templates/portal-deployment.yaml
@@ -141,6 +141,30 @@ spec:
             - name: GRAFANA_DASHBOARD_UID
               value: {{ . | quote }}
             {{- end }}
+            {{- with .Values.portal.digest.webhookUrl }}
+            - name: DIGEST_WEBHOOK_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- if and .Values.portal.digest.webhookUrl .Values.managed.enabled
+                       (or .Values.managed.adminToken.value .Values.managed.adminToken.existingSecret) }}
+            # The digest task runs with no operator session; the receiver's
+            # admin credential is how it reads the log store saved through
+            # the wizard. Only mounted when the digest is actually on, so a
+            # portal without one never holds it.
+            - name: RECEIVER_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.managed.adminToken.existingSecret | default (printf "%s-admin" (include "ai-guard.fullname" .)) }}
+                  key: adminToken
+            {{- end }}
+            {{- with .Values.portal.digest.day }}
+            - name: DIGEST_DAY
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.portal.digest.hour }}
+            - name: DIGEST_HOUR
+              value: {{ . | quote }}
+            {{- end }}
           volumeMounts:
             - name: registry
               mountPath: /etc/ai-guard

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -272,6 +272,21 @@ portal:
   overview:
     widgets: []
 
+  # A weekly summary to a Slack-compatible incoming webhook: personal
+  # accounts, tools in use, silent sources. Sent by the portal's background
+  # task, which holds no operator session - so on the managed default,
+  # where the log store is saved through the wizard, it reads via the
+  # receiver's admin credential: set managed.adminToken (value or
+  # existingSecret) and the chart mounts it for the portal automatically
+  # while the digest is on. A deployment that sets the portal's log store
+  # by env instead needs no credential. Distinct from the receiver's
+  # webhook_url setting, which fires on new discovery candidates the
+  # moment they appear.
+  digest:
+    webhookUrl: ""
+    day: ""      # mon..sun, default mon
+    hour: ""     # 0-23 UTC, default 8
+
   # Panel ids are not knowable until Grafana is running with data, so this is
   # usually a second pass. See the chart README.
   grafana:

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,8 +1,10 @@
 # Local demo
 
 See the platform work with synthetic data in about five minutes. No cluster,
-no credentials, no real estate touched. Everything here is fake: demo users
-are named after Pokemon, findings are seeded locally.
+no real estate touched. Everything here is fake: demo users are named after
+Pokemon, findings are seeded locally. The only credential involved is the
+one the demo itself mints: the portal runs managed mode like a real
+deployment, so the first visit walks the real first-boot path.
 
 The demo shows both halves of the platform: the detection pipeline landing
 in a Grafana dashboard, and the browser paste guard intercepting secrets
@@ -28,11 +30,24 @@ docker compose down -v
 
 ## The portal
 
-Open http://localhost:8091. It lands on a setup view showing which detection
-sources are reporting and what each silent one would need. In the demo most
-are not reporting - that's what a partly-configured deployment looks like,
-and the page exists so you can always tell "not set up" apart from "nothing
-to report".
+Open http://localhost:8091. It asks you to create the admin account - the
+receiver printed a one-time setup code to its log when it started:
+
+```bash
+docker compose logs receiver | grep setup_code
+```
+
+Paste the code, pick a username and password, and you are in - the same
+first-boot flow as a real deployment, which is why the demo does not skip
+it. Being signed in unlocks the managed half of the platform: the setup
+wizard (the portal offers it, or go to `#wizard`), central settings, the
+fleet view and enrollment tokens.
+
+After login it lands on a sources view showing which detection sources are
+reporting and what each silent one would need. In the demo most are not
+reporting - that's what a partly-configured deployment looks like, and the
+page exists so you can always tell "not set up" apart from "nothing to
+report".
 
 The other tabs are the part Grafana cannot do. Findings are a flat stream of
 isolated rows; the portal derives the relationships between them, so a device

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -8,7 +8,10 @@
 # Then open either:
 #
 #   http://localhost:8091   the portal: devices, tools, people, and what is
-#                           reporting. Start here.
+#                           reporting. Start here. It runs managed mode like
+#                           a real deployment, so it asks for the one-time
+#                           setup code the receiver printed:
+#                               docker compose logs receiver | grep setup_code
 #   http://localhost:3000   Grafana (anonymous, no login), the "Shadow AI"
 #                           dashboard.
 #
@@ -73,8 +76,16 @@ services:
       REGISTRY_PATH: "/etc/ai-guard/registry.json"
       COLLECTOR_REGISTRY_PATH: "/etc/ai-guard/collector.json"
       DISPLAY_TZ: "UTC"
+      # Managed mode, because it is the default everywhere else: enrollment,
+      # the portal login and central settings, backed by one SQLite file on
+      # the named volume below. `down -v` wipes it, so every fresh start of
+      # the demo walks the real first-boot path: setup code, admin account,
+      # wizard.
+      MANAGED_MODE: "true"
+      STATE_DB_PATH: /var/lib/ai-guard/state.db
     volumes:
       - registry-dist:/etc/ai-guard:ro
+      - managed-state:/var/lib/ai-guard
     depends_on:
       loki:
         condition: service_healthy
@@ -145,11 +156,14 @@ services:
     build: ../portal
     environment:
       LOKI_URL: "http://loki:3100"
-      # The portal refuses to start without authentication, deliberately: it
-      # names who runs what on which machine. This demo is seeded with fake
-      # Pokemon users and bound to loopback, so it opts out explicitly rather
-      # than shipping a credential someone might carry into production.
-      PORTAL_AUTH: "none"
+      # Managed mode, same as a real deployment: admin actions proxy to the
+      # receiver and the portal gets a real login. The receiver prints a
+      # one-time setup code to its log on first boot - find it with
+      #     docker compose logs receiver | grep setup_code
+      # and create the admin account from the login screen. That unlocks the
+      # settings, the wizard (#wizard), fleet and enrollment tokens - the
+      # parts of the platform a no-auth demo could not show.
+      RECEIVER_URL: "http://receiver:8080"
       REGISTRY_PATH: "/etc/ai-guard/registry.json"
       # Governance decisions. Optional everywhere, including here: comment
       # this out and the register falls back to the registry's own approved
@@ -211,3 +225,4 @@ services:
 
 volumes:
   registry-dist:
+  managed-state:

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -144,6 +144,14 @@ services:
       # than an empty page; an unknown name renders an error card naming what
       # is valid, rather than quietly not appearing.
       OVERVIEW_WIDGETS: ${OVERVIEW_WIDGETS:-}
+      # Weekly digest to a Slack-compatible webhook, sent by the portal.
+      # Needs LOKI_URL above as the log store the background task reads.
+      DIGEST_WEBHOOK_URL: ${DIGEST_WEBHOOK_URL:-}
+      DIGEST_DAY: ${DIGEST_DAY:-}
+      DIGEST_HOUR: ${DIGEST_HOUR:-}
+      # The digest task reads the wizard-saved log store with the receiver's
+      # admin credential - the same AIGUARD_ADMIN_TOKEN the receiver gets.
+      RECEIVER_ADMIN_TOKEN: ${AIGUARD_ADMIN_TOKEN:-}
       # There is no chart here, so the portal's settings page shows this and
       # leaves the Kubernetes-only fields empty rather than guessing at them.
       DEPLOY_CHART_VERSION: ${DEPLOY_CHART_VERSION:-compose}


### PR DESCRIPTION
Merge after #149.

- **Chart** (0.10.6): `portal.digest` values (webhook URL, day, hour). When the digest is on and `managed.adminToken` is set, the chart mounts the admin credential for the portal's background reads — only then, so a portal without a digest never holds it.
- **Compose**: `DIGEST_*` passthrough, and `RECEIVER_ADMIN_TOKEN` from the same `AIGUARD_ADMIN_TOKEN` the receiver gets.
- **Demo**: managed mode, because it is the default everywhere else. A fresh start walks the real first-boot path — setup code from the receiver log, admin account, wizard — which is exactly the flow worth showing. State on a named volume; `down -v` wipes it.

`helm lint` clean; the RECEIVER_ADMIN_TOKEN conditional verified with `helm template`.