### PR TITLE
Portal: the fix the error message recommended now works

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.15.0
+version: 0.15.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.15.0"
+appVersion: "0.15.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.1
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.1
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -538,12 +538,29 @@ def _log_store(request):
                     log.warning("receiver call failed for %s: %s",
                                 _redact_url(RECEIVER_URL), e.detail)
                 if e.status == 403:
+                    # A read-only account cannot recover the stored
+                    # credential, by design. If this portal has a log
+                    # store of its own, that is a configured source and
+                    # the right thing is to use it - the message here
+                    # has always offered exactly that as the fix, and
+                    # raising instead meant the advice did not work.
+                    # Not silent: the fallback is logged, and
+                    # Diagnostics reports which credential is in use.
+                    if LOKI_URL:
+                        log.info(
+                            "reading findings from the portal's own log "
+                            "store: this account cannot read the "
+                            "receiver-stored credentials")
+                        return (LOKI_URL, LOKI_USERNAME or "",
+                                LOKI_PASSWORD or "", "env")
                     raise HTTPException(
                         403, "this account cannot read the log-store "
-                             "credentials (read-only accounts never can). "
-                             "Give the portal RECEIVER_ADMIN_TOKEN - the "
-                             "receiver's ADMIN_TOKEN - so it reads with "
-                             "its own credential, or set LOKI_URL by env.")
+                             "credentials (read-only accounts never can), "
+                             "and this portal has no log store of its own "
+                             "to fall back to. Give it RECEIVER_ADMIN_TOKEN "
+                             "- the receiver's ADMIN_TOKEN - so it reads "
+                             "with its own credential, or set LOKI_URL and "
+                             "its credentials on the portal.")
                 raise HTTPException(
                     e.status, "could not read the log-store configuration "
                               "from the receiver (%s)" % e.detail)
@@ -870,6 +887,17 @@ def diagnostics(_=Depends(require_auth)):
             "started_at": STARTED_AT,
             "uptime_seconds": round(time.time() - STARTED_AT),
             "loki_configured": bool(LOKI_URL),
+            # Whether reads depend on who is signed in. Without a
+            # credential of its own, a managed portal reads with the
+            # operator's session - which works for an admin and is
+            # refused for a viewer, so read-only accounts see an empty
+            # estate. It is the single most confusing state this
+            # product has, and it was only discoverable by creating a
+            # viewer account and looking.
+            "portal_read_credential": (
+                "receiver admin token" if RECEIVER_ADMIN_TOKEN
+                else "own log store" if LOKI_URL
+                else "the signed-in account" if LOGIN_MODE else "env"),
             "loki_last_success": _last_loki_ok or None,
             "loki_last_error": _last_loki_error,
             "loki_last_error_at": _last_loki_error_at or None,

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2629,6 +2629,15 @@ function diagnosticsCards() {
   <div class="wcard" style="margin-bottom:10px"><h3>Loki</h3>
   <dl class="kv">
     <dt>Configured</dt><dd>${yn(r.loki_configured)}</dd>
+    <dt>Reads with</dt><dd>${esc(r.portal_read_credential || '')}
+      ${r.portal_read_credential === 'the signed-in account' ? `
+      <div class="src-note" style="color:var(--warn)">This portal has no
+      log-store credential of its own, so every read is made with the
+      account that is signed in. That works for an admin and is refused
+      for a viewer, so read-only accounts see an empty estate. Give it
+      <span class="mono">RECEIVER_ADMIN_TOKEN</span> (the receiver's
+      ADMIN_TOKEN), or its own <span class="mono">LOKI_URL</span> and
+      credentials.</div>` : ''}</dd>
     <dt>Last successful read</dt><dd>${ago(r.loki_last_success)}</dd>
     ${r.loki_last_error ? `<dt>Last error</dt><dd style="color:var(--dstr)">${esc(r.loki_last_error)}${r.loki_last_error_at ? ` · ${ago(r.loki_last_error_at)}` : ''}</dd>` : ''}
     ${r.loki_last_error && r.loki_last_error_at && r.loki_last_error_at > (r.loki_last_success || 0)

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -322,3 +322,61 @@ def test_a_local_username_still_wins_over_the_hostname():
     matched, _u = derive.suggest_identity_rows(
         devices, {"jo.bloggs": {}, "sam.smith": {}})
     assert matched[0]["identity"] == "sam.smith"
+
+
+# ------------------------------------- reading without the operator's seat --
+
+
+def test_a_viewer_falls_back_to_the_portals_own_log_store():
+    """The 403 message has always said "or set LOKI_URL by env" as the
+    fix, and raising instead meant that advice did not work: a portal
+    with its own store still refused every read-only account."""
+    from unittest.mock import patch
+
+    from app import main as pm
+    from app import managed as mg
+
+    def refuse(*a, **k):
+        raise mg.ReceiverError(403, "read-only")
+
+    with patch.object(pm, "LOGIN_MODE", True), \
+            patch.object(pm, "RECEIVER_URL", "http://receiver:8080"), \
+            patch.object(pm, "RECEIVER_ADMIN_TOKEN", ""), \
+            patch.object(pm, "LOKI_URL", "http://loki:3100"), \
+            patch.object(pm, "LOKI_USERNAME", "reader"), \
+            patch.object(pm.managed, "receiver_request", refuse):
+        pm._log_store_cache.update(at=0.0, data=None)
+
+        class Req:
+            cookies = {"aiguard_session": "aigt_viewer"}
+
+        url, user, _pw, source = pm._log_store(Req())
+    assert (url, user, source) == ("http://loki:3100", "reader", "env")
+
+
+def test_without_any_store_of_its_own_it_still_says_what_to_configure():
+    from unittest.mock import patch
+
+    import pytest
+    from fastapi import HTTPException
+
+    from app import main as pm
+    from app import managed as mg
+
+    def refuse(*a, **k):
+        raise mg.ReceiverError(403, "read-only")
+
+    with patch.object(pm, "LOGIN_MODE", True), \
+            patch.object(pm, "RECEIVER_URL", "http://receiver:8080"), \
+            patch.object(pm, "RECEIVER_ADMIN_TOKEN", ""), \
+            patch.object(pm, "LOKI_URL", ""), \
+            patch.object(pm.managed, "receiver_request", refuse):
+        pm._log_store_cache.update(at=0.0, data=None)
+
+        class Req:
+            cookies = {"aiguard_session": "aigt_viewer"}
+
+        with pytest.raises(HTTPException) as e:
+            pm._log_store(Req())
+    assert e.value.status_code == 403
+    assert "RECEIVER_ADMIN_TOKEN" in e.value.detail

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.1
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Found while explaining to an operator which of the two documented fixes to choose for read-only accounts seeing an empty portal.

A viewer cannot recover the receiver-stored log-store credential - deliberate, since that credential is usually write-capable. The refusal has always named the alternative in its own text ("or set `LOKI_URL` by env"), but the code raised instead of taking it, so **a portal configured with its own log store still refused every viewer**. The advice was right; the implementation did not follow it.

- On a 403, a portal that has its own `LOKI_URL` now reads from it, and logs that it did - a fallback, but never a silent one.
- With no store of its own, the refusal stands and now names both fixes instead of one.
- **Diagnostics gains a "reads with" row**: "receiver admin token", "own log store", or "the signed-in account" - and warns on the last, because a managed portal with no credential of its own reads as whoever is signed in, which works for an admin and is refused for a viewer. That state was previously only discoverable by creating a viewer account and looking at an empty estate.

This matters for the choice of fix: `RECEIVER_ADMIN_TOKEN` grants the portal a full admin credential, which is more than it needs (a read-scoped service role is a known deferred item). Giving the portal its own read-only log-store credentials is the better posture, and until now it did not actually work for viewers.

Portal 391 green.

Chart 0.15.1, appVersion 0.15.1.