### PR TITLE
A 200 from /report now means the store has the finding; release v0.11.3

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -105,6 +105,9 @@ is unchanged.
 Where your log store can mint separate tokens, give the receiver a
 write-only one and the portal a read-only one (`portal.loki.*` in the
 chart): a compromised portal then never holds anything that can write.
+The portal's service credential is the receiver's full admin credential
+for now; a purpose-built read-scoped service role is on the list, so a
+compromised portal would hold less than it needs to today.
 
 The login route is throttled at the application level, because it is
 necessarily unauthenticated and scrypt is deliberately expensive: past a

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -116,11 +116,13 @@ without.
 **This is the most misleading failure in the system, so check it first when
 data is missing.**
 
-The receiver returns `200` to the reporting source even when it cannot write to
-Loki, deliberately: a log store being down should not make a collector think its
-finding was rejected and throw it away. The consequence is that every collector
-is satisfied, the finding exists in the receiver's stdout, and nothing reaches
-either view.
+Since 0.11.3 a failed push answers the collector with a `503`, so collectors
+keep the finding and retry - on current versions this failure shows up as
+`POST-FAILED` in collector logs rather than silence. On 0.11.2 and earlier
+the receiver returned `200` even when it could not write to Loki: every
+collector was satisfied, the finding existed in the receiver's stdout, and
+nothing reached either view. Either way, the receiver's own metrics name
+the cause:
 
 Check the receiver's own metrics:
 

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.11.2
+version: 0.11.3
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.11.2"
+appVersion: "0.11.3"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/README.md
+++ b/charts/ai-guard/README.md
@@ -238,8 +238,8 @@ misconfiguration.
 
 On Grafana Cloud the username is a numeric instance id rather than an email,
 and the access policy needs `logs:write` AND `logs:read`. A read-only token
-produces a 401 on every push that the receiver counts and logs while still
-answering 200 to the collector, so findings look accepted and are not stored.
+produces a 401 on every push, which the receiver counts, logs, and answers
+to the collector as a 503 so nothing is silently discarded.
 `aiguard_loki_push_total` staying at zero while findings arrive is that
 failure.
 

--- a/deploy/compose/README.md
+++ b/deploy/compose/README.md
@@ -26,13 +26,10 @@ Those two differ on purpose. `LOKI_PUSH_URL` is the full push endpoint the
 receiver POSTs to verbatim, and posting to the base URL returns 404. `LOKI_URL`
 is the base the portal appends its own query path to.
 
-A wrong `LOKI_PUSH_URL` is quiet in a way worth knowing about: the receiver
-still returns 200 to the reporting source, because a log-store failure should
-not lose a collector's finding, and the failure is logged rather than raised.
-So the collector is satisfied, the finding exists in the receiver's stdout, and
-nothing reaches the portal. If the portal shows nothing after a finding was
-accepted, check `docker compose logs receiver` for a Loki error before anything
-else.
+A wrong `LOKI_PUSH_URL` answers the reporting source with a 503 rather
+than a quiet 200: collectors keep the finding and retry, and the failure is
+logged with the likely cause. If collectors report POST failures, check
+`docker compose logs receiver` for a Loki error before anything else.
 
 ## Setup
 
@@ -79,10 +76,10 @@ page for your stack.
 is the base URL without it, because the portal appends its own query path. Same
 host, two different values.
 
-The access policy needs both `logs:write` and `logs:read`. A read-only token
-produces a 401 on every push that the receiver counts and logs, while still
-answering 200 to the collector, so findings look accepted and are not stored.
-Check before you assume it worked:
+The access policy needs both `logs:write` and `logs:read`. A read-only
+token produces a 401 on every push, which the receiver counts, logs, and
+answers to the collector as a 503 so nothing is silently discarded. Check
+before you assume it worked:
 
     curl -s localhost:8080/metrics | grep -E 'loki_push_total|failures_total'
 
@@ -128,12 +125,10 @@ a Mac and deploy on Linux.
 
 ## When findings stop arriving
 
-The receiver answers 200 to a reporting source even when the push to the log
-store fails, and that is deliberate: a log store being down should not lose a
-collector's finding, which is on stdout regardless. It does mean a
-misconfigured push is invisible from the collector's side.
-
-Three things make it visible:
+When a push target is configured, a failed push answers the reporting
+source with a 503, and collectors keep the finding and retry next run - so
+a store outage delays evidence rather than losing it. Three things make the
+failure itself visible:
 
     docker compose logs receiver | grep '"kind": "error"'
 

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.2
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.3
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.2
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.3
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -266,7 +266,7 @@ findings are stored and cannot be read back, and neither container reports an
 error you would attribute to the right cause. On Grafana Cloud the username is
 a numeric instance id rather than an email, and the access policy needs both
 `logs:write` and `logs:read`: a read-only token produces a 401 the receiver
-counts while still answering 200 to the collector, so findings look accepted
+counts, logs, and answers to the collector as a 503 - so findings retry
 and are not stored. `aiguard_loki_push_total` staying at zero while findings
 arrive is that failure.
 
@@ -303,7 +303,8 @@ back to the registry's own `approved` flag and devices show as serials.
 
 ## When findings stop arriving
 
-The receiver answers 200 to a reporting source even when the push to the log
+With a push target configured, a failed push is a 503 and collectors
+retry; the failure is also visible where the receiver writes to the log
 store fails. That is deliberate - a log store being down should not lose a
 collector's finding, which is on stdout regardless - but it means a
 misconfigured push is invisible from the collector's side.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -124,10 +124,11 @@ If nothing appears within a minute:
 - **The collector printed an error about the receiver URL or token** - it
   never reached the receiver. Re-download the script (each download carries a
   fresh token) and check the URL is reachable from that machine.
-- **The collector said it reported, but the portal is empty** - the receiver
-  got the finding but couldn't push it to the log store. Check the receiver's
-  logs for lines with `"kind": "error"`; they name the URL it tried and the
-  likely fix. The Diagnostics view in the portal shows the same thing.
+- **The collector reported a POST failure** - the receiver refused the
+  finding because it couldn't deliver it to the log store (the collector
+  keeps it and retries). Check the receiver's logs for lines with
+  `"kind": "error"`; they name the URL it tried and the likely fix. The
+  Diagnostics view in the portal shows the same thing.
 - Anything else: [Troubleshooting](../TROUBLESHOOTING.md).
 
 ## Where to go next

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -147,10 +147,14 @@ no receiver restart.
 
 ## When findings stop arriving
 
-The receiver answers 200 to a reporting source even when the push to the log
-store fails. That is deliberate - a log store being down should not lose a
-collector's finding, which is on stdout regardless - but it means a
-misconfigured push is invisible from the collector's side.
+When a push target is configured, a failed push is a **503** back to the
+reporting source, and collectors keep the finding and retry on their next
+run - a 200 means the finding actually reached the store. It used to be a
+200 either way, which made a broken token produce a clean-looking dashboard
+while collectors discarded findings the store never received. With no push
+target configured, stdout is the contract and /report answers 200 as ever.
+The retry costs a duplicate stdout line; duplicate evidence beats silently
+missing evidence.
 
 Push failures log at error with the URL and, for the codes that account for
 almost every misconfiguration, the likely cause: a 404 usually means

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -995,16 +995,24 @@ def login(req: LoginRequest):
         raise HTTPException(
             429, "too many failed sign-ins; try again in a few minutes",
             headers={"Retry-After": str(LOGIN_WINDOW_SECONDS)})
+    # The slot is taken without blocking: a burst that beats the failure
+    # counters must be refused, not queued, or the waiters themselves
+    # occupy worker threads - the exhaustion the gate exists to prevent.
+    if not _scrypt_gate.acquire(blocking=False):
+        raise HTTPException(
+            429, "too many concurrent sign-ins; try again in a moment",
+            headers={"Retry-After": "5"})
     try:
-        with _scrypt_gate:
-            return STATE.login(req.username, req.password, SESSION_TTL_HOURS,
-                               log_failure=user_n < LOGIN_LOGGED_FAILURES)
+        return STATE.login(req.username, req.password, SESSION_TTL_HOURS,
+                           log_failure=user_n < LOGIN_LOGGED_FAILURES)
     except _state.AuthError as e:
         _login_failed(req.username)
         if user_n + 1 == LOGIN_MAX_FAILURES_PER_USER:
             STATE.record_login_throttled(req.username)
         time.sleep(LOGIN_FAILURE_DELAY_SECONDS)
         raise HTTPException(e.status, e.detail)
+    finally:
+        _scrypt_gate.release()
 
 
 @app.post("/admin/logout")
@@ -1910,9 +1918,12 @@ _LOKI_HINTS = {
 
 
 async def _push_loki(f: Finding, line: str, url: str, username: str,
-                     password: str):
-    """Fire-and-forget push to Loki. Bounded labels only (no tool/device:
-    unbounded values stay inside the JSON line, parsed at query time)."""
+                     password: str) -> bool:
+    """Push to Loki and say whether it worked. Bounded labels only (no
+    tool/device: unbounded values stay inside the JSON line, parsed at
+    query time). The caller turns False into a 503, because collectors
+    treat only a 200 as delivered - answering 200 on a failed push is what
+    made them discard findings the store never received."""
     payload = {
         "streams": [
             {
@@ -1948,6 +1959,7 @@ async def _push_loki(f: Finding, line: str, url: str, username: str,
         if code in _LOKI_HINTS:
             entry["hint"] = _LOKI_HINTS[code]
         log.error(json.dumps(entry))
+        return False
     except httpx.HTTPError as e:
         LOKI_PUSH_FAILURES.labels(reason=type(e).__name__).inc()
         log.error(json.dumps({
@@ -1958,9 +1970,11 @@ async def _push_loki(f: Finding, line: str, url: str, username: str,
             "error": "loki push failed: %s" % type(e).__name__,
             "url": _redact_url(url),
         }))
+        return False
     else:
         LOKI_PUSH_OK.inc()
         LOKI_PUSH_LAST_SUCCESS.set(time.time())
+        return True
 
 
 async def _fire_alert(f: Finding, alertmanager_url: str):
@@ -2044,11 +2058,23 @@ async def report(f: Finding, request: Request, authorization: str = Header(defau
     # when a push target is configured - the portal-saved log store when
     # one exists, LOKI_PUSH_URL otherwise. Resolved per finding, so a
     # store configured in the wizard takes effect with no restart.
+    #
+    # A failed push is a 503, not a 200. Collectors advance their delivered
+    # state only on 200, so acknowledging a finding the store rejected made
+    # them discard it - a broken token produced a clean-looking dashboard
+    # because telemetry silently stopped reaching storage, which is the
+    # exact failure this platform exists to catch. The retry costs a
+    # duplicate stdout line; duplicate evidence beats silently missing
+    # evidence. Metrics, gauges and alerting run only on the stored path,
+    # so a retried finding counts once, when it is actually stored.
     line = json.dumps({"app": "ai-guard-receiver", "kind": "finding", **f.model_dump()})
     log.info(line)
     push_url, push_user, push_pass = _effective_log_push()
     if push_url:
-        await _push_loki(f, line, push_url, push_user, push_pass)
+        if not await _push_loki(f, line, push_url, push_user, push_pass):
+            raise HTTPException(
+                503, "finding accepted locally but log-store delivery "
+                     "failed; retry")
 
     FINDINGS.labels(
         surface=f.surface, severity=f.severity, os=f.os

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.2
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.3
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/receiver/tests/test_report_delivery.py
+++ b/receiver/tests/test_report_delivery.py
@@ -1,0 +1,101 @@
+"""Delivery semantics: a 200 from /report means the finding reached the
+configured log store, not merely this container's stdout.
+
+Collectors advance their delivered state only on 200, so acknowledging a
+finding the store rejected made them discard it: a broken token produced a
+clean-looking dashboard because telemetry silently stopped reaching
+storage - the exact failure the platform exists to catch. The properties
+under test: a failed push is a 503 the collector will retry, a successful
+push is a 200, and no push configured keeps the stdout-only contract.
+"""
+
+import os
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from app import main
+from app.main import app
+
+client = TestClient(app)
+
+AUTH = {"Authorization": "Bearer test-token-for-ci"}
+
+FINDING = {
+    "tool": "claude-code", "surface": "cli", "os": "macos",
+    "account_domain": "gmail.com", "device": "MAC-1", "user": "sam",
+    "evidence": "~/.claude.json", "severity": "warn",
+    "reported_at": "2026-08-24T12:00:00Z", "source": "collector-macos",
+}
+
+
+@pytest.fixture
+def pushing(monkeypatch):
+    """A configured push target; each test decides whether it works."""
+    monkeypatch.setattr(main, "LOKI_PUSH_URL",
+                        "http://loki.example/loki/api/v1/push")
+    yield
+
+
+def _fake_post(result):
+    class FakeResponse:
+        status_code = 401
+
+        def raise_for_status(self):
+            if not result:
+                raise httpx.HTTPStatusError(
+                    "no", request=None, response=self)
+
+    async def post(self, url, **kw):
+        return FakeResponse()
+
+    return post
+
+
+def test_a_failed_push_is_a_503_the_collector_will_retry(pushing, monkeypatch):
+    monkeypatch.setattr(httpx.AsyncClient, "post", _fake_post(False))
+    r = client.post("/report", headers=AUTH, json=FINDING)
+    assert r.status_code == 503
+    assert "retry" in r.json()["detail"]
+
+
+def test_a_successful_push_is_a_200(pushing, monkeypatch):
+    monkeypatch.setattr(httpx.AsyncClient, "post", _fake_post(True))
+    r = client.post("/report", headers=AUTH, json=FINDING)
+    assert r.status_code == 200
+
+
+def test_no_push_configured_keeps_the_stdout_contract(monkeypatch):
+    monkeypatch.setattr(main, "LOKI_PUSH_URL", "")
+    r = client.post("/report", headers=AUTH, json=FINDING)
+    assert r.status_code == 200
+
+
+def test_a_full_scrypt_gate_is_a_cheap_429(tmp_path, monkeypatch):
+    """A first-burst of logins that beats the failure counters is refused
+    rather than queued: waiters on the gate would occupy the worker threads
+    the gate exists to protect."""
+    from app import state as state_mod
+    st = state_mod.State(str(tmp_path / "state.db"))
+    monkeypatch.setattr(main, "STATE", st)
+    monkeypatch.setattr(main, "_login_failures", {})
+    st.create_admin("root", "a-long-enough-password")
+    for _ in range(4):
+        assert main._scrypt_gate.acquire(blocking=False)
+    try:
+        r = client.post("/admin/login",
+                        json={"username": "root",
+                              "password": "a-long-enough-password"})
+        assert r.status_code == 429
+        assert "Retry-After" in r.headers
+    finally:
+        for _ in range(4):
+            main._scrypt_gate.release()
+    # Slots free again: the same login succeeds.
+    r = client.post("/admin/login",
+                    json={"username": "root",
+                          "password": "a-long-enough-password"})
+    assert r.status_code == 200

--- a/receiver/tests/test_smoke.py
+++ b/receiver/tests/test_smoke.py
@@ -241,14 +241,12 @@ def test_collector_registry_is_untouched_when_no_corp_domains(tmp_path, monkeypa
 
 
 def test_a_rejected_push_is_counted_and_says_why():
-    """A push that fails is a finding that exists only in this container's
-    stdout. The receiver still answers 200, which is right - a log store being
-    down should not lose a collector's finding - so the failure is invisible
-    from the outside unless something counts it.
+    """A push that fails is counted, logged with a hint, and reported back
+    to the sender as a 503 (test_report_delivery.py covers the status). The
+    metric matters regardless: it is what an operator alerts on.
 
     This was logged at info with no metric, and a wrong LOKI_PUSH_URL
-    therefore produced a 404 per finding that nobody read while every
-    collector saw a 200.
+    therefore produced a 404 per finding that nobody read.
     """
     import asyncio
 


### PR DESCRIPTION
The second external review found the one behaviour where the code's own reasoning was backwards: the receiver answered 200 even when the direct Loki push failed, "so a store outage does not lose a collector's finding" - but collectors advance their delivered state only on a 200, so the 200 is exactly what made them discard findings the store never received. A broken token produced a clean-looking dashboard because telemetry silently stopped reaching storage: the failure the platform exists to catch.

- **A failed push is now a 503**; collectors keep the finding and retry next run. Metrics, gauges and alerting run only on the stored path, so a retried finding counts once. The retry costs a duplicate stdout line - duplicate evidence beats silently missing evidence. No push target configured keeps the stdout-only contract unchanged.
- **Login gate hardening** from the same review: the scrypt slot is taken without blocking, so a first-burst that beats the failure counters gets a cheap 429 instead of queuing on worker threads.
- Every doc that taught the old semantics is rewritten, TROUBLESHOOTING included (with the version boundary stated, since 0.11.2-and-earlier behaviour is what an upgrading operator has been living with).
- SECURITY.md notes the portal's service credential is broader than it needs to be; a read-scoped service role is on the list.

Four new delivery/gate regression tests. Receiver 157, portal 366, all green. Second commit is the v0.11.3 release bump; tag follows the merge.