### PR TITLE
Budget: automatic currency conversion, with its working shown

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -126,8 +126,9 @@ makes that an authenticated network probe. That is the price of supporting
 private, self-hosted stores; it is an *admin* capability, gated like every
 other write, and worth knowing when deciding who gets an admin account.
 The Budget user sync is deliberately narrower: its outbound
-destinations are the vendors' API hosts, hardcoded in the receiver, so a
-stored key can only ever be presented to the vendor it belongs to.
+destinations are the vendors' API hosts plus the keyless ECB
+exchange-rate source, all hardcoded in the receiver, so a stored key can
+only ever be presented to the vendor it belongs to.
 
 The chart's public receiver ingress carries only the reporting surfaces
 (/report, /flag, /enroll, /registry, /candidates, /healthz) by default;

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.12.4
+version: 0.12.5
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.12.4"
+appVersion: "0.12.5"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/budget.md
+++ b/docs/budget.md
@@ -105,12 +105,16 @@ view) is what turns those into names.
 ## Currency
 
 Each subscription records its own currency - the one the vendor actually
-invoices in. The headline reports one total per currency ("£934 + $546")
-rather than converting: a converted number would drift with the exchange
-rate while the invoices it summarises would not, so the portal never
-invents one. A **preferred currency** (Settings, or step 3 of the setup
-wizard) orders the headline and prefills newly linked tools; it converts
-nothing.
+invoices in - and those per-currency totals are always shown. Set a
+**preferred currency** (Settings, or step 3 of the setup wizard) and the
+headline additionally converts into it using the ECB's daily reference
+rate, fetched by the receiver from the keyless Frankfurter API and
+cached for half a day. The conversion never hides its working: the rate
+date and the unconverted per-currency figures sit right beside the
+converted number, and if the rate source cannot answer - or a
+subscription uses a currency the ECB does not fix - the headline simply
+falls back to the per-currency breakdown. Newly linked tools default to
+the preferred currency.
 
 ## Seat tiers
 

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.4
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.5
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.4
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.5
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -2181,6 +2181,15 @@ def api_budget_sync(req: BudgetToolRef, _=Depends(require_auth),
     return _receiver("POST", "/admin/budget/sync", token, req.model_dump())
 
 
+@app.get("/api/budget/fx")
+def api_budget_fx(to: str = Query(min_length=3, max_length=3,
+                                  pattern="^[A-Za-z]{3}$"),
+                  _=Depends(require_auth),
+                  token: str = Depends(_admin_forward)):
+    return _receiver("GET", "/admin/budget/fx?to=%s"
+                     % urllib.parse.quote(to), token)
+
+
 @app.get("/")
 def index(_=Depends(require_page_auth)):
     return FileResponse(STATIC / "index.html")

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -299,7 +299,7 @@ let WIZSTORE = 'self', TESTS = {};
 // The budget view: the fetched spend data, the link-a-tool wizard's state
 // (null = closed), the last action's one-line outcome, and a parsed CSV
 // preview waiting for confirmation.
-let BUDGET = null, BWIZ = null, BMSG = '', BCSV = null;
+let BUDGET = null, BWIZ = null, BMSG = '', BCSV = null, BFX = null;
 // Whether the register's watchlist section is expanded. Tracked because a
 // decision re-renders the view, and a <details> that snaps shut under the
 // operator mid-triage would lose their place.
@@ -352,7 +352,7 @@ function showLogin(msg) {
   GOVEDIT = null; GOVPRE = null; GOVERR = ''; SETMSG = '';
   REGTOOLS = null; GOVDECS = null; TESTS = {}; WLOPEN = false;
   RENTRIES = null; REDIT = null; RPRE = null; RERR = ''; RADV = false;
-  BUDGET = null; BWIZ = null; BMSG = ''; BCSV = null;
+  BUDGET = null; BWIZ = null; BMSG = ''; BCSV = null; BFX = null;
   chrome(false);
   const create = AUTH && AUTH.setup_needed;
   app.innerHTML = `<div style="max-width:470px;margin:9vh auto 0">
@@ -407,7 +407,7 @@ async function load(force) {
   const q = force ? '?refresh=true' : '';
   // Refresh must clear the views that read a second endpoint too, or the
   // button refreshes some of the page and silently not the rest.
-  if (force) { DIAG = null; REG = null; EV = null; PG = null; FLEET = null; TOKENS = null; SETTINGS = null; REGTOOLS = null; GOVDECS = null; RENTRIES = null; CAND = null; PSTAT = null; AUDITLOG = null; USERS = null; BUDGET = null; }
+  if (force) { DIAG = null; REG = null; EV = null; PG = null; FLEET = null; TOKENS = null; SETTINGS = null; REGTOOLS = null; GOVDECS = null; RENTRIES = null; CAND = null; PSTAT = null; AUDITLOG = null; USERS = null; BUDGET = null; BFX = null; }
   try {
     const cr = await fetch('/api/config');
     if (cr.status === 401 && AUTH && AUTH.mode === 'login') { sessionLost(); return; }
@@ -441,6 +441,11 @@ async function load(force) {
       try {
         const br = await mfetch('/api/budget');
         if (br.ok) BUDGET = await br.json();
+        if (!SETTINGS) {
+          const wr = await mfetch('/api/settings');
+          if (wr.ok) SETTINGS = await wr.json();
+        }
+        await bFetchFx();
       } catch (e) { /* the tile simply stays absent */ }
     }
     // Same again for the review queue: it draws from the register, and in
@@ -636,7 +641,10 @@ const WIDGETS = {
       a + bMatch(s.members || [], bObserved(s.tool_id)).unobserved.length, 0);
     return `<div class="wcard w6"><h3>AI spend</h3>
     <dl class="stats" style="margin-bottom:0">
-      <div><dt>${bSpendParts(subs).join(' + ')}</dt><dd>tracked / month</dd></div>
+      <div><dt>${(() => { const c = bConverted(subs);
+        return c ? bMoney(c.total, bPrefCur()) : bSpendParts(subs).join(' + '); })()}</dt>
+        <dd>tracked / month${(() => { const c = bConverted(subs);
+        return c ? ` (${bSpendParts(subs).join(' + ')}, ECB ${esc(c.date)})` : ''; })()}</dd></div>
       <div><dt>${subs.length}</dt><dd>tools linked</dd></div>
       <div><dt${unob ? ' style="color:var(--warn)"' : ''}>${unob}</dt><dd>paid seats never observed</dd></div>
     </dl>
@@ -2175,9 +2183,10 @@ async function wizard() {
       placeholder="GBP"
       value="${esc(((s.budget_currency || {}).value) || '')}">
     <button class="mini" data-act="save-setting" data-key="budget_currency">save</button>
-    <div class="src-note">Preferred currency, for the Budget view: its
-    headline reports in it and newly linked tools default to it. A display
-    preference - nothing is ever converted.</div>
+    <div class="src-note">Preferred currency, for the Budget view: the
+    headline converts into it at the ECB's daily reference rate (the rate's
+    date is named right beside the number), newly linked tools default to
+    it, and the per-currency figures stay visible.</div>
   </div></div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>4 · Governance baseline</h3>
@@ -2343,7 +2352,7 @@ function alertingSettings() {
       'Embeds one whole dashboard instead of panels. Pasting the full dashboard URL works: it is trimmed to the UID.')}
     ${settingRow('budget_currency', 'Preferred currency',
       'GBP',
-      'The Budget headline reports in it and newly linked tools default to it. Display preference only - nothing is converted.')}
+      'The Budget headline converts into it at the ECB daily reference rate, naming the rate date inline; newly linked tools default to it.')}
     ${settingRow('overview_widgets', 'Overview widgets',
       'stat_row, top_tools, …  (empty = sensible default)', '')}
   </dl></div>`;
@@ -2871,6 +2880,44 @@ function bSpendParts(subs) {
     .map(([c, v]) => bMoney(v, c));
 }
 
+// The per-currency totals folded into the preferred currency at the
+// ECB's daily reference rate (fetched by the receiver, cached half a
+// day). Null when there is nothing to convert - no preference, a single
+// currency, no rates, or a currency the ECB does not fix - and callers
+// then fall back to the per-currency parts, so a rate source that
+// cannot answer degrades to the honest breakdown rather than an error.
+// A subscription with no currency recorded counts as already-preferred:
+// the preference is exactly the currency this organisation thinks in.
+function bConverted(subs) {
+  const pref = bPrefCur();
+  if (!pref || !BFX || !BFX.ok || BFX.base !== pref) return null;
+  const byCur = {};
+  (subs || []).forEach(s => {
+    const c = (s.currency || '').toUpperCase();
+    byCur[c] = (byCur[c] || 0) + bSubMonthly(s);
+  });
+  const foreign = Object.keys(byCur).filter(c => c && c !== pref);
+  if (!foreign.length) return null;
+  let total = 0;
+  for (const [c, v] of ents(byCur)) {
+    if (!c || c === pref) total += v;
+    else if ((BFX.rates || {})[c]) total += v / BFX.rates[c];
+    else return null;
+  }
+  return {total, date: BFX.date || ''};
+}
+
+async function bFetchFx() {
+  const pref = bPrefCur();
+  if (!pref || (BFX && BFX.base === pref)) return;
+  try {
+    const r = await mfetch('/api/budget/fx?to=' + encodeURIComponent(pref));
+    // The base is kept even on a refusal, so a source that cannot answer
+    // is asked once per session, not once per render.
+    if (r.ok) BFX = Object.assign({base: pref}, await r.json());
+  } catch (e) { /* the per-currency parts are the fallback */ }
+}
+
 // One delimited row, with just enough quote handling for "Last, First"
 // name cells. Not a general CSV parser and not trying to be one.
 function bCsvRow(line, delim) {
@@ -3269,11 +3316,15 @@ async function budget() {
     const r = await fetch('/api/registry-tools');
     REGTOOLS = r.ok ? (await r.json()).tools || [] : [];
   }
+  await bFetchFx();
   if (BCSV) return budgetImport();
   if (BWIZ) return budgetWizard();
   const ro = AUTH && AUTH.role === 'viewer';
   const subs = BUDGET.subscriptions || [];
-  const spend = bSpendParts(subs).join(' + ') || '0';
+  const spendParts = bSpendParts(subs);
+  const conv = bConverted(subs);
+  const spend = conv ? bMoney(conv.total, bPrefCur())
+    : spendParts.join(' + ') || '0';
   return `<h2>Budget</h2>
   <p class="lede">The AI tools the organisation pays for, against what the
   estate is observed doing: seats nobody uses, users no seat covers, and
@@ -3282,7 +3333,8 @@ async function budget() {
   the numbers work the same either way and each card says which it is.</p>
   ${BMSG ? `<div class="note">${esc(BMSG)}</div>` : ''}
   ${subs.length ? `<dl class="stats" style="margin-bottom:14px">
-    <div><dt>${spend}</dt><dd>tracked spend / month</dd></div>
+    <div><dt>${spend}</dt><dd>tracked spend / month${conv
+      ? ` · ${spendParts.join(' + ')} at ECB ${esc(conv.date)}` : ''}</dd></div>
     <div><dt>${subs.length}</dt><dd>tools linked</dd></div>
   </dl>` : ''}
   ${subs.map(budgetCard).join('')}

--- a/portal/tests/test_budget.py
+++ b/portal/tests/test_budget.py
@@ -62,6 +62,7 @@ def test_each_route_forwards_the_right_verb_and_path(receiver_spy):
                                       token=token)
     main.api_budget_subscription_delete(main.BudgetToolRef(tool_id="claude"),
                                         token=token)
+    main.api_budget_fx("GBP", token=token)
 
     got = [(c["method"], c["path"]) for c in receiver_spy]
     assert got == [
@@ -72,6 +73,7 @@ def test_each_route_forwards_the_right_verb_and_path(receiver_spy):
         ("POST", "/admin/budget/sync"),
         ("POST", "/admin/budget/connection/delete"),
         ("POST", "/admin/budget/subscription/delete"),
+        ("GET", "/admin/budget/fx?to=GBP"),
     ]
     # The operator's own session rides every call - the portal holds no
     # credential of its own for this.

--- a/receiver/app/budget.py
+++ b/receiver/app/budget.py
@@ -30,6 +30,7 @@ pretending a connector could exist.
 """
 
 import json
+import time
 
 import httpx
 
@@ -203,3 +204,51 @@ async def sync_fireflies(api_key: str) -> list[dict]:
 
 
 SYNCERS = {"anthropic": sync_anthropic, "fireflies": sync_fireflies}
+
+
+# ----------------------------------------------------------------- fx --
+# Daily ECB reference rates via the Frankfurter API: keyless, free, one
+# fixed host - the same no-request-supplied-URL rule as the vendor syncs.
+# The portal uses them to show the Budget headline in the preferred
+# currency, always naming the rate's date inline, and falls back to
+# per-currency figures when this cannot answer. ECB publishes once per
+# working day around 16:00 CET, so a half-day cache never serves a rate
+# the source itself has moved past.
+
+FRANKFURTER_URL = "https://api.frankfurter.dev/v1/latest"
+_FX_TTL = 12 * 3600
+_fx_cache: dict = {}
+
+
+async def fx_rates(base: str) -> dict:
+    """{"base", "date", "rates"} - units of each currency per one `base`,
+    per the ECB's latest daily reference fixing. Cached per base."""
+    now = time.time()
+    hit = _fx_cache.get(base)
+    if hit and now - hit[0] < _FX_TTL:
+        return hit[1]
+    async with httpx.AsyncClient(timeout=10) as client:
+        try:
+            r = await client.get(FRANKFURTER_URL, params={"base": base})
+        except httpx.HTTPError as e:
+            raise SyncError("could not reach the exchange-rate source (%s)"
+                            % type(e).__name__)
+    if r.status_code == 404:
+        # Frankfurter answers 404 for a currency the ECB does not fix.
+        raise SyncError("the ECB publishes no reference rate for %s" % base)
+    if r.status_code != 200:
+        raise _refusal(r.status_code, "the exchange-rate source")
+    try:
+        body = r.json()
+    except json.JSONDecodeError:
+        raise SyncError("the exchange-rate source answered 200, but not "
+                        "with JSON")
+    rates = {}
+    for k, v in (body.get("rates") or {}).items():
+        if isinstance(k, str) and len(k) == 3 and isinstance(v, (int, float)) \
+                and v > 0 and len(rates) < 64:
+            rates[k.upper()] = float(v)
+    out = {"base": base, "date": str(body.get("date") or "")[:10],
+           "rates": rates}
+    _fx_cache[base] = (now, out)
+    return out

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -2017,6 +2017,25 @@ def delete_budget_connection(req: BudgetToolRef,
     return {"ok": True}
 
 
+_CURRENCY_RE = re.compile(r"^[A-Za-z]{3}$")
+
+
+@app.get("/admin/budget/fx")
+async def budget_fx(to: str = "", authorization: str = Header(default="")):
+    """The ECB's latest daily reference rates into the named currency,
+    for the portal's converted headline. Read-only and cached; a source
+    that cannot answer is a rendered fallback (ok: false), not a 5xx -
+    the page shows per-currency figures instead."""
+    _admin_auth(authorization)
+    if not _CURRENCY_RE.match(to or ""):
+        raise HTTPException(422, "to must be a 3-letter currency code")
+    try:
+        out = await _budget.fx_rates(to.upper())
+    except _budget.SyncError as e:
+        return {"ok": False, "detail": e.detail}
+    return dict(out, ok=True)
+
+
 @app.post("/admin/budget/sync")
 async def budget_sync(req: BudgetToolRef,
                       authorization: str = Header(default="")):

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.4
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.5
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/receiver/tests/test_budget.py
+++ b/receiver/tests/test_budget.py
@@ -311,6 +311,41 @@ def test_sync_without_a_connection_is_a_404(managed):
     assert r.status_code == 404
 
 
+def test_fx_rates_relay_and_cache(managed, monkeypatch):
+    calls = []
+
+    def handler(request):
+        calls.append(str(request.url))
+        assert request.url.host == "api.frankfurter.dev"
+        return httpx.Response(200, json={
+            "amount": 1.0, "base": "GBP", "date": "2026-08-27",
+            "rates": {"USD": 1.27, "EUR": 1.17, "bad": "x"}})
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    monkeypatch.setattr(budget_mod, "_fx_cache", {})
+    out = client.get("/admin/budget/fx?to=gbp", headers=ADMIN).json()
+    assert out["ok"] is True and out["base"] == "GBP"
+    assert out["rates"]["USD"] == 1.27 and "bad" not in out["rates"]
+    # Second read answers from the cache, not the network.
+    client.get("/admin/budget/fx?to=gbp", headers=ADMIN)
+    assert len(calls) == 1
+
+
+def test_fx_refusals_are_answers(managed, monkeypatch):
+    monkeypatch.setattr(budget_mod, "_fx_cache", {})
+
+    def handler(request):
+        return httpx.Response(404, json={"message": "not found"})
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    out = client.get("/admin/budget/fx?to=XXX", headers=ADMIN).json()
+    assert out["ok"] is False and "no reference rate" in out["detail"]
+    assert client.get("/admin/budget/fx?to=pounds",
+                      headers=ADMIN).status_code == 422
+
+
 def test_replaced_key_resets_sync_history(managed, monkeypatch):
     def handler(request):
         return httpx.Response(200, json={"data": [], "has_more": False})


### PR DESCRIPTION
The follow-up ask to per-currency totals: convert automatically. Done, with the honesty constraints kept:

- The receiver fetches the ECB's daily reference rates from the keyless Frankfurter API (`api.frankfurter.dev`, hardcoded host - the same no-request-supplied-URL rule as the vendor syncs), cached half a day, relayed at `/admin/budget/fx`. ECB publishes once per working day, so the cache never serves a rate the source has moved past.
- With a preferred currency set and mixed currencies present, the Budget headline and the overview spend tile show the converted total **with the rate's provenance inline**: "£206 · £74 + $180 at ECB 2026-08-26". The per-currency figures never disappear behind the conversion, and each card keeps its vendor's own currency.
- Degradation is graceful and honest: rate source unreachable, or a subscription in a currency the ECB does not fix, and the headline falls back to the per-currency breakdown - a fallback, not an error, asked once per session.
- SECURITY.md's outbound-destinations note now names the fx host alongside the vendor APIs; docs/budget.md's Currency section rewritten.

Verified live in the demo against the real API: £74 + $180 converting to £206 at the current fixing, on both the Budget headline and the overview tile, and receiver tests cover the relay, the cache (one upstream call for two reads), the 404-for-unfixed-currency refusal, and the 422 on a malformed code. Receiver 175 / portal 371 green. Chart 0.12.5, appVersion 0.12.5, pins bumped to tag straight after merge.