### PR TITLE
docs, wizard: say out loud that the hostnames need DNS

### DIFF
--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -52,6 +52,37 @@ governance baseline, the extension ID, and pre-configured deployment
 downloads for every surface. Nothing after `helm install` touches a values
 file, and everything the wizard sets is editable later under Settings.
 
+## Making the hostnames resolve
+
+The chart creates the routing rules inside the cluster; it cannot make
+`ai-guard.example.com` resolve from the internet. That part is DNS you own:
+
+1. Your ingress controller sits behind one entry point - a load balancer IP,
+   or a hostname on a cloud provider. `kubectl get ingress -n ai-guard`
+   shows it under ADDRESS once the chart is installed.
+2. Point both names at it: an A record to the IP, or an ALIAS/CNAME to the
+   hostname (in Route 53, an alias to the ELB). Both hosts go to the same
+   place - the ingress controller routes by the Host header, which is how
+   two names share one entry point. A wildcard record (`*.example.com`) does
+   the same job once for every service you will ever add.
+3. TLS comes after DNS, not before: cert-manager with Let's Encrypt can only
+   issue a certificate for a name that already resolves. Set
+   `ingress.tls.secretName` to what it issues.
+
+Teams that automate step 2 run external-dns, which watches Ingress resources
+and writes the records itself.
+
+Two audiences, one nuance: the receiver's name must resolve from **every
+machine that reports** - a laptop on hotel wifi included - so it needs real
+public DNS. The portal's name only has to resolve for the people who open
+it, so internal DNS or VPN-only is a legitimate choice there.
+
+The Tailscale route above skips all of this: the operator registers the
+names in your tailnet's own DNS and issues the certificates itself, with
+nothing exposed publicly. The wizard's probe button is the check either
+way - it tells you when a saved name does not resolve or the certificate
+does not match.
+
 ## The short way: classic mode
 
 The file-and-environment deployment, for teams that want configuration in a

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -33,7 +33,10 @@ helm install ai-guard oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard \
 
 The two hosts are the URLs your machines will reach the receiver on and you
 will reach the portal on. Anything that gives those two services a hostname
-works: an ingress controller, Tailscale, a reverse proxy.
+works: an ingress controller, Tailscale, a reverse proxy. With an ingress
+controller, both names need a DNS record pointing at its load balancer -
+[the deployment docs](deployment/kubernetes.md) walk that through; Tailscale
+handles names and certificates itself.
 
 **Docker Compose:**
 

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2081,8 +2081,10 @@ async function wizard() {
   <div class="wcard" style="margin-bottom:10px"><h3>1 · Where your machines reach the receiver</h3>
   <p class="lede" style="margin-bottom:10px">The URL your laptops and servers
   will send findings to. It gets baked into every download below, so it has
-  to work from those machines - not just from inside the cluster. Save it,
-  then hit probe to check.</p>
+  to work from those machines - not just from inside the cluster. That means
+  a DNS record pointing this name at your ingress or reverse proxy, plus a
+  certificate - unless something like a Tailscale operator handles both for
+  you. Save it, then hit probe to check.</p>
   <dl class="kv">
     ${settingRow('receiver_public_url', 'Public receiver URL',
       'https://ai-guard.your-tailnet.ts.net', '')}


### PR DESCRIPTION
The requirement was stated everywhere - an HTTPS-reachable hostname - and the mechanics nowhere: what record, pointing at what, and why TLS comes after DNS.

- **kubernetes.md**: a "Making the hostnames resolve" section - the ingress controller's one entry point, A/ALIAS records (Route 53 alias to the ELB included), the wildcard shortcut, external-dns for automation, cert-manager ordering, and the nuance that the receiver's name must resolve from every reporting machine while the portal's can stay internal. Notes that the Tailscale route skips the whole thing.
- **getting-started**: one sentence at the install step pointing there.
- **wizard step 1**: the lede now says the name needs a DNS record and a certificate, not just "has to work", so the probe failure is expected rather than mysterious.

Copy only; the wizard change rides the next release.