### PR TITLE
Diagnostics: count tools, not tools that happen to have a domain

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.15.1
+version: 0.15.2
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.15.1"
+appVersion: "0.15.2"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.1
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.2
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.1
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.2
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -866,11 +866,20 @@ def diagnostics(_=Depends(require_auth)):
     No secret values, ever. Whether a credential is configured is useful.
     What it is, is not.
     """
-    reg_ok, reg_tools, reg_err = False, 0, ""
+    reg_ok, reg_tools, reg_domain_tools, reg_err = False, 0, 0, ""
     try:
-        dm = derive.load_domain_map(REGISTRY_PATH)
-        reg_ok = bool(dm)
-        reg_tools = len(set(dm.values())) if dm else 0
+        # Tools, and separately the tools that carry a domain. This row
+        # used to report only the second and call it "Tools", so a
+        # registry of 32 whose 4 CLI-only entries have no domain read as
+        # 28 - and a review of a live deployment spent real time hunting
+        # a stale registry file that did not exist. Both numbers, both
+        # named.
+        loaded = derive.load_registry(REGISTRY_PATH)
+        tools = (loaded or {}).get("tools") or []
+        dm = derive.load_domain_map_from(loaded)
+        reg_ok = bool(tools)
+        reg_tools = len(tools)
+        reg_domain_tools = len(set(dm.values())) if dm else 0
     except Exception as e:  # pragma: no cover - defensive
         # A parse failure names the file, the line and the column. That is the
         # right thing in a log and the wrong thing in a response body: the path
@@ -909,6 +918,10 @@ def diagnostics(_=Depends(require_auth)):
             "auth_configured": bool(PORTAL_AUTH != "none"),
             "registry_loaded": reg_ok,
             "registry_tools": reg_tools,
+            # Detection by domain only covers tools that have one; a CLI
+            # tool is found by its config file instead. A gap between
+            # these two is normal, not a fault.
+            "registry_tools_with_domains": reg_domain_tools,
             "registry_error": reg_err,
             "registry_path": REGISTRY_PATH,
             "identity_map_configured": bool(

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2651,7 +2651,9 @@ function diagnosticsCards() {
   <div class="wcard" style="margin-bottom:10px"><h3>Registry</h3>
   <dl class="kv">
     <dt>Loaded</dt><dd>${yn(r.registry_loaded)}</dd>
-    <dt>Tools</dt><dd>${esc(r.registry_tools)}</dd>
+    <dt>Tools</dt><dd>${esc(r.registry_tools)}${
+      r.registry_tools_with_domains != null && r.registry_tools_with_domains !== r.registry_tools
+        ? ` <span style="color:var(--mut)">· ${esc(r.registry_tools_with_domains)} with a domain</span>` : ''}</dd>
     <dt>Path</dt><dd>${esc(r.registry_path)}</dd>
     ${r.registry_error ? `<dt>Error</dt><dd style="color:var(--dstr)">${esc(r.registry_error)}</dd>` : ''}
   </dl>

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -13,6 +13,7 @@ report gave, so a regression fails with the same sum the reviewer
 noticed rather than a vague inequality.
 """
 
+import json
 import os
 
 os.environ.setdefault("PORTAL_AUTH", "none")
@@ -380,3 +381,24 @@ def test_without_any_store_of_its_own_it_still_says_what_to_configure():
             pm._log_store(Req())
     assert e.value.status_code == 403
     assert "RECEIVER_ADMIN_TOKEN" in e.value.detail
+
+
+def test_diagnostics_counts_tools_not_tools_with_domains(tmp_path, monkeypatch):
+    """Reported as "the registry is 28 here and 32 there", and it cost a
+    reviewer and a maintainer real time hunting a stale file. Both
+    numbers were right: this row counted only the tools carrying a
+    domain, and called it "Tools"."""
+    from app import main as pm
+
+    reg = tmp_path / "registry.json"
+    reg.write_text(json.dumps({"version": 1, "tools": [
+        {"id": "chatgpt", "name": "ChatGPT", "domains": ["chatgpt.com"]},
+        {"id": "claude", "name": "Claude", "domains": ["claude.ai"]},
+        # Found by its config file, not by a domain - and still a tool.
+        {"id": "claude-code", "name": "Claude Code", "domains": []},
+    ]}))
+    monkeypatch.setattr(pm, "REGISTRY_PATH", str(reg))
+    runtime = pm.diagnostics(_=None)["runtime"]
+    assert runtime["registry_tools"] == 3
+    assert runtime["registry_tools_with_domains"] == 2
+    assert runtime["registry_loaded"] is True

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.1
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.15.2
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Reported from a live deployment as "the registry is 28 in Diagnostics and 32 everywhere else" - one of the review's MAJOR findings, and it sent both the reviewer and me hunting a stale registry ConfigMap that turned out not to exist.

Every number was right. This row computed `len(set(domain_map.values()))` - the tools carrying at least one domain - and labelled it **Tools**. A CLI tool is detected by its config file and has no domain at all, so a registry of 32 with four such entries reads as 28, and an operator comparing it against the 32 the portal serves concludes something is stale.

- Diagnostics now reports the tool count from the loaded registry, with the domain-carrying count named beside it ("32 · 28 with a domain") when they differ.
- `registry_loaded` is now true when the file has tools, rather than when it has domains - a registry of CLI-only tools was previously reported as failing to load.

The deployment that reported this had no stale file, no missing tools and nothing to fix: a mislabelled metric produced a bug hunt across three components.

Portal 392 green. Chart 0.15.2, appVersion 0.15.2.