### PR TITLE
Portal: one person is one identity, and the map downloads as a working copy

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.16.0
+version: 0.16.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.16.0"
+appVersion: "0.16.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.1
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.1
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/README.md
+++ b/portal/README.md
@@ -195,10 +195,19 @@ that finds none.
 The portal does not resolve identity. It carries enough for you to resolve it
 against whatever you run.
 
+One person is one identity. A cloud source supplies a UPN local part
+(jeff.gillings) while another supplies a display name (jeff gillings), and
+the estate used to carry them as two people - two rows on People, one of
+them "unmapped" because the identity map attached the device to the other
+spelling. Spellings that normalise to the same name are merged, the others
+are listed as "also seen as", and personal-account rows use the spelling
+People shows.
+
 In managed mode the map lives in the portal: Inventory > People has an
-Identity map panel that downloads the proposal, takes the corrected file
-back by upload or paste, previews which keys match a device the estate has
-actually seen, and saves. A mounted file still works and still applies -
+Identity map panel that downloads the proposal, exports the map currently
+in effect (the mounted file and the portal's rows merged, in the format the
+upload accepts), takes the corrected file back by upload or paste, previews
+which keys match a device the estate has actually seen, and saves. A mounted file still works and still applies -
 rows saved in the portal win over it per key, the same rule every other
 setting follows - so a deployment that keeps a large CSV in a ConfigMap can
 still correct a handful of rows in the product. Saving replaces the whole

--- a/portal/README.md
+++ b/portal/README.md
@@ -204,10 +204,13 @@ are listed as "also seen as", and personal-account rows use the spelling
 People shows.
 
 In managed mode the map lives in the portal: Inventory > People has an
-Identity map panel that downloads the proposal, exports the map currently
-in effect (the mounted file and the portal's rows merged, in the format the
-upload accepts), takes the corrected file back by upload or paste, previews
-which keys match a device the estate has actually seen, and saves. A mounted file still works and still applies -
+Identity map panel whose download is a working copy - the rows in effect
+now, then every machine with nobody attached, commented out, with a name
+filled in where a local username or the machine's own name suggests one and
+blank where nothing does. Uncomment what you believe, delete the rest,
+upload or paste it back; the panel previews which keys match a device the
+estate has actually seen, and saves. Feeding the file straight back changes
+nothing, because every proposal is inert until a human uncomments it. A mounted file still works and still applies -
 rows saved in the portal win over it per key, the same rule every other
 setting follows - so a deployment that keeps a large CSV in a ConfigMap can
 still correct a handful of rows in the product. Saving replaces the whole

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -503,6 +503,8 @@ def build(findings, domain_map=None, identity_map=None):
     identities = defaultdict(lambda: {
         "tools": set(), "surfaces": set(), "sources": set(),
         "accounts": set(), "findings": 0, "devices": set(),
+        # Other spellings of this person that sources reported.
+        "aliases": set(),
     })
     # Tool nodes are keyed on the tool, with surface as an attribute. Merging
     # surfaces into one number would lose the distinction the platform exists
@@ -666,6 +668,19 @@ def build(findings, domain_map=None, identity_map=None):
                 b["devices"].discard(bare)
                 b["devices"].add(canon)
 
+    # One person, one identity. Do this before devices are attributed,
+    # so a device mapped to either spelling lands on the same person.
+    for variant, canon in _identity_aliases(identities).items():
+        src, dst = identities.pop(variant), identities[canon]
+        for field in ("tools", "surfaces", "sources", "accounts", "devices"):
+            dst[field] = (dst.get(field) or set()) | (src.get(field) or set())
+        dst["findings"] += src["findings"]
+        dst["aliases"].add(variant)
+        for t in tools.values():
+            if variant in t["identities"]:
+                t["identities"].discard(variant)
+                t["identities"].add(canon)
+
     # Attach a person to each device, if the deployer supplied a mapping.
     # Device key first, then any local username: an MDM keys on the serial, a
     # spreadsheet is more likely to key on the name someone logs in with.
@@ -693,6 +708,41 @@ def build(findings, domain_map=None, identity_map=None):
 # it fixes.
 _MIN_ALIAS_KEY = 6
 _ALIAS_SEPARATORS = ("-", "_", ".", ":")
+
+
+def _identity_aliases(identities):
+    """{variant: canonical} where two identity strings are the same
+    person spelled differently.
+
+    A cloud source supplies a UPN local part (jeff.gillings), another
+    supplies a display name (jeff gillings), and the estate carried them
+    as two people: two rows on People, one of them "unmapped" because
+    the identity map attached the device to the other spelling, and both
+    reaching a finance report as separate unlicensed users.
+
+    Normalisation is the existing one - lowercase, alphanumerics only,
+    local part of an address - so a merge needs the letters to be
+    identical. Two genuinely different people would have to share a name
+    exactly, and no source could tell them apart either.
+    """
+    by_norm = {}
+    for name in identities:
+        norm = _norm_person(name)
+        if norm:
+            by_norm.setdefault(norm, []).append(name)
+    out = {}
+    for names in by_norm.values():
+        if len(names) < 2:
+            continue
+        # The spelling the estate saw most wins, so the name on screen is
+        # the one most sources use; alphabetical to keep it deterministic
+        # when they tie.
+        canon = sorted(names,
+                       key=lambda n: (-identities[n]["findings"], n))[0]
+        for n in names:
+            if n != canon:
+                out[n] = canon
+    return out
 
 
 def _device_aliases(devices):
@@ -753,7 +803,8 @@ def _domain_matches(account, listed):
 
 
 def personal_accounts_from(findings, domain_map=None, corp_domains=None,
-                           tool_domains=None, device_person=None):
+                           tool_domains=None, device_person=None,
+                           identity_canon=None):
     """One row per personal account seen on a tool, with when it was first and
     last observed.
 
@@ -779,6 +830,14 @@ def personal_accounts_from(findings, domain_map=None, corp_domains=None,
     # resolves the one the device inventory already holds, and says the
     # attribution came from the device rather than the source.
     device_person = device_person or {}
+    # Normalised name -> the spelling People shows, so the two views
+    # cannot name the same person differently. Keyed on the normalised
+    # form rather than on known variants: the spelling that reaches a
+    # personal-account row often comes from a finding that carries a
+    # device, which never becomes an identity of its own, so there is no
+    # variant to look up - only a name that normalises to the same
+    # person.
+    identity_canon = identity_canon or {}
     rows = {}
     for f in findings:
         if (f.get("severity") or "") != "warn":
@@ -815,6 +874,8 @@ def personal_accounts_from(findings, domain_map=None, corp_domains=None,
 
         device = (f.get("device") or "").strip()
         user = (f.get("user") or "").strip()
+        if user:
+            user = identity_canon.get(_norm_person(user), user)
         canon, via = device, ""
         if device in device_person:
             canon, person = device_person[device]
@@ -1048,7 +1109,8 @@ def graph_from(findings, domain_map=None, identity_map=None, hours=168,
         "unattributed": unattributed,
         "personal_accounts": personal_accounts_from(
             findings, domain_map, corp_domains, tool_domains_from(reg),
-            device_person_map(devices)),
+            device_person_map(devices),
+            {_norm_person(k): k for k in identities}),
         "mcp_servers": mcp_from(findings),
         "trends": trends_from(findings, domain_map, hours),
         "counts": {

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -2330,34 +2330,79 @@ def api_identity_map(_=Depends(require_auth),
 
 
 @app.get("/api/identity-map.csv")
-def api_identity_map_csv(request: Request, _=Depends(require_auth)):
-    """The map currently IN EFFECT, as the CSV this page accepts back.
+def api_identity_map_csv(request: Request,
+                         hours: float = Query(default=None, gt=0, le=24 * 90),
+                         _=Depends(require_auth)):
+    """The working copy of the identity map: what is in effect, plus
+    every machine still without a person.
 
-    Not the same thing as the proposal: this is what the portal is
-    actually resolving with, mounted file and portal-saved rows merged.
-    An operator moving a mounted map into the portal, or keeping a copy
-    of what is live, had no way to get it out - the only download was a
-    set of suggestions.
+    One file that round-trips. The rows already mapped come back
+    unchanged, anything newly seen and unattributed arrives commented
+    out - with a proposal filled in where local usernames or the
+    hostname suggest one, and blank where nothing does. Uncomment the
+    lines you believe, delete the rest, upload it back.
+
+    The two halves used to be separate downloads: the map lived only in
+    a mounted file with no way out, and the proposal was a list of
+    suggestions with none of your existing work in it. Keeping them
+    apart meant merging two files by hand every time a laptop appeared.
     """
-    rows = sorted(_identity_map(request).items())
-    body = ["# key,identity",
-            "# The identity map in effect: the mounted file, with rows",
-            "# saved in the portal taking precedence. Edit and upload it",
-            "# back on Inventory > People.",
-            "key,identity"]
-    for key, identity in rows:
+    hours = hours or LOOKBACK_HOURS
+    in_use = _identity_map(request)
+    findings = _findings(hours, request)
+    domain_map = derive.load_domain_map_from(_registry(request))
+    devices, identities, _t, _b, _u = derive.build(
+        findings, domain_map, in_use)
+    unmapped = {k for k, d in devices.items() if not d.get("person")}
+    matched, unmatched = derive.suggest_identity_rows(devices, identities)
+
+    def row(key, identity):
+        # The characters the loader refuses. A value that cannot survive
+        # the round trip is named rather than written as a row that
+        # would not come back.
         if derive._UNSAFE_IN_KEY.search(key) or \
                 derive._UNSAFE_IN_KEY.search(identity):
-            # The same characters the loader refuses. A value that
-            # cannot survive the round trip is named in a comment
-            # rather than written as a row that would not come back.
-            body.append("# skipped, unsafe characters: %s"
-                        % derive.csv_safe(key)[:60])
-            continue
-        body.append("%s,%s" % (derive.csv_safe(key),
-                               derive.csv_safe(identity)))
+            return "# skipped, unsafe characters: %s" % derive.csv_safe(key)[:60]
+        return "%s,%s" % (derive.csv_safe(key), derive.csv_safe(identity))
+
+    out = [
+        "# The identity map in use, and every machine still without a",
+        "# person. Edit and upload it back on Inventory > People.",
+        "#",
+        "# Rows below the header are in effect now. Below them, commented",
+        "# lines are machines with nobody attached: uncomment the ones you",
+        "# believe and fill in the blanks. Proposals are string matches on",
+        "# local usernames and machine names - they are suggestions, and a",
+        "# name you accept without checking is a wrong name on a report.",
+        "key,identity",
+    ]
+    out += [row(k, v) for k, v in sorted(in_use.items())]
+
+    proposed = [m for m in matched if m["key"] in unmapped]
+    if proposed:
+        out += ["#", "# --- proposed: uncomment to accept ---"]
+        for m in proposed:
+            # Say what matched, not just the string that matched: "via
+            # local user jo" and "via hostname JO-MBP" are different
+            # kinds of evidence, and one is much weaker than the other.
+            why = (m["via"] if m["via"].startswith("hostname")
+                   else "local user %s" % m["via"])
+            out.append("# %s  # via %s%s" % (
+                row(m["key"], m["identity"]), why,
+                " on %s" % m["device_name"] if m["device_name"] else ""))
+
+    blank = [u for u in unmatched if u["key"] in unmapped]
+    if blank:
+        out += ["#", "# --- no person known: fill in and uncomment ---"]
+        for u in blank:
+            hint = ", ".join(u["local_users"][:3])
+            out.append("# %s,  # %s%s" % (
+                derive.csv_safe(u["key"]),
+                u["device_name"] or "no machine name",
+                " · local users: %s" % hint if hint else ""))
+
     return PlainTextResponse(
-        "\n".join(body) + "\n",
+        "\n".join(out) + "\n",
         headers={"Content-Disposition":
                  'attachment; filename="identity-map.csv"'})
 

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -2329,6 +2329,39 @@ def api_identity_map(_=Depends(require_auth),
     return _receiver("GET", "/admin/identity-map", token)
 
 
+@app.get("/api/identity-map.csv")
+def api_identity_map_csv(request: Request, _=Depends(require_auth)):
+    """The map currently IN EFFECT, as the CSV this page accepts back.
+
+    Not the same thing as the proposal: this is what the portal is
+    actually resolving with, mounted file and portal-saved rows merged.
+    An operator moving a mounted map into the portal, or keeping a copy
+    of what is live, had no way to get it out - the only download was a
+    set of suggestions.
+    """
+    rows = sorted(_identity_map(request).items())
+    body = ["# key,identity",
+            "# The identity map in effect: the mounted file, with rows",
+            "# saved in the portal taking precedence. Edit and upload it",
+            "# back on Inventory > People.",
+            "key,identity"]
+    for key, identity in rows:
+        if derive._UNSAFE_IN_KEY.search(key) or \
+                derive._UNSAFE_IN_KEY.search(identity):
+            # The same characters the loader refuses. A value that
+            # cannot survive the round trip is named in a comment
+            # rather than written as a row that would not come back.
+            body.append("# skipped, unsafe characters: %s"
+                        % derive.csv_safe(key)[:60])
+            continue
+        body.append("%s,%s" % (derive.csv_safe(key),
+                               derive.csv_safe(identity)))
+    return PlainTextResponse(
+        "\n".join(body) + "\n",
+        headers={"Content-Disposition":
+                 'attachment; filename="identity-map.csv"'})
+
+
 @app.post("/api/identity-map")
 def api_identity_map_write(req: IdentityMapWrite, _=Depends(require_auth),
                            token: str = Depends(_admin_forward)):

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -976,6 +976,7 @@ function identityMapPanel(unattributed) {
   ${unattributed} device${unattributed === 1 ? '' : 's'} still ${unattributed === 1 ? 'has' : 'have'} no person attached.</p>
   <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px">
     <button class="mini" data-act="id-download">download the proposed map (CSV)</button>
+    <button class="mini" data-act="id-export">download the map in effect (CSV)</button>
     ${ro ? '' : `<button class="mini" data-act="id-open">${IDPARSE ? 'editing…' : 'upload or paste a map'}</button>`}
     ${!ro && saved.length ? `<button class="mini" data-act="id-clear">clear the saved map</button>` : ''}
   </div>
@@ -1057,7 +1058,9 @@ async function people() {
   than machines. Devices appear here only where an identity map attaches them.</p>
   ${identityMapPanel(unattributed)}
   <div class="tcard"><table><tr><th>identity</th><th>tools</th><th>devices</th></tr>
-  ${rows.map(([k,i]) => `<tr><td>${esc(k)}</td>
+  ${rows.map(([k,i]) => `<tr><td>${esc(k)}${(i.aliases||[]).length
+    ? `<br><span class="src-note" style="font-style:normal">also seen as
+       ${(i.aliases).map(a => esc(a)).join(', ')}</span>` : ''}</td>
     <td>${(i.tools||[]).map(t=>`<span class="pill p-mut">${esc(t)}</span>`).join('')}</td>
     <td>${(i.devices||[]).map(d=>`<span class="pill p-acc">${esc(d)}</span>`).join('') || '<span class="pill p-mut">unmapped</span>'}</td></tr>`).join('')}
   </table></div>`;
@@ -4232,6 +4235,10 @@ async function managedAction(act, el) {
   if (act.startsWith('b-')) return budgetAction(act, el);
   if (act === 'id-download') {
     window.location = '/api/suggest-identities?fmt=csv';
+    return;
+  }
+  if (act === 'id-export') {
+    window.location = '/api/identity-map.csv';
     return;
   }
   if (act === 'id-open') {

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -975,18 +975,19 @@ function identityMapPanel(unattributed) {
       ? ` · a file is also mounted, and rows saved here win over it` : ''}.
   ${unattributed} device${unattributed === 1 ? '' : 's'} still ${unattributed === 1 ? 'has' : 'have'} no person attached.</p>
   <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px">
-    <button class="mini" data-act="id-download">download the proposed map (CSV)</button>
-    <button class="mini" data-act="id-export">download the map in effect (CSV)</button>
+    <button class="mini" data-act="id-export">download map in use (CSV)</button>
     ${ro ? '' : `<button class="mini" data-act="id-open">${IDPARSE ? 'editing…' : 'upload or paste a map'}</button>`}
     ${!ro && saved.length ? `<button class="mini" data-act="id-clear">clear the saved map</button>` : ''}
   </div>
   ${IDMSG ? `<div class="note">${esc(IDMSG)}</div>` : ''}
-  <p class="src-note" style="margin-top:0">The proposal matches local
-  usernames, and machine names where a hostname spells out a known
-  person, against identities the cloud sources supplied. They are string
-  matches: review them before saving. Nothing here is applied on its own -
-  a mapping this platform invented and then acted on is how the wrong
-  name lands on a report.</p>
+  <p class="src-note" style="margin-top:0">The download is the working
+  copy: the rows in effect now, then every machine with nobody attached,
+  commented out - with a name filled in where a local username or the
+  machine's own name suggests one, and blank where nothing does.
+  Uncomment what you believe, delete the rest, upload it back. Those
+  proposals are string matches: nothing is applied on its own, because a
+  mapping this platform invented and then acted on is how the wrong name
+  lands on a report.</p>
   ${IDPARSE ? identityMapEditor() : ''}
   ${saved.length ? `<details style="margin-top:8px"><summary>Saved rows (${saved.length})</summary>
     <table><tr><th>key</th><th>person</th><th>changed</th><th>by</th></tr>

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -451,19 +451,46 @@ def test_personal_account_rows_use_the_same_spelling_as_people():
     assert [r["user"] for r in graph["personal_accounts"]] == ["jeff gillings"]
 
 
-def test_the_map_in_effect_can_be_exported(monkeypatch, tmp_path):
-    """An operator moving a mounted map into the portal had no way to
-    get the current one out: the only download was the proposal, which
-    is a set of suggestions, not what is being resolved with."""
+def test_the_map_in_use_downloads_as_a_working_copy(monkeypatch, tmp_path):
+    """One file that round-trips: the rows in effect, then every machine
+    with nobody attached - proposed where something suggests a name,
+    blank where nothing does. The two used to be separate downloads, so
+    a new laptop meant merging two files by hand."""
+    from unittest.mock import patch
+
     from app import main as pm
 
     f = tmp_path / "identity-map.csv"
-    f.write_text("key,identity\nC02XXXX,jo.bloggs\nWEIRD=KEY,x\n")
+    f.write_text("key,identity\nC02MAPPED,jo.bloggs\n")
     monkeypatch.setattr(pm, "IDENTITY_MAP", str(f))
     monkeypatch.setattr(pm, "LOGIN_MODE", False)
-    body = bytes(pm.api_identity_map_csv(None, _=None).body).decode()
-    assert "C02XXXX,jo.bloggs" in body
-    # It round-trips through the parser it is written for.
-    assert derive.load_identity_map(str(f))["C02XXXX"] == "jo.bloggs"
-    # A formula-shaped value is neutralised rather than exported live.
-    assert "\n=" not in body
+    monkeypatch.setattr(pm, "REGISTRY_PATH", "")
+
+    findings = [
+        # Already mapped: stays as a live row, never re-proposed.
+        _f(device="C02MAPPED", tool="claude", surface="cli"),
+        # Unattributed, but the hostname names someone the estate knows.
+        _f(device="C02NEW", device_name="Jo-Bloggs-MacBook", tool="claude"),
+        # Unattributed with nothing to go on.
+        _f(device="DESKTOP-9Z1", tool="claude", user=""),
+        _f(tool="claude", surface="cloud", device="", user="jo.bloggs"),
+    ]
+    with patch.object(pm, "_findings", lambda h, request=None: findings):
+        body = bytes(pm.api_identity_map_csv(None, _=None).body).decode()
+
+    lines = body.splitlines()
+    live = [l for l in lines if l and not l.startswith("#")]
+    assert "C02MAPPED,jo.bloggs" in live
+    # The mapped device is not offered again.
+    assert not any("C02MAPPED" in l for l in lines if l.startswith("#"))
+    # The new one arrives proposed, commented, with its reason.
+    assert any(l.startswith("# C02NEW,jo.bloggs") and "via hostname" in l
+               for l in lines)
+    # And the one nothing can name arrives blank, with a hint.
+    assert any(l.startswith("# DESKTOP-9Z1,") for l in lines)
+    # Every proposal is inert until a human uncomments it: feeding this
+    # straight back changes nothing.
+    round_trip = tmp_path / "round-trip.csv"
+    round_trip.write_text(body)
+    assert derive.load_identity_map(str(round_trip)) == {
+        "C02MAPPED": "jo.bloggs"}

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -402,3 +402,68 @@ def test_diagnostics_counts_tools_not_tools_with_domains(tmp_path, monkeypatch):
     assert runtime["registry_tools"] == 3
     assert runtime["registry_tools_with_domains"] == 2
     assert runtime["registry_loaded"] is True
+
+
+def test_one_person_spelled_two_ways_is_one_identity():
+    """A cloud source supplies a UPN local part and another a display
+    name, so the estate carried one colleague as two people: two rows on
+    People, one of them "unmapped" because the identity map attached the
+    device to the other spelling."""
+    findings = [
+        _f(tool="claude", surface="cloud", device="", user="jeff.gillings"),
+        _f(tool="chatgpt", surface="cloud", device="", user="jeff gillings"),
+        _f(tool="chatgpt", surface="cloud", device="", user="jeff gillings"),
+    ]
+    graph = derive.graph_from(findings, {}, {})
+    ids = graph["identities"]
+    # The spelling the estate saw most often is the one shown.
+    assert list(ids) == ["jeff gillings"]
+    assert ids["jeff gillings"]["aliases"] == ["jeff.gillings"]
+    assert set(ids["jeff gillings"]["tools"]) == {"claude", "chatgpt"}
+    assert ids["jeff gillings"]["findings"] == 3
+    # The tool edge follows, or a tool page links to a person who is gone.
+    assert graph["tools"]["claude"]["identities"] == ["jeff gillings"]
+
+
+def test_a_device_mapped_to_either_spelling_reaches_the_same_person():
+    findings = [
+        _f(tool="claude", surface="cloud", device="", user="jeff.gillings"),
+        _f(tool="chatgpt", surface="cloud", device="", user="jeff gillings"),
+        _f(tool="claude-code", surface="cli", device="LAPTOP-1",
+           user="jgillings"),
+    ]
+    graph = derive.graph_from(findings, {}, {"LAPTOP-1": "jeff gillings"})
+    ids = graph["identities"]
+    assert len(ids) == 1
+    person = list(ids)[0]
+    assert ids[person]["devices"] == ["LAPTOP-1"]
+
+
+def test_personal_account_rows_use_the_same_spelling_as_people():
+    findings = [
+        _f(tool="claude", surface="cloud", device="", user="jeff gillings"),
+        _f(tool="claude", surface="cloud", device="", user="jeff gillings"),
+        _f(tool="chatgpt", surface="browser", device="D1",
+           user="jeff.gillings", severity="warn",
+           account_domain="gmail.example"),
+    ]
+    graph = derive.graph_from(findings, {}, {})
+    assert [r["user"] for r in graph["personal_accounts"]] == ["jeff gillings"]
+
+
+def test_the_map_in_effect_can_be_exported(monkeypatch, tmp_path):
+    """An operator moving a mounted map into the portal had no way to
+    get the current one out: the only download was the proposal, which
+    is a set of suggestions, not what is being resolved with."""
+    from app import main as pm
+
+    f = tmp_path / "identity-map.csv"
+    f.write_text("key,identity\nC02XXXX,jo.bloggs\nWEIRD=KEY,x\n")
+    monkeypatch.setattr(pm, "IDENTITY_MAP", str(f))
+    monkeypatch.setattr(pm, "LOGIN_MODE", False)
+    body = bytes(pm.api_identity_map_csv(None, _=None).body).decode()
+    assert "C02XXXX,jo.bloggs" in body
+    # It round-trips through the parser it is written for.
+    assert derive.load_identity_map(str(f))["C02XXXX"] == "jo.bloggs"
+    # A formula-shaped value is neutralised rather than exported live.
+    assert "\n=" not in body

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.1
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Two findings from working through a real deployment's identity map.

**One person, two spellings.** A cloud source supplies a UPN local part (`jeff.gillings`), another a display name (`jeff gillings`), and the estate carried them as two people: two rows on People, one marked "unmapped" because the identity map had attached the device to the *other* spelling, and both reaching the budget report as separate unlicensed users. 0.14.3 stopped the budget join double-counting them; this fixes the estate itself.

- Spellings that normalise to the same name merge, the most-seen spelling is shown, the rest listed as "also seen as".
- Tool edges follow the surviving name, and a device mapped to either spelling reaches the same person.
- Personal-account rows are canonicalised on the normalised name, so the two views cannot call one person two things. Keyed on the normalised form rather than known variants, because the spelling on such a row usually comes from a finding that carries a device and never becomes an identity of its own.
- A merge needs the letters identical after normalisation: two genuinely different people would have to share a name exactly, and no source could tell them apart either.

**The download is now a working copy.** It used to be two buttons - a proposal with none of your existing work in it, and nothing at all that exported the map in effect - so a new laptop meant merging two files by hand, and a map that lived in a mounted ConfigMap could not be got out at all. One button now, "download map in use":

- the rows in effect (mounted file and portal-saved rows merged), then
- every machine with nobody attached, commented out: a name filled in where a local username or the machine's own name proposes one, blank where nothing does, each saying what matched - "via local user jo" and "via hostname JO-MBP" are different strengths of evidence.

Feeding the file straight back changes nothing, because every proposal is inert until a human uncomments it - asserted in the tests. It also makes the ConfigMap migration one click: download, upload, then drop the mount.

Portal 396 green. Chart 0.16.1, appVersion 0.16.1.