### PR TITLE
Budget sync: refusal detail as a field, not str(exception)

### DIFF
--- a/receiver/app/budget.py
+++ b/receiver/app/budget.py
@@ -72,7 +72,17 @@ PROVIDERS = {
 class SyncError(Exception):
     """A failed sync, carrying what the operator should hear. Never the
     key, and never a raw vendor body - those are logged nowhere and
-    echoed nowhere."""
+    echoed nowhere.
+
+    The message lives in .detail, assigned from this module's own
+    templates at each raise site. The route reads that field rather than
+    str()-ing the caught exception, so nothing exception-shaped flows
+    into a response body - the property CodeQL's stack-trace-exposure
+    query checks for, held structurally instead of by convention."""
+
+    def __init__(self, detail: str):
+        self.detail = detail
+        super().__init__(detail)
 
 
 def _refusal(status: int, vendor: str) -> SyncError:

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -2028,8 +2028,11 @@ async def budget_sync(req: BudgetToolRef,
     try:
         members = await _budget.SYNCERS[provider](key)
     except _budget.SyncError as e:
-        STATE.record_budget_sync(req.tool_id, False, str(e), 0, by)
-        return {"ok": False, "detail": str(e)}
+        # e.detail, not str(e): the field is assigned only from budget.py's
+        # own message templates, so the response provably cannot carry a
+        # stack trace however the sync failed.
+        STATE.record_budget_sync(req.tool_id, False, e.detail, 0, by)
+        return {"ok": False, "detail": e.detail}
     STATE.replace_budget_members(req.tool_id, members, "api", by)
     STATE.record_budget_sync(req.tool_id, True, "", len(members), by)
     return {"ok": True, "count": len(members)}


### PR DESCRIPTION
Closes code-scanning alert #41 (py/stack-trace-exposure, medium): the sync route returned `str(e)` of a caught `SyncError` in its failure body. The messages were already operator-safe templates - that is what `SyncError` is for - but the property was held by convention, and the scanner rightly cannot see a convention.

`SyncError` now carries the message in a `.detail` field assigned only from `budget.py`'s own templates, and the route (and the recorded sync history) reads that field instead of stringifying the caught exception. No behaviour change - the same strings reach the same places - but nothing exception-shaped flows into a response body any more, which is the property the query checks, held structurally.