### PR TITLE
Budget import: detect the delimiter

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.12.1
+version: 0.12.2
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.12.1"
+appVersion: "0.12.2"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/budget.md
+++ b/docs/budget.md
@@ -57,9 +57,12 @@ organisation's **primary owner** creates it:
 
 **Claude Team plans do not offer admin keys** - the API section is
 simply absent from a Team workspace's organization settings, even for
-the primary owner. A Team workspace uses the Import path instead: copy
-the list from Organization settings → Members and paste it into the
-card's import. Everything downstream behaves identically.
+the primary owner. A Team workspace uses the Import path instead:
+Organization settings → Members has a CSV export (name, email, role,
+status, seat tier), and the import understands it directly - the seat
+tier column maps onto the subscription's tiers by name. Pasting the
+rows out of a spreadsheet works too; the parser handles tabs as well
+as commas. Everything downstream behaves identically.
 
 Select **read-only scopes** when creating it. The sync only ever lists
 members; a key that can also write members is more credential than this

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.1
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.2
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.1
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.2
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2777,44 +2777,64 @@ function bMoney(n, cur) {
   return sign ? sign + v : (cur ? esc(cur) + ' ' + v : v);
 }
 
-// One CSV row, with just enough quote handling for "Last, First" name
-// cells. Not a general CSV parser and not trying to be one.
-function bCsvRow(line) {
+// One delimited row, with just enough quote handling for "Last, First"
+// name cells. Not a general CSV parser and not trying to be one.
+function bCsvRow(line, delim) {
   const out = []; let cur = '', q = false;
   for (const c of line) {
     if (q) { if (c === '"') q = false; else cur += c; }
     else if (c === '"') q = true;
-    else if (c === ',') { out.push(cur); cur = ''; }
+    else if (c === delim) { out.push(cur); cur = ''; }
     else cur += c;
   }
   out.push(cur);
   return out.map(s => s.trim());
 }
 
-// A pasted member export from any vendor's admin page. Column mapping is
-// by header name (email/name/role/seat, with the spellings the vendors
-// actually use); a file with no header row works when its first column
-// is the addresses. Returns {members, skipped} - skipped rows are shown,
-// never silently dropped, because an import that quietly lost three rows
-// reads as three people who left.
+const B_EMAIL_RE = /^[^@\s]+@[^@\s]+$/;
+
+// A pasted member export from any vendor's admin page. The delimiter is
+// detected, not assumed: a saved .csv pastes with commas, but copying
+// the same rows out of Excel or Numbers puts TABS on the clipboard, and
+// the first deployment to try this skipped every row because the parser
+// only knew commas. Column mapping is by header name (the spellings the
+// vendors actually use - Claude's export is name,email,role,status,seat
+// tier; ChatGPT's is email,role,seat type); with no header row, the
+// email column is found by looking for an address in the first row.
+// Returns {members, skipped} - skipped rows are counted and shown, never
+// silently dropped, because an import that quietly lost three rows reads
+// as three people who left.
 function parseUsersCsv(text) {
-  const lines = String(text || '').split(/\r?\n/)
+  const lines = String(text || '').replace(/^\uFEFF/, '').split(/\r?\n/)
     .filter(l => l.trim() && !l.trim().startsWith('#'));
   if (!lines.length) return {members: [], skipped: 0};
-  const head = bCsvRow(lines[0]).map(h => h.toLowerCase());
+  const delim = lines[0].includes('\t') ? '\t'
+    : (lines[0].split(';').length > lines[0].split(',').length ? ';' : ',');
+  const row = l => bCsvRow(l, delim);
+  const head = row(lines[0]).map(h => h.toLowerCase());
+  // A header row names columns; a data row contains an address. The
+  // distinction matters because "email" appears in both a header cell
+  // and jane@example.com's cell.
+  const hasHeader = !head.some(h => B_EMAIL_RE.test(h));
   const col = names => head.findIndex(h => names.some(n => h.includes(n)));
-  let iEmail = col(['email', 'e-mail', 'mail']);
-  const hasHeader = iEmail >= 0;
-  const iName = hasHeader ? col(['name', 'member', 'user']) : -1;
-  const iRole = hasHeader ? col(['role']) : -1;
-  const iTier = hasHeader ? col(['seat', 'tier', 'license', 'licence', 'plan']) : -1;
-  if (!hasHeader) iEmail = 0;
+  let iEmail, iName = -1, iRole = -1, iTier = -1;
+  if (hasHeader) {
+    iEmail = col(['email', 'e-mail', 'mail']);
+    iName = col(['name', 'member', 'user']);
+    iRole = col(['role']);
+    iTier = col(['seat', 'tier', 'license', 'licence', 'plan']);
+    if (iEmail < 0) return {members: [], skipped: lines.length};
+  } else {
+    // No header: the email column is wherever the first row keeps its
+    // address.
+    iEmail = Math.max(0, row(lines[0]).findIndex(c => B_EMAIL_RE.test(c)));
+  }
   const members = []; let skipped = 0;
   const seen = new Set();
   lines.slice(hasHeader ? 1 : 0).forEach(l => {
-    const cells = bCsvRow(l);
+    const cells = row(l);
     const email = (cells[iEmail] || '').toLowerCase();
-    if (!/^[^@\s]+@[^@\s]+$/.test(email) || seen.has(email)) { skipped++; return; }
+    if (!B_EMAIL_RE.test(email) || seen.has(email)) { skipped++; return; }
     seen.add(email);
     members.push({
       email,
@@ -3003,9 +3023,13 @@ function budgetCard(sub) {
   const {matched, unobserved, strangers} = bMatch(sub.members || [], obs);
   const days = sub.renewal_date
     ? Math.ceil((Date.parse(sub.renewal_date) - Date.now()) / 86400000) : null;
+  // Keyed lowercase: the CSV import normalises tiers to lowercase and
+  // the wizard stores whatever the operator typed, and "Premium" not
+  // counting against "premium" would be a silent zero.
   const tierOf = {};
   (sub.members || []).forEach(m => {
-    tierOf[m.seat_tier] = (tierOf[m.seat_tier] || 0) + 1;
+    const k = (m.seat_tier || '').toLowerCase();
+    tierOf[k] = (tierOf[k] || 0) + 1;
   });
   const usageBits = m => {
     const u = m.usage || {};
@@ -3036,7 +3060,7 @@ function budgetCard(sub) {
     ${sub.owner ? ' · owner: ' + esc(sub.owner) : ''}</p>` : ''}
   ${tiers.length ? `<table class="plain"><tr><th>tier</th><th>seats paid</th><th>assigned to users</th><th>price/seat</th><th>monthly</th></tr>
     ${tiers.map(t => `<tr><td>${esc(t.name)}</td><td class="num">${t.seats}</td>
-      <td class="num">${tierOf[t.name] || 0}</td>
+      <td class="num">${tierOf[(t.name || '').toLowerCase()] || 0}</td>
       <td class="num">${bMoney(t.unit_price_monthly, sub.currency)}</td>
       <td class="num">${bMoney((t.seats || 0) * (t.unit_price_monthly || 0), sub.currency)}</td></tr>`).join('')}</table>` : ''}
   ${(sub.members || []).length ? `<details style="margin-top:8px"><summary>Users
@@ -3091,8 +3115,10 @@ function budgetImport() {
   return `<h2>Import users — ${esc(BCSV.tool_id)}</h2>
   <p class="lede">Paste the member export from the vendor's admin page
   (ChatGPT Business: Workspace settings → Members; Claude: Organization
-  settings → Members). A header row with email / name / role / seat
-  columns is understood; so is a plain list of addresses.</p>
+  settings → Members, which exports name / email / role / status / seat
+  tier). A header row with email / name / role / seat columns is
+  understood, commas or tabs - so pasting rows straight out of Excel or
+  Numbers works - and so is a plain list of addresses.</p>
   ${BMSG ? `<div class="note">${esc(BMSG)}</div>` : ''}
   <div class="wcard" style="max-width:760px">
   <textarea id="b-csv" class="mfield" style="width:100%;min-height:140px;font-family:var(--monofont,monospace)"

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.1
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.2
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Field report from the first deployment doing a real users import: pasting Claude's Team member export skipped every row.

Cause: the export was copied out of a spreadsheet, which puts tab-separated rows on the clipboard, and the parser only split on commas - each line became one cell that failed the address test (while the header still "matched", because the mega-cell contained the word email). Fixes:

- The delimiter is detected per paste: tabs, then semicolons (European Excel), then commas. Rows straight out of Excel/Numbers now parse.
- Claude's Team export shape (`name, email, role, status, seat tier`) parses as-is - and note the plan **does** have an export button, contrary to the docs' earlier guess, so docs/budget.md now says where it is and what it produces.
- Header detection is by content (a header row contains no address), so a headerless spreadsheet paste finds its email column wherever it is.
- A leading BOM is stripped; a header without any email column reports every row as skipped instead of importing nothing silently.
- Tier matching between imported rows and the subscription's tiers is case-insensitive - an exported "Premium" now counts against a tier typed "premium" instead of showing a silent zero in "assigned to users".

Verified in the demo through the real UI: a tab-separated five-column paste previews 3/0 skipped and lands on the card with tiers counted. Chart 0.12.2, appVersion 0.12.2, pins bumped to tag straight after merge.