### PR TITLE
Settings: overview widgets as toggles

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.12.5
+version: 0.12.6
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.12.5"
+appVersion: "0.12.6"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.5
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.6
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.5
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.6
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -698,6 +698,12 @@ def config(request: Request, _=Depends(require_auth)):
         "version": APP_VERSION,
         "overview_widgets": _widgets(_remote_value(rs, "overview_widgets",
                                                    OVERVIEW_WIDGETS)),
+        # The full catalogue, name and description, so the Settings page
+        # can offer widgets as toggles instead of a comma-separated string
+        # an operator has to know the tokens for - and so a widget added
+        # in a release shows up as an option instead of staying invisible
+        # behind whatever list was saved before it existed.
+        "overview_widget_catalog": KNOWN_WIDGETS,
         # enabled says the portal can reach an admin API; artifacts_ready
         # says downloads can bake a URL agents can reach. Separate flags,
         # because a deployment can sensibly have the first without the

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -843,8 +843,8 @@ function overview() {
   const rest = ws.filter(w => w.kind !== 'stat_row');
   return `<h2>Overview</h2>
   ${truncNote(G.findings_truncated)}
-  <p class="lede">You can choose which widgets appear here: the overview
-  widgets setting takes a comma-separated list.</p>
+  <p class="lede">You can choose which widgets appear here: they are
+  toggles under Settings.</p>
   ${stat.map(w => WIDGETS.stat_row(w)).join('')}
   <div class="grid">${rest.map(w =>
     (WIDGETS[w.kind] ? WIDGETS[w.kind](w) : WIDGETS.error({error:'no renderer for '+w.kind}))
@@ -1776,6 +1776,47 @@ function settingRow(key, label, placeholder, note) {
 // re-push. Split in two: behaviour (what the guard does) and delivery
 // (where the packed extension lives), because the guide puts them on
 // different pages while Settings shows everything flat.
+// The overview's widgets as toggles. The stored value underneath is
+// still the comma-separated overview_widgets string an env-configured
+// deployment sets, but a managed operator should never have to know the
+// tokens: every widget the portal can draw is offered here by name, and
+// one added in a release shows up as an unchecked option instead of
+// hiding behind a list saved before it existed. Configured Grafana
+// panels ride along as their own toggles.
+function widgetPickerRow() {
+  const catalog = CFG.overview_widget_catalog || {};
+  const eff = CFG.overview_widgets || [];
+  const on = new Set(eff.filter(w => w.kind && w.kind !== 'grafana'
+    && w.kind !== 'error').map(w => w.kind));
+  const refs = new Set(eff.filter(w => w.kind === 'grafana')
+    .map(w => String(w.ref)));
+  const box = (id, checked, ref, label, desc) => `
+    <label style="display:flex;align-items:baseline;gap:8px;margin-bottom:5px;cursor:pointer">
+      <input type="checkbox" id="${id}" ${ref ? `data-ref="${esc(ref)}"` : ''}
+        style="min-width:0;margin:0;accent-color:var(--pri)" ${checked ? 'checked' : ''}>
+      <span>${label}${desc ? ` <span style="color:var(--mut)">— ${esc(desc)}</span>` : ''}</span>
+    </label>`;
+  const panels = (CFG.grafana_panels || []).filter(p => !p.error);
+  const panelRef = p => p.title || String(p.panel_id);
+  const orphans = [...refs].filter(r =>
+    !panels.some(p => r === p.title || r === String(p.panel_id)));
+  return `<dt>Overview widgets${INFO}</dt><dd>
+    ${ents(catalog).map(([k, d]) => box('ow-' + k, on.has(k), '',
+      `<span class="mono">${esc(k)}</span>`, d)).join('')}
+    ${panels.map((p, i) => box('owg-' + i,
+      refs.has(p.title) || refs.has(String(p.panel_id)), panelRef(p),
+      `<span class="mono">grafana:${esc(panelRef(p))}</span>`,
+      'embedded Grafana panel')).join('')}
+    ${orphans.map((r, i) => box('owo-' + i, true, r,
+      `<span class="mono">grafana:${esc(r)}</span>`,
+      'saved panel reference (no longer in the panels list)')).join('')}
+    <button class="mini" data-act="save-widgets" style="margin-top:4px">save</button>
+    <div class="src-note fnote">What the overview draws, in this order.
+    Unticking everything is refused rather than saved: an empty list falls
+    back to the default set, which is probably not what you meant.</div>
+  </dd>`;
+}
+
 function pasteGuardBehaviourFields() {
   const s = (SETTINGS && SETTINGS.settings) || {};
   const mode = (s.paste_guard_mode || {}).value || '';
@@ -2353,8 +2394,7 @@ function alertingSettings() {
     ${settingRow('budget_currency', 'Preferred currency',
       'GBP',
       'The Budget headline converts into it at the ECB daily reference rate, naming the rate date inline; newly linked tools default to it.')}
-    ${settingRow('overview_widgets', 'Overview widgets',
-      'stat_row, top_tools, …  (empty = sensible default)', '')}
+    ${widgetPickerRow()}
   </dl></div>`;
 }
 
@@ -3752,6 +3792,38 @@ async function managedAction(act, el) {
     if (r.ok) { SETTINGS = await r.json(); SETMSG = 'Saved. Regenerate the extension artifacts to roll it out.'; }
     else if (r.status === 401) { sessionLost(); return; }
     else { let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {} SETMSG = 'Not saved: ' + d; }
+    render(); return;
+  }
+  if (act === 'save-widgets') {
+    const catalog = CFG.overview_widget_catalog || {};
+    const parts = Object.keys(catalog)
+      .filter(k => document.getElementById('ow-' + k)?.checked);
+    document.querySelectorAll('[id^="owg-"],[id^="owo-"]').forEach(el => {
+      if (el.checked) parts.push('grafana:' + el.getAttribute('data-ref'));
+    });
+    if (!parts.length) {
+      SETMSG = 'Pick at least one widget: an empty list falls back to the '
+        + 'default set, which is probably not what unticking everything meant.';
+      render(); return;
+    }
+    const r = await mfetch('/api/settings', {method: 'POST',
+      body: JSON.stringify({overview_widgets: parts.join(',')})});
+    if (r.status === 401) { sessionLost(); return; }
+    if (!r.ok) { SETMSG = 'Not saved: ' + await _refusal(r); render(); return; }
+    SETTINGS = await r.json();
+    SETMSG = 'Saved. The overview draws these from now on.';
+    // The overview reads the effective list from config, and a freshly
+    // enabled spend tile needs its data - refetch both so the change is
+    // visible on the very next click, not the next full reload.
+    try {
+      CFG = await (await fetch('/api/config')).json();
+      if ((CFG.overview_widgets || []).some(w => w.kind === 'budget_spend')
+          && CFG.managed && CFG.managed.enabled && !BUDGET) {
+        const br = await mfetch('/api/budget');
+        if (br.ok) BUDGET = await br.json();
+        await bFetchFx();
+      }
+    } catch (e) { /* the overview picks it up on its next load */ }
     render(); return;
   }
   if (act === 'save-setting') {

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.5
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.6
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Field feedback on the managed experience: enabling the new spend tile meant knowing to type `budget_spend` into a comma-separated setting, which is git-clone-era configuration wearing a settings page.

- `/api/config` now serves the widget catalogue (name and description), and Settings offers every widget as a toggle - the effective set checked, newly shipped widgets appearing as unchecked options instead of hiding behind a list saved before they existed. Configured Grafana panels ride along as their own toggles, and a saved panel reference that no longer matches the panels list is shown labelled rather than silently dropped.
- Unticking everything is refused with an explanation (an empty string would fall back to the defaults, which is not what unticking everything means).
- Saving writes the same `overview_widgets` string as ever - env-configured deployments are untouched - and refreshes the overview immediately, fetching the spend tile's data if it was just enabled.
- The overview's lede points at the toggles instead of teaching the comma string.

Verified in the demo: catalogue rendered with the effective set checked, a toggle saved and drawn on the overview in the same click. Portal 371 green. Chart 0.12.6, appVersion 0.12.6, pins bumped to tag straight after merge.