### PR TITLE
chart: survive helm upgrade --reuse-values; release v0.11.1

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.11.0
+version: 0.11.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.11.0"
+appVersion: "0.11.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/templates/portal-deployment.yaml
+++ b/charts/ai-guard/templates/portal-deployment.yaml
@@ -141,11 +141,17 @@ spec:
             - name: GRAFANA_DASHBOARD_UID
               value: {{ . | quote }}
             {{- end }}
-            {{- with .Values.portal.digest.webhookUrl }}
+            {{- /* default dict, because `helm upgrade --reuse-values`
+                 renders old values against this new template and the digest
+                 key does not exist there. Chained access on the missing key
+                 is a nil-pointer render error, which turned every
+                 reuse-values upgrade into a failure (v0.11.0). */}}
+            {{- $digest := .Values.portal.digest | default dict }}
+            {{- with $digest.webhookUrl }}
             - name: DIGEST_WEBHOOK_URL
               value: {{ . | quote }}
             {{- end }}
-            {{- if and .Values.portal.digest.webhookUrl .Values.managed.enabled
+            {{- if and $digest.webhookUrl .Values.managed.enabled
                        (or .Values.managed.adminToken.value .Values.managed.adminToken.existingSecret) }}
             # The digest task runs with no operator session; the receiver's
             # admin credential is how it reads the log store saved through
@@ -157,11 +163,11 @@ spec:
                   name: {{ .Values.managed.adminToken.existingSecret | default (printf "%s-admin" (include "ai-guard.fullname" .)) }}
                   key: adminToken
             {{- end }}
-            {{- with .Values.portal.digest.day }}
+            {{- with $digest.day }}
             - name: DIGEST_DAY
               value: {{ . | quote }}
             {{- end }}
-            {{- with .Values.portal.digest.hour }}
+            {{- with $digest.hour }}
             - name: DIGEST_HOUR
               value: {{ . | quote }}
             {{- end }}

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -94,14 +94,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.1
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.1
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.1
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
`helm upgrade --reuse-values` renders the previous release's values against the new chart's templates without merging in the new defaults — so the digest block's chained `.Values.portal.digest.webhookUrl` lookup hit a missing key and **every reuse-values upgrade to 0.11.0 failed to render**. Found upgrading a live 0.10.x deployment.

Fix: resolve the digest map once with a `dict` default and read fields off that. Verified with `helm template` against a real 0.10.x release's stored values (renders, digest block skipped) and with digest + adminToken set (both envs present).

Second commit is the v0.11.1 release bump; tag follows the merge.