### PR TITLE
Budget: preferred currency, honest totals, forgiving tier matching, spend tile

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.12.3
+version: 0.12.4
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.12.3"
+appVersion: "0.12.4"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/budget.md
+++ b/docs/budget.md
@@ -102,6 +102,16 @@ it"*; an unmatched observed user is *"not matched to a seat"*, not
 counted separately and excluded from both lists - an identity map (Sources
 view) is what turns those into names.
 
+## Currency
+
+Each subscription records its own currency - the one the vendor actually
+invoices in. The headline reports one total per currency ("£934 + $546")
+rather than converting: a converted number would drift with the exchange
+rate while the invoices it summarises would not, so the portal never
+invents one. A **preferred currency** (Settings, or step 3 of the setup
+wizard) orders the headline and prefills newly linked tools; it converts
+nothing.
+
 ## Seat tiers
 
 Vendors sell mixed plans (Claude Team and ChatGPT Business both split
@@ -110,4 +120,8 @@ tiers, each with a seat count and a per-seat monthly price. Tier names
 matter: a user row whose seat tier matches a tier's name counts against
 that tier's seats, which is how "8 premium seats paid, 3 assigned" falls
 out. The vendor APIs do not expose per-user tiers, so tier assignment
-comes from the CSV import or the card either way.
+comes from the CSV import or the card either way. Tier matching is
+forgiving: an imported "Premium seat" counts against a tier named
+"premium" (the tier's name just has to appear in the value), and
+whatever matches nothing is named under the table with a count, never
+silently dropped to zero.

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.3
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.4
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.3
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.4
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -738,9 +738,10 @@ KNOWN_WIDGETS = {
     "source_health": "Sources reporting versus silent",
     "paste_guard": "Pastes warned, overridden and blocked",
     "review_queue": "Observed tools awaiting a governance decision",
+    "budget_spend": "Tracked AI spend against observed use (managed mode)",
 }
 
-DEFAULT_WIDGETS = ["stat_row", "review_queue", "top_tools",
+DEFAULT_WIDGETS = ["stat_row", "review_queue", "budget_spend", "top_tools",
                    "recent_personal_accounts", "detection_coverage"]
 
 
@@ -1376,6 +1377,7 @@ class SettingsWrite(BaseModel):
     firefox_extension_id: str | None = Field(default=None, max_length=128)
     classification_markings: list[str] | None = Field(default=None,
                                                       max_length=50)
+    budget_currency: str | None = Field(default=None, max_length=8)
 
 
 class DecisionWrite(BaseModel):

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -432,6 +432,17 @@ async function load(force) {
         }
       } catch (e) { /* open rows are the honest fallback */ }
     }
+    // The spend tile needs the budget data, fetched only when the widget
+    // is configured and this is a signed-in managed portal - everywhere
+    // else the tile renders as nothing rather than an error.
+    if ((CFG.overview_widgets || []).some(w => w.kind === 'budget_spend')
+        && CFG.managed && CFG.managed.enabled && AUTH
+        && AUTH.mode === 'login' && !BUDGET) {
+      try {
+        const br = await mfetch('/api/budget');
+        if (br.ok) BUDGET = await br.json();
+      } catch (e) { /* the tile simply stays absent */ }
+    }
     // Same again for the review queue: it draws from the register, and in
     // managed mode from the discovery candidates queue too.
     if ((CFG.overview_widgets || []).some(w => w.kind === 'review_queue')) {
@@ -605,6 +616,31 @@ const WIDGETS = {
       <div><dt>${ents(G.tools).length}</dt><dd>tools</dd></div>
       <div><dt${gaps.length ? ' style="color:var(--warn)"' : ''}>${gaps.length}</dt><dd>coverage gaps</dd></div>
     </dl>`;
+  },
+
+  budget_spend: () => {
+    // Managed mode only, and quiet until the budget has been fetched
+    // (load() fetches it when this widget is configured). A tile of
+    // zeros on a deployment that never linked a tool would be noise.
+    if (!BUDGET) return '';
+    const subs = BUDGET.subscriptions || [];
+    if (!subs.length) {
+      return `<div class="wcard w6"><h3>AI spend</h3>
+      <p class="lede">Nothing linked yet. The Budget view records what
+      each AI tool costs and joins it against observed use.</p>
+      <p class="src-note"><button class="mini" data-nav="budget">open Budget</button></p></div>`;
+    }
+    const next = subs.filter(s => s.renewal_date)
+      .sort((a, b) => a.renewal_date.localeCompare(b.renewal_date))[0];
+    const unob = subs.reduce((a, s) =>
+      a + bMatch(s.members || [], bObserved(s.tool_id)).unobserved.length, 0);
+    return `<div class="wcard w6"><h3>AI spend</h3>
+    <dl class="stats" style="margin-bottom:0">
+      <div><dt>${bSpendParts(subs).join(' + ')}</dt><dd>tracked / month</dd></div>
+      <div><dt>${subs.length}</dt><dd>tools linked</dd></div>
+      <div><dt${unob ? ' style="color:var(--warn)"' : ''}>${unob}</dt><dd>paid seats never observed</dd></div>
+    </dl>
+    <p class="src-note">${next ? `next renewal: ${esc(next.tool_id)} ${when(next.renewal_date)} · ` : ''}<button class="mini" data-nav="budget">open Budget</button></p></div>`;
   },
 
   top_tools: () => {
@@ -2133,7 +2169,16 @@ async function wizard() {
   <input id="set-domains" class="mfield" style="min-width:340px"
     placeholder="example.com, example.co.uk"
     value="${esc((cd.value || []).join(', '))}">
-  <button class="mini" data-act="save-domains">save</button></div>
+  <button class="mini" data-act="save-domains">save</button>
+  <div style="margin-top:12px">
+    <input id="set-budget_currency" class="mfield" style="min-width:120px"
+      placeholder="GBP"
+      value="${esc(((s.budget_currency || {}).value) || '')}">
+    <button class="mini" data-act="save-setting" data-key="budget_currency">save</button>
+    <div class="src-note">Preferred currency, for the Budget view: its
+    headline reports in it and newly linked tools default to it. A display
+    preference - nothing is ever converted.</div>
+  </div></div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>4 · Governance baseline</h3>
   <p class="lede" style="margin-bottom:10px">Which AI tools your organisation
@@ -2296,6 +2341,9 @@ function alertingSettings() {
     ${settingRow('grafana_dashboard_uid', 'Grafana dashboard UID',
       'the /d/ segment of the dashboard URL',
       'Embeds one whole dashboard instead of panels. Pasting the full dashboard URL works: it is trimmed to the UID.')}
+    ${settingRow('budget_currency', 'Preferred currency',
+      'GBP',
+      'The Budget headline reports in it and newly linked tools default to it. Display preference only - nothing is converted.')}
     ${settingRow('overview_widgets', 'Overview widgets',
       'stat_row, top_tools, …  (empty = sensible default)', '')}
   </dl></div>`;
@@ -2797,6 +2845,32 @@ function bMoney(n, cur) {
   return sign ? sign + v : (cur ? esc(cur) + ' ' + v : v);
 }
 
+// The preferred currency saved in Settings, or ''. A display preference:
+// it orders the headline and prefills the wizard, and nothing is ever
+// converted - a converted number would drift with the exchange rate
+// while the invoices it summarises would not.
+const bPrefCur = () => (((SETTINGS && SETTINGS.settings || {})
+  .budget_currency || {}).value || '').toUpperCase();
+
+const bSubMonthly = s => (s.seat_tiers || []).reduce(
+  (x, t) => x + (t.seats || 0) * (t.unit_price_monthly || 0), 0);
+
+// Monthly totals per currency, preferred first: "£934 + $546" is the
+// honest spelling of a mixed estate - one summed number over two
+// currencies would be a figure that lies.
+function bSpendParts(subs) {
+  const byCur = {};
+  (subs || []).forEach(s => {
+    const c = (s.currency || '').toUpperCase();
+    byCur[c] = (byCur[c] || 0) + bSubMonthly(s);
+  });
+  const pref = bPrefCur();
+  return ents(byCur)
+    .sort((a, b) => (b[0] === pref) - (a[0] === pref)
+      || a[0].localeCompare(b[0]))
+    .map(([c, v]) => bMoney(v, c));
+}
+
 // One delimited row, with just enough quote handling for "Last, First"
 // name cells. Not a general CSV parser and not trying to be one.
 function bCsvRow(line, delim) {
@@ -3056,13 +3130,23 @@ function budgetCard(sub) {
   const {matched, unobserved, strangers} = bMatch(sub.members || [], obs);
   const days = sub.renewal_date
     ? Math.ceil((Date.parse(sub.renewal_date) - Date.now()) / 86400000) : null;
-  // Keyed lowercase: the CSV import normalises tiers to lowercase and
-  // the wizard stores whatever the operator typed, and "Premium" not
-  // counting against "premium" would be a silent zero.
-  const tierOf = {};
+  // A member's tier string rarely equals the tier's name byte for byte:
+  // exports write "Premium seat" where the wizard says "premium".
+  // Resolve by normalised equality first, then by the tier's name
+  // appearing inside the member's value (longest tier name wins). What
+  // resolves to nothing is counted and said below the table, because
+  // "assigned 0" beside thirteen imported users was exactly this
+  // mismatch presenting as silence.
+  const tierKeys = tiers.map(t => bNorm(t.name)).filter(Boolean)
+    .sort((a, b) => b.length - a.length);
+  const tierOf = {}; let noTier = 0; const oddTiers = {};
   (sub.members || []).forEach(m => {
-    const k = (m.seat_tier || '').toLowerCase();
-    tierOf[k] = (tierOf[k] || 0) + 1;
+    const k = bNorm(m.seat_tier);
+    if (!k) { noTier++; return; }
+    const hit = tierKeys.find(tk => k === tk)
+      || tierKeys.find(tk => k.includes(tk));
+    if (hit) tierOf[hit] = (tierOf[hit] || 0) + 1;
+    else oddTiers[m.seat_tier] = (oddTiers[m.seat_tier] || 0) + 1;
   });
   const usageBits = m => {
     const u = m.usage || {};
@@ -3093,9 +3177,11 @@ function budgetCard(sub) {
     ${sub.owner ? ' · owner: ' + esc(sub.owner) : ''}</p>` : ''}
   ${tiers.length ? `<table class="plain"><tr><th>tier</th><th>seats paid</th><th>assigned to users</th><th>price/seat</th><th>monthly</th></tr>
     ${tiers.map(t => `<tr><td>${esc(t.name)}</td><td class="num">${t.seats}</td>
-      <td class="num">${tierOf[(t.name || '').toLowerCase()] || 0}</td>
+      <td class="num">${tierOf[bNorm(t.name)] || 0}</td>
       <td class="num">${bMoney(t.unit_price_monthly, sub.currency)}</td>
       <td class="num">${bMoney((t.seats || 0) * (t.unit_price_monthly || 0), sub.currency)}</td></tr>`).join('')}</table>` : ''}
+  ${tiers.length && noTier ? `<p class="src-note">${noTier} user${noTier === 1 ? '' : 's'} carr${noTier === 1 ? 'ies' : 'y'} no seat tier${conn && conn.last_sync_at ? ' - the vendor API does not report tiers; a CSV import or the add-member row sets them' : ''}.</p>` : ''}
+  ${ents(oddTiers).length ? `<p class="src-note" style="color:var(--warn)">User tiers matching no tier above: ${ents(oddTiers).map(([v, n]) => `"${esc(v)}" (${n})`).join(', ')}. Rename a tier in edit, or re-import, to line them up.</p>` : ''}
   ${(sub.members || []).length ? `<details style="margin-top:8px"><summary>Users
       (${(sub.members || []).length}) — ${bProvenance(sub, conn) || 'manual'}</summary>
     <table><tr><th>member</th><th>role</th><th>seat</th><th>vendor usage</th><th>source</th></tr>
@@ -3187,14 +3273,7 @@ async function budget() {
   if (BWIZ) return budgetWizard();
   const ro = AUTH && AUTH.role === 'viewer';
   const subs = BUDGET.subscriptions || [];
-  const total = subs.reduce((a, s) => a + (s.seat_tiers || []).reduce(
-    (x, t) => x + (t.seats || 0) * (t.unit_price_monthly || 0), 0), 0);
-  // One headline number is only honest when everything is priced in one
-  // currency; a £ sign over a sum that mixes currencies would be a number
-  // that lies. Mixed gets the bare figure and says why.
-  const curs = new Set(subs.map(s => (s.currency || '').toUpperCase()));
-  const mixed = curs.size > 1;
-  const cur = mixed ? '' : [...curs][0] || '';
+  const spend = bSpendParts(subs).join(' + ') || '0';
   return `<h2>Budget</h2>
   <p class="lede">The AI tools the organisation pays for, against what the
   estate is observed doing: seats nobody uses, users no seat covers, and
@@ -3203,7 +3282,7 @@ async function budget() {
   the numbers work the same either way and each card says which it is.</p>
   ${BMSG ? `<div class="note">${esc(BMSG)}</div>` : ''}
   ${subs.length ? `<dl class="stats" style="margin-bottom:14px">
-    <div><dt>${bMoney(total, cur)}</dt><dd>tracked spend / month${mixed ? ' (mixed currencies)' : ''}</dd></div>
+    <div><dt>${spend}</dt><dd>tracked spend / month</dd></div>
     <div><dt>${subs.length}</dt><dd>tools linked</dd></div>
   </dl>` : ''}
   ${subs.map(budgetCard).join('')}
@@ -3235,7 +3314,8 @@ async function budgetAction(act, el) {
       .sort((a, b) => a.name.localeCompare(b.name))
       .find(t => seen.has(t.id)) || (REGTOOLS || [])[0];
     BWIZ = {step: 1, tool_id: first ? first.id : '',
-            source: 'csv', provider: 'anthropic', tiers: [], api_key: ''};
+            source: 'csv', provider: 'anthropic', tiers: [], api_key: '',
+            currency: bPrefCur()};
     render(); return;
   }
   if (act === 'b-edit') {

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -1154,6 +1154,10 @@ _STR_SETTINGS = (
     # Fired on a NEW discovery candidate - the moment a human decision
     # becomes needed - and never per finding, which would be a firehose.
     ("webhook_url", True, 500),
+    # The currency the Budget view's headline reports in, and the default
+    # for newly linked tools. A display preference, not money math: the
+    # portal never converts between currencies.
+    ("budget_currency", False, 8),
 )
 
 # What the paste guard does when a marked document is pasted into an AI
@@ -1184,6 +1188,7 @@ class SettingsUpdate(BaseModel):
     extension_crx_url: str | None = Field(default=None, max_length=500)
     extension_xpi_url: str | None = Field(default=None, max_length=500)
     webhook_url: str | None = Field(default=None, max_length=500)
+    budget_currency: str | None = Field(default=None, max_length=8)
     paste_guard_mode: str | None = Field(default=None, max_length=8)
     firefox_extension_id: str | None = Field(default=None, max_length=128)
     classification_markings: list[str] | None = Field(default=None,
@@ -1248,6 +1253,7 @@ def get_settings(authorization: str = Header(default="")):
         "extension_crx_url": plain("extension_crx_url"),
         "extension_xpi_url": plain("extension_xpi_url"),
         "paste_guard_mode": plain("paste_guard_mode"),
+        "budget_currency": plain("budget_currency"),
         "firefox_extension_id": plain("firefox_extension_id"),
         # An incoming webhook URL is itself a bearer capability - whoever
         # holds it can post to the channel - so it is masked like the log

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.3
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.4
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Feedback from the second day of the Budget view in real use, plus the overview ask:

- **Preferred currency** is a central setting: the onboarding wizard's step 3 asks for it, Settings edits it (generic save path), the Budget headline orders by it, and newly linked tools default to it. It deliberately converts nothing - a converted figure would drift with the exchange rate while the invoices it summarises would not - and the docs say so.
- **The headline reports one total per currency**  instead of an unsummed number labelled "(mixed currencies)".
- **"Assigned to users: 0" beside a full import is fixed**: tier matching now normalises both sides and accepts the tier's name appearing inside the member's value, so an exported "Premium seat" counts against a tier named "premium". Members whose tier matches nothing, or who carry none, are counted and named under the table (amber note listing the exact unmatched values) - the mismatch now diagnoses itself instead of presenting as silence.
- **An `budget_spend` overview widget**: per-currency totals, tools linked, paid-seats-never-observed, and the next renewal, with a jump to the Budget view. Added to the default widget set; deployments with a configured `overview_widgets` list add `budget_spend` to it. Renders as nothing on classic-mode or nothing-linked deployments.

Verified in the demo: mixed-currency headline with GBP-first ordering, "Premium seat"/"Claude Premium" both resolving to the premium tier, the no-tier count, the amber unmatched-values note, and the overview tile. Chart 0.12.4, appVersion 0.12.4, pins bumped to tag straight after merge.
