### PR TITLE
Portal: one machine is one device, whatever its sources call it

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.14.1
+version: 0.14.2
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.14.1"
+appVersion: "0.14.2"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.1
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.2
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.1
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.2
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/README.md
+++ b/portal/README.md
@@ -195,6 +195,17 @@ that finds none.
 The portal does not resolve identity. It carries enough for you to resolve it
 against whatever you run.
 
+One machine is one device even when its sources disagree about the key. An
+endpoint collector reports an asset-tagged serial and a browser extension
+reports the bare one, so the same laptop used to arrive as two devices with
+its tools split across both. Keys that differ only by a prefix are merged,
+the other spellings are listed on the device's detail, and a personal-account
+row whose source reported no account name takes the person the identity map
+attaches to that machine - labelled "via device", because it was inferred
+from the hardware rather than read from the source. An ambiguous key (the
+tail of two prefixed keys) or one too short to be an identifier is left
+alone: merging the wrong two machines is worse than showing two cards.
+
 Endpoint findings carry a device and a local username. The username is a hint,
 not a key: it is `firstname.lastname` on a Jamf Connect Mac, a local account on
 a Mac enrolled before that, the work account on Autopilot Windows, and whatever

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -456,6 +456,10 @@ def build(findings, domain_map=None, identity_map=None):
         "tool_accounts": defaultdict(set),
         "person": "", "collector_seen": False, "scanner_seen": False,
         "collector_version": "",
+        # Other keys the same machine arrived under. Kept so the detail
+        # view can show what each source called it, and so a lookup by
+        # any of them still finds the device.
+        "aliases": set(),
     })
     identities = defaultdict(lambda: {
         "tools": set(), "surfaces": set(), "sources": set(),
@@ -578,6 +582,42 @@ def build(findings, domain_map=None, identity_map=None):
                 "evidence": f.get("evidence", ""),
             })
 
+    # One machine, one device. Sources disagree about the key: an
+    # endpoint collector reports an asset-tagged serial (TGT-XXXX) and a
+    # browser extension reports the bare one (XXXX), so the same laptop
+    # arrived as two devices - two cards under one hostname, its tools
+    # split across both, and a personal-account row that could not find
+    # the person the other half already knew. Merge before anything is
+    # counted or attributed.
+    for bare, canon in _device_aliases(devices).items():
+        src, dst = devices.pop(bare), devices[canon]
+        for field in ("os", "tools", "surfaces", "local_users", "sources",
+                      "accounts", "personal_accounts"):
+            dst[field] |= src[field]
+        for tool, accts in src["tool_accounts"].items():
+            dst["tool_accounts"].setdefault(tool, set())
+            dst["tool_accounts"][tool] |= accts
+        dst["findings"] += src["findings"]
+        dst["device_name"] = dst["device_name"] or src["device_name"]
+        dst["collector_seen"] = dst["collector_seen"] or src["collector_seen"]
+        dst["scanner_seen"] = dst["scanner_seen"] or src["scanner_seen"]
+        dst["collector_version"] = (dst["collector_version"]
+                                    or src["collector_version"])
+        dst["aliases"].add(bare)
+        # Every tool edge pointed at the key that just went away.
+        for t in tools.values():
+            if bare in t["devices"]:
+                t["devices"].discard(bare)
+                t["devices"].add(canon)
+            for surf, ds in t["devices_by_surface"].items():
+                if bare in ds:
+                    ds.discard(bare)
+                    ds.add(canon)
+        for b in bridges.values():
+            if bare in b["devices"]:
+                b["devices"].discard(bare)
+                b["devices"].add(canon)
+
     # Attach a person to each device, if the deployer supplied a mapping.
     # Device key first, then any local username: an MDM keys on the serial, a
     # spreadsheet is more likely to key on the name someone logs in with.
@@ -597,6 +637,49 @@ def build(findings, domain_map=None, identity_map=None):
             i["surfaces"] |= d["surfaces"]
 
     return devices, identities, tools, bridges, unattributed
+
+
+# Long enough that a shared suffix means something. Six characters of
+# serial matching by accident is a stretch; two or three is not, and
+# merging a junk key like "A" into "TGT-A" would be worse than the split
+# it fixes.
+_MIN_ALIAS_KEY = 6
+_ALIAS_SEPARATORS = ("-", "_", ".", ":")
+
+
+def _device_aliases(devices):
+    """{bare key: canonical key} where one key is another with a source
+    prefix on the front.
+
+    Only prefix-and-separator relationships count, and only where the
+    bare key is long enough to be an identifier rather than a label. An
+    ambiguous bare key - one that is the tail of two different prefixed
+    keys - is left alone: merging the wrong pair of machines is worse
+    than showing two cards.
+    """
+    keys = [k for k in devices if k]
+    lowered = {k: k.lower() for k in keys}
+    out, ambiguous = {}, set()
+    for bare in keys:
+        low = lowered[bare]
+        if len(low) < _MIN_ALIAS_KEY:
+            continue
+        for other in keys:
+            if other == bare:
+                continue
+            o = lowered[other]
+            if len(o) <= len(low):
+                continue
+            if any(o.endswith(sep + low) for sep in _ALIAS_SEPARATORS):
+                if bare in out:
+                    ambiguous.add(bare)
+                out[bare] = other
+    for k in ambiguous:
+        out.pop(k, None)
+    # A key cannot be both a bare form and a canonical one: A -> B while
+    # B -> C would drop A's findings onto a key that is itself merging
+    # away. Rare, but cheap to refuse.
+    return {b: c for b, c in out.items() if c not in out}
 
 
 def jsonable(d):
@@ -622,7 +705,7 @@ def _domain_matches(account, listed):
 
 
 def personal_accounts_from(findings, domain_map=None, corp_domains=None,
-                           tool_domains=None):
+                           tool_domains=None, device_person=None):
     """One row per personal account seen on a tool, with when it was first and
     last observed.
 
@@ -640,6 +723,14 @@ def personal_accounts_from(findings, domain_map=None, corp_domains=None,
     domain_map = domain_map or {}
     corp_domains = corp_domains or []
     tool_domains = tool_domains or {}
+    # {device key (canonical or alias): (canonical key, person)}. A
+    # browser extension reports no user, so its rows read "no identity"
+    # even where the estate had already attached a person to that exact
+    # machine through the identity map - the same person named on the
+    # cli row directly above. Nothing here invents an identity: it
+    # resolves the one the device inventory already holds, and says the
+    # attribution came from the device rather than the source.
+    device_person = device_person or {}
     rows = {}
     for f in findings:
         if (f.get("severity") or "") != "warn":
@@ -676,11 +767,20 @@ def personal_accounts_from(findings, domain_map=None, corp_domains=None,
 
         device = (f.get("device") or "").strip()
         user = (f.get("user") or "").strip()
+        canon, via = device, ""
+        if device in device_person:
+            canon, person = device_person[device]
+            if not user and person:
+                user, via = person, "device"
+        device = canon
         key = (user, acct, tool, device)
         r = rows.get(key)
         if r is None:
             r = rows[key] = {
                 "user": user, "account_domain": acct, "tool": tool,
+                # "" when the source named the person, "device" when the
+                # identity map named them through the machine.
+                "user_via": via,
                 "device": device, "device_name": "", "os": "",
                 "surfaces": set(), "sources": set(),
                 "first_seen": "", "last_seen": "", "findings": 0,
@@ -864,6 +964,19 @@ def tool_domains_from(reg):
     return out
 
 
+def device_person_map(devices):
+    """Every key a device answers to - canonical and alias - pointing at
+    (canonical key, person). Built after the merge, so a row keyed on
+    whichever spelling its source used still resolves."""
+    out = {}
+    for k, d in devices.items():
+        entry = (k, d.get("person") or "")
+        out[k] = entry
+        for alias in d.get("aliases") or ():
+            out[alias] = entry
+    return out
+
+
 def graph_from(findings, domain_map=None, identity_map=None, hours=168,
                corp_domains=None, reg=None):
     """Everything above, assembled into the shape the API and the UI read."""
@@ -886,7 +999,8 @@ def graph_from(findings, domain_map=None, identity_map=None, hours=168,
         "bridges": {k: jsonable(v) for k, v in bridges.items()},
         "unattributed": unattributed,
         "personal_accounts": personal_accounts_from(
-            findings, domain_map, corp_domains, tool_domains_from(reg)),
+            findings, domain_map, corp_domains, tool_domains_from(reg),
+            device_person_map(devices)),
         "mcp_servers": mcp_from(findings),
         "trends": trends_from(findings, domain_map, hours),
         "counts": {

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -989,6 +989,9 @@ function deviceDetail(k) {
   const bridges = ents(G.bridges||{}).filter(([,b]) => (b.devices||[]).includes(k)).map(([n])=>n);
   return `<h2>${esc(label(k,d))}</h2>
   <p class="lede">${esc(k)} · ${esc((d.os||[]).join(', ')) || 'os unknown'} · ${d.findings} findings</p>
+  ${(d.aliases||[]).length ? `<p class="src-note" style="margin-top:-6px">Also
+    reported as ${(d.aliases).map(a => `<span class="mono">${esc(a)}</span>`).join(', ')}
+    — one machine, merged here because sources key it differently.</p>` : ''}
   <table>
     <tr><th>person</th><td>${d.person ? esc(d.person) : '<span class="pill p-mut">unattributed</span>'}</td></tr>
     <tr><th>local users</th><td>${esc((d.local_users||[]).join(', ')) || '—'}</td></tr>
@@ -1125,7 +1128,10 @@ function personal() {
   <th>surface</th><th>first seen</th><th>last seen</th><th>source</th>
   ${lifecycle ? '<th>status</th>' : ''}</tr>
   ${rows.map(r => `<tr${paStatus(r) ? ' style="opacity:.6"' : ''}>
-    <td>${r.user ? esc(r.user) : '<span class="pill p-mut">no identity</span>'}</td>
+    <td>${r.user
+      ? esc(r.user) + (r.user_via === 'device'
+        ? ' <span class="pill p-mut" title="This source reported no account name. The person is the one the identity map attaches to this machine.">via device</span>' : '')
+      : '<span class="pill p-mut">no identity</span>'}</td>
     <td><span class="pill p-warn">${esc(r.account_domain)}</span></td>
     <td>${esc(r.tool)}</td>
     <td>${esc(r.device_name || r.device || '—')}</td>

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -175,3 +175,62 @@ def test_servers_differing_only_in_case_are_one_server():
     assert rows[0]["devices"] == ["D1", "D2"]
     # The spelling somebody actually wrote is the one shown.
     assert rows[0]["server"] == "Figma"
+
+
+# ------------------------------------------------- one machine, one device --
+
+
+def test_a_machine_reported_under_two_keys_is_one_device():
+    """The endpoint collector reports an asset-tagged serial and the
+    browser extension reports the bare one, so one laptop arrived as two
+    devices: two cards under one hostname, tools split across both, and
+    the review counted 69 cards over 65 distinct names."""
+    findings = [
+        _f(device="TGT-ABC123", device_name="LAPTOP-1", tool="claude-code",
+           surface="cli", source="collector-macos"),
+        _f(device="ABC123", device_name="LAPTOP-1", tool="chatgpt",
+           surface="browser", source="browser_extension"),
+    ]
+    devices, identities, tools, _b, _u = derive.build(findings, {}, {})
+    assert list(devices) == ["TGT-ABC123"]
+    d = devices["TGT-ABC123"]
+    assert d["tools"] == {"claude-code", "chatgpt"}
+    assert d["aliases"] == {"ABC123"}
+    assert d["findings"] == 2
+    # The tool edges follow the surviving key, or a tool page would link
+    # to a device that no longer exists.
+    assert tools["chatgpt"]["devices"] == {"TGT-ABC123"}
+
+
+def test_the_person_the_estate_already_knows_is_not_no_identity():
+    """15 of 34 personal-account rows read "no identity" for machines the
+    Devices view named on the row above - the browser extension reports
+    no user, and the join never asked the device."""
+    findings = [
+        _f(device="TGT-ABC123", user="alice", tool="claude-code",
+           surface="cli", source="collector-macos"),
+        _f(device="ABC123", tool="chatgpt", surface="browser",
+           severity="warn", account_domain="gmail.example",
+           source="browser_extension"),
+    ]
+    graph = derive.graph_from(findings, {}, {"TGT-ABC123": "alice"})
+    rows = graph["personal_accounts"]
+    assert len(rows) == 1
+    assert rows[0]["user"] == "alice"
+    # And it says the attribution came from the machine, not the source.
+    assert rows[0]["user_via"] == "device"
+    assert rows[0]["device"] == "TGT-ABC123"
+
+
+def test_an_ambiguous_or_short_key_is_left_alone():
+    """Merging the wrong two machines is worse than showing two cards."""
+    findings = [
+        _f(device="AB1", tool="claude"),          # too short to be an id
+        _f(device="TGT-AB1", tool="claude"),
+        _f(device="SERIAL7", tool="claude"),      # tail of two prefixed keys
+        _f(device="TGT-SERIAL7", tool="claude"),
+        _f(device="TNG-SERIAL7", tool="claude"),
+    ]
+    devices, _i, _t, _b, _u = derive.build(findings, {}, {})
+    assert set(devices) == {"AB1", "TGT-AB1", "SERIAL7",
+                            "TGT-SERIAL7", "TNG-SERIAL7"}

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.1
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.2
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
The review's root cause, and the reviewer was right that it sits upstream of three other findings (F-A01, and parts of F-A02, F-A05, F-A14, F-A24).

An endpoint collector reports an asset-tagged serial; a browser extension reports the bare one. The same laptop therefore arrived as **two devices**: two cards under one hostname (the reported "69 cards, 65 distinct names"), its tools split across both, and - the damaging one - a personal-account row reading **"no identity" for a machine the estate had already named on the row directly above**, 15 of 34 rows on the reviewed deployment.

- Keys differing only by a prefix-and-separator are merged before anything is counted or attributed. Tool and bridge edges follow the surviving key, so a tool page cannot link to a device that no longer exists; the other spellings are listed on the device's detail ("also reported as …"); a lookup by any spelling still resolves.
- A personal-account row whose source reported no account name takes the person the identity map attaches to that machine, tagged **"via device"** - an inferred attribution must never read as a reported one.
- Deliberately conservative: a bare key that is the tail of two different prefixed keys is ambiguous and left alone, as is any key shorter than six characters. Merging the wrong two machines is worse than showing two cards.

Verified end to end on a miniature of the reported estate: two keys collapse to one device, the browser row resolves to the person the cli row named, and "affected people" reads 1 where it previously read 3. Tests cover the merge, the resolution, the tool-edge rewrite, and both refusals. Portal 384 green.

Chart 0.14.2, appVersion 0.14.2.