### PR TITLE
Budget: paid seats against observed use

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ not a fork; if you are not sure which you want, start with managed. The
 | Operate the portal | [Portal](portal/README.md) |
 | Configure the receiver | [Receiver](receiver/README.md) |
 | Record approvals, owners and review dates | [Governance decisions](docs/governance.md) |
+| Track paid seats against observed use | [Budget](docs/budget.md) |
 | Produce evidence for an AI management system | [Evidence](docs/evidence.md) |
 | Deploy macOS collection | [macOS collector](endpoint/macos/README.md) |
 | Deploy Windows collection | [Windows collector](endpoint/windows/README.md) |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -89,7 +89,7 @@ password - are stored as hashes only; a copied database file cannot
 impersonate anything. **Integration secrets** are different: a log store
 password saved in the portal, a notification webhook URL (itself a
 bearer capability - whoever holds it can post to the channel), and a
-vendor admin API key saved for a Budget roster sync, are stored
+vendor admin API key saved for a Budget user sync, are stored
 recoverable, because the receiver must present them outward. Both are
 masked everywhere in the UI and in the ordinary settings API. The log-store
 plaintext exists on exactly one admin-only route the portal uses
@@ -125,7 +125,7 @@ http(s) locations, including internal ones, and the log-store test button
 makes that an authenticated network probe. That is the price of supporting
 private, self-hosted stores; it is an *admin* capability, gated like every
 other write, and worth knowing when deciding who gets an admin account.
-The Budget roster sync is deliberately narrower: its outbound
+The Budget user sync is deliberately narrower: its outbound
 destinations are the vendors' API hosts, hardcoded in the receiver, so a
 stored key can only ever be presented to the vendor it belongs to.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,8 +87,9 @@ A word on what the state DB holds, because it changed in 0.9.8. **Fleet
 credentials** - enrollment tokens, device credentials, sessions, the admin
 password - are stored as hashes only; a copied database file cannot
 impersonate anything. **Integration secrets** are different: a log store
-password saved in the portal, and a notification webhook URL (itself a
-bearer capability - whoever holds it can post to the channel), are stored
+password saved in the portal, a notification webhook URL (itself a
+bearer capability - whoever holds it can post to the channel), and a
+vendor admin API key saved for a Budget roster sync, are stored
 recoverable, because the receiver must present them outward. Both are
 masked everywhere in the UI and in the ordinary settings API. The log-store
 plaintext exists on exactly one admin-only route the portal uses
@@ -124,6 +125,9 @@ http(s) locations, including internal ones, and the log-store test button
 makes that an authenticated network probe. That is the price of supporting
 private, self-hosted stores; it is an *admin* capability, gated like every
 other write, and worth knowing when deciding who gets an admin account.
+The Budget roster sync is deliberately narrower: its outbound
+destinations are the vendors' API hosts, hardcoded in the receiver, so a
+stored key can only ever be presented to the vendor it belongs to.
 
 The chart's public receiver ingress carries only the reporting surfaces
 (/report, /flag, /enroll, /registry, /candidates, /healthz) by default;

--- a/TESTING.md
+++ b/TESTING.md
@@ -45,7 +45,7 @@ Then:
   dashboard. It should already have data in it
 - open http://localhost:8090/demo/ and paste one of the test values on the
   page into the box. The paste guard should stop it
-- optionally, try the Budget tab: link a tool and import the sample roster
+- optionally, try the Budget tab: link a tool and import the sample users
   from [demo/README.md](demo/README.md) to see paid seats joined against
   the seeded findings
 - stop and wipe with `docker compose down -v`

--- a/TESTING.md
+++ b/TESTING.md
@@ -45,6 +45,9 @@ Then:
   dashboard. It should already have data in it
 - open http://localhost:8090/demo/ and paste one of the test values on the
   page into the box. The paste guard should stop it
+- optionally, try the Budget tab: link a tool and import the sample roster
+  from [demo/README.md](demo/README.md) to see paid seats joined against
+  the seeded findings
 - stop and wipe with `docker compose down -v`
 
 What this tells me: whether a clean clone works, whether the first-boot flow

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.11.3
+version: 0.12.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.11.3"
+appVersion: "0.12.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/examples/networkpolicy.yaml
+++ b/charts/ai-guard/examples/networkpolicy.yaml
@@ -77,7 +77,7 @@ spec:
         - protocol: TCP
           port: 9093
 
-    # Budget roster sync (docs/budget.md): the receiver calls the vendor
+    # Budget user sync (docs/budget.md): the receiver calls the vendor
     # admin APIs (api.anthropic.com, api.fireflies.ai) over HTTPS. Delete
     # this rule if you do not use the Budget view's automatic sync - a
     # webhook_url notification target also rides on it. Plain

--- a/charts/ai-guard/examples/networkpolicy.yaml
+++ b/charts/ai-guard/examples/networkpolicy.yaml
@@ -76,3 +76,21 @@ spec:
       ports:
         - protocol: TCP
           port: 9093
+
+    # Budget roster sync (docs/budget.md): the receiver calls the vendor
+    # admin APIs (api.anthropic.com, api.fireflies.ai) over HTTPS. Delete
+    # this rule if you do not use the Budget view's automatic sync - a
+    # webhook_url notification target also rides on it. Plain
+    # NetworkPolicy cannot scope egress to a hostname; if your CNI offers
+    # FQDN rules (Cilium, Calico Enterprise), tighten this to the two
+    # vendor hosts.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+      ports:
+        - protocol: TCP
+          port: 443

--- a/demo/README.md
+++ b/demo/README.md
@@ -63,6 +63,25 @@ portal explains how on the setup page. It proposes one and will not apply it:
 the proposals are string matches against local usernames, and a mapping this
 platform invented and then acted on is how the wrong name ends up on a report.
 
+The Budget tab is worth trying with the seeded data. Link `fireflies`
+(or `chatgpt`), skip the API connection, and import this roster when the
+card offers it:
+
+```csv
+email,role,seat type
+squirtle@example.com,member,standard
+psyduck@example.com,member,standard
+misty@example.com,admin,premium
+```
+
+Give the standard tier a couple of seats and a price in the wizard and the
+card does the join the page exists for: psyduck shows as a paid seat with
+observed use, misty as a paid seat never observed, and squirtle's personal
+gmail sign-in surfaces right under the seats being paid for. With a real
+Anthropic or Fireflies admin key the roster syncs from the vendor's API
+instead of the CSV - the demo has no real org behind it, so the import is
+the honest path here.
+
 The portal is never in the ingest path. Stop that one service and
 collection carries on, which is a property worth seeing for yourself.
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -64,7 +64,7 @@ the proposals are string matches against local usernames, and a mapping this
 platform invented and then acted on is how the wrong name ends up on a report.
 
 The Budget tab is worth trying with the seeded data. Link `fireflies`
-(or `chatgpt`), skip the API connection, and import this roster when the
+(or `chatgpt`), skip the API connection, and import these users when the
 card offers it:
 
 ```csv
@@ -78,7 +78,7 @@ Give the standard tier a couple of seats and a price in the wizard and the
 card does the join the page exists for: psyduck shows as a paid seat with
 observed use, misty as a paid seat never observed, and squirtle's personal
 gmail sign-in surfaces right under the seats being paid for. With a real
-Anthropic or Fireflies admin key the roster syncs from the vendor's API
+Anthropic or Fireflies admin key the user list syncs from the vendor's API
 instead of the CSV - the demo has no real org behind it, so the import is
 the honest path here.
 

--- a/demo/seed.sh
+++ b/demo/seed.sh
@@ -33,6 +33,9 @@ post "{\"tool\":\"claude-code\",\"surface\":\"cli\",\"os\":\"macos\",\"account_d
 post "{\"tool\":\"github-copilot\",\"surface\":\"ide\",\"os\":\"windows\",\"account_domain\":\"\",\"device\":\"WIN-SNORLAX\",\"user\":\"snorlax\",\"evidence\":\".vscode/extensions/github.copilot\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"collector-windows\"}"
 post "{\"tool\":\"claude\",\"surface\":\"desktop\",\"os\":\"linux\",\"account_domain\":\"example.com\",\"device\":\"NIX-MEW\",\"user\":\"mew\",\"evidence\":\"~/.config/Claude\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"collector-linux\"}"
 
+post "{\"tool\":\"fireflies\",\"surface\":\"cloud\",\"os\":\"unknown\",\"account_domain\":\"example.com\",\"device\":\"\",\"user\":\"psyduck\",\"evidence\":\"interactive sign-in to Fireflies\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"entra_sign_in\"}"
+post "{\"tool\":\"chatgpt\",\"surface\":\"cloud\",\"os\":\"unknown\",\"account_domain\":\"example.com\",\"device\":\"\",\"user\":\"eevee\",\"evidence\":\"interactive sign-in to ChatGPT\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"entra_sign_in\"}"
+
 # --- presence only, no account readable ---
 post "{\"tool\":\"cursor\",\"surface\":\"desktop\",\"os\":\"macos\",\"account_domain\":\"\",\"device\":\"C02GENGAR\",\"user\":\"gengar\",\"evidence\":\"~/.cursor\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"collector-macos\"}"
 post "{\"tool\":\"ollama\",\"surface\":\"desktop\",\"os\":\"linux\",\"account_domain\":\"\",\"device\":\"NIX-DITTO\",\"user\":\"ditto\",\"evidence\":\"ollama binary\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"collector-linux\"}"

--- a/docs/budget.md
+++ b/docs/budget.md
@@ -1,0 +1,105 @@
+# Budget: paid seats against observed use
+
+The detection pipeline answers *who uses which AI tools*. The Budget view
+adds the other half of the question: *which of those does the organisation
+pay for, and do the two lists agree*. Link a tool, record what its seats
+cost, give the portal the member list the plan covers, and each tool's
+card shows:
+
+- **paid seats never observed** - members on the vendor roster that no
+  detection surface has matched to activity. Downgrade candidates, with
+  the caveat the card itself carries: a coverage gap looks identical to
+  absence, so check the Sources view before acting.
+- **observed users not matched to a seat** - identities the estate has
+  seen on the tool that match nobody on the roster.
+- **personal-account use alongside the paid plan** - the same rows the
+  Personal accounts view holds, surfaced under the seats being paid for,
+  because that is where the spend question lives.
+- the per-tier arithmetic: seats paid versus seats assigned on the
+  roster, price per seat, monthly total, and the renewal date with a
+  warning inside 30 days.
+
+Budget is managed-mode only. The subscriptions, rosters and connections
+are receiver state, every write is role-gated (viewers read, admins
+write) and lands in the audit trail, and the portal remains a page over
+data others hold.
+
+## Where the roster comes from
+
+Three sources, per tool, and each card names which one its rows came from:
+
+| Source | How | Good for |
+| --- | --- | --- |
+| Automatic | The vendor's admin API, synced on demand with a stored key | Anthropic (Claude Team / Enterprise), Fireflies |
+| Import | Paste the member export from the vendor's admin page | ChatGPT Business, and any vendor without an admin API |
+| Manual | Add members by hand on the card | Small teams, one-off seats |
+
+The three coexist: an API sync replaces the previous sync, a re-import
+replaces the previous import, and neither touches rows added by hand.
+
+Automatic setup currently supports **Anthropic** and **Fireflies**. More
+vendors will be added for automatic configuration - if you want a
+particular tool supported, [raise an issue on
+GitHub](https://github.com/AmanSK5/shadow-ai-guard/issues).
+
+**ChatGPT Business is import-only, and that is OpenAI's boundary, not
+this project's**: the Business (formerly Team) plan exposes no admin API,
+and SCIM and the Compliance API are Enterprise-only. The workspace member
+list exports from Workspace settings → Members, and the import understands
+its `email,role,seat type` shape directly.
+
+### The Anthropic connection
+
+The sync needs a scoped Admin API key with the `read:members` scope. The
+organisation's **primary owner** creates it:
+
+- Claude work orgs (claude.ai): Organization settings → API → Keys
+- Claude Console (platform.claude.com) orgs: Settings → Admin keys
+
+Select **read-only scopes** when creating it. The sync only ever lists
+members; a key that can also write members is more credential than this
+feature needs, and the receiver will happily use less.
+
+### The Fireflies connection
+
+An API key from fireflies.ai → Integrations → Fireflies API. A team
+admin's key lists the whole team, and the sync also records the per-user
+usage the API reports (transcripts, minutes), which shows up in the
+roster table.
+
+## Where the key lives, exactly
+
+The vendor API key is stored by the receiver in its state database,
+alongside the log-store credential and under the same documented trade
+(SECURITY.md): recoverable by design, because the receiver must present
+it outward to sync. It is written by one admin request and never read
+back out by any route - the portal masks it, `/admin/budget` reports only
+that one is set, and a sync spends it server-side. Replacing the key
+resets the sync history, since what the old key last did says nothing
+about the new one.
+
+## How matching works, and what it will not claim
+
+Findings deliberately carry account **domains** and identity hints, never
+full addresses - that is a privacy property of the platform, and Budget
+does not weaken it. A roster email is matched against observed identities
+(cloud sign-in names, and people attached to devices through the identity
+map) by normalising both sides to bare letters and digits, the same trick
+the identity-map suggestions use.
+
+That makes the matching honest but fuzzy, and the cards phrase it
+accordingly: an unmatched member is *"never observed"*, not *"not using
+it"*; an unmatched observed user is *"not matched to a seat"*, not
+*"unlicensed"*. Devices running the tool with no person attached are
+counted separately and excluded from both lists - an identity map (Sources
+view) is what turns those into names.
+
+## Seat tiers
+
+Vendors sell mixed plans (Claude Team and ChatGPT Business both split
+standard from premium seats), so a subscription holds up to ten named
+tiers, each with a seat count and a per-seat monthly price. Tier names
+matter: a roster row whose seat tier matches a tier's name counts against
+that tier's seats, which is how "8 premium seats paid, 3 assigned" falls
+out. The vendor APIs do not expose per-user tiers, so tier assignment
+comes from the CSV import or the card either way.

--- a/docs/budget.md
+++ b/docs/budget.md
@@ -6,25 +6,24 @@ pay for, and do the two lists agree*. Link a tool, record what its seats
 cost, give the portal the member list the plan covers, and each tool's
 card shows:
 
-- **paid seats never observed** - members on the vendor roster that no
+- **paid seats never observed** - users on the vendor's member list that no
   detection surface has matched to activity. Downgrade candidates, with
   the caveat the card itself carries: a coverage gap looks identical to
   absence, so check the Sources view before acting.
 - **observed users not matched to a seat** - identities the estate has
-  seen on the tool that match nobody on the roster.
+  seen on the tool that match nobody on the member list.
 - **personal-account use alongside the paid plan** - the same rows the
   Personal accounts view holds, surfaced under the seats being paid for,
   because that is where the spend question lives.
-- the per-tier arithmetic: seats paid versus seats assigned on the
-  roster, price per seat, monthly total, and the renewal date with a
+- the per-tier arithmetic: seats paid versus seats assigned to users, price per seat, monthly total, and the renewal date with a
   warning inside 30 days.
 
-Budget is managed-mode only. The subscriptions, rosters and connections
+Budget is managed-mode only. The subscriptions, user lists and connections
 are receiver state, every write is role-gated (viewers read, admins
 write) and lands in the audit trail, and the portal remains a page over
 data others hold.
 
-## Where the roster comes from
+## Where the user list comes from
 
 Three sources, per tool, and each card names which one its rows came from:
 
@@ -65,7 +64,7 @@ feature needs, and the receiver will happily use less.
 An API key from fireflies.ai → Integrations → Fireflies API. A team
 admin's key lists the whole team, and the sync also records the per-user
 usage the API reports (transcripts, minutes), which shows up in the
-roster table.
+users table.
 
 ## Where the key lives, exactly
 
@@ -82,7 +81,7 @@ about the new one.
 
 Findings deliberately carry account **domains** and identity hints, never
 full addresses - that is a privacy property of the platform, and Budget
-does not weaken it. A roster email is matched against observed identities
+does not weaken it. A user's email is matched against observed identities
 (cloud sign-in names, and people attached to devices through the identity
 map) by normalising both sides to bare letters and digits, the same trick
 the identity-map suggestions use.
@@ -99,7 +98,7 @@ view) is what turns those into names.
 Vendors sell mixed plans (Claude Team and ChatGPT Business both split
 standard from premium seats), so a subscription holds up to ten named
 tiers, each with a seat count and a per-seat monthly price. Tier names
-matter: a roster row whose seat tier matches a tier's name counts against
+matter: a user row whose seat tier matches a tier's name counts against
 that tier's seats, which is how "8 premium seats paid, 3 assigned" falls
 out. The vendor APIs do not expose per-user tiers, so tier assignment
 comes from the CSV import or the card either way.

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.3
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.3
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -2074,6 +2074,111 @@ def api_candidate_dismiss(req: CandidateDismiss, _=Depends(require_auth),
         % urllib.parse.quote(req.key, safe=""), token)
 
 
+# ------------------------------------------------------------- budget --
+# The spend view's write path: thin proxies to the receiver, which owns
+# storage, validation and the role gate, exactly like governance and the
+# registry above. POST throughout on the portal side (the JSON-only CSRF
+# rule covers POST); the receiver keeps its PUTs. The vendor API key
+# passes through one request on its way in and no route reads it back -
+# the receiver spends it server-side when the portal asks for a sync.
+
+
+class BudgetSeatTier(BaseModel):
+    model_config = {"extra": "forbid"}
+    name: str = Field(min_length=1, max_length=64)
+    seats: int = Field(default=0, ge=0, le=100000)
+    unit_price_monthly: float = Field(default=0, ge=0, le=1000000)
+
+
+class BudgetSubscriptionWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool_id: str = Field(min_length=1, max_length=100)
+    vendor: str = Field(default="", max_length=200)
+    plan: str = Field(default="", max_length=100)
+    currency: str = Field(default="", max_length=8)
+    renewal_date: str = Field(default="", max_length=10)
+    owner: str = Field(default="", max_length=200)
+    notes: str = Field(default="", max_length=1000)
+    seat_tiers: list[BudgetSeatTier] = Field(default_factory=list,
+                                             max_length=10)
+
+
+class BudgetMemberWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    email: str = Field(min_length=3, max_length=254)
+    name: str = Field(default="", max_length=200)
+    role: str = Field(default="", max_length=64)
+    seat_tier: str = Field(default="", max_length=64)
+
+
+class BudgetMembersWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool_id: str = Field(min_length=1, max_length=100)
+    source: str = Field(min_length=1, max_length=16)
+    members: list[BudgetMemberWrite] = Field(default_factory=list,
+                                             max_length=5000)
+
+
+class BudgetConnectionWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool_id: str = Field(min_length=1, max_length=100)
+    provider: str = Field(min_length=1, max_length=32)
+    api_key: str = Field(min_length=8, max_length=512)
+
+
+class BudgetToolRef(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool_id: str = Field(min_length=1, max_length=100)
+
+
+@app.get("/api/budget")
+def api_budget(_=Depends(require_auth), token: str = Depends(_admin_forward)):
+    return _receiver("GET", "/admin/budget", token)
+
+
+@app.post("/api/budget/subscription")
+def api_budget_subscription(req: BudgetSubscriptionWrite,
+                            _=Depends(require_auth),
+                            token: str = Depends(_admin_forward)):
+    return _receiver("PUT", "/admin/budget/subscription", token,
+                     req.model_dump())
+
+
+@app.post("/api/budget/subscription-delete")
+def api_budget_subscription_delete(req: BudgetToolRef,
+                                   _=Depends(require_auth),
+                                   token: str = Depends(_admin_forward)):
+    return _receiver("POST", "/admin/budget/subscription/delete", token,
+                     req.model_dump())
+
+
+@app.post("/api/budget/members")
+def api_budget_members(req: BudgetMembersWrite, _=Depends(require_auth),
+                       token: str = Depends(_admin_forward)):
+    return _receiver("PUT", "/admin/budget/members", token, req.model_dump())
+
+
+@app.post("/api/budget/connection")
+def api_budget_connection(req: BudgetConnectionWrite,
+                          _=Depends(require_auth),
+                          token: str = Depends(_admin_forward)):
+    return _receiver("PUT", "/admin/budget/connection", token,
+                     req.model_dump())
+
+
+@app.post("/api/budget/connection-delete")
+def api_budget_connection_delete(req: BudgetToolRef, _=Depends(require_auth),
+                                 token: str = Depends(_admin_forward)):
+    return _receiver("POST", "/admin/budget/connection/delete", token,
+                     req.model_dump())
+
+
+@app.post("/api/budget/sync")
+def api_budget_sync(req: BudgetToolRef, _=Depends(require_auth),
+                    token: str = Depends(_admin_forward)):
+    return _receiver("POST", "/admin/budget/sync", token, req.model_dump())
+
+
 @app.get("/")
 def index(_=Depends(require_page_auth)):
     return FileResponse(STATIC / "index.html")

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -296,6 +296,10 @@ let REGTOOLS = null, GOVDECS = null, WIZOWNER = '', WIZREVIEW = '';
 // Which log-store shape the wizard's step 2 shows, and the last result of
 // each connection test, keyed by API name, so a result survives re-renders.
 let WIZSTORE = 'self', TESTS = {};
+// The budget view: the fetched spend data, the link-a-tool wizard's state
+// (null = closed), the last action's one-line outcome, and a parsed CSV
+// preview waiting for confirmation.
+let BUDGET = null, BWIZ = null, BMSG = '', BCSV = null;
 // Whether the register's watchlist section is expanded. Tracked because a
 // decision re-renders the view, and a <details> that snaps shut under the
 // operator mid-triage would lose their place.
@@ -348,6 +352,7 @@ function showLogin(msg) {
   GOVEDIT = null; GOVPRE = null; GOVERR = ''; SETMSG = '';
   REGTOOLS = null; GOVDECS = null; TESTS = {}; WLOPEN = false;
   RENTRIES = null; REDIT = null; RPRE = null; RERR = ''; RADV = false;
+  BUDGET = null; BWIZ = null; BMSG = ''; BCSV = null;
   chrome(false);
   const create = AUTH && AUTH.setup_needed;
   app.innerHTML = `<div style="max-width:470px;margin:9vh auto 0">
@@ -402,7 +407,7 @@ async function load(force) {
   const q = force ? '?refresh=true' : '';
   // Refresh must clear the views that read a second endpoint too, or the
   // button refreshes some of the page and silently not the rest.
-  if (force) { DIAG = null; REG = null; EV = null; PG = null; FLEET = null; TOKENS = null; SETTINGS = null; REGTOOLS = null; GOVDECS = null; RENTRIES = null; CAND = null; PSTAT = null; AUDITLOG = null; USERS = null; }
+  if (force) { DIAG = null; REG = null; EV = null; PG = null; FLEET = null; TOKENS = null; SETTINGS = null; REGTOOLS = null; GOVDECS = null; RENTRIES = null; CAND = null; PSTAT = null; AUDITLOG = null; USERS = null; BUDGET = null; }
   try {
     const cr = await fetch('/api/config');
     if (cr.status === 401 && AUTH && AUTH.mode === 'login') { sessionLost(); return; }
@@ -493,6 +498,7 @@ const NAV = [
                                             ['mcp','MCP servers']]},
   {id:'governance',lbl:'Governance', items:[['register','AI register'],['registry','Tool registry'],
                                             ['paste','Paste guard'],['iso','ISO 42001 evidence']]},
+  {id:'spend',     lbl:'Budget',     items:[['budget','Budget']]},
   {id:'health',    lbl:'Health',     items:[['setup','Sources'],['coverage','Uncovered devices']]},
   {id:'managed',   lbl:'Fleet',      items:[['fleet','Devices'],['tokens','Enrollment tokens']]},
   {id:'system',    lbl:'Settings',   items:[['settings','Settings']]},
@@ -501,6 +507,7 @@ const NAVICONS = {
   home:'<path d="M3 12l9-8 9 8"/><path d="M5 10v10h14V10"/>',
   inventory:'<rect x="3" y="4" width="18" height="6" rx="1.5"/><rect x="3" y="14" width="18" height="6" rx="1.5"/>',
   governance:'<path d="M12 3l8 3v5.5c0 4.7-3.2 8.2-8 10-4.8-1.8-8-5.3-8-10V6l8-3z"/>',
+  spend:'<rect x="3" y="6" width="18" height="12" rx="2"/><path d="M3 10h18"/><path d="M7 15h4"/>',
   health:'<path d="M3 12h4l3-7 4 14 3-7h4"/>',
   managed:'<rect x="3" y="5" width="18" height="12" rx="1.5"/><path d="M8 21h8"/>',
   system:'<circle cx="12" cy="12" r="3"/><path d="M12 2v3m0 14v3M2 12h3m14 0h3M4.9 4.9l2.1 2.1m10 10l2.1 2.1M19.1 4.9l-2.1 2.1m-10 10l-2.1 2.1"/>',
@@ -2718,6 +2725,546 @@ async function tokens() {
 
 const _val = id => (document.getElementById(id)?.value || '').trim();
 
+// ------------------------------------------------------------- budget --
+// What the organisation pays for, joined against what the estate is
+// observed doing. The stored half (subscriptions, rosters, connections)
+// lives in the receiver; the observed half is the same graph every other
+// view reads. The join happens here, in the page, from data both halves
+// already sent - no new endpoint learns anything new about anyone.
+
+// A person, normalised for matching: lowercase, letters and digits only.
+// The same trick suggest_identity_rows uses server-side, for the same
+// reason - jane.smith, Jane Smith and jsmith@ need to have a chance of
+// meeting in the middle. A miss here is reported as "not matched", never
+// as "not a member", because a name that failed to normalise into an
+// email is exactly that: unmatched, not absent.
+const bNorm = s => String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+
+// Findings never carry full addresses - the platform stores account
+// DOMAINS and identity hints, deliberately - so a roster email is matched
+// on its local part against the observed identities and mapped persons.
+function bObserved(toolId) {
+  const t = (G.tools || {})[toolId] || {};
+  const names = new Set(t.identities || []);
+  let devices = 0, unlinked = 0;
+  ents(G.devices).forEach(([k, d]) => {
+    if (!(d.tools || []).includes(toolId)) return;
+    devices++;
+    if (d.person) names.add(d.person); else unlinked++;
+  });
+  const personal = (G.personal_accounts || []).filter(r => r.tool === toolId);
+  return {names: [...names], devices, unlinked, personal};
+}
+
+function bMatch(members, obs) {
+  const seen = new Map(obs.names.map(n => [bNorm(n), n]));
+  const matched = [], unobserved = [];
+  const used = new Set();
+  members.forEach(m => {
+    const keys = [bNorm(m.email.split('@')[0]), bNorm(m.name)].filter(Boolean);
+    const hit = keys.find(k => seen.has(k));
+    if (hit) { matched.push(m); used.add(hit); }
+    else unobserved.push(m);
+  });
+  const strangers = obs.names.filter(n => !used.has(bNorm(n)));
+  return {matched, unobserved, strangers};
+}
+
+const CURRENCY_SIGNS = {GBP: '£', USD: '$', EUR: '€'};
+function bMoney(n, cur) {
+  const v = Math.round(n).toLocaleString('en-GB');
+  const sign = CURRENCY_SIGNS[(cur || '').toUpperCase()];
+  return sign ? sign + v : (cur ? esc(cur) + ' ' + v : v);
+}
+
+// One CSV row, with just enough quote handling for "Last, First" name
+// cells. Not a general CSV parser and not trying to be one.
+function bCsvRow(line) {
+  const out = []; let cur = '', q = false;
+  for (const c of line) {
+    if (q) { if (c === '"') q = false; else cur += c; }
+    else if (c === '"') q = true;
+    else if (c === ',') { out.push(cur); cur = ''; }
+    else cur += c;
+  }
+  out.push(cur);
+  return out.map(s => s.trim());
+}
+
+// A pasted member export from any vendor's admin page. Column mapping is
+// by header name (email/name/role/seat, with the spellings the vendors
+// actually use); a file with no header row works when its first column
+// is the addresses. Returns {members, skipped} - skipped rows are shown,
+// never silently dropped, because a roster that quietly lost three rows
+// reads as three people who left.
+function parseRosterCsv(text) {
+  const lines = String(text || '').split(/\r?\n/)
+    .filter(l => l.trim() && !l.trim().startsWith('#'));
+  if (!lines.length) return {members: [], skipped: 0};
+  const head = bCsvRow(lines[0]).map(h => h.toLowerCase());
+  const col = names => head.findIndex(h => names.some(n => h.includes(n)));
+  let iEmail = col(['email', 'e-mail', 'mail']);
+  const hasHeader = iEmail >= 0;
+  const iName = hasHeader ? col(['name', 'member', 'user']) : -1;
+  const iRole = hasHeader ? col(['role']) : -1;
+  const iTier = hasHeader ? col(['seat', 'tier', 'license', 'licence', 'plan']) : -1;
+  if (!hasHeader) iEmail = 0;
+  const members = []; let skipped = 0;
+  const seen = new Set();
+  lines.slice(hasHeader ? 1 : 0).forEach(l => {
+    const cells = bCsvRow(l);
+    const email = (cells[iEmail] || '').toLowerCase();
+    if (!/^[^@\s]+@[^@\s]+$/.test(email) || seen.has(email)) { skipped++; return; }
+    seen.add(email);
+    members.push({
+      email,
+      name: iName >= 0 ? (cells[iName] || '') : '',
+      role: iRole >= 0 ? (cells[iRole] || '').toLowerCase() : '',
+      seat_tier: iTier >= 0 ? (cells[iTier] || '').toLowerCase() : '',
+    });
+  });
+  return {members, skipped};
+}
+
+const BPROVIDER_NONE = `ChatGPT Business (Team) has no admin API - OpenAI
+  keeps SCIM and the Compliance API for Enterprise - so its roster comes in
+  through the guided import below. That is the vendor's boundary, not this
+  page's.`;
+
+function bTierRows(tiers) {
+  const rows = [...(tiers || [])];
+  while (rows.length < Math.min(4, (tiers || []).length + 2)) rows.push({});
+  return rows.map((t, i) => `<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:6px">
+    <input id="bt-name-${i}" class="mfield" style="min-width:140px" placeholder="tier, e.g. premium"
+      value="${esc(t.name || '')}">
+    <input id="bt-seats-${i}" class="mfield" style="min-width:80px" placeholder="seats"
+      value="${t.seats != null ? esc(String(t.seats)) : ''}">
+    <input id="bt-price-${i}" class="mfield" style="min-width:120px" placeholder="price / seat / month"
+      value="${t.unit_price_monthly != null ? esc(String(t.unit_price_monthly)) : ''}">
+  </div>`).join('');
+}
+
+function bReadTiers() {
+  const tiers = [];
+  for (let i = 0; i < 6; i++) {
+    const name = _val('bt-name-' + i);
+    if (!name) continue;
+    tiers.push({name,
+      seats: parseInt(_val('bt-seats-' + i), 10) || 0,
+      unit_price_monthly: parseFloat(_val('bt-price-' + i)) || 0});
+  }
+  return tiers;
+}
+
+// Read whatever wizard inputs are on screen into BWIZ, so moving between
+// steps loses nothing.
+function bStash() {
+  const w = BWIZ; if (!w) return;
+  if (document.getElementById('bw-tool')) w.tool_id = _val('bw-tool');
+  if (document.getElementById('bw-vendor')) {
+    w.vendor = _val('bw-vendor'); w.plan = _val('bw-plan');
+  }
+  if (document.getElementById('bw-source')) {
+    w.source = (document.querySelector('input[name="bw-source"]:checked') || {}).value || w.source;
+    w.provider = (document.getElementById('bw-provider') || {}).value || w.provider;
+    if (document.getElementById('bw-key')) w.api_key = _val('bw-key');
+  }
+  if (document.getElementById('bt-name-0')) {
+    w.tiers = bReadTiers();
+    w.currency = _val('bw-currency'); w.renewal = _val('bw-renewal');
+    w.owner = _val('bw-owner');
+  }
+}
+
+function budgetWizard() {
+  const w = BWIZ;
+  const tools = (REGTOOLS || []).slice()
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const providers = (BUDGET && BUDGET.providers) || {};
+  const step = n => w.step === n;
+  const linked = new Set((BUDGET.subscriptions || []).map(s => s.tool_id));
+  return `<h2>${w.editing ? 'Edit ' + esc(w.tool_id) : 'Link a tool'}</h2>
+  <p class="lede">Three steps: which tool, where its member list comes
+  from, and what the seats cost. Everything here can be changed later.</p>
+  ${BMSG ? `<div class="note">${esc(BMSG)}</div>` : ''}
+  <div class="wcard" style="max-width:760px">
+  <p class="src-note" style="margin-top:0">step ${w.step} of 3</p>
+  ${step(1) ? `
+    <dl class="kv">
+      <dt>Tool</dt><dd>
+        ${w.editing ? `<span class="mono">${esc(w.tool_id)}</span>` : `
+        <select id="bw-tool" class="mfield" style="min-width:220px">
+          ${tools.map(t => `<option value="${esc(t.id)}"
+            ${t.id === w.tool_id ? 'selected' : ''}
+            ${linked.has(t.id) && t.id !== w.tool_id ? 'disabled' : ''}>
+            ${esc(t.name)}${linked.has(t.id) && t.id !== w.tool_id ? ' (linked)' : ''}</option>`).join('')}
+        </select>
+        <div class="src-note">The registry is the menu. A tool that is not
+        in it yet is added in the Tool registry view first, so detection
+        and spend stay one list.</div>`}</dd>
+      <dt>Vendor</dt><dd><input id="bw-vendor" class="mfield" value="${esc(w.vendor || '')}" placeholder="e.g. Anthropic"></dd>
+      <dt>Plan</dt><dd><input id="bw-plan" class="mfield" value="${esc(w.plan || '')}" placeholder="e.g. Team (standard + premium seats)"></dd>
+    </dl>
+    <button class="mini" data-act="b-step" data-key="2">next</button>` : ''}
+  ${step(2) ? `
+    <p style="margin-top:0"><strong>Where does the member list come from?</strong></p>
+    <div id="bw-source">
+    <label style="display:block;margin-bottom:6px"><input type="radio" name="bw-source" value="api"
+      ${w.source === 'api' ? 'checked' : ''}> Automatic - the vendor's admin API, synced on demand</label>
+    <label style="display:block;margin-bottom:6px"><input type="radio" name="bw-source" value="csv"
+      ${w.source === 'csv' ? 'checked' : ''}> Import - paste or upload the member export from the vendor's admin page</label>
+    <label style="display:block;margin-bottom:10px"><input type="radio" name="bw-source" value="manual"
+      ${w.source === 'manual' ? 'checked' : ''}> Manual - add members by hand on the tool's card</label>
+    </div>
+    <dl class="kv"><dt>Provider</dt><dd>
+      <select id="bw-provider" class="mfield" style="min-width:280px">
+        ${ents(providers).map(([id, p]) => `<option value="${esc(id)}"
+          ${id === w.provider ? 'selected' : ''}>${esc(p.label)}</option>`).join('')}
+      </select>
+      <div class="src-note">Only used by Automatic. ${esc(BPROVIDER_NONE)}
+      Automatic setup for more vendors lands by request: if you want a
+      particular tool supported, open an issue at
+      <a href="https://github.com/AmanSK5/shadow-ai-guard/issues" target="_blank" rel="noopener">github.com/AmanSK5/shadow-ai-guard/issues</a>.</div>
+    </dd>
+    <dt>API key</dt><dd>
+      <input id="bw-key" class="mfield" type="password" style="min-width:280px"
+        placeholder="${w.key_set ? 'saved - paste to replace' : 'paste the vendor API key'}"
+        autocomplete="off" value="${esc(w.api_key || '')}">
+      <div class="src-note">Automatic only. Stored by the receiver and
+      spent server-side; no page ever reads it back.
+      ${esc(((providers[w.provider] || {}).key_hint) || '')}</div>
+    </dd></dl>
+    <button class="mini" data-act="b-step" data-key="1">back</button>
+    <button class="mini" data-act="b-step" data-key="3">next</button>` : ''}
+  ${step(3) ? `
+    <p style="margin-top:0"><strong>Seats and pricing</strong></p>
+    ${bTierRows(w.tiers)}
+    <dl class="kv">
+      <dt>Currency</dt><dd><input id="bw-currency" class="mfield" style="min-width:80px"
+        value="${esc(w.currency || '')}" placeholder="GBP"></dd>
+      <dt>Renews</dt><dd><input id="bw-renewal" class="mfield" style="min-width:140px"
+        value="${esc(w.renewal || '')}" placeholder="YYYY-MM-DD"></dd>
+      <dt>Owner</dt><dd><input id="bw-owner" class="mfield"
+        value="${esc(w.owner || '')}" placeholder="who holds this budget"></dd>
+    </dl>
+    <p class="src-note">Tier names matter: a roster row whose seat tier
+    matches a name here is counted against that tier's seats. The vendor
+    APIs do not expose per-user tiers, so tiers come from you either way.</p>
+    <button class="mini" data-act="b-step" data-key="2">back</button>
+    <button class="mini" data-act="b-save">${w.editing ? 'save changes' : 'link tool'}</button>` : ''}
+  <p class="src-note" style="margin-bottom:0">
+    <button class="mini" data-act="b-cancel">cancel</button></p>
+  </div>`;
+}
+
+function bProvenance(sub, conn) {
+  const srcs = new Set((sub.members || []).map(m => m.source));
+  const bits = [];
+  if (conn) {
+    if (conn.last_sync_at) {
+      bits.push((conn.last_sync_ok
+        ? `roster synced via API ${when(conn.last_sync_at)}`
+        : `last API sync failed ${when(conn.last_sync_at)}: ${esc(conn.last_sync_detail)}`));
+    } else bits.push('API connection saved, never synced');
+  }
+  if (srcs.has('csv')) {
+    const at = (sub.members.filter(m => m.source === 'csv')
+      .map(m => m.updated_at).sort().pop() || '');
+    bits.push(`imported from CSV ${when(at)}`);
+  }
+  if (srcs.has('manual')) bits.push('manual entries');
+  return bits.join(' · ');
+}
+
+function budgetCard(sub) {
+  const ro = AUTH && AUTH.role === 'viewer';
+  const conn = ((BUDGET.connections || []).find(c => c.tool_id === sub.tool_id)) || null;
+  const tiers = sub.seat_tiers || [];
+  const monthly = tiers.reduce((a, t) => a + (t.seats || 0) * (t.unit_price_monthly || 0), 0);
+  const seats = tiers.reduce((a, t) => a + (t.seats || 0), 0);
+  const obs = bObserved(sub.tool_id);
+  const {matched, unobserved, strangers} = bMatch(sub.members || [], obs);
+  const days = sub.renewal_date
+    ? Math.ceil((Date.parse(sub.renewal_date) - Date.now()) / 86400000) : null;
+  const tierOf = {};
+  (sub.members || []).forEach(m => {
+    tierOf[m.seat_tier] = (tierOf[m.seat_tier] || 0) + 1;
+  });
+  const usageBits = m => {
+    const u = m.usage || {};
+    const b = [];
+    if (u.transcripts != null) b.push(u.transcripts + ' transcripts');
+    if (u.minutes != null) b.push(u.minutes + ' min');
+    return b.join(', ');
+  };
+  const memberRow = m => `<tr>
+    <td>${esc(m.email)}${m.name ? `<br><span style="font-size:11px;color:var(--mut)">${esc(m.name)}</span>` : ''}</td>
+    <td>${esc(m.role || '—')}</td><td>${esc(m.seat_tier || '—')}</td>
+    <td>${esc(usageBits(m) || '')}</td>
+    <td>${m.source === 'manual' && !ro
+      ? `<button class="mini" data-act="b-mdel" data-tool="${esc(sub.tool_id)}" data-key="${esc(m.email)}">remove</button>`
+      : `<span class="pill p-mut">${esc(m.source)}</span>`}</td></tr>`;
+  return `<div class="wcard" style="margin-bottom:12px"><h3>${esc(sub.tool_id)}
+    ${sub.plan ? `<span class="pill p-acc">${esc(sub.plan)}</span>` : ''}</h3>
+  <dl class="stats">
+    <div><dt>${bMoney(monthly, sub.currency)}</dt><dd>per month, ${seats} seats</dd></div>
+    <div><dt>${(sub.members || []).length}</dt><dd>on the company account</dd></div>
+    <div><dt>${matched.length}</dt><dd>of them observed by ai-guard</dd></div>
+    <div><dt${unobserved.length ? ' style="color:var(--warn)"' : ''}>${unobserved.length}</dt><dd>paid seats never observed</dd></div>
+    <div><dt${strangers.length ? ' style="color:var(--warn)"' : ''}>${strangers.length}</dt><dd>observed users not matched to a seat</dd></div>
+    <div><dt${obs.personal.length ? ' style="color:var(--dstr)"' : ''}>${obs.personal.length}</dt><dd>personal-account uses</dd></div>
+  </dl>
+  ${days != null ? `<p class="src-note">renews ${when(sub.renewal_date)}
+    ${days <= 30 ? `<span class="pill p-amb">${days <= 0 ? 'past due' : 'in ' + days + 'd'}</span>` : ''}
+    ${sub.owner ? ' · owner: ' + esc(sub.owner) : ''}</p>` : ''}
+  ${tiers.length ? `<table class="plain"><tr><th>tier</th><th>seats paid</th><th>assigned on roster</th><th>price/seat</th><th>monthly</th></tr>
+    ${tiers.map(t => `<tr><td>${esc(t.name)}</td><td class="num">${t.seats}</td>
+      <td class="num">${tierOf[t.name] || 0}</td>
+      <td class="num">${bMoney(t.unit_price_monthly, sub.currency)}</td>
+      <td class="num">${bMoney((t.seats || 0) * (t.unit_price_monthly || 0), sub.currency)}</td></tr>`).join('')}</table>` : ''}
+  ${(sub.members || []).length ? `<details style="margin-top:8px"><summary>Roster
+      (${(sub.members || []).length}) — ${bProvenance(sub, conn) || 'manual'}</summary>
+    <table><tr><th>member</th><th>role</th><th>seat</th><th>vendor usage</th><th>source</th></tr>
+    ${(sub.members || []).map(memberRow).join('')}</table></details>`
+    : `<p class="src-note">No roster yet${conn ? ' - run a sync' : ''}.</p>`}
+  ${unobserved.length ? `<details><summary>${unobserved.length} paid
+      ${unobserved.length === 1 ? 'seat' : 'seats'} with no observed use — downgrade candidates</summary>
+    <p class="src-note">"Never observed" means no detection surface has
+    matched this member to activity on ${esc(sub.tool_id)} in the current
+    window. Coverage gaps look the same as absence: check the Sources view
+    before acting on this list.</p>
+    <ul>${unobserved.map(m => `<li>${esc(m.email)}${m.seat_tier ? ` <span class="pill p-mut">${esc(m.seat_tier)}</span>` : ''}</li>`).join('')}</ul></details>` : ''}
+  ${strangers.length ? `<details><summary>${strangers.length} observed
+      ${strangers.length === 1 ? 'user' : 'users'} not matched to any seat</summary>
+    <p class="src-note">Observed identities that matched nobody on the
+    roster. Matching is by name, and a miss is "unmatched", not proof
+    someone is unlicensed - but several of these alongside personal
+    accounts below is the shadow-spend picture this page exists for.</p>
+    <ul>${strangers.map(n => `<li>${esc(n)}</li>`).join('')}</ul></details>` : ''}
+  ${obs.personal.length ? `<details><summary style="color:var(--dstr)">${obs.personal.length}
+      personal-account ${obs.personal.length === 1 ? 'use' : 'uses'} of ${esc(sub.tool_id)}</summary>
+    <table><tr><th>who</th><th>account domain</th><th>device</th><th>last seen</th></tr>
+    ${obs.personal.map(r => `<tr><td>${esc(r.user || '—')}</td>
+      <td class="mono">${esc(r.account_domain)}</td>
+      <td>${esc(r.device_name || r.device || '—')}</td>
+      <td>${when(r.last_seen)}</td></tr>`).join('')}</table>
+    <p class="src-note">These are on the Personal accounts view too; they
+    appear here because paying for seats while personal accounts carry the
+    same tool is exactly the spend question.</p></details>` : ''}
+  ${obs.unlinked ? `<p class="src-note">${obs.unlinked}
+    device${obs.unlinked === 1 ? '' : 's'} run${obs.unlinked === 1 ? 's' : ''}
+    ${esc(sub.tool_id)} with no person attached - not counted anywhere
+    above. An identity map (Sources view) links them.</p>` : ''}
+  ${ro ? '' : `<div style="margin-top:10px;display:flex;gap:6px;flex-wrap:wrap">
+    ${conn ? `<button class="mini" data-act="b-sync" data-key="${esc(sub.tool_id)}">sync roster now</button>` : ''}
+    <button class="mini" data-act="b-edit" data-key="${esc(sub.tool_id)}">edit</button>
+    <button class="mini" data-act="b-import" data-key="${esc(sub.tool_id)}">import roster CSV</button>
+    <button class="mini" data-act="b-unlink" data-key="${esc(sub.tool_id)}">unlink</button>
+  </div>
+  <div style="margin-top:8px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
+    <input id="bm-email-${esc(sub.tool_id)}" class="mfield" placeholder="add member: email" autocomplete="off">
+    <input id="bm-tier-${esc(sub.tool_id)}" class="mfield" style="min-width:110px" placeholder="seat tier">
+    <button class="mini" data-act="b-madd" data-key="${esc(sub.tool_id)}">add</button>
+  </div>`}
+  </div>`;
+}
+
+function budgetImport() {
+  const parsed = BCSV && BCSV.parsed;
+  return `<h2>Import roster — ${esc(BCSV.tool_id)}</h2>
+  <p class="lede">Paste the member export from the vendor's admin page
+  (ChatGPT Business: Workspace settings → Members; Claude: Organization
+  settings → Members). A header row with email / name / role / seat
+  columns is understood; so is a plain list of addresses.</p>
+  ${BMSG ? `<div class="note">${esc(BMSG)}</div>` : ''}
+  <div class="wcard" style="max-width:760px">
+  <textarea id="b-csv" class="mfield" style="width:100%;min-height:140px;font-family:var(--monofont,monospace)"
+    placeholder="email,role,seat type&#10;jane@corp.example,member,premium">${esc(BCSV.text || '')}</textarea>
+  <div style="margin-top:8px;display:flex;gap:6px">
+    <button class="mini" data-act="b-csv-parse">preview</button>
+    <button class="mini" data-act="b-csv-cancel">cancel</button>
+    ${parsed && parsed.members.length ? `<button class="mini" data-act="b-csv-save">import ${parsed.members.length} members</button>` : ''}
+  </div>
+  ${parsed ? `<p class="src-note">${parsed.members.length} rows understood,
+    ${parsed.skipped} skipped (no address, or a duplicate). Importing
+    replaces the previous CSV import for this tool; API-synced and manual
+    rows are untouched.</p>
+    ${parsed.members.length ? `<table><tr><th>email</th><th>role</th><th>seat</th></tr>
+    ${parsed.members.slice(0, 8).map(m => `<tr><td>${esc(m.email)}</td>
+      <td>${esc(m.role || '—')}</td><td>${esc(m.seat_tier || '—')}</td></tr>`).join('')}
+    ${parsed.members.length > 8 ? `<tr><td colspan="3" style="color:var(--mut)">… and ${parsed.members.length - 8} more</td></tr>` : ''}</table>` : ''}` : ''}
+  </div>`;
+}
+
+async function budget() {
+  const gate = managedGate('Budget'); if (gate) return gate;
+  if (!BUDGET) {
+    const r = await mfetch('/api/budget');
+    if (!r.ok) return managedError(r, 'Budget');
+    BUDGET = await r.json();
+  }
+  if (!REGTOOLS) {
+    const r = await fetch('/api/registry-tools');
+    REGTOOLS = r.ok ? (await r.json()).tools || [] : [];
+  }
+  if (BCSV) return budgetImport();
+  if (BWIZ) return budgetWizard();
+  const ro = AUTH && AUTH.role === 'viewer';
+  const subs = BUDGET.subscriptions || [];
+  const total = subs.reduce((a, s) => a + (s.seat_tiers || []).reduce(
+    (x, t) => x + (t.seats || 0) * (t.unit_price_monthly || 0), 0), 0);
+  // One headline number is only honest when everything is priced in one
+  // currency; a £ sign over a sum that mixes currencies would be a number
+  // that lies. Mixed gets the bare figure and says why.
+  const curs = new Set(subs.map(s => (s.currency || '').toUpperCase()));
+  const mixed = curs.size > 1;
+  const cur = mixed ? '' : [...curs][0] || '';
+  return `<h2>Budget</h2>
+  <p class="lede">The AI tools the organisation pays for, against what the
+  estate is observed doing: seats nobody uses, users no seat covers, and
+  personal accounts running alongside paid ones. Rosters come from a
+  vendor's admin API where one exists, or a CSV export where one does not -
+  the numbers work the same either way and each card says which it is.</p>
+  ${BMSG ? `<div class="note">${esc(BMSG)}</div>` : ''}
+  ${subs.length ? `<dl class="stats" style="margin-bottom:14px">
+    <div><dt>${bMoney(total, cur)}</dt><dd>tracked spend / month${mixed ? ' (mixed currencies)' : ''}</dd></div>
+    <div><dt>${subs.length}</dt><dd>tools linked</dd></div>
+  </dl>` : ''}
+  ${subs.map(budgetCard).join('')}
+  ${subs.length ? '' : `<div class="note">Nothing linked yet. Link a tool
+    to record what it costs and see the roster-versus-reality picture the
+    detection data already holds.</div>`}
+  ${ro ? '' : `<p style="margin-top:10px">
+    <button class="mini" data-act="b-open">Link a tool</button></p>`}
+  <p class="src-note">Automatic roster sync currently supports
+  ${ents((BUDGET.providers) || {}).map(([, p]) => esc(p.label)).join(' and ') || 'no vendors yet'}.
+  More vendors will be added for automatic configuration - if you want a
+  particular tool, please raise an issue on
+  <a href="https://github.com/AmanSK5/shadow-ai-guard/issues" target="_blank" rel="noopener">GitHub</a>.
+  ChatGPT Business has no admin API on that plan, so it uses the CSV
+  import.</p>`;
+}
+
+async function budgetAction(act, el) {
+  const key = el ? el.getAttribute('data-key') : '';
+  const post = async (path, body) => {
+    const r = await mfetch(path, {method: 'POST', body: JSON.stringify(body)});
+    if (r.status === 401) { sessionLost(); return null; }
+    return r;
+  };
+  if (act === 'b-open') {
+    BMSG = '';
+    BWIZ = {step: 1, tool_id: (REGTOOLS || [])[0] ? REGTOOLS[0].id : '',
+            source: 'csv', provider: 'anthropic', tiers: [], api_key: ''};
+    render(); return;
+  }
+  if (act === 'b-edit') {
+    const sub = (BUDGET.subscriptions || []).find(s => s.tool_id === key);
+    const conn = (BUDGET.connections || []).find(c => c.tool_id === key);
+    BMSG = '';
+    BWIZ = {step: 1, editing: true, tool_id: key, vendor: sub.vendor,
+            plan: sub.plan, source: conn ? 'api' : 'csv',
+            provider: conn ? conn.provider : 'anthropic', api_key: '',
+            key_set: !!conn, tiers: sub.seat_tiers || [],
+            currency: sub.currency, renewal: sub.renewal_date,
+            owner: sub.owner};
+    render(); return;
+  }
+  if (act === 'b-cancel') { BWIZ = null; BMSG = ''; render(); return; }
+  if (act === 'b-step') { bStash(); BWIZ.step = parseInt(key, 10); render(); return; }
+  if (act === 'b-save') {
+    bStash();
+    const w = BWIZ;
+    if (!w.tool_id) { BMSG = 'Pick a tool first.'; render(); return; }
+    let r = await post('/api/budget/subscription', {
+      tool_id: w.tool_id, vendor: w.vendor || '', plan: w.plan || '',
+      currency: (w.currency || '').toUpperCase(), renewal_date: w.renewal || '',
+      owner: w.owner || '', seat_tiers: w.tiers || []});
+    if (!r) return;
+    if (!r.ok) { BMSG = 'Not saved: ' + await _refusal(r); render(); return; }
+    if (w.source === 'api' && w.api_key) {
+      r = await post('/api/budget/connection', {
+        tool_id: w.tool_id, provider: w.provider, api_key: w.api_key});
+      if (!r) return;
+      if (!r.ok) { BMSG = 'Subscription saved, but the connection was refused: '
+        + await _refusal(r); BUDGET = null; BWIZ = null; render(); return; }
+      const s = await post('/api/budget/sync', {tool_id: w.tool_id});
+      if (!s) return;
+      const out = s.ok ? await s.json() : {ok: false, detail: await _refusal(s)};
+      BMSG = out.ok ? `Linked. Synced ${out.count} members from the vendor.`
+        : 'Linked, but the first sync failed: ' + out.detail;
+    } else if (w.source === 'csv' && !w.editing) {
+      BWIZ = null; BUDGET = null;
+      BCSV = {tool_id: w.tool_id, text: '', parsed: null};
+      BMSG = '';
+      render(); return;
+    } else BMSG = w.editing ? 'Saved.' : 'Linked. Add the roster from the card.';
+    BWIZ = null; BUDGET = null; render(); return;
+  }
+  if (act === 'b-sync') {
+    const r = await post('/api/budget/sync', {tool_id: key});
+    if (!r) return;
+    const out = r.ok ? await r.json() : {ok: false, detail: await _refusal(r)};
+    BMSG = out.ok ? `Synced ${out.count} members for ${key}.`
+      : `Sync failed for ${key}: ` + out.detail;
+    BUDGET = null; render(); return;
+  }
+  if (act === 'b-unlink') {
+    const r = await post('/api/budget/subscription-delete', {tool_id: key});
+    if (!r) return;
+    BMSG = r.ok ? `Unlinked ${key}. Its roster and any stored key went with it.`
+      : 'Not unlinked: ' + await _refusal(r);
+    BUDGET = null; render(); return;
+  }
+  if (act === 'b-import') {
+    BMSG = ''; BCSV = {tool_id: key, text: '', parsed: null};
+    render(); return;
+  }
+  if (act === 'b-csv-parse') {
+    BCSV.text = document.getElementById('b-csv').value;
+    BCSV.parsed = parseRosterCsv(BCSV.text);
+    BMSG = ''; render(); return;
+  }
+  if (act === 'b-csv-cancel') { BCSV = null; BMSG = ''; render(); return; }
+  if (act === 'b-csv-save') {
+    const r = await post('/api/budget/members', {
+      tool_id: BCSV.tool_id, source: 'csv', members: BCSV.parsed.members});
+    if (!r) return;
+    BMSG = r.ok ? `Imported ${BCSV.parsed.members.length} members for ${BCSV.tool_id}.`
+      : 'Not imported: ' + await _refusal(r);
+    if (r.ok) { BCSV = null; BUDGET = null; }
+    render(); return;
+  }
+  if (act === 'b-madd') {
+    const email = _val('bm-email-' + key), tier = _val('bm-tier-' + key);
+    if (!email) return;
+    const sub = (BUDGET.subscriptions || []).find(s => s.tool_id === key);
+    const manual = (sub.members || []).filter(m => m.source === 'manual')
+      .map(m => ({email: m.email, name: m.name, role: m.role,
+                  seat_tier: m.seat_tier}));
+    manual.push({email, seat_tier: tier});
+    const r = await post('/api/budget/members',
+                         {tool_id: key, source: 'manual', members: manual});
+    if (!r) return;
+    BMSG = r.ok ? '' : 'Not added: ' + await _refusal(r);
+    if (r.ok) BUDGET = null;
+    render(); return;
+  }
+  if (act === 'b-mdel') {
+    const tool = el.getAttribute('data-tool');
+    const sub = (BUDGET.subscriptions || []).find(s => s.tool_id === tool);
+    const manual = (sub.members || [])
+      .filter(m => m.source === 'manual' && m.email !== key)
+      .map(m => ({email: m.email, name: m.name, role: m.role,
+                  seat_tier: m.seat_tier}));
+    const r = await post('/api/budget/members',
+                         {tool_id: tool, source: 'manual', members: manual});
+    if (!r) return;
+    if (r.ok) BUDGET = null;
+    render(); return;
+  }
+}
+
 // Set, accept or clear a finding's lifecycle status, then refresh the
 // local copy so the row shows the answer that was just recorded.
 async function paWrite(key, status, reason) {
@@ -2742,6 +3289,7 @@ async function _refusal(r) {
 }
 
 async function managedAction(act, el) {
+  if (act.startsWith('b-')) return budgetAction(act, el);
   if (act === 'user-create') {
     const role = (document.getElementById('user-role') || {}).value || 'viewer';
     const r = await mfetch('/api/users', {method: 'POST', body: JSON.stringify(
@@ -3206,6 +3754,7 @@ async function render() {
   if (view === 'wizard') { app.innerHTML = await wizard(); return; }
   if (view === 'extsetup') { app.innerHTML = await extSetup(); return; }
   if (view === 'registry') { app.innerHTML = tb + await registryView(); return; }
+  if (view === 'budget') { app.innerHTML = tb + await budget(); return; }
   app.innerHTML = tb + ({setup, overview, devices, people, tools, coverage,
                          dashboard, personal, mcp})[view]();
 }

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2727,7 +2727,7 @@ const _val = id => (document.getElementById(id)?.value || '').trim();
 
 // ------------------------------------------------------------- budget --
 // What the organisation pays for, joined against what the estate is
-// observed doing. The stored half (subscriptions, rosters, connections)
+// observed doing. The stored half (subscriptions, user lists, connections)
 // lives in the receiver; the observed half is the same graph every other
 // view reads. The join happens here, in the page, from data both halves
 // already sent - no new endpoint learns anything new about anyone.
@@ -2741,7 +2741,7 @@ const _val = id => (document.getElementById(id)?.value || '').trim();
 const bNorm = s => String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
 
 // Findings never carry full addresses - the platform stores account
-// DOMAINS and identity hints, deliberately - so a roster email is matched
+// DOMAINS and identity hints, deliberately - so a user's email is matched
 // on its local part against the observed identities and mapped persons.
 function bObserved(toolId) {
   const t = (G.tools || {})[toolId] || {};
@@ -2795,9 +2795,9 @@ function bCsvRow(line) {
 // by header name (email/name/role/seat, with the spellings the vendors
 // actually use); a file with no header row works when its first column
 // is the addresses. Returns {members, skipped} - skipped rows are shown,
-// never silently dropped, because a roster that quietly lost three rows
+// never silently dropped, because an import that quietly lost three rows
 // reads as three people who left.
-function parseRosterCsv(text) {
+function parseUsersCsv(text) {
   const lines = String(text || '').split(/\r?\n/)
     .filter(l => l.trim() && !l.trim().startsWith('#'));
   if (!lines.length) return {members: [], skipped: 0};
@@ -2827,7 +2827,7 @@ function parseRosterCsv(text) {
 }
 
 const BPROVIDER_NONE = `ChatGPT Business (Team) has no admin API - OpenAI
-  keeps SCIM and the Compliance API for Enterprise - so its roster comes in
+  keeps SCIM and the Compliance API for Enterprise - so its users come in
   through the guided import below. That is the vendor's boundary, not this
   page's.`;
 
@@ -2947,7 +2947,7 @@ function budgetWizard() {
       <dt>Owner</dt><dd><input id="bw-owner" class="mfield"
         value="${esc(w.owner || '')}" placeholder="who holds this budget"></dd>
     </dl>
-    <p class="src-note">Tier names matter: a roster row whose seat tier
+    <p class="src-note">Tier names matter: a user row whose seat tier
     matches a name here is counted against that tier's seats. The vendor
     APIs do not expose per-user tiers, so tiers come from you either way.</p>
     <button class="mini" data-act="b-step" data-key="2">back</button>
@@ -2963,7 +2963,7 @@ function bProvenance(sub, conn) {
   if (conn) {
     if (conn.last_sync_at) {
       bits.push((conn.last_sync_ok
-        ? `roster synced via API ${when(conn.last_sync_at)}`
+        ? `users synced via API ${when(conn.last_sync_at)}`
         : `last API sync failed ${when(conn.last_sync_at)}: ${esc(conn.last_sync_detail)}`));
     } else bits.push('API connection saved, never synced');
   }
@@ -3017,16 +3017,16 @@ function budgetCard(sub) {
   ${days != null ? `<p class="src-note">renews ${when(sub.renewal_date)}
     ${days <= 30 ? `<span class="pill p-amb">${days <= 0 ? 'past due' : 'in ' + days + 'd'}</span>` : ''}
     ${sub.owner ? ' · owner: ' + esc(sub.owner) : ''}</p>` : ''}
-  ${tiers.length ? `<table class="plain"><tr><th>tier</th><th>seats paid</th><th>assigned on roster</th><th>price/seat</th><th>monthly</th></tr>
+  ${tiers.length ? `<table class="plain"><tr><th>tier</th><th>seats paid</th><th>assigned to users</th><th>price/seat</th><th>monthly</th></tr>
     ${tiers.map(t => `<tr><td>${esc(t.name)}</td><td class="num">${t.seats}</td>
       <td class="num">${tierOf[t.name] || 0}</td>
       <td class="num">${bMoney(t.unit_price_monthly, sub.currency)}</td>
       <td class="num">${bMoney((t.seats || 0) * (t.unit_price_monthly || 0), sub.currency)}</td></tr>`).join('')}</table>` : ''}
-  ${(sub.members || []).length ? `<details style="margin-top:8px"><summary>Roster
+  ${(sub.members || []).length ? `<details style="margin-top:8px"><summary>Users
       (${(sub.members || []).length}) — ${bProvenance(sub, conn) || 'manual'}</summary>
     <table><tr><th>member</th><th>role</th><th>seat</th><th>vendor usage</th><th>source</th></tr>
     ${(sub.members || []).map(memberRow).join('')}</table></details>`
-    : `<p class="src-note">No roster yet${conn ? ' - run a sync' : ''}.</p>`}
+    : `<p class="src-note">No users yet${conn ? ' - run a sync' : ''}.</p>`}
   ${unobserved.length ? `<details><summary>${unobserved.length} paid
       ${unobserved.length === 1 ? 'seat' : 'seats'} with no observed use — downgrade candidates</summary>
     <p class="src-note">"Never observed" means no detection surface has
@@ -3037,7 +3037,7 @@ function budgetCard(sub) {
   ${strangers.length ? `<details><summary>${strangers.length} observed
       ${strangers.length === 1 ? 'user' : 'users'} not matched to any seat</summary>
     <p class="src-note">Observed identities that matched nobody on the
-    roster. Matching is by name, and a miss is "unmatched", not proof
+    user list. Matching is by name, and a miss is "unmatched", not proof
     someone is unlicensed - but several of these alongside personal
     accounts below is the shadow-spend picture this page exists for.</p>
     <ul>${strangers.map(n => `<li>${esc(n)}</li>`).join('')}</ul></details>` : ''}
@@ -3056,9 +3056,9 @@ function budgetCard(sub) {
     ${esc(sub.tool_id)} with no person attached - not counted anywhere
     above. An identity map (Sources view) links them.</p>` : ''}
   ${ro ? '' : `<div style="margin-top:10px;display:flex;gap:6px;flex-wrap:wrap">
-    ${conn ? `<button class="mini" data-act="b-sync" data-key="${esc(sub.tool_id)}">sync roster now</button>` : ''}
+    ${conn ? `<button class="mini" data-act="b-sync" data-key="${esc(sub.tool_id)}">sync users now</button>` : ''}
     <button class="mini" data-act="b-edit" data-key="${esc(sub.tool_id)}">edit</button>
-    <button class="mini" data-act="b-import" data-key="${esc(sub.tool_id)}">import roster CSV</button>
+    <button class="mini" data-act="b-import" data-key="${esc(sub.tool_id)}">import users</button>
     <button class="mini" data-act="b-unlink" data-key="${esc(sub.tool_id)}">unlink</button>
   </div>
   <div style="margin-top:8px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
@@ -3071,7 +3071,7 @@ function budgetCard(sub) {
 
 function budgetImport() {
   const parsed = BCSV && BCSV.parsed;
-  return `<h2>Import roster — ${esc(BCSV.tool_id)}</h2>
+  return `<h2>Import users — ${esc(BCSV.tool_id)}</h2>
   <p class="lede">Paste the member export from the vendor's admin page
   (ChatGPT Business: Workspace settings → Members; Claude: Organization
   settings → Members). A header row with email / name / role / seat
@@ -3122,7 +3122,7 @@ async function budget() {
   return `<h2>Budget</h2>
   <p class="lede">The AI tools the organisation pays for, against what the
   estate is observed doing: seats nobody uses, users no seat covers, and
-  personal accounts running alongside paid ones. Rosters come from a
+  personal accounts running alongside paid ones. User lists come from a
   vendor's admin API where one exists, or a CSV export where one does not -
   the numbers work the same either way and each card says which it is.</p>
   ${BMSG ? `<div class="note">${esc(BMSG)}</div>` : ''}
@@ -3132,11 +3132,11 @@ async function budget() {
   </dl>` : ''}
   ${subs.map(budgetCard).join('')}
   ${subs.length ? '' : `<div class="note">Nothing linked yet. Link a tool
-    to record what it costs and see the roster-versus-reality picture the
+    to record what it costs and see the users-versus-reality picture the
     detection data already holds.</div>`}
   ${ro ? '' : `<p style="margin-top:10px">
     <button class="mini" data-act="b-open">Link a tool</button></p>`}
-  <p class="src-note">Automatic roster sync currently supports
+  <p class="src-note">Automatic user sync currently supports
   ${ents((BUDGET.providers) || {}).map(([, p]) => esc(p.label)).join(' and ') || 'no vendors yet'}.
   More vendors will be added for automatic configuration - if you want a
   particular tool, please raise an issue on
@@ -3198,7 +3198,7 @@ async function budgetAction(act, el) {
       BCSV = {tool_id: w.tool_id, text: '', parsed: null};
       BMSG = '';
       render(); return;
-    } else BMSG = w.editing ? 'Saved.' : 'Linked. Add the roster from the card.';
+    } else BMSG = w.editing ? 'Saved.' : 'Linked. Add users from the card.';
     BWIZ = null; BUDGET = null; render(); return;
   }
   if (act === 'b-sync') {
@@ -3212,7 +3212,7 @@ async function budgetAction(act, el) {
   if (act === 'b-unlink') {
     const r = await post('/api/budget/subscription-delete', {tool_id: key});
     if (!r) return;
-    BMSG = r.ok ? `Unlinked ${key}. Its roster and any stored key went with it.`
+    BMSG = r.ok ? `Unlinked ${key}. Its users and any stored key went with it.`
       : 'Not unlinked: ' + await _refusal(r);
     BUDGET = null; render(); return;
   }
@@ -3222,7 +3222,7 @@ async function budgetAction(act, el) {
   }
   if (act === 'b-csv-parse') {
     BCSV.text = document.getElementById('b-csv').value;
-    BCSV.parsed = parseRosterCsv(BCSV.text);
+    BCSV.parsed = parseUsersCsv(BCSV.text);
     BMSG = ''; render(); return;
   }
   if (act === 'b-csv-cancel') { BCSV = null; BMSG = ''; render(); return; }

--- a/portal/tests/test_budget.py
+++ b/portal/tests/test_budget.py
@@ -1,0 +1,116 @@
+"""The budget proxies and the page that draws them. Same direct-call
+harness as the suite: the receiver owns storage and validation, so what
+the portal must hold is thinner and worth stating exactly - each route
+forwards the right verb to the right receiver path with the operator's
+own session, classic mode refuses with the message that names the fix,
+and the page ships with the view wired into the shell."""
+
+import os
+from pathlib import Path
+
+os.environ.setdefault("PORTAL_AUTH", "none")
+
+import pytest
+from fastapi import HTTPException
+
+from app import main
+
+INDEX = (Path(__file__).parent.parent / "app" / "static"
+         / "index.html").read_text()
+
+
+@pytest.fixture
+def receiver_spy(monkeypatch):
+    """Managed mode with the receiver replaced by a recorder."""
+    calls = []
+
+    def fake(base, method, path, token, body=None):
+        calls.append({"method": method, "path": path, "token": token,
+                      "body": body})
+        return {"ok": True}
+
+    monkeypatch.setattr(main, "RECEIVER_URL", "http://receiver:8080")
+    monkeypatch.setattr(main.managed, "receiver_request", fake)
+    return calls
+
+
+class _Req:
+    cookies = {"aiguard_session": "aigt_test"}
+
+
+# ----------------------------------------------------------- the proxies --
+
+
+def test_each_route_forwards_the_right_verb_and_path(receiver_spy):
+    token = main._admin_forward(_Req())
+
+    main.api_budget(token=token)
+    sub = main.BudgetSubscriptionWrite(
+        tool_id="claude", vendor="Anthropic", plan="Team",
+        seat_tiers=[main.BudgetSeatTier(name="premium", seats=5,
+                                        unit_price_monthly=100)])
+    main.api_budget_subscription(sub, token=token)
+    main.api_budget_members(main.BudgetMembersWrite(
+        tool_id="claude", source="csv",
+        members=[main.BudgetMemberWrite(email="a@corp.example")]),
+        token=token)
+    main.api_budget_connection(main.BudgetConnectionWrite(
+        tool_id="claude", provider="anthropic",
+        api_key="sk-ant-api01-test"), token=token)
+    main.api_budget_sync(main.BudgetToolRef(tool_id="claude"), token=token)
+    main.api_budget_connection_delete(main.BudgetToolRef(tool_id="claude"),
+                                      token=token)
+    main.api_budget_subscription_delete(main.BudgetToolRef(tool_id="claude"),
+                                        token=token)
+
+    got = [(c["method"], c["path"]) for c in receiver_spy]
+    assert got == [
+        ("GET", "/admin/budget"),
+        ("PUT", "/admin/budget/subscription"),
+        ("PUT", "/admin/budget/members"),
+        ("PUT", "/admin/budget/connection"),
+        ("POST", "/admin/budget/sync"),
+        ("POST", "/admin/budget/connection/delete"),
+        ("POST", "/admin/budget/subscription/delete"),
+    ]
+    # The operator's own session rides every call - the portal holds no
+    # credential of its own for this.
+    assert all(c["token"] == "aigt_test" for c in receiver_spy)
+
+
+def test_the_body_reaches_the_receiver_intact(receiver_spy):
+    token = main._admin_forward(_Req())
+    main.api_budget_connection(main.BudgetConnectionWrite(
+        tool_id="fireflies", provider="fireflies",
+        api_key="ff-key-123"), token=token)
+    body = receiver_spy[-1]["body"]
+    assert body == {"tool_id": "fireflies", "provider": "fireflies",
+                    "api_key": "ff-key-123"}
+
+
+def test_classic_mode_refuses_and_names_the_fix(monkeypatch):
+    monkeypatch.setattr(main, "RECEIVER_URL", "")
+    with pytest.raises(HTTPException) as e:
+        main._admin_forward(_Req())
+    assert e.value.status_code == 503
+    assert "RECEIVER_URL" in e.value.detail
+
+
+# ---------------------------------------------------------------- the page --
+
+
+def test_the_shell_ships_the_budget_view():
+    # The nav entry, the view function, and the fragment round trip: a view
+    # reachable only by typing its fragment is a view nobody finds.
+    assert "['budget','Budget']" in INDEX
+    assert "async function budget()" in INDEX
+    assert "view === 'budget'" in INDEX
+
+
+def test_the_wizard_names_the_honest_provider_set():
+    # ChatGPT Business gets the guided import and the page says why - the
+    # absence of an admin API on that plan is OpenAI's, and presenting it
+    # as ai-guard's gap (or hiding it) would both be wrong.
+    assert "no admin API" in INDEX
+    # The roadmap note: automatic setup grows by request, on GitHub.
+    assert "github.com/AmanSK5/shadow-ai-guard/issues" in INDEX

--- a/receiver/app/budget.py
+++ b/receiver/app/budget.py
@@ -1,4 +1,4 @@
-"""Vendor roster sync for the budget view.
+"""Vendor user sync for the budget view.
 
 Each provider here is a vendor whose admin API can list the members of a
 paid workspace. The receiver holds the connection key (state.py, the same
@@ -7,7 +7,7 @@ spends it: one outward call per sync, against a URL hardcoded below -
 never one the request supplies, so there is nothing here for a crafted
 request to point somewhere else.
 
-What a provider returns is a roster, not a judgement: email, name, the
+What a provider returns is a member list, not a judgement: email, name, the
 vendor's own role string, a seat tier where the API exposes one, and any
 usage counters the vendor reports. The reconciliation against what the
 fleet actually does happens in the portal, against findings this module
@@ -33,7 +33,7 @@ import json
 
 import httpx
 
-# One bound for every provider: a roster bigger than this is either the
+# One bound for every provider: a member list bigger than this is either the
 # wrong key (a reseller org?) or an API looping; both deserve a refusal
 # that names the cap rather than an unbounded crawl.
 MAX_MEMBERS = 5000
@@ -127,7 +127,7 @@ async def sync_anthropic(api_key: str) -> list[dict]:
                 })
                 if len(members) > MAX_MEMBERS:
                     raise SyncError("more than %d members: refusing rather "
-                                    "than store a partial roster as if it "
+                                    "than store a partial member list as if it "
                                     "were complete" % MAX_MEMBERS)
             if not body.get("has_more"):
                 return members
@@ -167,7 +167,7 @@ async def sync_fireflies(api_key: str) -> list[dict]:
     users = (body.get("data") or {}).get("users") or []
     if len(users) > MAX_MEMBERS:
         raise SyncError("more than %d members: refusing rather than store "
-                        "a partial roster as if it were complete"
+                        "a partial member list as if it were complete"
                         % MAX_MEMBERS)
     members = []
     for u in users:

--- a/receiver/app/budget.py
+++ b/receiver/app/budget.py
@@ -1,0 +1,192 @@
+"""Vendor roster sync for the budget view.
+
+Each provider here is a vendor whose admin API can list the members of a
+paid workspace. The receiver holds the connection key (state.py, the same
+recoverable-by-design trade as the log store password) and this module
+spends it: one outward call per sync, against a URL hardcoded below -
+never one the request supplies, so there is nothing here for a crafted
+request to point somewhere else.
+
+What a provider returns is a roster, not a judgement: email, name, the
+vendor's own role string, a seat tier where the API exposes one, and any
+usage counters the vendor reports. The reconciliation against what the
+fleet actually does happens in the portal, against findings this module
+never sees.
+
+Providers are deliberately few and honest about what each can do:
+
+  anthropic   Claude work orgs (Team / Enterprise). GET /v1/organizations/
+              users with a scoped admin key (read:members is enough). The
+              API paginates; seat tiers are not exposed, so tier stays
+              blank and the operator records tiers on the subscription.
+  fireflies   Fireflies.ai. One GraphQL query for the team's users, which
+              also reports per-user usage (transcripts, minutes) - the
+              rare vendor that hands over the usage half too.
+
+ChatGPT Business is the named absence: OpenAI exposes no admin API on
+that plan (SCIM and the Compliance API are Enterprise-only), so it is a
+guided CSV import in the portal, and the wizard says so rather than
+pretending a connector could exist.
+"""
+
+import json
+
+import httpx
+
+# One bound for every provider: a roster bigger than this is either the
+# wrong key (a reseller org?) or an API looping; both deserve a refusal
+# that names the cap rather than an unbounded crawl.
+MAX_MEMBERS = 5000
+_TIMEOUT = 15.0
+
+ANTHROPIC_URL = "https://api.anthropic.com/v1/organizations/users"
+FIREFLIES_URL = "https://api.fireflies.ai/graphql"
+
+# What the portal needs to offer the wizard: which providers exist, what
+# each one's key looks like and where an admin creates it. Data, not
+# secrets - served as-is by /admin/budget.
+PROVIDERS = {
+    "anthropic": {
+        "label": "Anthropic (Claude Team / Enterprise)",
+        "key_hint": "Scoped Admin API key with the read:members scope. The "
+                    "org's primary owner creates it at claude.ai > "
+                    "Organization settings > API (Console orgs: Settings > "
+                    "Admin keys). Select read-only scopes: this sync never "
+                    "writes.",
+        "syncs": "members and roles. Seat tiers are not in the API - "
+                 "record them on the subscription.",
+    },
+    "fireflies": {
+        "label": "Fireflies.ai",
+        "key_hint": "API key from fireflies.ai > Integrations > Fireflies "
+                    "API. A team admin's key lists the whole team.",
+        "syncs": "members, admin flag, and per-user usage (transcripts, "
+                 "minutes).",
+    },
+}
+
+
+class SyncError(Exception):
+    """A failed sync, carrying what the operator should hear. Never the
+    key, and never a raw vendor body - those are logged nowhere and
+    echoed nowhere."""
+
+
+def _refusal(status: int, vendor: str) -> SyncError:
+    if status == 401:
+        return SyncError("%s answered 401: the key is wrong, expired or "
+                         "revoked" % vendor)
+    if status == 403:
+        return SyncError("%s answered 403: the key lacks the scope this "
+                         "sync needs (read:members for Anthropic)" % vendor)
+    if status == 429:
+        return SyncError("%s answered 429 (rate limited): try again in a "
+                         "minute" % vendor)
+    return SyncError("%s answered HTTP %d" % (vendor, status))
+
+
+async def sync_anthropic(api_key: str) -> list[dict]:
+    """The org's members via the Anthropic Admin API, all pages.
+
+    Pagination is id-based: page with after_id until has_more is false.
+    The page cap backs MAX_MEMBERS - the loop cannot run away even if the
+    API misbehaves.
+    """
+    members: list[dict] = []
+    after = ""
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        for _ in range(MAX_MEMBERS // 100 + 1):
+            params = {"limit": "100"}
+            if after:
+                params["after_id"] = after
+            try:
+                r = await client.get(
+                    ANTHROPIC_URL, params=params,
+                    headers={"x-api-key": api_key,
+                             "anthropic-version": "2023-06-01"})
+            except httpx.HTTPError as e:
+                raise SyncError("could not reach the Anthropic API (%s)"
+                                % type(e).__name__)
+            if r.status_code != 200:
+                raise _refusal(r.status_code, "the Anthropic API")
+            try:
+                body = r.json()
+            except json.JSONDecodeError:
+                raise SyncError("the Anthropic API answered 200, but not "
+                                "with JSON")
+            for u in body.get("data") or []:
+                email = str(u.get("email") or "").strip().lower()
+                if not email:
+                    continue
+                members.append({
+                    "email": email,
+                    "name": str(u.get("name") or "")[:200],
+                    "role": str(u.get("role") or "")[:64],
+                    "seat_tier": "",
+                    "usage": {},
+                })
+                if len(members) > MAX_MEMBERS:
+                    raise SyncError("more than %d members: refusing rather "
+                                    "than store a partial roster as if it "
+                                    "were complete" % MAX_MEMBERS)
+            if not body.get("has_more"):
+                return members
+            after = str(body.get("last_id") or "")
+            if not after:
+                # has_more with no cursor would loop on page one forever.
+                return members
+    raise SyncError("the Anthropic API kept paginating past %d members"
+                    % MAX_MEMBERS)
+
+
+_FIREFLIES_QUERY = ("{ users { name email is_admin num_transcripts "
+                    "minutes_consumed } }")
+
+
+async def sync_fireflies(api_key: str) -> list[dict]:
+    """The team's users via the Fireflies GraphQL API, usage included."""
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        try:
+            r = await client.post(
+                FIREFLIES_URL, json={"query": _FIREFLIES_QUERY},
+                headers={"Authorization": "Bearer " + api_key})
+        except httpx.HTTPError as e:
+            raise SyncError("could not reach the Fireflies API (%s)"
+                            % type(e).__name__)
+    if r.status_code != 200:
+        raise _refusal(r.status_code, "the Fireflies API")
+    try:
+        body = r.json()
+    except json.JSONDecodeError:
+        raise SyncError("the Fireflies API answered 200, but not with JSON")
+    if body.get("errors"):
+        # GraphQL reports refusals in-band. The first message is the story
+        # ("Invalid API key", "not authorized"); the rest repeat it.
+        msg = str((body["errors"][0] or {}).get("message") or "error")[:200]
+        raise SyncError("the Fireflies API refused the query: %s" % msg)
+    users = (body.get("data") or {}).get("users") or []
+    if len(users) > MAX_MEMBERS:
+        raise SyncError("more than %d members: refusing rather than store "
+                        "a partial roster as if it were complete"
+                        % MAX_MEMBERS)
+    members = []
+    for u in users:
+        email = str(u.get("email") or "").strip().lower()
+        if not email:
+            continue
+        usage = {}
+        if u.get("num_transcripts") is not None:
+            usage["transcripts"] = int(u["num_transcripts"] or 0)
+        if u.get("minutes_consumed") is not None:
+            usage["minutes"] = round(float(u["minutes_consumed"] or 0))
+        members.append({
+            "email": email,
+            "name": str(u.get("name") or "")[:200],
+            "role": "admin" if u.get("is_admin") else "member",
+            "seat_tier": "",
+            "usage": usage,
+        })
+    return members
+
+
+SYNCERS = {"anthropic": sync_anthropic, "fireflies": sync_fireflies}

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -50,6 +50,7 @@ from pydantic import BaseModel, Field
 
 # Importing the module costs nothing stateful: the SQLite file only exists
 # once State() is instantiated, which only happens under MANAGED_MODE below.
+from . import budget as _budget
 from . import state as _state
 
 # ------------------------------------------------------------------ config --
@@ -1838,6 +1839,200 @@ def put_governance(req: GovernanceUpdate, authorization: str = Header(default=""
     for tid in req.delete:
         STATE.delete_decision(tid, by)
     return {"decisions": STATE.list_decisions()}
+
+
+# ------------------------------------------------------------- budget --
+# What the organisation pays for, per tool: subscription, seat tiers,
+# roster, and (where a vendor has an admin API) the connection that syncs
+# the roster. Storage in state.py, vendor calls in budget.py; these routes
+# validate shape and hold the role gate. The vendor key is written here
+# and never read back out by any route - sync spends it server-side.
+
+_TIER_NAME_RE = re.compile(r"^[^\x00-\x1f]{1,64}$")
+# Not RFC 5322 - a roster row needs an @ with something either side, and
+# a tighter pattern only manufactures reasons to refuse a real address.
+_EMAIL_RE = re.compile(r"^[^@\s]{1,180}@[^@\s]{1,253}$")
+
+
+class SeatTierWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    name: str = Field(min_length=1, max_length=64)
+    seats: int = Field(default=0, ge=0, le=100000)
+    unit_price_monthly: float = Field(default=0, ge=0, le=1000000)
+
+
+class BudgetSubscriptionWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool_id: str = Field(min_length=1, max_length=100)
+    vendor: str = Field(default="", max_length=200)
+    plan: str = Field(default="", max_length=100)
+    currency: str = Field(default="", max_length=8)
+    renewal_date: str = Field(default="", max_length=10)
+    owner: str = Field(default="", max_length=200)
+    notes: str = Field(default="", max_length=1000)
+    seat_tiers: list[SeatTierWrite] = Field(default_factory=list,
+                                            max_length=10)
+
+
+class BudgetMemberWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    email: str = Field(min_length=3, max_length=254)
+    name: str = Field(default="", max_length=200)
+    role: str = Field(default="", max_length=64)
+    seat_tier: str = Field(default="", max_length=64)
+
+
+class BudgetMembersWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool_id: str = Field(min_length=1, max_length=100)
+    # csv and manual only: "api" rows are written by sync alone, and a
+    # request that could claim to be a sync would let a CSV wear an
+    # API-synced provenance label in the portal.
+    source: str = Field(min_length=1, max_length=16)
+    members: list[BudgetMemberWrite] = Field(default_factory=list,
+                                             max_length=_budget.MAX_MEMBERS)
+
+
+class BudgetConnectionWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool_id: str = Field(min_length=1, max_length=100)
+    provider: str = Field(min_length=1, max_length=32)
+    api_key: str = Field(min_length=8, max_length=512)
+
+
+class BudgetToolRef(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool_id: str = Field(min_length=1, max_length=100)
+
+
+@app.get("/admin/budget")
+def get_budget(authorization: str = Header(default="")):
+    """Subscriptions with rosters, connection metadata (never keys), and
+    the provider catalogue the wizard offers."""
+    _admin_auth(authorization)
+    out = STATE.list_budget()
+    out["providers"] = _budget.PROVIDERS
+    return out
+
+
+@app.put("/admin/budget/subscription")
+def put_budget_subscription(req: BudgetSubscriptionWrite,
+                            authorization: str = Header(default="")):
+    _admin_auth(authorization, write=True)
+    if not _TOOL_ID_RE.match(req.tool_id):
+        raise HTTPException(422, "malformed tool id: %s" % req.tool_id[:60])
+    if req.renewal_date:
+        try:
+            date.fromisoformat(req.renewal_date)
+        except ValueError:
+            raise HTTPException(
+                422, "renewal_date must be an ISO date (YYYY-MM-DD)")
+    names = [t.name.strip() for t in req.seat_tiers]
+    for n in names:
+        if not _TIER_NAME_RE.match(n):
+            raise HTTPException(422, "malformed seat tier name")
+    if len(set(n.lower() for n in names)) != len(names):
+        raise HTTPException(422, "seat tier names must be unique")
+    STATE.upsert_budget_subscription(
+        req.tool_id,
+        {"vendor": req.vendor.strip(), "plan": req.plan.strip(),
+         "currency": req.currency.strip(),
+         "renewal_date": req.renewal_date, "owner": req.owner.strip(),
+         "notes": req.notes.strip(),
+         "seat_tiers": [{"name": n, "seats": t.seats,
+                         "unit_price_monthly": t.unit_price_monthly}
+                        for n, t in zip(names, req.seat_tiers)]},
+        _admin_actor(authorization))
+    return get_budget(authorization)
+
+
+@app.post("/admin/budget/subscription/delete")
+def delete_budget_subscription(req: BudgetToolRef,
+                               authorization: str = Header(default="")):
+    _admin_auth(authorization, write=True)
+    if not STATE.delete_budget_subscription(req.tool_id,
+                                            _admin_actor(authorization)):
+        raise HTTPException(404, "no subscription for that tool")
+    return get_budget(authorization)
+
+
+@app.put("/admin/budget/members")
+def put_budget_members(req: BudgetMembersWrite,
+                       authorization: str = Header(default="")):
+    """Replace the roster rows the named source owns. Validated as a
+    batch before anything is written: a 422 means nothing changed."""
+    _admin_auth(authorization, write=True)
+    if not _TOOL_ID_RE.match(req.tool_id):
+        raise HTTPException(422, "malformed tool id: %s" % req.tool_id[:60])
+    if req.source not in ("csv", "manual"):
+        raise HTTPException(422, "source must be csv or manual")
+    seen = set()
+    members = []
+    for m in req.members:
+        email = m.email.strip().lower()
+        if not _EMAIL_RE.match(email):
+            raise HTTPException(422, "not an email address: %s" % email[:60])
+        if email in seen:
+            raise HTTPException(422, "duplicate email: %s" % email[:60])
+        seen.add(email)
+        members.append({"email": email, "name": m.name.strip(),
+                        "role": m.role.strip(),
+                        "seat_tier": m.seat_tier.strip()})
+    count = STATE.replace_budget_members(req.tool_id, members, req.source,
+                                         _admin_actor(authorization))
+    return {"ok": True, "count": count}
+
+
+@app.put("/admin/budget/connection")
+def put_budget_connection(req: BudgetConnectionWrite,
+                          authorization: str = Header(default="")):
+    _admin_auth(authorization, write=True)
+    if not _TOOL_ID_RE.match(req.tool_id):
+        raise HTTPException(422, "malformed tool id: %s" % req.tool_id[:60])
+    if req.provider not in _budget.SYNCERS:
+        raise HTTPException(
+            422, "provider must be one of: " + ", ".join(_budget.SYNCERS))
+    key = req.api_key.strip()
+    if any(ord(c) < 33 for c in key):
+        raise HTTPException(422, "the API key contains whitespace or "
+                                 "control characters - check the paste")
+    STATE.set_budget_connection(req.tool_id, req.provider, key,
+                                _admin_actor(authorization))
+    return {"ok": True}
+
+
+@app.post("/admin/budget/connection/delete")
+def delete_budget_connection(req: BudgetToolRef,
+                             authorization: str = Header(default="")):
+    _admin_auth(authorization, write=True)
+    if not STATE.delete_budget_connection(req.tool_id,
+                                          _admin_actor(authorization)):
+        raise HTTPException(404, "no connection for that tool")
+    return {"ok": True}
+
+
+@app.post("/admin/budget/sync")
+async def budget_sync(req: BudgetToolRef,
+                      authorization: str = Header(default="")):
+    """One roster sync, now, with the stored connection. The failure body
+    is the operator's answer (ok: false with the reason), not a 5xx: the
+    vendor refusing a key is an expected state the page must render, and
+    the result is recorded either way so the card can show it later."""
+    _admin_auth(authorization, write=True)
+    by = _admin_actor(authorization)
+    conn = STATE.sync_connection_key(req.tool_id)
+    if conn is None:
+        raise HTTPException(404, "no connection for that tool: save one "
+                                 "first")
+    provider, key = conn
+    try:
+        members = await _budget.SYNCERS[provider](key)
+    except _budget.SyncError as e:
+        STATE.record_budget_sync(req.tool_id, False, str(e), 0, by)
+        return {"ok": False, "detail": str(e)}
+    STATE.replace_budget_members(req.tool_id, members, "api", by)
+    STATE.record_budget_sync(req.tool_id, True, "", len(members), by)
+    return {"ok": True, "count": len(members)}
 
 
 @app.post("/admin/password")

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -1843,13 +1843,13 @@ def put_governance(req: GovernanceUpdate, authorization: str = Header(default=""
 
 # ------------------------------------------------------------- budget --
 # What the organisation pays for, per tool: subscription, seat tiers,
-# roster, and (where a vendor has an admin API) the connection that syncs
-# the roster. Storage in state.py, vendor calls in budget.py; these routes
+# members, and (where a vendor has an admin API) the connection that syncs
+# them. Storage in state.py, vendor calls in budget.py; these routes
 # validate shape and hold the role gate. The vendor key is written here
 # and never read back out by any route - sync spends it server-side.
 
 _TIER_NAME_RE = re.compile(r"^[^\x00-\x1f]{1,64}$")
-# Not RFC 5322 - a roster row needs an @ with something either side, and
+# Not RFC 5322 - a member row needs an @ with something either side, and
 # a tighter pattern only manufactures reasons to refuse a real address.
 _EMAIL_RE = re.compile(r"^[^@\s]{1,180}@[^@\s]{1,253}$")
 
@@ -1907,7 +1907,7 @@ class BudgetToolRef(BaseModel):
 
 @app.get("/admin/budget")
 def get_budget(authorization: str = Header(default="")):
-    """Subscriptions with rosters, connection metadata (never keys), and
+    """Subscriptions with members, connection metadata (never keys), and
     the provider catalogue the wizard offers."""
     _admin_auth(authorization)
     out = STATE.list_budget()
@@ -1959,7 +1959,7 @@ def delete_budget_subscription(req: BudgetToolRef,
 @app.put("/admin/budget/members")
 def put_budget_members(req: BudgetMembersWrite,
                        authorization: str = Header(default="")):
-    """Replace the roster rows the named source owns. Validated as a
+    """Replace the member rows the named source owns. Validated as a
     batch before anything is written: a 422 means nothing changed."""
     _admin_auth(authorization, write=True)
     if not _TOOL_ID_RE.match(req.tool_id):
@@ -2014,7 +2014,7 @@ def delete_budget_connection(req: BudgetToolRef,
 @app.post("/admin/budget/sync")
 async def budget_sync(req: BudgetToolRef,
                       authorization: str = Header(default="")):
-    """One roster sync, now, with the stored connection. The failure body
+    """One user sync, now, with the stored connection. The failure body
     is the operator's answer (ok: false with the reason), not a 5xx: the
     vendor refusing a key is an expected state the page must render, and
     the result is recorded either way so the card can show it later."""

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -156,6 +156,41 @@ CREATE TABLE IF NOT EXISTS finding_status (
   actor  TEXT NOT NULL DEFAULT '',
   at     TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS budget_subscriptions (
+  tool_id      TEXT PRIMARY KEY,
+  vendor       TEXT NOT NULL DEFAULT '',
+  plan         TEXT NOT NULL DEFAULT '',
+  currency     TEXT NOT NULL DEFAULT '',
+  renewal_date TEXT NOT NULL DEFAULT '',
+  owner        TEXT NOT NULL DEFAULT '',
+  notes        TEXT NOT NULL DEFAULT '',
+  seat_tiers   TEXT NOT NULL DEFAULT '[]',
+  created_at   TEXT NOT NULL,
+  updated_at   TEXT NOT NULL,
+  updated_by   TEXT NOT NULL DEFAULT ''
+);
+CREATE TABLE IF NOT EXISTS budget_members (
+  tool_id    TEXT NOT NULL,
+  email      TEXT NOT NULL,
+  name       TEXT NOT NULL DEFAULT '',
+  role       TEXT NOT NULL DEFAULT '',
+  seat_tier  TEXT NOT NULL DEFAULT '',
+  source     TEXT NOT NULL DEFAULT 'manual',
+  usage      TEXT NOT NULL DEFAULT '{}',
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (tool_id, email)
+);
+CREATE TABLE IF NOT EXISTS budget_connections (
+  tool_id          TEXT PRIMARY KEY,
+  provider         TEXT NOT NULL,
+  api_key          TEXT NOT NULL,
+  last_sync_at     TEXT,
+  last_sync_ok     INTEGER NOT NULL DEFAULT 0,
+  last_sync_detail TEXT NOT NULL DEFAULT '',
+  members_synced   INTEGER NOT NULL DEFAULT 0,
+  created_at       TEXT NOT NULL,
+  updated_by       TEXT NOT NULL DEFAULT ''
+);
 """
 
 # Columns added after the first release, applied to databases that predate
@@ -710,6 +745,187 @@ class State:
                 self._event("decision_cleared", {"tool": tool_id, "by": by})
             self._db.commit()
         return bool(cur.rowcount)
+
+    # ---------------------------------------------- budget (managed) --
+    # What the organisation pays for, per tool: the subscription (plan,
+    # renewal, seat tiers with pricing), the roster of members that plan
+    # covers, and - where a vendor exposes an admin API - the connection
+    # that syncs the roster automatically. The vendor API key follows the
+    # log-store password's documented trade (SECURITY.md): recoverable by
+    # design, because the receiver must present it outward to sync, unlike
+    # fleet credentials, which are hashes. It is never echoed by any list
+    # or GET; sync_connection_key below is its only reader.
+
+    def list_budget(self) -> dict:
+        """Everything the budget view shows: subscriptions with their
+        members, and each connection's metadata - provider, sync history,
+        whether a key is stored - never the key itself."""
+        with self._lock:
+            subs = self._db.execute(
+                "SELECT tool_id, vendor, plan, currency, renewal_date,"
+                " owner, notes, seat_tiers, created_at, updated_at,"
+                " updated_by FROM budget_subscriptions ORDER BY tool_id"
+            ).fetchall()
+            members = self._db.execute(
+                "SELECT tool_id, email, name, role, seat_tier, source,"
+                " usage, updated_at FROM budget_members"
+                " ORDER BY tool_id, email"
+            ).fetchall()
+            conns = self._db.execute(
+                "SELECT tool_id, provider, last_sync_at, last_sync_ok,"
+                " last_sync_detail, members_synced, created_at, updated_by"
+                " FROM budget_connections ORDER BY tool_id"
+            ).fetchall()
+        by_tool: dict[str, list] = {}
+        for m in members:
+            by_tool.setdefault(m["tool_id"], []).append({
+                "email": m["email"], "name": m["name"], "role": m["role"],
+                "seat_tier": m["seat_tier"], "source": m["source"],
+                "usage": json.loads(m["usage"] or "{}"),
+                "updated_at": m["updated_at"],
+            })
+        return {
+            "subscriptions": [dict(
+                r, seat_tiers=json.loads(r["seat_tiers"] or "[]"),
+                members=by_tool.get(r["tool_id"], [])) for r in subs],
+            "connections": [{
+                "tool_id": c["tool_id"], "provider": c["provider"],
+                "key_set": True, "last_sync_at": c["last_sync_at"],
+                "last_sync_ok": bool(c["last_sync_ok"]),
+                "last_sync_detail": c["last_sync_detail"],
+                "members_synced": c["members_synced"],
+                "created_at": c["created_at"], "updated_by": c["updated_by"],
+            } for c in conns],
+        }
+
+    def upsert_budget_subscription(self, tool_id: str, fields: dict,
+                                   by: str = ""):
+        now = _now()
+        with self._lock:
+            self._db.execute(
+                "INSERT INTO budget_subscriptions (tool_id, vendor, plan,"
+                " currency, renewal_date, owner, notes, seat_tiers,"
+                " created_at, updated_at, updated_by)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                " ON CONFLICT(tool_id) DO UPDATE SET"
+                " vendor = excluded.vendor, plan = excluded.plan,"
+                " currency = excluded.currency,"
+                " renewal_date = excluded.renewal_date,"
+                " owner = excluded.owner, notes = excluded.notes,"
+                " seat_tiers = excluded.seat_tiers,"
+                " updated_at = excluded.updated_at,"
+                " updated_by = excluded.updated_by",
+                (tool_id, fields.get("vendor", ""), fields.get("plan", ""),
+                 fields.get("currency", ""), fields.get("renewal_date", ""),
+                 fields.get("owner", ""), fields.get("notes", ""),
+                 json.dumps(fields.get("seat_tiers") or []), now, now, by),
+            )
+            self._event("budget_subscription_saved",
+                        {"tool": tool_id, "by": by})
+            self._db.commit()
+
+    def delete_budget_subscription(self, tool_id: str, by: str = "") -> bool:
+        """The subscription and everything hanging off it: a roster or a
+        stored vendor key with no subscription is orphaned data nobody can
+        see or manage, which is the worst kind to keep."""
+        with self._lock:
+            cur = self._db.execute(
+                "DELETE FROM budget_subscriptions WHERE tool_id = ?",
+                (tool_id,))
+            self._db.execute(
+                "DELETE FROM budget_members WHERE tool_id = ?", (tool_id,))
+            self._db.execute(
+                "DELETE FROM budget_connections WHERE tool_id = ?", (tool_id,))
+            if cur.rowcount:
+                self._event("budget_subscription_deleted",
+                            {"tool": tool_id, "by": by})
+            self._db.commit()
+        return bool(cur.rowcount)
+
+    def replace_budget_members(self, tool_id: str, members: list[dict],
+                               source: str, by: str = "") -> int:
+        """Replace the roster rows this source owns; other sources' rows
+        stay. A CSV re-import replaces the previous import, an API sync
+        replaces the previous sync, and neither clobbers a manual entry.
+        The event carries counts, never addresses - the audit trail's
+        ids-only rule covers people most of all."""
+        now = _now()
+        with self._lock:
+            self._db.execute(
+                "DELETE FROM budget_members WHERE tool_id = ? AND source = ?",
+                (tool_id, source))
+            for m in members:
+                self._db.execute(
+                    "INSERT INTO budget_members (tool_id, email, name, role,"
+                    " seat_tier, source, usage, updated_at)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+                    " ON CONFLICT(tool_id, email) DO UPDATE SET"
+                    " name = excluded.name, role = excluded.role,"
+                    " seat_tier = excluded.seat_tier,"
+                    " source = excluded.source, usage = excluded.usage,"
+                    " updated_at = excluded.updated_at",
+                    (tool_id, m["email"], m.get("name", ""),
+                     m.get("role", ""), m.get("seat_tier", ""), source,
+                     json.dumps(m.get("usage") or {}), now),
+                )
+            self._event("budget_members_replaced",
+                        {"tool": tool_id, "source": source,
+                         "count": len(members), "by": by})
+            self._db.commit()
+        return len(members)
+
+    def set_budget_connection(self, tool_id: str, provider: str,
+                              api_key: str, by: str = ""):
+        """Store or replace the vendor connection. A replaced key resets
+        the sync history: what the old key last did says nothing about
+        what the new one can do."""
+        with self._lock:
+            self._db.execute(
+                "INSERT INTO budget_connections (tool_id, provider, api_key,"
+                " last_sync_at, last_sync_ok, last_sync_detail,"
+                " members_synced, created_at, updated_by)"
+                " VALUES (?, ?, ?, NULL, 0, '', 0, ?, ?)"
+                " ON CONFLICT(tool_id) DO UPDATE SET"
+                " provider = excluded.provider, api_key = excluded.api_key,"
+                " last_sync_at = NULL, last_sync_ok = 0,"
+                " last_sync_detail = '', members_synced = 0,"
+                " updated_by = excluded.updated_by",
+                (tool_id, provider, api_key, _now(), by),
+            )
+            self._event("budget_connection_saved",
+                        {"tool": tool_id, "provider": provider, "by": by})
+            self._db.commit()
+
+    def delete_budget_connection(self, tool_id: str, by: str = "") -> bool:
+        with self._lock:
+            cur = self._db.execute(
+                "DELETE FROM budget_connections WHERE tool_id = ?", (tool_id,))
+            if cur.rowcount:
+                self._event("budget_connection_deleted",
+                            {"tool": tool_id, "by": by})
+            self._db.commit()
+        return bool(cur.rowcount)
+
+    def sync_connection_key(self, tool_id: str) -> tuple[str, str] | None:
+        """(provider, api_key) for the sync call, or None. The only reader
+        of the key's plaintext; every other query masks it."""
+        with self._lock:
+            row = self._db.execute(
+                "SELECT provider, api_key FROM budget_connections"
+                " WHERE tool_id = ?", (tool_id,)).fetchone()
+        return (row["provider"], row["api_key"]) if row else None
+
+    def record_budget_sync(self, tool_id: str, ok: bool, detail: str,
+                           count: int, by: str = ""):
+        with self._lock:
+            self._db.execute(
+                "UPDATE budget_connections SET last_sync_at = ?,"
+                " last_sync_ok = ?, last_sync_detail = ?, members_synced = ?"
+                " WHERE tool_id = ?",
+                (_now(), int(ok), detail, count, tool_id))
+            self._event("budget_sync", {"tool": tool_id, "ok": ok,
+                                        "count": count, "by": by})
+            self._db.commit()
 
     # -------------------------------------- custom registry (managed) --
     # Portal-defined tools, the same shape as a shipped registry entry.

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -748,9 +748,9 @@ class State:
 
     # ---------------------------------------------- budget (managed) --
     # What the organisation pays for, per tool: the subscription (plan,
-    # renewal, seat tiers with pricing), the roster of members that plan
+    # renewal, seat tiers with pricing), the list of members that plan
     # covers, and - where a vendor exposes an admin API - the connection
-    # that syncs the roster automatically. The vendor API key follows the
+    # that syncs the members automatically. The vendor API key follows the
     # log-store password's documented trade (SECURITY.md): recoverable by
     # design, because the receiver must present it outward to sync, unlike
     # fleet credentials, which are hashes. It is never echoed by any list
@@ -825,7 +825,7 @@ class State:
             self._db.commit()
 
     def delete_budget_subscription(self, tool_id: str, by: str = "") -> bool:
-        """The subscription and everything hanging off it: a roster or a
+        """The subscription and everything hanging off it: a member list or a
         stored vendor key with no subscription is orphaned data nobody can
         see or manage, which is the worst kind to keep."""
         with self._lock:
@@ -844,7 +844,7 @@ class State:
 
     def replace_budget_members(self, tool_id: str, members: list[dict],
                                source: str, by: str = "") -> int:
-        """Replace the roster rows this source owns; other sources' rows
+        """Replace the member rows this source owns; other sources' rows
         stay. A CSV re-import replaces the previous import, an API sync
         replaces the previous sync, and neither clobbers a manual entry.
         The event carries counts, never addresses - the audit trail's

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.11.3
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/receiver/tests/test_budget.py
+++ b/receiver/tests/test_budget.py
@@ -1,0 +1,329 @@
+"""The budget store and its routes: subscriptions, rosters, connections,
+and the vendor sync.
+
+Same harness shape as test_settings. The properties held here are the
+ones that matter: the vendor key never comes back out of any route, a
+viewer can read and cannot write, a CSV import cannot wear the "api"
+provenance, and a sync failure is a rendered answer rather than a 5xx.
+"""
+
+import json
+import os
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from app import budget as budget_mod
+from app import state as state_mod
+from app.main import app
+
+client = TestClient(app)
+
+ADMIN = {"Authorization": "Bearer admin-test-token"}
+
+
+@pytest.fixture
+def managed(tmp_path, monkeypatch):
+    from app import main
+
+    st = state_mod.State(str(tmp_path / "state.db"))
+    monkeypatch.setattr(main, "STATE", st)
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"Bearer admin-test-token")
+    return st
+
+
+@pytest.fixture
+def viewer(managed):
+    """A live viewer session riding a real account."""
+    managed.create_admin("admin", "a-long-password")
+    managed.create_user("watcher", "another-long-pass", "viewer", by="admin")
+    out = managed.login("watcher", "another-long-pass")
+    return {"Authorization": "Bearer " + out["token"]}
+
+
+SUB = {"tool_id": "claude", "vendor": "Anthropic", "plan": "Team",
+       "currency": "GBP", "renewal_date": "2027-01-01", "owner": "IT",
+       "seat_tiers": [
+           {"name": "standard", "seats": 10, "unit_price_monthly": 25},
+           {"name": "premium", "seats": 5, "unit_price_monthly": 100},
+       ]}
+
+
+# ------------------------------------------------------------ mode gating --
+
+
+def test_budget_routes_do_not_exist_in_classic_mode():
+    assert client.get("/admin/budget", headers=ADMIN).status_code == 404
+    assert client.put("/admin/budget/subscription", headers=ADMIN,
+                      json=SUB).status_code == 404
+
+
+def test_budget_requires_a_credential(managed):
+    assert client.get("/admin/budget").status_code == 401
+
+
+# --------------------------------------------------------- subscriptions --
+
+
+def test_subscription_round_trip(managed):
+    r = client.put("/admin/budget/subscription", headers=ADMIN, json=SUB)
+    assert r.status_code == 200
+    subs = r.json()["subscriptions"]
+    assert len(subs) == 1
+    assert subs[0]["tool_id"] == "claude"
+    assert subs[0]["seat_tiers"][1] == {
+        "name": "premium", "seats": 5, "unit_price_monthly": 100}
+    assert subs[0]["members"] == []
+    # The provider catalogue rides along for the wizard.
+    assert "anthropic" in r.json()["providers"]
+
+
+def test_subscription_validation(managed):
+    bad = dict(SUB, renewal_date="soon")
+    assert client.put("/admin/budget/subscription", headers=ADMIN,
+                      json=bad).status_code == 422
+    bad = dict(SUB, seat_tiers=[{"name": "a", "seats": 1},
+                                {"name": "A", "seats": 2}])
+    r = client.put("/admin/budget/subscription", headers=ADMIN, json=bad)
+    assert r.status_code == 422
+    assert "unique" in r.json()["detail"]
+    bad = dict(SUB, tool_id="../etc")
+    assert client.put("/admin/budget/subscription", headers=ADMIN,
+                      json=bad).status_code == 422
+
+
+def test_delete_takes_the_roster_and_connection_with_it(managed):
+    client.put("/admin/budget/subscription", headers=ADMIN, json=SUB)
+    client.put("/admin/budget/members", headers=ADMIN, json={
+        "tool_id": "claude", "source": "csv",
+        "members": [{"email": "a@corp.example"}]})
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "claude", "provider": "anthropic",
+        "api_key": "sk-ant-api01-test"})
+    r = client.post("/admin/budget/subscription/delete", headers=ADMIN,
+                    json={"tool_id": "claude"})
+    assert r.status_code == 200
+    out = client.get("/admin/budget", headers=ADMIN).json()
+    assert out["subscriptions"] == [] and out["connections"] == []
+    assert managed.sync_connection_key("claude") is None
+
+
+# ---------------------------------------------------------------- roster --
+
+
+def test_members_replace_by_source_not_wholesale(managed):
+    client.put("/admin/budget/subscription", headers=ADMIN, json=SUB)
+    client.put("/admin/budget/members", headers=ADMIN, json={
+        "tool_id": "claude", "source": "manual",
+        "members": [{"email": "kept@corp.example", "name": "Kept"}]})
+    client.put("/admin/budget/members", headers=ADMIN, json={
+        "tool_id": "claude", "source": "csv",
+        "members": [{"email": "old@corp.example"}]})
+    # A re-import replaces the previous import and leaves manual rows.
+    client.put("/admin/budget/members", headers=ADMIN, json={
+        "tool_id": "claude", "source": "csv",
+        "members": [{"email": "new@corp.example", "seat_tier": "premium"}]})
+    ms = client.get("/admin/budget", headers=ADMIN).json()[
+        "subscriptions"][0]["members"]
+    emails = {m["email"]: m for m in ms}
+    assert set(emails) == {"kept@corp.example", "new@corp.example"}
+    assert emails["new@corp.example"]["seat_tier"] == "premium"
+    assert emails["new@corp.example"]["source"] == "csv"
+
+
+def test_members_validation(managed):
+    r = client.put("/admin/budget/members", headers=ADMIN, json={
+        "tool_id": "claude", "source": "csv",
+        "members": [{"email": "not-an-email"}]})
+    assert r.status_code == 422
+    r = client.put("/admin/budget/members", headers=ADMIN, json={
+        "tool_id": "claude", "source": "csv",
+        "members": [{"email": "a@b.example"}, {"email": "A@B.example"}]})
+    assert r.status_code == 422 and "duplicate" in r.json()["detail"]
+    # "api" provenance belongs to sync alone: a CSV must not wear it.
+    r = client.put("/admin/budget/members", headers=ADMIN, json={
+        "tool_id": "claude", "source": "api",
+        "members": [{"email": "a@b.example"}]})
+    assert r.status_code == 422
+
+
+# ------------------------------------------------------------ connections --
+
+
+def test_the_key_never_comes_back_out(managed):
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "claude", "provider": "anthropic",
+        "api_key": "sk-ant-api01-SECRETSECRET"})
+    body = json.dumps(client.get("/admin/budget", headers=ADMIN).json())
+    assert "SECRETSECRET" not in body
+    conn = client.get("/admin/budget", headers=ADMIN).json()["connections"][0]
+    assert conn["key_set"] is True and conn["provider"] == "anthropic"
+    # The audit trail keeps the rule too.
+    events = json.dumps(client.get("/admin/events", headers=ADMIN).json())
+    assert "SECRETSECRET" not in events
+
+
+def test_connection_validation(managed):
+    r = client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "claude", "provider": "chatgpt-business",
+        "api_key": "whatever-key"})
+    assert r.status_code == 422
+    r = client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "claude", "provider": "anthropic",
+        "api_key": "has a space"})
+    assert r.status_code == 422
+
+
+# -------------------------------------------------------------- role gate --
+
+
+def test_viewer_reads_and_cannot_write(managed, viewer):
+    client.put("/admin/budget/subscription", headers=ADMIN, json=SUB)
+    assert client.get("/admin/budget", headers=viewer).status_code == 200
+    assert client.put("/admin/budget/subscription", headers=viewer,
+                      json=SUB).status_code == 403
+    assert client.put("/admin/budget/members", headers=viewer, json={
+        "tool_id": "claude", "source": "csv", "members": []}).status_code == 403
+    assert client.put("/admin/budget/connection", headers=viewer, json={
+        "tool_id": "claude", "provider": "anthropic",
+        "api_key": "sk-ant-api01-x"}).status_code == 403
+    assert client.post("/admin/budget/sync", headers=viewer,
+                       json={"tool_id": "claude"}).status_code == 403
+
+
+# ------------------------------------------------------------------ sync --
+
+
+_REAL_ASYNC_CLIENT = httpx.AsyncClient
+
+
+def _mock_async_client(handler):
+    """A factory standing in for httpx.AsyncClient that answers from the
+    handler instead of the network. Binds the real class first: the patch
+    replaces httpx.AsyncClient itself, and a factory that resolved it at
+    call time would call itself forever."""
+    def factory(**kwargs):
+        kwargs.pop("transport", None)
+        return _REAL_ASYNC_CLIENT(
+            transport=httpx.MockTransport(handler), **kwargs)
+    return factory
+
+
+def test_sync_anthropic_pages_and_stores(managed, monkeypatch):
+    pages = {
+        "": {"data": [{"email": "One@Corp.example", "name": "One",
+                       "role": "user"}],
+             "has_more": True, "last_id": "u1"},
+        "u1": {"data": [{"email": "two@corp.example", "name": "Two",
+                         "role": "claude_code_user"}],
+               "has_more": False, "last_id": "u2"},
+    }
+
+    def handler(request):
+        assert request.url.host == "api.anthropic.com"
+        assert request.headers["x-api-key"] == "sk-ant-api01-k"
+        after = request.url.params.get("after_id", "")
+        return httpx.Response(200, json=pages[after])
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "claude", "provider": "anthropic",
+        "api_key": "sk-ant-api01-k"})
+    r = client.post("/admin/budget/sync", headers=ADMIN,
+                    json={"tool_id": "claude"})
+    assert r.json() == {"ok": True, "count": 2}
+
+    client.put("/admin/budget/subscription", headers=ADMIN, json=SUB)
+    out = client.get("/admin/budget", headers=ADMIN).json()
+    ms = out["subscriptions"][0]["members"]
+    assert [m["email"] for m in ms] == ["one@corp.example",
+                                       "two@corp.example"]
+    assert all(m["source"] == "api" for m in ms)
+    conn = out["connections"][0]
+    assert conn["last_sync_ok"] is True and conn["members_synced"] == 2
+
+
+def test_sync_fireflies_maps_usage(managed, monkeypatch):
+    def handler(request):
+        assert request.url.host == "api.fireflies.ai"
+        assert request.headers["Authorization"] == "Bearer ff-key-123"
+        return httpx.Response(200, json={"data": {"users": [
+            {"name": "Ash", "email": "ash@corp.example", "is_admin": True,
+             "num_transcripts": 12, "minutes_consumed": 340.7},
+        ]}})
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "fireflies", "provider": "fireflies",
+        "api_key": "ff-key-123"})
+    r = client.post("/admin/budget/sync", headers=ADMIN,
+                    json={"tool_id": "fireflies"})
+    assert r.json() == {"ok": True, "count": 1}
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=dict(SUB, tool_id="fireflies"))
+    m = client.get("/admin/budget", headers=ADMIN).json()[
+        "subscriptions"][0]["members"][0]
+    assert m["role"] == "admin"
+    assert m["usage"] == {"transcripts": 12, "minutes": 341}
+
+
+def test_sync_refusal_is_an_answer_not_a_500(managed, monkeypatch):
+    def handler(request):
+        return httpx.Response(401, json={"error": "invalid key"})
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "claude", "provider": "anthropic",
+        "api_key": "sk-ant-api01-bad"})
+    r = client.post("/admin/budget/sync", headers=ADMIN,
+                    json={"tool_id": "claude"})
+    assert r.status_code == 200
+    assert r.json()["ok"] is False and "401" in r.json()["detail"]
+    conn = client.get("/admin/budget", headers=ADMIN).json()["connections"][0]
+    assert conn["last_sync_ok"] is False and "401" in conn["last_sync_detail"]
+
+
+def test_sync_fireflies_graphql_error_is_surfaced(managed, monkeypatch):
+    def handler(request):
+        return httpx.Response(200, json={
+            "errors": [{"message": "Invalid API key"}]})
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "fireflies", "provider": "fireflies",
+        "api_key": "ff-key-bad"})
+    r = client.post("/admin/budget/sync", headers=ADMIN,
+                    json={"tool_id": "fireflies"})
+    assert r.json()["ok"] is False
+    assert "Invalid API key" in r.json()["detail"]
+
+
+def test_sync_without_a_connection_is_a_404(managed):
+    r = client.post("/admin/budget/sync", headers=ADMIN,
+                    json={"tool_id": "claude"})
+    assert r.status_code == 404
+
+
+def test_replaced_key_resets_sync_history(managed, monkeypatch):
+    def handler(request):
+        return httpx.Response(200, json={"data": [], "has_more": False})
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "claude", "provider": "anthropic",
+        "api_key": "sk-ant-api01-one"})
+    client.post("/admin/budget/sync", headers=ADMIN,
+                json={"tool_id": "claude"})
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "claude", "provider": "anthropic",
+        "api_key": "sk-ant-api01-two"})
+    conn = client.get("/admin/budget", headers=ADMIN).json()["connections"][0]
+    assert conn["last_sync_at"] is None and conn["members_synced"] == 0

--- a/receiver/tests/test_budget.py
+++ b/receiver/tests/test_budget.py
@@ -1,4 +1,4 @@
-"""The budget store and its routes: subscriptions, rosters, connections,
+"""The budget store and its routes: subscriptions, members, connections,
 and the vendor sync.
 
 Same harness shape as test_settings. The properties held here are the
@@ -95,7 +95,7 @@ def test_subscription_validation(managed):
                       json=bad).status_code == 422
 
 
-def test_delete_takes_the_roster_and_connection_with_it(managed):
+def test_delete_takes_the_members_and_connection_with_it(managed):
     client.put("/admin/budget/subscription", headers=ADMIN, json=SUB)
     client.put("/admin/budget/members", headers=ADMIN, json={
         "tool_id": "claude", "source": "csv",
@@ -111,7 +111,7 @@ def test_delete_takes_the_roster_and_connection_with_it(managed):
     assert managed.sync_connection_key("claude") is None
 
 
-# ---------------------------------------------------------------- roster --
+# --------------------------------------------------------------- members --
 
 
 def test_members_replace_by_source_not_wholesale(managed):


### PR DESCRIPTION
A Budget entry in the portal navigation. Link an AI tool the organisation pays for, record its plan, seat tiers and per-seat pricing, and give it the member list the plan covers. Each tool's card then joins that roster against what the estate is actually observed doing:

- paid seats never observed by any detection surface (downgrade candidates, with the coverage-gap caveat stated on the card)
- observed users not matched to any seat
- personal-account use of the tool running alongside the paid plan
- per-tier arithmetic: seats paid vs assigned, monthly totals, renewal warnings inside 30 days

**Roster sources.** Three, coexisting per tool, each labelled with its provenance: automatic sync from the vendor's admin API (Anthropic Claude work orgs via the scoped Admin API's `read:members`; Fireflies via its GraphQL API, which also reports per-user usage), a guided CSV import (ChatGPT Business exposes no admin API on that plan - SCIM and the Compliance API are Enterprise-only - so its member export imports directly, `email,role,seat type` shape included), and manual entries on the card. An API sync replaces the previous sync, a re-import replaces the previous import, neither touches manual rows, and a request cannot claim the `api` provenance - sync alone writes it.

**Storage and trust.** Subscriptions, rosters and connections are receiver state, next to governance and settings. The vendor API key follows the log-store password's documented trade (SECURITY.md updated): recoverable by design because the receiver must present it outward, written by one admin request, never echoed by any route, and spent server-side against vendor URLs hardcoded in the receiver - nothing request-supplied to point elsewhere. Viewers read, admins write, every write lands in the audit trail with counts, never addresses.

**Privacy.** Findings still carry account domains and identity hints only. The reconciliation runs client-side in the page, matching roster emails against observed identities by normalised name - the join is phrased honestly ("never observed", "not matched", never "unlicensed"), devices with no person attached are counted separately, and no endpoint learns anything it did not already serve.

Docs: `docs/budget.md`, README table row, SECURITY.md, TESTING.md, and a demo walkthrough in `demo/README.md` with matching seed data. Tested end to end against the compose demo: wizard, CSV import preview/skip counts, manual add/remove, failed-sync surfacing with the refusal recorded on the connection, key masking, role gates, and both themes.

No new dependencies (the receiver's vendor calls use its existing httpx), so no lockfile changes.