### PR TITLE
Chart: refresh the bundled registry copies

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.13.0
+version: 0.13.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.13.0"
+appVersion: "0.13.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/files/registry.json
+++ b/charts/ai-guard/files/registry.json
@@ -6,6 +6,7 @@
       "name": "Claude",
       "vendor": "Anthropic",
       "category": "assistant",
+      "license_group": "anthropic-claude",
       "approved": false,
       "added_by": "manual",
       "domains": [
@@ -50,6 +51,7 @@
       "name": "Claude Code",
       "vendor": "Anthropic",
       "category": "coding",
+      "license_group": "anthropic-claude",
       "approved": false,
       "added_by": "manual",
       "domains": [],
@@ -86,6 +88,7 @@
       "name": "ChatGPT",
       "vendor": "OpenAI",
       "category": "assistant",
+      "license_group": "openai-chatgpt",
       "approved": false,
       "added_by": "manual",
       "domains": [
@@ -124,6 +127,7 @@
       "name": "Codex CLI",
       "vendor": "OpenAI",
       "category": "coding",
+      "license_group": "openai-chatgpt",
       "approved": false,
       "added_by": "manual",
       "domains": [],
@@ -148,6 +152,7 @@
       "name": "Gemini",
       "vendor": "Google",
       "category": "assistant",
+      "license_group": "google-gemini",
       "approved": false,
       "added_by": "manual",
       "domains": [
@@ -165,6 +170,7 @@
       "name": "Gemini CLI",
       "vendor": "Google",
       "category": "coding",
+      "license_group": "google-gemini",
       "approved": false,
       "added_by": "manual",
       "domains": [],

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.13.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.13.1
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.13.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.13.1
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.13.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.13.1
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
The helm job on #173 failed after merge: the chart ships byte-copies of the built registry, and the license_group rebuild did not refresh them. The v0.13.0 tag build fails at the same check, so 0.13.0's images and chart never publish - this supersedes it as 0.13.1.

Beyond CI: helm deployments mount the bundled registry copy, so this is what actually delivers the licence groups to a deployed portal's wizard.

(Also fixed on the maintainer side: the auto-merge gate treated an empty `gh pr checks` response as all-green; it now requires a non-empty, all-passing listing.)