### PR TITLE
Budget: single-tier plans assign automatically

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.12.7
+version: 0.12.8
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.12.7"
+appVersion: "0.12.8"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/budget.md
+++ b/docs/budget.md
@@ -128,8 +128,11 @@ standard from premium seats), so a subscription holds up to ten named
 tiers, each with a seat count and a per-seat monthly price. Tier names
 matter: a user row whose seat tier matches a tier's name counts against
 that tier's seats, which is how "8 premium seats paid, 3 assigned" falls
-out. The vendor APIs do not expose per-user tiers, so tier assignment
-comes from the CSV import or the card either way. Tier matching is
+out. The vendor APIs do not expose per-user tiers - a plan with a
+**single tier** therefore counts every member against it automatically
+(everyone on the plan is on that tier by definition, the one derivation
+that needs no vendor data). On multi-tier plans tier assignment comes
+from the CSV import or the card. Tier matching is
 forgiving: an imported "Premium seat" counts against a tier named
 "premium" (the tier's name just has to appear in the value), and
 whatever matches nothing is named under the table with a count, never

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.7
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.8
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.7
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.8
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -3233,10 +3233,22 @@ function budgetCard(sub) {
   // mismatch presenting as silence.
   const tierKeys = tiers.map(t => bNorm(t.name)).filter(Boolean)
     .sort((a, b) => b.length - a.length);
+  // A single-tier plan needs no per-user tier data at all: everyone on
+  // the plan is on that tier by definition, so members with none
+  // recorded count against it automatically. That is exactly the case
+  // the vendor APIs leave behind - they report members but no seats -
+  // and it is the one derivation that needs no vendor data to be true.
+  // Multi-tier plans cannot guess, so there the no-tier members stay
+  // counted and named below the table.
+  const soleTier = tierKeys.length === 1 ? tierKeys[0] : null;
   const tierOf = {}; let noTier = 0; const oddTiers = {};
   (sub.members || []).forEach(m => {
     const k = bNorm(m.seat_tier);
-    if (!k) { noTier++; return; }
+    if (!k) {
+      if (soleTier) tierOf[soleTier] = (tierOf[soleTier] || 0) + 1;
+      else noTier++;
+      return;
+    }
     const hit = tierKeys.find(tk => k === tk)
       || tierKeys.find(tk => k.includes(tk));
     if (hit) tierOf[hit] = (tierOf[hit] || 0) + 1;

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.7
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.8
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Follow-up to "shouldn't API syncs do that automatically" - they would if the vendor APIs reported seats, and neither does (Anthropic's members endpoint: email/name/role/joined; Fireflies: name/email/admin/usage). But there is one case that needs no vendor data: a subscription with a single tier, where everyone on the plan is on that tier by definition. Members with no recorded tier now count against a sole tier automatically, which makes an API-synced single-tier plan (the reporting deployment's Fireflies Enterprise) read correctly with zero manual tier work. Multi-tier plans cannot guess, so they keep the explicit counted-and-named notes from 0.12.7.

Verified in the demo: a single-tier card absorbing its no-tier members into the count while a genuinely mismatched tier value stays flagged. Portal 371 green. Chart 0.12.8, appVersion 0.12.8, pins bumped to tag straight after merge.