### PR TITLE
Portal: numbers that described the same thing and disagreed

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.14.0
+version: 0.14.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.14.0"
+appVersion: "0.14.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.1
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.1
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -603,7 +603,26 @@ def jsonable(d):
     return {k: (sorted(v) if isinstance(v, set) else v) for k, v in d.items()}
 
 
-def personal_accounts_from(findings, domain_map=None):
+def _domain_matches(account, listed):
+    """Is `account` this domain, or a subdomain of it?
+
+    Both sides are normalised - trimmed, lowercased, leading dots and a
+    leading www. removed - because the two lists are typed by different
+    people at different times: corporate domains come from an operator in
+    Settings, the account domain from whatever the reporting agent read.
+    Suffix rather than equality so mail.corp.example matches corp.example.
+    """
+    a = (account or "").strip().lower().lstrip(".")
+    b = (listed or "").strip().lower().lstrip(".")
+    if not a or not b:
+        return False
+    if a.startswith("www."):
+        a = a[4:]
+    return a == b or a.endswith("." + b)
+
+
+def personal_accounts_from(findings, domain_map=None, corp_domains=None,
+                           tool_domains=None):
     """One row per personal account seen on a tool, with when it was first and
     last observed.
 
@@ -619,6 +638,8 @@ def personal_accounts_from(findings, domain_map=None):
     of attributes.
     """
     domain_map = domain_map or {}
+    corp_domains = corp_domains or []
+    tool_domains = tool_domains or {}
     rows = {}
     for f in findings:
         if (f.get("severity") or "") != "warn":
@@ -633,6 +654,25 @@ def personal_accounts_from(findings, domain_map=None):
         if source in BRIDGE_SOURCES:
             continue
         tool = normalise_tool(tool, domain_map)
+
+        # Severity is the reporter's judgement, made against the corporate
+        # domain list IT HELD AT THE TIME. A browser extension carries that
+        # list baked into its policy, so a domain added in Settings after
+        # the last policy push keeps arriving flagged as personal - and a
+        # domain that is literally in the operator's own list then appears
+        # under "personal accounts", including in the shareable budget
+        # report. The reporter is not re-judged here (that would be two
+        # definitions of personal); the row is simply not presented as
+        # personal when the current list says otherwise.
+        if any(_domain_matches(acct, d) for d in corp_domains):
+            continue
+
+        # A tool's own sign-in domain is not a personal account on that
+        # tool. Signing into the meeting-notes product with an account on
+        # the meeting-notes product's domain was being reported as
+        # personal use of the licence being paid for.
+        if any(_domain_matches(acct, d) for d in tool_domains.get(tool, ())):
+            continue
 
         device = (f.get("device") or "").strip()
         user = (f.get("user") or "").strip()
@@ -718,9 +758,14 @@ def mcp_from(findings):
         device = (f.get("device") or "").strip()
         ts = f.get("reported_at") or ""
         for srv in servers:
-            r = rows.get(srv)
+            # Keyed case-folded: "Figma" and "figma" are one server
+            # configured by two people, and listing them separately
+            # inflated the server count. The first spelling seen is the
+            # one shown, because that is what somebody wrote.
+            key = srv.lower()
+            r = rows.get(key)
             if r is None:
-                r = rows[srv] = {"server": srv, "tools": set(), "devices": set(),
+                r = rows[key] = {"server": srv, "tools": set(), "devices": set(),
                                  "device_names": set(), "findings": 0,
                                  "first_seen": "", "last_seen": ""}
             r["findings"] += 1
@@ -808,7 +853,19 @@ def trends_from(findings, domain_map=None, hours=168):
     }
 
 
-def graph_from(findings, domain_map=None, identity_map=None, hours=168):
+def tool_domains_from(reg):
+    """tool id -> the domains the registry says are that tool's own, used
+    to keep a tool's own sign-in domain out of its personal-account rows."""
+    out = {}
+    for t in (reg or {}).get("tools") or []:
+        tid = t.get("id")
+        if tid and t.get("domains"):
+            out[tid] = [d for d in t["domains"] if d]
+    return out
+
+
+def graph_from(findings, domain_map=None, identity_map=None, hours=168,
+               corp_domains=None, reg=None):
     """Everything above, assembled into the shape the API and the UI read."""
     devices, identities, tools, bridges, unattributed = build(
         findings, domain_map, identity_map)
@@ -828,7 +885,8 @@ def graph_from(findings, domain_map=None, identity_map=None, hours=168):
         },
         "bridges": {k: jsonable(v) for k, v in bridges.items()},
         "unattributed": unattributed,
-        "personal_accounts": personal_accounts_from(findings, domain_map),
+        "personal_accounts": personal_accounts_from(
+            findings, domain_map, corp_domains, tool_domains_from(reg)),
         "mcp_servers": mcp_from(findings),
         "trends": trends_from(findings, domain_map, hours),
         "counts": {

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -440,6 +440,11 @@ STARTED_AT = time.time()
 # happening", and only this tells them apart.
 _last_loki_ok: float = 0.0
 _last_loki_error: str = ""
+# When the last failure happened. Without it Diagnostics could only age
+# the last SUCCESS, so a portal whose reads had been failing for a day
+# looked identical to one nobody had opened - on the page a self-hoster
+# opens precisely when the portal looks empty.
+_last_loki_error_at: float = 0.0
 # Whether the most recent Loki read stopped at LOKI_MAX_FINDINGS. Reported
 # on every derived response and in the evidence manifest, because a count
 # computed over a sample must never present itself as a total (issue #104).
@@ -579,6 +584,24 @@ def _custom_registry_entries(request) -> list:
     return entries
 
 
+def _corp_domains(request) -> list:
+    """The corporate domains this deployment currently claims.
+
+    Read from the receiver's settings (managed mode), which is the same
+    list the collectors are served at runtime. It is used to stop a
+    domain the operator has since added from still being presented as a
+    personal account by an agent carrying an older copy - a browser
+    extension bakes the list into its policy, so it can lag by a whole
+    redeploy. Quiet on failure: the list only ever removes rows, so an
+    unreadable one shows more than it should rather than hiding
+    something.
+    """
+    entry = (_remote_settings(request) or {}).get("corp_domains")
+    if isinstance(entry, dict):
+        return [d for d in (entry.get("value") or []) if d]
+    return []
+
+
 def _registry(request) -> dict:
     """The registry every portal view should reason over: the shipped file
     plus the portal-defined entries, merged exactly as the receiver serves
@@ -613,6 +636,7 @@ def _findings(hours, request=None):
                    "store the receiver writes to.",
         )
     global _last_loki_ok, _last_loki_error, _last_read_truncated
+    global _last_loki_error_at
     try:
         out = derive.fetch_from_loki(
             # The bearer token is env configuration and belongs to the env
@@ -633,6 +657,7 @@ def _findings(hours, request=None):
             exc_info=True,
         )
         _last_loki_error = type(e).__name__
+        _last_loki_error_at = time.time()
         # Say which of the two this is. A portal that shows an empty graph
         # when it cannot reach Loki is indistinguishable from one reporting a
         # clean estate, which is the failure this project keeps finding. The
@@ -813,6 +838,7 @@ def diagnostics(_=Depends(require_auth)):
             "loki_configured": bool(LOKI_URL),
             "loki_last_success": _last_loki_ok or None,
             "loki_last_error": _last_loki_error,
+            "loki_last_error_at": _last_loki_error_at or None,
             "loki_last_read_truncated": _last_read_truncated,
             "lookback_hours": LOOKBACK_HOURS,
             "cache_ttl_seconds": CACHE_TTL,
@@ -852,9 +878,11 @@ def graph(request: Request,
         _cache.pop("graph", None)
     def build():
         findings = _findings(hours, request)
-        domain_map = derive.load_domain_map_from(_registry(request))
+        reg = _registry(request)
+        domain_map = derive.load_domain_map_from(reg)
         identity_map = derive.load_identity_map(IDENTITY_MAP) if IDENTITY_MAP else {}
-        return derive.graph_from(findings, domain_map, identity_map, hours)
+        return derive.graph_from(findings, domain_map, identity_map, hours,
+                                 corp_domains=_corp_domains(request), reg=reg)
 
     value, at = _cached("graph", hours, build)
     return JSONResponse(dict(value, derived_at=at, hours=hours,
@@ -901,7 +929,9 @@ def evidence_snapshot(request: Request,
     doc = evidence.evidence_from(
         derive.register_from(findings, reg, domain_map, gov, exceptions),
         derive.status_from(findings),
-        derive.personal_accounts_from(findings, domain_map),
+        derive.personal_accounts_from(
+            findings, domain_map, _corp_domains(request),
+            derive.tool_domains_from(reg)),
         derive.mcp_from(findings),
         paste_guard.paste_guard_from(findings, domain_map),
         registry_path=REGISTRY_PATH,

--- a/portal/app/paste_guard.py
+++ b/portal/app/paste_guard.py
@@ -126,8 +126,14 @@ def paste_guard_from(findings, domain_map=None):
     # from the event counts on purpose: a heartbeat is not something somebody
     # tried to paste.
     guard_devices = set()
-    guard_versions = defaultdict(set)
-    guard_modes = defaultdict(set)
+    # device -> (timestamp, version) and (timestamp, mode): the LATEST
+    # heartbeat wins. Keeping a set of devices per version instead put a
+    # device that upgraded during the window in two buckets, so the split
+    # summed past the device count ("39 devices running the guard" over a
+    # breakdown of 41) - and a rollout view wants where the fleet is now,
+    # not everywhere it has been.
+    guard_device_version = {}
+    guard_device_mode = {}
 
     for f in findings:
         if (f.get("source") or "") != "paste_guard":
@@ -138,10 +144,15 @@ def paste_guard_from(findings, domain_map=None):
         if version is not None:
             if device:
                 guard_devices.add(device)
+                ts = f.get("reported_at") or ""
                 if version:
-                    guard_versions[version].add(device)
+                    prev = guard_device_version.get(device)
+                    if prev is None or ts >= prev[0]:
+                        guard_device_version[device] = (ts, version)
                 if mode:
-                    guard_modes[mode].add(device)
+                    prev = guard_device_mode.get(device)
+                    if prev is None or ts >= prev[0]:
+                        guard_device_mode[device] = (ts, mode)
             continue
 
         action, detectors = _parse(f.get("evidence"))
@@ -182,7 +193,14 @@ def paste_guard_from(findings, domain_map=None):
             "warned": t["warned"],
             "blocked": t["blocked"],
             "overridden": t["overridden"],
-            "events": t["warned"] + t["blocked"] + t["overridden"],
+            # warned + blocked, NOT + overridden. guard.js reports the
+            # interception ("warned") and then, if the person proceeds,
+            # a second finding ("overridden") for the same paste - so
+            # adding all three counted every override twice, and the ISO
+            # evidence document inherited it ("8 paste events, 4
+            # overridden" for four pastes). Overridden is a subset of
+            # warned, and is reported as its own number beside this one.
+            "events": t["warned"] + t["blocked"],
             "devices": len(t["devices"]),
             # Which detectors fired here, commonest first. Identifiers only:
             # "aws_access_key", never what matched it.
@@ -202,7 +220,7 @@ def paste_guard_from(findings, domain_map=None):
         "warned": counts["warned"],
         "blocked": counts["blocked"],
         "overridden": counts["overridden"],
-        "events": sum(counts.values()),
+        "events": counts["warned"] + counts["blocked"],
         "devices": len(devices),
         "tools": len(rows),
         "detectors": [
@@ -215,12 +233,17 @@ def paste_guard_from(findings, domain_map=None):
         # and an estate where the extension was never deployed, and those are
         # the same number.
         "guard_devices": len(guard_devices),
-        "guard_versions": [
-            {"version": v, "devices": len(d)}
-            for v, d in sorted(guard_versions.items(), reverse=True)
-        ],
-        "guard_modes": [
-            {"mode": m, "devices": len(d)}
-            for m, d in sorted(guard_modes.items())
-        ],
+        "guard_versions": _split(guard_device_version, "version"),
+        "guard_modes": _split(guard_device_mode, "mode"),
     }
+
+
+def _split(by_device, field):
+    """One device, one bucket: the value from its latest heartbeat. These
+    splits are read as "where the fleet is", so they have to sum to the
+    number of devices running the guard."""
+    counts = defaultdict(int)
+    for _ts, value in by_device.values():
+        counts[value] += 1
+    return [{field: v, "devices": n} for v, n in
+            sorted(counts.items(), reverse=(field == "version"))]

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -644,7 +644,16 @@ const WIDGETS = {
           ? ` title="${pa.length - open.length} more accepted with a reason"` : ''}>
         open personal accounts</dd>${spark(tr.personal, true)}</div>
       <div><dt>${fresh}</dt><dd>new this week</dd></div>
-      <div><dt>${new Set(pa.map(r=>r.user||r.device)).size}</dt><dd>affected people</dd></div>
+      ${(() => {
+        // People and unattributed devices, counted apart. This was one
+        // tile of `user || device`, so an unattributed laptop counted as
+        // a person - and a person seen on two surfaces, named on one and
+        // unresolved on the other, counted twice in the same number.
+        const named = new Set(pa.filter(r => r.user).map(r => r.user));
+        const anon = new Set(pa.filter(r => !r.user && r.device).map(r => r.device));
+        return `<div><dt>${named.size}</dt><dd>affected people</dd></div>
+      ${anon.size ? `<div><dt>${anon.size}</dt><dd title="Personal-account rows whose device no identity map covers - counted apart, because a device is not a person">unattributed devices</dd></div>` : ''}`;
+      })()}
       <div><dt>${new Set(pa.map(r=>r.tool)).size}</dt><dd>affected tools</dd></div>
       <div><dt>${devs.length}</dt><dd>devices</dd>${spark(tr.devices)}</div>
       <div><dt>${ents(G.tools).length}</dt><dd>tools</dd></div>
@@ -2508,7 +2517,11 @@ function diagnosticsCards() {
   <dl class="kv">
     <dt>Configured</dt><dd>${yn(r.loki_configured)}</dd>
     <dt>Last successful read</dt><dd>${ago(r.loki_last_success)}</dd>
-    ${r.loki_last_error ? `<dt>Last error</dt><dd style="color:var(--dstr)">${esc(r.loki_last_error)}</dd>` : ''}
+    ${r.loki_last_error ? `<dt>Last error</dt><dd style="color:var(--dstr)">${esc(r.loki_last_error)}${r.loki_last_error_at ? ` · ${ago(r.loki_last_error_at)}` : ''}</dd>` : ''}
+    ${r.loki_last_error && r.loki_last_error_at && r.loki_last_error_at > (r.loki_last_success || 0)
+      ? `<dt></dt><dd class="src-note" style="color:var(--warn)">The last read
+         attempt FAILED. Anything this portal shows is from the last
+         successful read above, or is empty because there was none.</dd>` : ''}
     <dt>Lookback window</dt><dd>${esc(r.lookback_hours)}h</dd>
     <dt>Cache TTL</dt><dd>${esc(r.cache_ttl_seconds)}s</dd>
   </dl></div>

--- a/portal/tests/test_paste_guard.py
+++ b/portal/tests/test_paste_guard.py
@@ -118,7 +118,13 @@ def test_actions_are_counted_separately():
     ])
 
     assert (out["warned"], out["overridden"], out["blocked"]) == (2, 1, 1)
-    assert out["events"] == 4
+    # Three pastes, not four. extension/src/guard.js reports the
+    # interception ("warned") and then a SECOND finding ("overridden")
+    # for the same paste when the person proceeds, so overridden is a
+    # subset of warned rather than a fourth action. Adding all three
+    # counted every override twice, and the ISO evidence document
+    # inherited it: "8 paste events, 4 overridden" for four pastes.
+    assert out["events"] == 3
 
 
 def test_rows_are_per_tool_and_keep_both_events_and_devices():
@@ -267,7 +273,8 @@ def test_the_endpoint_returns_metadata_and_excludes_heartbeats():
         pm._cache.clear()
         body = _json.loads(bytes(pm.paste_guard_events(None, hours=168).body))
 
-    assert body["events"] == 2
+    # One interception, which was overridden - not two events.
+    assert body["events"] == 1
     assert body["overridden"] == 1
     # Both findings resolve to one tool through the domain map.
     assert [r["tool"] for r in body["rows"]] == ["chatgpt"]

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -1,0 +1,177 @@
+"""The contradictions a full review of a live deployment turned up.
+
+Every case here was reported as "these two numbers describe the same
+thing and disagree", against real data none of the existing tests
+carried: an estate large enough for a person to be seen on two surfaces,
+a corporate domain added after an agent last shipped, a vendor whose
+users sign in on the vendor's own domain, a device that upgraded the
+guard mid-window.
+
+The fixture is synthetic and reproduces the shape, not the size. Where a
+finding had exact counts they are asserted against the arithmetic the
+report gave, so a regression fails with the same sum the reviewer
+noticed rather than a vague inequality.
+"""
+
+import os
+
+os.environ.setdefault("PORTAL_AUTH", "none")
+
+from app import derive, evidence, paste_guard
+
+CORP = ["corp.example", "corp-two.example"]
+
+REG = {"tools": [
+    {"id": "chatgpt", "name": "ChatGPT", "domains": ["chatgpt.com"]},
+    {"id": "claude", "name": "Claude", "domains": ["claude.ai"]},
+    {"id": "fireflies", "name": "Fireflies", "domains": ["fireflies.ai"]},
+]}
+
+
+def _f(**kw):
+    f = {"tool": "chatgpt", "surface": "browser", "os": "macos",
+         "account_domain": "", "device": "DEV-1", "user": "",
+         "evidence": "", "severity": "info", "source": "collector-macos",
+         "reported_at": "2026-08-27T10:00:00Z", "device_name": ""}
+    f.update(kw)
+    return f
+
+
+def _personal(**kw):
+    return _f(severity="warn", **kw)
+
+
+# ------------------------------------------------- personal accounts --
+
+
+def test_a_configured_corporate_domain_is_not_a_personal_account():
+    """The reporter judges severity against the domain list it held at
+    the time, and a browser extension bakes that list into its policy -
+    so a domain added in Settings afterwards keeps arriving flagged.
+    The review found one of the operator's OWN corporate domains listed
+    under personal accounts, and travelling into the shareable budget
+    report."""
+    findings = [
+        _personal(account_domain="corp-two.example", device="DEV-1"),
+        _personal(account_domain="gmail.example", device="DEV-2"),
+    ]
+    rows = derive.personal_accounts_from(findings, {}, CORP)
+    assert [r["account_domain"] for r in rows] == ["gmail.example"]
+
+
+def test_subdomains_and_spelling_of_a_corporate_domain_are_covered():
+    findings = [
+        _personal(account_domain="mail.corp.example", device="D1"),
+        _personal(account_domain="CORP.EXAMPLE", device="D2"),
+        _personal(account_domain="www.corp.example", device="D3"),
+        # Not a subdomain - a different registrable domain that merely
+        # ends with the same letters.
+        _personal(account_domain="notcorp.example", device="D4"),
+    ]
+    rows = derive.personal_accounts_from(findings, {}, ["corp.example"])
+    assert [r["device"] for r in rows] == ["D4"]
+
+
+def test_a_tools_own_domain_is_not_personal_use_of_that_tool():
+    """Four rows on the meeting-notes vendor's own domain were counted
+    as personal-account use of the licence being paid for, and were all
+    four of that licence's personal-account uses in the finance report."""
+    findings = [
+        _personal(tool="fireflies", account_domain="fireflies.ai",
+                  device="D1"),
+        _personal(tool="fireflies", account_domain="gmail.example",
+                  device="D2"),
+        # The same domain on a DIFFERENT tool is still personal: signing
+        # into ChatGPT with a fireflies.ai account is not a work account.
+        _personal(tool="chatgpt", account_domain="fireflies.ai",
+                  device="D3"),
+    ]
+    rows = derive.personal_accounts_from(
+        findings, {}, CORP, derive.tool_domains_from(REG))
+    assert sorted((r["tool"], r["device"]) for r in rows) == [
+        ("chatgpt", "D3"), ("fireflies", "D2")]
+
+
+def test_the_exclusions_reach_the_evidence_document_too():
+    """The ISO document and the page must not disagree about how many
+    personal accounts the estate has."""
+    findings = [
+        _personal(account_domain="corp-two.example", device="D1"),
+        _personal(tool="fireflies", account_domain="fireflies.ai",
+                  device="D2"),
+        _personal(account_domain="gmail.example", device="D3"),
+    ]
+    rows = derive.personal_accounts_from(
+        findings, {}, CORP, derive.tool_domains_from(REG))
+    doc = evidence.evidence_from([], {}, rows, [], {}, hours=168)
+    assert len(rows) == 1
+    assert doc["personal_accounts"] == 1
+
+
+# ------------------------------------------------------ paste guard --
+
+
+def _heartbeat(device, version, at):
+    return _f(tool="paste-guard", source="paste_guard", surface="browser",
+              device=device, reported_at=at, severity="info",
+              evidence="heartbeat version=%s mode=warn reason=installed"
+                       % version)
+
+
+def test_a_device_that_upgraded_appears_in_one_version_bucket():
+    """"39 devices running the guard" sat directly above a version split
+    summing to 41: two devices had reported two versions inside the
+    window and were counted in both buckets."""
+    findings = [
+        _heartbeat("D1", "1.3.0", "2026-08-20T10:00:00Z"),
+        _heartbeat("D1", "1.4.0", "2026-08-27T10:00:00Z"),
+        _heartbeat("D2", "1.3.0", "2026-08-27T10:00:00Z"),
+    ]
+    out = paste_guard.paste_guard_from(findings, {})
+    assert out["guard_devices"] == 2
+    assert sum(v["devices"] for v in out["guard_versions"]) == 2
+    # The latest heartbeat wins: the fleet is where it is now, not
+    # everywhere it has been.
+    assert {v["version"]: v["devices"] for v in out["guard_versions"]} == {
+        "1.4.0": 1, "1.3.0": 1}
+    assert sum(m["devices"] for m in out["guard_modes"]) == 2
+
+
+def test_an_override_is_not_a_second_paste():
+    """guard.js reports the interception and then a second finding when
+    the person proceeds, so "8 paste events, 4 overridden" on the ISO
+    page described four pastes."""
+    findings = [
+        _f(source="paste_guard", severity="warn",
+           evidence="paste warned: aws_access_key"),
+        _f(source="paste_guard", severity="warn",
+           evidence="paste overridden: aws_access_key"),
+        _f(source="paste_guard", severity="warn",
+           evidence="paste blocked: private_key"),
+    ]
+    out = paste_guard.paste_guard_from(findings, {})
+    assert (out["warned"], out["overridden"], out["blocked"]) == (1, 1, 1)
+    # One warned interception plus one blocked one. The override is the
+    # outcome of a warning already counted.
+    assert out["events"] == 2
+    assert sum(r["events"] for r in out["rows"]) == 2
+    doc = evidence.evidence_from([], {}, [], [], out, hours=168)
+    assert doc["paste_events"] == 2
+    assert doc["paste_overridden"] == 1
+
+
+# ------------------------------------------------------ mcp servers --
+
+
+def test_servers_differing_only_in_case_are_one_server():
+    findings = [
+        _f(surface="mcp", device="D1",
+           evidence=".claude.json mcpServers: Figma"),
+        _f(surface="mcp", device="D2",
+           evidence=".claude.json mcpServers: figma"),
+    ]
+    rows = derive.mcp_from(findings)
+    assert len(rows) == 1
+    assert rows[0]["devices"] == ["D1", "D2"]
+    # The spelling somebody actually wrote is the one shown.
+    assert rows[0]["server"] == "Figma"

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.1
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
A full review of a running deployment - viewer pass and admin pass - turned up a class of finding the test suite had no data to catch: two figures on the same estate that cannot both be true. This is the first batch, the ones where the arithmetic is provable.

- **An override is not a second paste.** `extension/src/guard.js` reports the interception (`warned`) and then a *second* finding (`overridden`) when the person proceeds. `events = warned + blocked + overridden` therefore counted every override twice, and the ISO evidence document - the compliance artifact - inherited it as "8 paste events, 4 overridden" for four pastes. Overridden is now stated as a subset of warned.
- **A device that upgraded mid-window was in two version buckets**, so "39 devices running the guard" printed directly above a split summing to 41. Each device now lands in one bucket at its latest heartbeat's version, which is also the question a rollout view is asking.
- **"Affected people" counted `user || device`**, so an unattributed laptop counted as a person and someone seen on two surfaces - named on one, unresolved on the other - counted twice. People and unattributed devices are counted apart now.
- **A configured corporate domain was listed as a personal account** and travelled into the shareable budget report. Severity stays the reporter's judgement made at detection time, but a row is no longer *presented* as personal when the deployment's current corporate-domain list contradicts it - a browser extension bakes that list into its policy, so it lags by a redeploy. Both sides normalised, subdomains covered.
- **A tool's own sign-in domain counted as personal use of that tool** - all four personal-account uses on one licence were the vendor's own domain. Excluded using the registry's existing per-tool `domains`, so every installer benefits with no schema change.
- **Two MCP servers differing only in capitalisation** were counted as two.
- **A failed log-store read left no trace.** Diagnostics could only age the last *success*, so a portal whose reads had been failing all day looked identical to one nobody had opened - on the page a self-hoster opens precisely when the portal looks empty. It now records the failure time and says plainly that what is displayed may be stale.

New `portal/tests/test_review_findings.py` carries a synthetic fixture reproducing each contradiction's shape, asserting against the arithmetic from the report so a regression fails with the same sum that was noticed. Portal 381 green.

Chart 0.14.1, appVersion 0.14.1.