### PR TITLE
Call it a beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@
 </p>
 
 > [!NOTE]
-> **Alpha release.** Early-stage and under active development. It works, but
-> has known limitations tracked in [Issues](../../issues).
+> **Beta release.** Under active development. It runs in production, the
+> finding schema is stable, and known limitations are tracked in
+> [Issues](../../issues).
 
 ---
 
@@ -334,8 +335,8 @@ monitoring in most jurisdictions and usually warrants a DPIA.
 
 ## Status and known limitations
 
-This is an alpha. It runs in production in one environment, and the rough
-edges are listed here rather than hidden.
+This is a beta. It runs in production, and the rough edges are listed here
+rather than hidden.
 
 The list keeps shrinking: registry fallback drift, the Entra scanner counting
 failed sign-ins as usage, unreported delegated access, and browser extension

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,6 +1,6 @@
 # Trying it, and telling me what broke
 
-This is an alpha. It runs in one environment, mine, and the useful thing
+This is a beta. It runs in one environment, mine, and the useful thing
 someone else can do is follow the documentation without knowing any of the
 history behind it and say where it stops making sense.
 

--- a/scanner/pyproject.toml
+++ b/scanner/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["ai", "security", "shadow-it", "mcp", "entra", "sentinelone"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: System Administrators",
     "Topic :: Security",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
The alpha label had fallen behind what the project actually is. The finding schema is stable and documented as the contract, releases ship pinned charts and multi-arch images from CI, the Portal carries the whole first-boot path, and it runs in production. Alpha tells a cautious reader not to deploy it, which no longer matches the docs telling them how.

This moves the three status declarations to beta: the README callout, the status section, TESTING.md's opening line, and the scanner's trove classifier (3 - Alpha to 4 - Beta). The 0.x version and the known-limitations list still carry the caveats; historical CHANGELOG entries are untouched.

Not touched here: the website copy, which follows once this lands.