### PR TITLE
Budget: Claude Team plans have no admin keys

### DIFF
--- a/docs/budget.md
+++ b/docs/budget.md
@@ -29,7 +29,7 @@ Three sources, per tool, and each card names which one its rows came from:
 
 | Source | How | Good for |
 | --- | --- | --- |
-| Automatic | The vendor's admin API, synced on demand with a stored key | Anthropic (Claude Team / Enterprise), Fireflies |
+| Automatic | The vendor's admin API, synced on demand with a stored key | Anthropic (Claude Enterprise / Console), Fireflies |
 | Import | Paste the member export from the vendor's admin page | ChatGPT Business, and any vendor without an admin API |
 | Manual | Add members by hand on the card | Small teams, one-off seats |
 
@@ -52,8 +52,14 @@ its `email,role,seat type` shape directly.
 The sync needs a scoped Admin API key with the `read:members` scope. The
 organisation's **primary owner** creates it:
 
-- Claude work orgs (claude.ai): Organization settings → API → Keys
+- Claude Enterprise orgs (claude.ai): Organization settings → API → Keys
 - Claude Console (platform.claude.com) orgs: Settings → Admin keys
+
+**Claude Team plans do not offer admin keys** - the API section is
+simply absent from a Team workspace's organization settings, even for
+the primary owner. A Team workspace uses the Import path instead: copy
+the list from Organization settings → Members and paste it into the
+card's import. Everything downstream behaves identically.
 
 Select **read-only scopes** when creating it. The sync only ever lists
 members; a key that can also write members is more credential than this

--- a/receiver/app/budget.py
+++ b/receiver/app/budget.py
@@ -47,12 +47,15 @@ FIREFLIES_URL = "https://api.fireflies.ai/graphql"
 # secrets - served as-is by /admin/budget.
 PROVIDERS = {
     "anthropic": {
-        "label": "Anthropic (Claude Team / Enterprise)",
+        "label": "Anthropic (Claude Enterprise / Console)",
         "key_hint": "Scoped Admin API key with the read:members scope. The "
                     "org's primary owner creates it at claude.ai > "
                     "Organization settings > API (Console orgs: Settings > "
                     "Admin keys). Select read-only scopes: this sync never "
-                    "writes.",
+                    "writes. Claude Team plans do not offer admin keys - "
+                    "the API section simply is not there - so a Team "
+                    "workspace uses the Import path instead, from "
+                    "Organization settings > Members.",
         "syncs": "members and roles. Seat tiers are not in the API - "
                  "record them on the subscription.",
     },


### PR DESCRIPTION
Verified on a real Claude Team workspace: `claude.ai/admin-settings/api-access` redirects to the overview and no API/Keys section is offered - admin keys are an Enterprise (and Console) surface. The provider label, the wizard's key hint, and docs/budget.md now say so and point Team workspaces at the Import path (Organization settings → Members), instead of implying there is a key to go find.

Text only; no behaviour change, no chart change. Ships with the next tag.