### PR TITLE
Identity map: the last thing that needed kubectl now lives in the portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ is operated:
   vendor's admin API where one exists and import from its member export where
   it does not, and one subscription covers every tool its licence entitles,
   so a Claude seat is counted once across Claude and Claude Code.
+- **Identity.** The platform never guesses who owns a machine, but it will
+  propose: download the suggested device-to-person map, correct it, and
+  upload it back in the portal. A mounted file still works; what you save in
+  the portal wins over it.
 - **The fleet.** Devices enroll with their own credential and can be revoked
   individually. Enrollment tokens are invitations; devices are badges; both
   are managed here.

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.14.3
+version: 0.15.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.14.3"
+appVersion: "0.15.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/values.yaml
+++ b/charts/ai-guard/values.yaml
@@ -233,6 +233,10 @@ portal:
   # invented and then acted on is how the wrong name lands on a report.
   #
   # This is personal data. A Secret is a defensible choice instead.
+  # Optional since 0.15.0: in managed mode the map is editable in the portal
+  # (Inventory > People), stored with the receiver's other state, and rows
+  # saved there win over this file per key. Mount one here when you generate
+  # it from an MDM or CMDB in CI, or when you run classic mode.
   identityMap:
     existingConfigMap: ""
 

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.3
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.3
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/README.md
+++ b/portal/README.md
@@ -195,6 +195,23 @@ that finds none.
 The portal does not resolve identity. It carries enough for you to resolve it
 against whatever you run.
 
+In managed mode the map lives in the portal: Inventory > People has an
+Identity map panel that downloads the proposal, takes the corrected file
+back by upload or paste, previews which keys match a device the estate has
+actually seen, and saves. A mounted file still works and still applies -
+rows saved in the portal win over it per key, the same rule every other
+setting follows - so a deployment that keeps a large CSV in a ConfigMap can
+still correct a handful of rows in the product. Saving replaces the whole
+map, because that is how an operator edits it: in a spreadsheet, not row by
+row. Admins write it; viewers read the names it produces anyway, so they can
+read it too.
+
+The proposal matches local usernames against known identities, and machine
+names where a hostname spells out a person the estate already knows - a
+review of a live deployment found five machines named after their owners
+sitting unattributed. Both are string matches, both are proposals, and
+nothing is applied until somebody saves it.
+
 One machine is one device even when its sources disagree about the key. An
 endpoint collector reports an asset-tagged serial and a browser extension
 reports the bare one, so the same laptop used to arrive as two devices with

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -282,6 +282,16 @@ def suggest_identity_rows(devices, identities):
             if cand:
                 hit = (lu, cand)
                 break
+        if not hit:
+            # Nothing in the local usernames, so try what the machine is
+            # called. A review of a live estate found five devices whose
+            # hostname spelled out their owner's name - two of them
+            # people already in the identity list - sitting unattributed
+            # because the only rule looked at local users. Containment
+            # rather than equality: a hostname is a name inside a label
+            # ("firstname-lastname-macbook", "FIRSTNAMEs-MacBook-Pro"),
+            # never the name alone.
+            hit = _hostname_match(d, by_norm)
         if hit:
             matched.append({"key": dev, "identity": hit[1], "via": hit[0],
                             "device_name": d["device_name"]})
@@ -289,6 +299,35 @@ def suggest_identity_rows(devices, identities):
             unmatched.append({"key": dev, "local_users": sorted(d["local_users"]),
                               "device_name": d["device_name"]})
     return matched, unmatched
+
+
+# Short normalised names match inside a hostname by accident - "al" is
+# in "Alienware", "sam" is in "SAMSUNG". Long enough that a hit means
+# something, and a proposal is reviewed before it is used anyway.
+_MIN_HOSTNAME_NAME = 6
+
+
+def _hostname_match(d, by_norm):
+    """(what matched, identity) where a device's own name contains a
+    known person's name, or None.
+
+    The longest matching identity wins, so "jo.smith" is not proposed for
+    a machine that names "jo.smithson". Ambiguity - two different people
+    matching one hostname - proposes neither: the point of this file is
+    that somebody reviews it, and a proposal that is wrong half the time
+    costs more review than it saves.
+    """
+    hay = _norm_person(d.get("device_name") or "")
+    if not hay:
+        return None
+    hits = [(norm, ident) for norm, ident in by_norm.items()
+            if len(norm) >= _MIN_HOSTNAME_NAME and norm in hay]
+    if not hits:
+        return None
+    hits.sort(key=lambda ni: len(ni[0]), reverse=True)
+    if len(hits) > 1 and len(hits[0][0]) == len(hits[1][0]):
+        return None
+    return ("hostname %s" % (d.get("device_name") or ""), hits[0][1])
 
 
 # A cell that a spreadsheet would run rather than display. csv handles commas

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -584,6 +584,40 @@ def _custom_registry_entries(request) -> list:
     return entries
 
 
+_identity_map_cache: dict = {"at": 0.0, "data": None}
+
+
+def _identity_map(request) -> dict:
+    """The effective device/username -> person map.
+
+    The mounted file as ever, with the map saved in the portal merged
+    over it per key - the same DB-wins-when-set rule every other setting
+    follows, so a deployment can keep a large CSV in a ConfigMap and
+    still correct a handful of rows in the product.
+
+    Quiet on failure: a map that cannot be read leaves devices
+    unattributed, which is a state this product renders honestly, and
+    refusing to draw the estate over it would be worse.
+    """
+    out = derive.load_identity_map(IDENTITY_MAP) if IDENTITY_MAP else {}
+    if not LOGIN_MODE or request is None:
+        return out
+    now = time.time()
+    if (_identity_map_cache["data"] is None
+            or now - _identity_map_cache["at"] >= SETTINGS_CACHE_TTL):
+        token = request.cookies.get(SESSION_COOKIE, "")
+        try:
+            saved = managed.receiver_request(
+                RECEIVER_URL, "GET", "/admin/identity-map", token)
+        except managed.ReceiverError:
+            return out
+        _identity_map_cache.update(
+            at=now, data={e["key"]: e["identity"]
+                          for e in saved.get("entries", [])})
+    out.update(_identity_map_cache["data"] or {})
+    return out
+
+
 def _corp_domains(request) -> list:
     """The corporate domains this deployment currently claims.
 
@@ -880,8 +914,8 @@ def graph(request: Request,
         findings = _findings(hours, request)
         reg = _registry(request)
         domain_map = derive.load_domain_map_from(reg)
-        identity_map = derive.load_identity_map(IDENTITY_MAP) if IDENTITY_MAP else {}
-        return derive.graph_from(findings, domain_map, identity_map, hours,
+        return derive.graph_from(findings, domain_map,
+                                 _identity_map(request), hours,
                                  corp_domains=_corp_domains(request), reg=reg)
 
     value, at = _cached("graph", hours, build)
@@ -1091,7 +1125,8 @@ def suggest_identities(request: Request,
     hours = hours or LOOKBACK_HOURS
     findings = _findings(hours, request)
     domain_map = derive.load_domain_map_from(_registry(request))
-    devices, identities, _t, _b, _u = derive.build(findings, domain_map, {})
+    devices, identities, _t, _b, _u = derive.build(
+        findings, domain_map, _identity_map(request))
     matched, unmatched = derive.suggest_identity_rows(devices, identities)
 
     if fmt == "csv":
@@ -2227,6 +2262,42 @@ def api_budget_fx(to: str = Query(min_length=3, max_length=3,
                   token: str = Depends(_admin_forward)):
     return _receiver("GET", "/admin/budget/fx?to=%s"
                      % urllib.parse.quote(to), token)
+
+
+# -------------------------------------------------------- identity map --
+# Who is behind a device key or a local username. The portal generates
+# the proposal (/api/suggest-identities), an operator corrects it, and
+# this is where the corrected version goes - so the loop closes in the
+# product rather than ending at a ConfigMap somebody has to kubectl.
+
+
+class IdentityRow(BaseModel):
+    model_config = {"extra": "forbid"}
+    key: str = Field(min_length=1, max_length=256)
+    identity: str = Field(min_length=1, max_length=200)
+
+
+class IdentityMapWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    entries: list[IdentityRow] = Field(default_factory=list, max_length=10000)
+
+
+@app.get("/api/identity-map")
+def api_identity_map(_=Depends(require_auth),
+                     token: str = Depends(_admin_forward)):
+    return _receiver("GET", "/admin/identity-map", token)
+
+
+@app.post("/api/identity-map")
+def api_identity_map_write(req: IdentityMapWrite, _=Depends(require_auth),
+                           token: str = Depends(_admin_forward)):
+    """Replace the map, then drop every derived cache: attribution runs
+    through the graph, so every page is a view of the world before this
+    write."""
+    out = _receiver("PUT", "/admin/identity-map", token, req.model_dump())
+    _identity_map_cache.update(at=0.0, data=None)
+    _cache.clear()
+    return out
 
 
 @app.get("/")

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -324,6 +324,9 @@ let WIZSTORE = 'self', TESTS = {};
 // (null = closed), the last action's one-line outcome, and a parsed CSV
 // preview waiting for confirmation.
 let BUDGET = null, BWIZ = null, BMSG = '', BCSV = null, BFX = null;
+// The identity map editor on People: the saved rows, a parsed upload
+// waiting for confirmation, and the last outcome.
+let IDMAP = null, IDPARSE = null, IDMSG = '';
 // The share view's one choice: whether people are named. A finance
 // recipient needs the names to act; a board pack does not, and the page
 // names individuals and their personal account domains, so withholding
@@ -382,6 +385,7 @@ function showLogin(msg) {
   REGTOOLS = null; GOVDECS = null; TESTS = {}; WLOPEN = false;
   RENTRIES = null; REDIT = null; RPRE = null; RERR = ''; RADV = false;
   BUDGET = null; BWIZ = null; BMSG = ''; BCSV = null; BFX = null; BRNAMES = true;
+  IDMAP = null; IDPARSE = null; IDMSG = '';
   chrome(false);
   const create = AUTH && AUTH.setup_needed;
   app.innerHTML = `<div style="max-width:470px;margin:9vh auto 0">
@@ -911,13 +915,110 @@ function devices() {
   ${rows.map(([k,d]) => card(k,d)).join('')}`;
 }
 
-function people() {
+// The identity map, editable here. It used to be the last piece of
+// configuration that still needed kubectl: the portal generated the
+// proposal and could not accept the corrected version back, so the loop
+// ended at a ConfigMap. A file mounted by the deployment still works and
+// still shows here - what is saved in the portal wins per key.
+function identityMapPanel(unattributed) {
+  const ro = AUTH && AUTH.role === 'viewer';
+  const saved = (IDMAP && IDMAP.entries) || [];
+  const managed = CFG.managed && CFG.managed.enabled;
+  if (!managed) return `<div class="wcard" style="margin-bottom:12px">
+    <h3>Identity map</h3><p class="src-note" style="margin-top:0">Classic
+    mode: the map is the file at <span class="mono">IDENTITY_MAP</span>.
+    ${CFG.identity_map_configured ? 'One is configured.' : 'None is configured.'}</p></div>`;
+  const last = saved.map(e => e.updated_at).sort().pop() || '';
+  return `<div class="wcard" style="margin-bottom:12px"><h3>Identity map</h3>
+  <p class="src-note" style="margin-top:0">Who is behind a device key or a
+  local username. ${saved.length
+    ? `<strong>${saved.length}</strong> ${saved.length === 1 ? 'row' : 'rows'} saved
+       here${last ? `, last changed ${when(last)}` : ''}`
+    : 'Nothing saved here yet'}${CFG.identity_map_configured
+      ? ` · a file is also mounted, and rows saved here win over it` : ''}.
+  ${unattributed} device${unattributed === 1 ? '' : 's'} still ${unattributed === 1 ? 'has' : 'have'} no person attached.</p>
+  <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px">
+    <button class="mini" data-act="id-download">download the proposed map (CSV)</button>
+    ${ro ? '' : `<button class="mini" data-act="id-open">${IDPARSE ? 'editing…' : 'upload or paste a map'}</button>`}
+    ${!ro && saved.length ? `<button class="mini" data-act="id-clear">clear the saved map</button>` : ''}
+  </div>
+  ${IDMSG ? `<div class="note">${esc(IDMSG)}</div>` : ''}
+  <p class="src-note" style="margin-top:0">The proposal matches local
+  usernames, and machine names where a hostname spells out a known
+  person, against identities the cloud sources supplied. They are string
+  matches: review them before saving. Nothing here is applied on its own -
+  a mapping this platform invented and then acted on is how the wrong
+  name lands on a report.</p>
+  ${IDPARSE ? identityMapEditor() : ''}
+  ${saved.length ? `<details style="margin-top:8px"><summary>Saved rows (${saved.length})</summary>
+    <table><tr><th>key</th><th>person</th><th>changed</th><th>by</th></tr>
+    ${saved.slice(0, 200).map(e => `<tr><td class="mono">${esc(e.key)}</td>
+      <td>${esc(e.identity)}</td><td>${when(e.updated_at)}</td>
+      <td style="color:var(--mut)">${esc(e.updated_by || '')}</td></tr>`).join('')}
+    </table>${saved.length > 200 ? `<p class="src-note">Showing the first 200 of ${saved.length}.</p>` : ''}</details>` : ''}
+  </div>`;
+}
+
+function identityMapEditor() {
+  const p = IDPARSE;
+  const known = new Set(Object.keys(G.devices || {}));
+  ents(G.devices || {}).forEach(([, d]) => (d.local_users || []).forEach(u => known.add(u)));
+  ents(G.devices || {}).forEach(([, d]) => (d.aliases || []).forEach(a => known.add(a)));
+  const unknown = (p.rows || []).filter(r => !known.has(r.key));
+  return `<div style="border-top:1px solid var(--bd);padding-top:10px;margin-top:6px">
+    <textarea id="id-csv" class="mfield" style="width:100%;min-height:130px;font-family:ui-monospace,monospace"
+      placeholder="key,identity&#10;C02XXXX,jo.bloggs&#10;jo.bloggs,Jo Bloggs">${esc(p.text || '')}</textarea>
+    <div style="margin-top:8px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
+      <input type="file" id="id-file" accept=".csv,text/csv,text/plain" class="mfield" style="min-width:0">
+      <button class="mini" data-act="id-parse">preview</button>
+      <button class="mini" data-act="id-cancel">cancel</button>
+      ${(p.rows || []).length ? `<button class="mini" data-act="id-save">save ${p.rows.length} ${p.rows.length === 1 ? 'row' : 'rows'}</button>` : ''}
+    </div>
+    ${p.rows ? `<p class="src-note">${p.rows.length} rows understood, ${p.skipped}
+      skipped (no key, no person, or a duplicate). Saving REPLACES the map
+      saved here; a mounted file is untouched.
+      ${unknown.length ? `<span style="color:var(--warn)">${unknown.length}
+        ${unknown.length === 1 ? 'key matches' : 'keys match'} no device or local
+        user in the current window - kept, in case the machine reports later.</span>` : ''}</p>
+      ${p.rows.length ? `<table><tr><th>key</th><th>person</th><th></th></tr>
+      ${p.rows.slice(0, 8).map(r => `<tr><td class="mono">${esc(r.key)}</td><td>${esc(r.identity)}</td>
+        <td>${known.has(r.key) ? '<span class="pill p-ok">matches</span>' : '<span class="pill p-mut">not seen yet</span>'}</td></tr>`).join('')}
+      ${p.rows.length > 8 ? `<tr><td colspan="3" style="color:var(--mut)">… and ${p.rows.length - 8} more</td></tr>` : ''}</table>` : ''}` : ''}
+  </div>`;
+}
+
+// key,identity - the format the proposal downloads in, so the file can go
+// straight back in. Comments and the header row are dropped exactly as the
+// server-side loader drops them.
+function parseIdentityCsv(text) {
+  const out = [], seen = new Set();
+  let skipped = 0;
+  String(text || '').replace(/^\uFEFF/, '').split(/\r\n|\r|\n/).forEach(line => {
+    const bare = line.split('#')[0].trim();
+    if (!bare) return;
+    const cells = bCsvRow(bare, bare.includes('\t') ? '\t' : ',');
+    const [key, identity] = [(cells[0] || '').trim(), (cells[1] || '').trim()];
+    if (!key || !identity) { if (bare) skipped++; return; }
+    if (['key', 'device', 'local_user'].includes(key.toLowerCase())) return;
+    if (seen.has(key.toLowerCase())) { skipped++; return; }
+    seen.add(key.toLowerCase());
+    out.push({key, identity});
+  });
+  return {rows: out, skipped};
+}
+
+async function people() {
+  if (CFG.managed && CFG.managed.enabled && AUTH && AUTH.mode === 'login'
+      && IDMAP === null) {
+    const r = await mfetch('/api/identity-map');
+    IDMAP = r.ok ? await r.json() : {entries: []};
+  }
   const rows = ents(G.identities).filter(([k]) => match(k))
     .sort((a,b) => (b[1].tools||[]).length - (a[1].tools||[]).length);
+  const unattributed = ents(G.devices).filter(([,d]) => !d.person).length;
   return `<h2>People</h2><p class="lede">Identities come from cloud sources, which know people rather
-  than machines. Devices appear here only where an identity map attaches them —
-  see <a href="/api/suggest-identities?fmt=csv" style="color:var(--pri)">a
-  proposed map</a> to start one.</p>
+  than machines. Devices appear here only where an identity map attaches them.</p>
+  ${identityMapPanel(unattributed)}
   <div class="tcard"><table><tr><th>identity</th><th>tools</th><th>devices</th></tr>
   ${rows.map(([k,i]) => `<tr><td>${esc(k)}</td>
     <td>${(i.tools||[]).map(t=>`<span class="pill p-mut">${esc(t)}</span>`).join('')}</td>
@@ -4038,6 +4139,45 @@ async function _refusal(r) {
 
 async function managedAction(act, el) {
   if (act.startsWith('b-')) return budgetAction(act, el);
+  if (act === 'id-download') {
+    window.location = '/api/suggest-identities?fmt=csv';
+    return;
+  }
+  if (act === 'id-open') {
+    IDMSG = '';
+    IDPARSE = IDPARSE || {text: '', rows: null, skipped: 0};
+    render(); return;
+  }
+  if (act === 'id-cancel') { IDPARSE = null; IDMSG = ''; render(); return; }
+  if (act === 'id-parse') {
+    const file = (document.getElementById('id-file') || {}).files;
+    const text = file && file[0]
+      ? await file[0].text()
+      : (document.getElementById('id-csv') || {}).value || '';
+    IDPARSE = Object.assign({text}, parseIdentityCsv(text));
+    IDMSG = ''; render(); return;
+  }
+  if (act === 'id-save' || act === 'id-clear') {
+    const entries = act === 'id-clear' ? [] : (IDPARSE.rows || []);
+    if (act === 'id-clear'
+        && !confirm('Clear the identity map saved in the portal? Devices it '
+                    + 'attributed become unattributed. A mounted file, if any, '
+                    + 'still applies.')) return;
+    const r = await mfetch('/api/identity-map', {method: 'POST',
+      body: JSON.stringify({entries})});
+    if (r.status === 401) { sessionLost(); return; }
+    if (!r.ok) { IDMSG = 'Not saved: ' + await _refusal(r); render(); return; }
+    const out = await r.json();
+    IDMSG = act === 'id-clear'
+      ? 'Cleared. Attribution falls back to the mounted file, if there is one.'
+      : `Saved ${out.count} rows. Every page re-derives with them now.`;
+    IDPARSE = null; IDMAP = null;
+    // Attribution runs through the graph, so the page must re-read it
+    // rather than re-render yesterday's answer with today's map.
+    await load(true);
+    return;
+  }
+
   if (act === 'user-create') {
     const role = (document.getElementById('user-role') || {}).value || 'viewer';
     const r = await mfetch('/api/users', {method: 'POST', body: JSON.stringify(
@@ -4578,7 +4718,8 @@ async function render() {
     app.innerHTML = budgetReport();
     return;
   }
-  app.innerHTML = tb + ({setup, overview, devices, people, tools, coverage,
+  if (view === 'people') { app.innerHTML = tb + await people(); return; }
+  app.innerHTML = tb + ({setup, overview, devices, tools, coverage,
                          dashboard, personal, mcp})[view]();
 }
 // A detail opens in the inspector beside the list rather than replacing it.

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -284,3 +284,41 @@ def test_the_shell_says_so_when_the_read_failed():
         assert "dataOk()" in before[-400:], gated
     # And it names the fix a self-hoster would otherwise have to find.
     assert "RECEIVER_ADMIN_TOKEN" in html
+
+
+# ------------------------------------------------- the identity map, in app --
+
+
+def test_a_hostname_that_names_its_owner_is_proposed():
+    """Five devices on the reviewed estate had their owner's name in the
+    hostname - two of those people already in the identity list - and sat
+    unattributed because the only rule looked at local usernames."""
+    devices = {
+        "D1": {"local_users": set(), "device_name": "Jo-Bloggs-MacBook-Pro"},
+        "D2": {"local_users": set(), "device_name": "DESKTOP-9Z1"},
+        # Too short a name to match inside a label by anything but luck.
+        "D3": {"local_users": set(), "device_name": "ALIENWARE-15"},
+    }
+    matched, unmatched = derive.suggest_identity_rows(
+        devices, {"jo.bloggs": {}, "al": {}})
+    assert [(m["key"], m["identity"]) for m in matched] == [("D1", "jo.bloggs")]
+    assert {u["key"] for u in unmatched} == {"D2", "D3"}
+    # The proposal says why, so a reviewer can judge it.
+    assert "hostname" in matched[0]["via"]
+
+
+def test_two_people_matching_one_hostname_propose_neither():
+    devices = {"D1": {"local_users": set(),
+                      "device_name": "jo.bloggs-and-sam.smith-shared"}}
+    matched, unmatched = derive.suggest_identity_rows(
+        devices, {"jo.bloggs": {}, "sam.smith": {}})
+    assert matched == []
+    assert [u["key"] for u in unmatched] == ["D1"]
+
+
+def test_a_local_username_still_wins_over_the_hostname():
+    devices = {"D1": {"local_users": {"sam.smith"},
+                      "device_name": "Jo-Bloggs-MacBook"}}
+    matched, _u = derive.suggest_identity_rows(
+        devices, {"jo.bloggs": {}, "sam.smith": {}})
+    assert matched[0]["identity"] == "sam.smith"

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -1847,6 +1847,65 @@ def put_governance(req: GovernanceUpdate, authorization: str = Header(default=""
     return {"decisions": STATE.list_decisions()}
 
 
+# ------------------------------------------------------- identity map --
+# Who is behind a device key or a local username. The portal generates
+# the proposal, an operator corrects it, and this is where the corrected
+# version lives - so the loop closes in the product instead of ending at
+# a ConfigMap. A deployment that mounts a file keeps working: the portal
+# merges, with what an operator saved here winning per key.
+
+# The same characters the file loader refuses, for the same reason: a
+# comma or a quote breaks the CSV round trip, and a hash starts the
+# comment the proposal generator writes after each row.
+_IDENTITY_UNSAFE = re.compile(r"[\x00-\x1f\x7f,\"'#]")
+MAX_IDENTITY_ROWS = 10000
+
+
+class IdentityRow(BaseModel):
+    model_config = {"extra": "forbid"}
+    key: str = Field(min_length=1, max_length=256)
+    identity: str = Field(min_length=1, max_length=200)
+
+
+class IdentityMapWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    entries: list[IdentityRow] = Field(default_factory=list,
+                                       max_length=MAX_IDENTITY_ROWS)
+
+
+@app.get("/admin/identity-map")
+def get_identity_map(authorization: str = Header(default="")):
+    """Readable by any account the portal authenticates: it renders these
+    names on every page that attributes a device, so withholding the map
+    from a viewer would only make the pages wrong, not private."""
+    _admin_auth(authorization)
+    return {"entries": STATE.list_identity_map()}
+
+
+@app.put("/admin/identity-map")
+def put_identity_map(req: IdentityMapWrite,
+                     authorization: str = Header(default="")):
+    """Replace the whole map. Validated as a batch before anything is
+    written, so a 422 means nothing changed."""
+    _admin_auth(authorization, write=True)
+    seen, entries = set(), []
+    for e in req.entries:
+        key, identity = e.key.strip(), e.identity.strip()
+        if not key or not identity:
+            raise HTTPException(422, "every row needs a key and an identity")
+        if _IDENTITY_UNSAFE.search(key) or _IDENTITY_UNSAFE.search(identity):
+            raise HTTPException(
+                422, "a key or identity contains a character that cannot "
+                     "survive the CSV round trip (comma, quote, hash or a "
+                     "control character): %s" % key[:60])
+        if key.lower() in seen:
+            raise HTTPException(422, "duplicate key: %s" % key[:60])
+        seen.add(key.lower())
+        entries.append({"key": key, "identity": identity})
+    count = STATE.replace_identity_map(entries, _admin_actor(authorization))
+    return {"ok": True, "count": count}
+
+
 # ------------------------------------------------------------- budget --
 # What the organisation pays for, per tool: subscription, seat tiers,
 # members, and (where a vendor has an admin API) the connection that syncs

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -156,6 +156,12 @@ CREATE TABLE IF NOT EXISTS finding_status (
   actor  TEXT NOT NULL DEFAULT '',
   at     TEXT NOT NULL
 );
+CREATE TABLE IF NOT EXISTS identity_map (
+  key        TEXT PRIMARY KEY,
+  identity   TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  updated_by TEXT NOT NULL DEFAULT ''
+);
 CREATE TABLE IF NOT EXISTS budget_subscriptions (
   tool_id      TEXT PRIMARY KEY,
   vendor       TEXT NOT NULL DEFAULT '',
@@ -759,6 +765,48 @@ class State:
                 self._event("decision_cleared", {"tool": tool_id, "by": by})
             self._db.commit()
         return bool(cur.rowcount)
+
+    # ------------------------------------------ identity map (managed) --
+    # Which person is behind a device key or a local username. The one
+    # piece of configuration that still needed kubectl: it lived only as
+    # a file the deployment mounted, while the portal generated the
+    # proposal for it and could not accept the corrected version back.
+    #
+    # Personal data, and the most personal this platform holds - names
+    # against machines. Stored plainly because the portal must resolve
+    # names to render them, replaced wholesale rather than patched
+    # (an operator edits the list in a spreadsheet, not row by row), and
+    # written by admins only.
+
+    def list_identity_map(self) -> list[dict]:
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT key, identity, updated_at, updated_by"
+                " FROM identity_map ORDER BY key").fetchall()
+        return [dict(r) for r in rows]
+
+    def replace_identity_map(self, entries: list[dict], by: str = "") -> int:
+        """The whole map, replacing whatever was there. An empty list
+        clears it, which is how a deployment falls back to the mounted
+        file - the same shape as clearing any other setting."""
+        now = _now()
+        with self._lock:
+            self._db.execute("DELETE FROM identity_map")
+            for e in entries:
+                self._db.execute(
+                    "INSERT INTO identity_map (key, identity, updated_at,"
+                    " updated_by) VALUES (?, ?, ?, ?)"
+                    " ON CONFLICT(key) DO UPDATE SET"
+                    " identity = excluded.identity,"
+                    " updated_at = excluded.updated_at,"
+                    " updated_by = excluded.updated_by",
+                    (e["key"], e["identity"], now, by))
+            # Counts, never names: the audit trail's ids-only rule covers
+            # people most of all, and this table is nothing but people.
+            self._event("identity_map_replaced",
+                        {"count": len(entries), "by": by})
+            self._db.commit()
+        return len(entries)
 
     # ---------------------------------------------- budget (managed) --
     # What the organisation pays for, per tool: the subscription (plan,

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.14.3
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/receiver/tests/test_identity_map.py
+++ b/receiver/tests/test_identity_map.py
@@ -1,0 +1,110 @@
+"""The identity map as portal-managed state.
+
+It was the last piece of configuration that still needed kubectl: the
+portal generated the proposal and could not accept the corrected version
+back, so the loop ended at a ConfigMap. Same harness shape as the other
+managed-mode suites.
+"""
+
+import json
+import os
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import state as state_mod
+from app.main import app
+
+client = TestClient(app)
+
+ADMIN = {"Authorization": "Bearer admin-test-token"}
+
+
+@pytest.fixture
+def managed(tmp_path, monkeypatch):
+    from app import main
+
+    st = state_mod.State(str(tmp_path / "state.db"))
+    monkeypatch.setattr(main, "STATE", st)
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"Bearer admin-test-token")
+    return st
+
+
+@pytest.fixture
+def viewer(managed):
+    managed.create_admin("admin", "a-long-password")
+    managed.create_user("watcher", "another-long-pass", "viewer", by="admin")
+    return {"Authorization": "Bearer " + managed.login(
+        "watcher", "another-long-pass")["token"]}
+
+
+ROWS = [{"key": "C02XXXX", "identity": "jo.bloggs"},
+        {"key": "jo.bloggs", "identity": "Jo Bloggs"}]
+
+
+def test_routes_do_not_exist_in_classic_mode():
+    assert client.get("/admin/identity-map", headers=ADMIN).status_code == 404
+
+
+def test_round_trip_and_wholesale_replace(managed):
+    r = client.put("/admin/identity-map", headers=ADMIN,
+                   json={"entries": ROWS})
+    assert r.json() == {"ok": True, "count": 2}
+    got = client.get("/admin/identity-map", headers=ADMIN).json()["entries"]
+    assert [(e["key"], e["identity"]) for e in got] == [
+        ("C02XXXX", "jo.bloggs"), ("jo.bloggs", "Jo Bloggs")]
+    assert got[0]["updated_by"] == "api"
+
+    # An operator edits this list in a spreadsheet, so a save is the whole
+    # map: a row dropped from the file is dropped from the map.
+    client.put("/admin/identity-map", headers=ADMIN,
+               json={"entries": [ROWS[0]]})
+    got = client.get("/admin/identity-map", headers=ADMIN).json()["entries"]
+    assert [e["key"] for e in got] == ["C02XXXX"]
+
+
+def test_an_empty_map_clears_it(managed):
+    client.put("/admin/identity-map", headers=ADMIN, json={"entries": ROWS})
+    client.put("/admin/identity-map", headers=ADMIN, json={"entries": []})
+    assert client.get("/admin/identity-map",
+                      headers=ADMIN).json()["entries"] == []
+
+
+def test_values_that_cannot_survive_the_csv_round_trip_are_refused(managed):
+    for bad in ({"key": "a,b", "identity": "x"},
+                {"key": "ok", "identity": 'say "hi"'},
+                {"key": "ok", "identity": "x # comment"},
+                # Interior, not trailing: surrounding whitespace is
+                # trimmed on the way in, which is what an operator
+                # pasting from a spreadsheet needs.
+                {"key": "ok\nbad", "identity": "x"}):
+        r = client.put("/admin/identity-map", headers=ADMIN,
+                       json={"entries": [bad]})
+        assert r.status_code == 422, bad
+    r = client.put("/admin/identity-map", headers=ADMIN, json={"entries": [
+        {"key": "SAME", "identity": "a"}, {"key": "same", "identity": "b"}]})
+    assert r.status_code == 422 and "duplicate" in r.json()["detail"]
+    # A refused batch changes nothing.
+    assert client.get("/admin/identity-map",
+                      headers=ADMIN).json()["entries"] == []
+
+
+def test_a_viewer_reads_it_and_cannot_write_it(managed, viewer):
+    """The portal renders these names on every page that attributes a
+    device, so withholding the map from a viewer would make the pages
+    wrong rather than private. Writing is another matter."""
+    client.put("/admin/identity-map", headers=ADMIN, json={"entries": ROWS})
+    assert client.get("/admin/identity-map",
+                      headers=viewer).status_code == 200
+    assert client.put("/admin/identity-map", headers=viewer,
+                      json={"entries": []}).status_code == 403
+
+
+def test_the_audit_trail_records_the_change_and_not_the_people(managed):
+    client.put("/admin/identity-map", headers=ADMIN, json={"entries": ROWS})
+    events = json.dumps(client.get("/admin/events", headers=ADMIN).json())
+    assert "identity_map_replaced" in events
+    # Counts, never names: this table is nothing but people.
+    assert "jo.bloggs" not in events and "Jo Bloggs" not in events


### PR DESCRIPTION
The portal generated the proposed device-to-person map and could not accept the corrected version back, so the loop ended at a ConfigMap and a redeploy - in a product whose whole claim is that it is operated from the portal.

- **The map is receiver state now**, like corporate domains, governance decisions, custom registry entries and the log store before it. Inventory > People has an Identity map panel: download the proposal, correct it, upload or paste it back, preview, save.
- **A mounted file still works and still applies.** Rows saved in the portal win over it per key - the same DB-wins-when-set rule every setting follows - so a deployment generating a large CSV from an MDM in CI can keep doing that and still correct a handful of rows in the product. Classic mode is unchanged. Compose gets the feature with no bind mount.
- **Saving replaces the whole map**, because that is how an operator edits it: in a spreadsheet, not row by row. Clearing it falls back to the file.
- **The preview says which keys match** a device or local user the estate has actually seen, and keeps the ones that do not (a machine may report later) rather than dropping them silently.
- Admins write it; viewers read it, because the portal renders these names on every page that attributes a device - withholding the map would make the pages wrong rather than private. Values that cannot survive the CSV round trip (comma, quote, hash, control characters) are refused as a batch, and the audit trail records the row count and never the names.
- **The proposal generator gains a hostname rule**: where a machine's name spells out a person the estate already knows, propose it. The review found five such machines unattributed, two of them people already in the identity list. Ambiguity proposes nothing, names shorter than six characters are ignored, and a local username still wins.

Verified end to end in the demo: paste with comments, a header row, a duplicate and a malformed line, preview reports 3 understood and 2 skipped and marks the key nothing has reported yet, save drops unattributed devices from 10 to 8 and attributes both machines immediately. Receiver 185 / portal 389 green.

Chart 0.15.0, appVersion 0.15.0.