### PR TITLE
Budget import: the preview shows its working

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.12.8
+version: 0.12.9
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.12.8"
+appVersion: "0.12.9"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.8
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.9
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.8
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.9
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2973,6 +2973,7 @@ function bCsvRow(line, delim) {
 }
 
 const B_EMAIL_RE = /^[^@\s]+@[^@\s]+$/;
+const ordinal = n => n + ({1: 'st', 2: 'nd', 3: 'rd'}[n % 10 > 3 || (n % 100 >= 11 && n % 100 <= 13) ? 0 : n % 10] || 'th');
 
 // A pasted member export from any vendor's admin page. The delimiter is
 // detected, not assumed: a saved .csv pastes with commas, but copying
@@ -2986,7 +2987,7 @@ const B_EMAIL_RE = /^[^@\s]+@[^@\s]+$/;
 // silently dropped, because an import that quietly lost three rows reads
 // as three people who left.
 function parseUsersCsv(text) {
-  const lines = String(text || '').replace(/^\uFEFF/, '').split(/\r?\n/)
+  const lines = String(text || '').replace(/^\uFEFF/, '').split(/\r\n|\r|\n/)
     .filter(l => l.trim() && !l.trim().startsWith('#'));
   if (!lines.length) return {members: [], skipped: 0};
   const delim = lines[0].includes('\t') ? '\t'
@@ -3031,7 +3032,13 @@ function parseUsersCsv(text) {
   // an assigned-seats table reads 0 under a full member list.
   return {members, skipped,
           headerless: !hasHeader && extra > 0,
-          missing: hasHeader ? {role: iRole < 0, tier: iTier < 0} : null};
+          missing: hasHeader ? {role: iRole < 0, tier: iTier < 0} : null,
+          // How the paste was read, for the preview to show: guessing at
+          // a delimiter mismatch over a support thread is slower than the
+          // page just saying what it decided.
+          map: {delim: delim === '\t' ? 'tabs' : delim === ';' ? 'semicolons' : 'commas',
+                header: hasHeader,
+                cols: {email: iEmail, name: iName, role: iRole, tier: iTier}}};
 }
 
 const BPROVIDER_NONE = `ChatGPT Business (Team) has no admin API - OpenAI
@@ -3361,6 +3368,11 @@ function budgetImport() {
     ${parsed.missing && parsed.missing.tier ? `<p class="src-note" style="color:var(--warn)">No
     seat/tier column recognised in the header, so seat tiers will import
     empty and the tier table cannot count these users against seats.</p>` : ''}
+    ${parsed.map ? `<p class="src-note">Read as: ${parsed.map.delim},
+    ${parsed.map.header ? 'header row found' : 'no header row'};
+    ${ents(parsed.map.cols).map(([f, i]) =>
+      `${f === 'tier' ? 'seat tier' : f} ${i >= 0 ? ordinal(i + 1) + ' column' : 'not found'}`)
+      .join(', ')}.</p>` : ''}
     <p class="src-note">${parsed.members.length} rows understood,
     ${parsed.skipped} skipped (no address, or a duplicate). Importing
     replaces the previous CSV import for this tool; API-synced and manual

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.8
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.12.9
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Field report: one vendor's CSV keeps importing with empty role and seat tier despite the header row being included, while the same-shaped export from another vendor imports fine. Every reconstruction of the file's plausible shapes (capitals, quotes, BOM, CRLF, tabs, semicolons, subsets) parses correctly, so the mismatch is something about the actual bytes that cannot be diagnosed blind.

The preview now states its working - "Read as: commas, header row found; email 2nd column, name 1st column, role 3rd column, seat tier 5th column" (or "not found") - so a delimiter or mapping mismatch names itself on screen instead of surfacing as silently empty fields. Also: bare-CR line endings now split into rows (they read as one giant line before; textarea pastes usually normalise them away, but not every path is a textarea paste forever).

Portal 371 green. Chart 0.12.9, appVersion 0.12.9, pins bumped to tag straight after merge.