### PR TITLE
Budget: match people by every shape their identity arrives in

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.12.2
+version: 0.12.3
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.12.2"
+appVersion: "0.12.3"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.2
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.3
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.2
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.3
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2756,17 +2756,37 @@ function bObserved(toolId) {
   return {names: [...names], devices, unlinked, personal};
 }
 
+// Every key a person can be recognised by: the whole string normalised,
+// plus the local part normalised when it is an address. The shapes in
+// play never agree - an Entra sign-in carries the full UPN
+// (jane@corp.example), a roster carries the address, a collector or an
+// identity map carries jane.smith or Jane Smith - and the first real
+// deployment proved it: whole-string-only matching left the same person
+// counted as an unused seat AND an unmatched user.
+function bKeys(s) {
+  const out = new Set();
+  const str = String(s || '');
+  const whole = bNorm(str);
+  if (whole) out.add(whole);
+  if (str.includes('@')) {
+    const local = bNorm(str.split('@')[0]);
+    if (local) out.add(local);
+  }
+  return out;
+}
+
 function bMatch(members, obs) {
-  const seen = new Map(obs.names.map(n => [bNorm(n), n]));
+  const seen = new Map();
+  obs.names.forEach(n => bKeys(n).forEach(k => seen.set(k, n)));
   const matched = [], unobserved = [];
-  const used = new Set();
+  const usedNames = new Set();
   members.forEach(m => {
-    const keys = [bNorm(m.email.split('@')[0]), bNorm(m.name)].filter(Boolean);
+    const keys = [...bKeys(m.email), ...bKeys(m.name)];
     const hit = keys.find(k => seen.has(k));
-    if (hit) { matched.push(m); used.add(hit); }
+    if (hit) { matched.push(m); usedNames.add(seen.get(hit)); }
     else unobserved.push(m);
   });
-  const strangers = obs.names.filter(n => !used.has(bNorm(n)));
+  const strangers = obs.names.filter(n => !usedNames.has(n));
   return {matched, unobserved, strangers};
 }
 

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.2
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.3
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Field report from the first real reconciliation: 13 seats imported, 12 showed "never observed", 19 observed users showed "not matched to a seat" - a near-total miss on both sides, which means the two lists never met rather than the estate actually looking like that.

Cause: the observed identities came from cloud sign-in findings, which carry full UPNs (`jane@corp.example`), while the matcher normalised roster emails to their local part only - `janecorpexample` never equals `jane`, so the same person counted as an unused seat and an unmatched user simultaneously. The demo's seeded identities are bare usernames, which is why it never surfaced there.

A person is now keyed by the normalised whole string and, when the string is an address, the normalised local part - on both sides of the join. A UPN, a roster address, a bare `jane.smith` from an identity map, and a display name all resolve to the same person; genuine strangers and genuinely unobserved seats still report as such (unit-checked against all four shapes).

Chart 0.12.3, appVersion 0.12.3, pins bumped to tag straight after merge.