### PR TITLE
Portal: a failed read is not a clean estate

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.14.2
+version: 0.14.3
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.14.2"
+appVersion: "0.14.3"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.2
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.3
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.2
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.3
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -521,6 +521,15 @@ def build(findings, domain_map=None, identity_map=None):
             continue
 
         tool = normalise_tool(tool, domain_map)
+        # One definition of "a tool in use", shared with the register.
+        # An MCP finding names its tool <tool>-mcp, which is evidence the
+        # tool is on that machine rather than a different tool - the
+        # register has always folded it, and the estate views did not, so
+        # the two pages disagreed about how many tools exist ("23 in use"
+        # against "26 tools", and a register "0 not in registry" beside
+        # three Inventory rows that are in no registry). The mcp surface
+        # still attaches, and the servers themselves stay their own view.
+        tool = _base_tool(tool)
 
         t = tools[tool]
         t["surfaces"].add(surface)

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -716,7 +716,9 @@ const WIDGETS = {
       <td>${esc(r.tool)}</td>
       <td style="color:var(--mut)">${esc((r.last_seen||'').slice(0,10))}</td>
     </tr>`).join('')}</table>`
-    : '<p class="lede">None seen. That is a result, not an absence of one.</p>'}
+    : dataOk()
+      ? '<p class="lede">None seen. That is a result, not an absence of one.</p>'
+      : '<p class="lede">Nothing to show: the findings could not be read.</p>'}
     </div>`;
   },
 
@@ -981,7 +983,9 @@ function coverage() {
   ${gaps.map(([k,d])=>`<tr><td>${esc(label(k,d))}</td>
     <td>${(d.sources||[]).map(s=>`<span class="pill p-mut">${esc(s)}</span>`).join('')}</td>
     <td>${(d.tools||[]).length}</td></tr>`).join('')}</table></div>`
-  : '<p class="lede">Every device with a scanner finding also has a collector reporting.</p>'}`;
+  : dataOk()
+    ? '<p class="lede">Every device with a scanner finding also has a collector reporting.</p>'
+    : '<p class="lede">Nothing to compare: the findings could not be read.</p>'}`;
 }
 
 function deviceDetail(k) {
@@ -1594,7 +1598,8 @@ async function register() {
         data-key="${esc(r.id)}">add to registry</button>` : ''}</div>` : ''}`}
     ${exceptionBlock(r)}
   </div>`).join('')}
-  </div>` : `<p class="lede">No AI tools observed in the last ${esc(win)}.
+  </div>` : !dataOk() ? `<p class="lede">No AI tools to show: the findings
+  could not be read. This is not an empty estate.</p>` : `<p class="lede">No AI tools observed in the last ${esc(win)}.
   That is a real answer for a small estate, and it is also what a fleet with no
   collectors deployed looks like: check Setup before reading it as a clean
   one.</p>`}
@@ -1766,7 +1771,8 @@ async function iso() {
   ${inputs.length ? `<ul class="inputs">
     ${inputs.map(([, text, target]) =>
       `<li><a href="#${target}">${esc(text)}</a></li>`).join('')}
-  </ul>` : `<p class="lede">Nothing outstanding in this window. Sanity check:
+  </ul>` : !dataOk() ? `<p class="lede">Nothing to review: the findings
+  could not be read.</p>` : `<p class="lede">Nothing outstanding in this window. Sanity check:
   ${e.sources_reporting} of ${e.sources_known} expected sources are reporting -
   an estate with nothing reporting looks "clean" too.</p>`}
 
@@ -2973,7 +2979,10 @@ function bReconcile(sub) {
   const keysByTool = {};
   eff.forEach(t => {
     const map = new Map();
-    obs.perTool[t].forEach(n => bKeys(n).forEach(k => map.set(k, n)));
+    obs.perTool[t].forEach(n => bKeys(n).forEach(k => {
+      if (!map.has(k)) map.set(k, new Set());
+      map.get(k).add(n);
+    }));
     keysByTool[t] = map;
   });
   const tiers = sub.seat_tiers || [];
@@ -2984,8 +2993,7 @@ function bReconcile(sub) {
     const keys = [...bKeys(m.email), ...bKeys(m.name)];
     const seenOn = eff.filter(t => keys.some(k => keysByTool[t].has(k)));
     seenOn.forEach(t => keys.forEach(k => {
-      const n = keysByTool[t].get(k);
-      if (n) usedNames.add(n);
+      (keysByTool[t].get(k) || []).forEach(n => usedNames.add(n));
     }));
     const tier = resolveTier(m);
     if (seenOn.length) matched.push({m, tier, seenOn});
@@ -4509,13 +4517,44 @@ function tabbar() {
     `<button data-nav="${id}" class="${view===id?'on':''}">${lbl}</button>`).join('')}</div>`;
 }
 
+// Did the estate data actually arrive? Every "none seen, and that is a
+// real answer" line on this page is a claim about the ESTATE, and it is
+// only true if the read succeeded. A viewer account whose reads are
+// refused used to get those same confident sentences over zeros, which
+// is the worst failure this product can have: it reports a clean estate
+// it never looked at.
+const dataOk = () => !loadError;
+
+// The banner that says so, above every view rather than on the one page
+// that happened to check.
+function loadBanner() {
+  if (!loadError) return '';
+  const denied = /401|403|login|permission|read-only|forbidden/i.test(loadError);
+  return `<div class="note" style="border-color:var(--dstr);margin-bottom:14px">
+    <strong>The findings could not be read, so this page is not an answer.</strong>
+    <div class="src-note" style="margin-top:4px;font-style:normal">${esc(loadError)}</div>
+    <div class="src-note" style="margin-top:6px">${denied
+      ? `This account was refused. Reads go through the portal, and this
+         deployment has no log-store credential of its own, so they are
+         being made with your session - which this role cannot use. An
+         admin can fix it for every account by setting
+         <span class="mono">RECEIVER_ADMIN_TOKEN</span> on the portal, or
+         giving it <span class="mono">LOKI_URL</span> and its own
+         credentials. Until then the counts below are zeros because
+         nothing was read, not because nothing is happening.`
+      : `Every count below is missing rather than zero. Settings >
+         Diagnostics records when the last read succeeded and when the
+         last one failed.`}</div>
+  </div>`;
+}
+
 async function render() {
   const sec = sectionOf(view);
   if (sec) SECTAB[sec.id] = view;
   drawNav();
   // A full render is a change of place, so the inspector closes with it.
   if (!detail) { DSTACK = []; document.body.classList.remove('open'); }
-  const tb = tabbar();
+  const tb = tabbar() + loadBanner();
   // settings and register each read a second endpoint, so they are async.
   if (view === 'settings') { app.innerHTML = tb + await settings(); return; }
   if (view === 'register') { app.innerHTML = tb + await register(); return; }

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -234,3 +234,53 @@ def test_an_ambiguous_or_short_key_is_left_alone():
     devices, _i, _t, _b, _u = derive.build(findings, {}, {})
     assert set(devices) == {"AB1", "TGT-AB1", "SERIAL7",
                             "TGT-SERIAL7", "TNG-SERIAL7"}
+
+
+# ---------------------------------------- one definition of a tool in use --
+
+
+def test_an_mcp_finding_is_the_tool_it_configures():
+    """The register folds <tool>-mcp into its parent and the estate views
+    did not, so the two pages disagreed about how many tools exist: "23
+    in use, 0 not in registry" beside "26 tools", three of which were in
+    no registry."""
+    findings = [
+        _f(tool="claude-code", surface="cli", device="D1"),
+        _f(tool="claude-code-mcp", surface="mcp", device="D1",
+           evidence=".claude.json mcpServers: figma"),
+        _f(tool="cursor-mcp:figma", surface="mcp", device="D2",
+           evidence=".cursor/mcp.json mcpServers"),
+    ]
+    graph = derive.graph_from(findings, {}, {})
+    assert set(graph["tools"]) == {"claude-code", "cursor"}
+    # The surface still lands, so "claude-code, seen on cli and mcp" is
+    # still sayable - it is the pseudo-tool that goes, not the evidence.
+    assert set(graph["tools"]["claude-code"]["surfaces"]) == {"cli", "mcp"}
+    # And the servers keep their own view, keyed as the collectors report.
+    assert [r["server"] for r in graph["mcp_servers"]] == ["figma"]
+
+
+# ------------------------------------- a failed read is not a clean estate --
+
+
+def test_the_shell_says_so_when_the_read_failed():
+    """Five viewer accounts on the reviewed deployment were refused by
+    the log store and shown zeros under "None seen. That is a result,
+    not an absence of one." - the product reporting a clean estate it
+    had never looked at."""
+    index = (os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    html = open(os.path.join(index, "app", "static", "index.html")).read()
+    # A banner above every view, not on the one page that checked.
+    assert "function loadBanner()" in html
+    assert "this page is not an answer" in html
+    assert "const tb = tabbar() + loadBanner();" in html
+    # The confident lines are gated on the read having worked.
+    assert "const dataOk = () => !loadError;" in html
+    for gated in ("None seen. That is a result",
+                  "also has a collector reporting",
+                  "Nothing outstanding in this window",
+                  "That is a real answer for a small estate"):
+        before = html.split(gated)[0]
+        assert "dataOk()" in before[-400:], gated
+    # And it names the fix a self-hoster would otherwise have to find.
+    assert "RECEIVER_ADMIN_TOKEN" in html

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.2
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.3
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
The worst failure this product can have, and a live-deployment review found it: from a viewer account whose reads were refused, the portal reported an empty estate **in its own confident voice** - "None seen. That is a result, not an absence of one.", "Every device with a scanner finding also has a collector reporting.", "No AI tools observed ... That is a real answer for a small estate." Only two views checked whether the read had worked. On the reviewed deployment five of six accounts were viewers, four of whom had never signed in - so this was the first impression waiting for four auditors.

- **A banner on every view when the read failed**, not on the one page that happened to check, and it names the fix rather than the symptom: an account refused because the portal has no log-store credential of its own is told to set `RECEIVER_ADMIN_TOKEN` (or give the portal `LOKI_URL` and its own credentials), and told plainly that the zeros below mean nothing was read.
- **The confident empty states are gated on a successful read** - each becomes "nothing to show: the findings could not be read".

Two more from the same review:

- **One definition of "a tool in use".** An MCP finding names its tool `<tool>-mcp`, which the register has always folded into its parent and the estate views did not - so the register said "23 in use, 0 not in registry" next to Inventory's "26 tools", three of which were in no registry, pinning at zero the one number designed to prompt action. The estate folds it too now; the mcp surface still attaches to the parent tool, and MCP servers keep their own view keyed as collectors report them.
- **The identity twin.** Where the estate holds both `first.last` and `first last`, matching a licence member consumed one spelling and left the other in the budget report as a second unlicensed person. Every spelling that normalises to a matched person is now consumed together.

Verified in the browser with a simulated 403: banner on Sources and the register, confident copy gone, fix named. Portal 386 green.

Chart 0.14.3, appVersion 0.14.3.