### PR TITLE
Settings: a tab name from the URL is checked against own properties

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.16.1
+version: 0.16.2
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.16.1"
+appVersion: "0.16.2"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.1
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.2
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.1
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.2
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2787,7 +2787,15 @@ async function settings() {
   const STABS = [['fleet', 'Fleet'], ['connection', 'Receiver & log store'],
                  ['alerting', 'Alerting & Grafana'], ['account', 'Account'],
                  ['diagnostics', 'Diagnostics']];
-  if (!SGROUPS[SETTAB]) SETTAB = 'fleet';
+  // Own properties only. SETTAB became reachable from the URL when the
+  // settings sub-tab moved into the fragment, and a truthiness check
+  // passes every name an object inherits: #settings/constructor,
+  // #settings/toString and #settings/__defineGetter__ all resolved to
+  // something callable, so the page dispatched into Object.prototype and
+  // rendered nonsense or threw. Nothing attacker-supplied can become a
+  // function here, but a crafted link could break the page for whoever
+  // opened it.
+  if (!Object.prototype.hasOwnProperty.call(SGROUPS, SETTAB)) SETTAB = 'fleet';
   return `<h2>Settings</h2>
   <p class="lede">Central settings are editable and reach the fleet at
   runtime - a value saved here overrides the matching environment variable.

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -494,3 +494,17 @@ def test_the_map_in_use_downloads_as_a_working_copy(monkeypatch, tmp_path):
     round_trip.write_text(body)
     assert derive.load_identity_map(str(round_trip)) == {
         "C02MAPPED": "jo.bloggs"}
+
+
+def test_the_settings_tab_from_the_url_cannot_dispatch_into_the_prototype():
+    """CodeQL js/unvalidated-dynamic-method-call, introduced when the
+    settings sub-tab moved into the URL fragment: the guard tested
+    truthiness, and every object inherits callable properties, so
+    #settings/constructor and #settings/__defineGetter__ dispatched into
+    Object.prototype - rendering nonsense, or throwing and taking the
+    page with it."""
+    index = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    html = open(os.path.join(index, "app", "static", "index.html")).read()
+    assert "Object.prototype.hasOwnProperty.call(SGROUPS, SETTAB)" in html
+    # The truthiness form must not come back.
+    assert "if (!SGROUPS[SETTAB])" not in html

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.1
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.2
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Closes code-scanning alert #42 (`js/unvalidated-dynamic-method-call`, high), which I introduced in 0.16.0 by moving the settings sub-tab into the URL fragment so a reload keeps your place.

That made `SETTAB` reachable from the URL, and the guard in front of `SGROUPS[SETTAB]()` tested truthiness. Every object inherits callable properties, so `#settings/constructor`, `#settings/toString` and `#settings/__defineGetter__` all passed it and dispatched into `Object.prototype` - rendering `[object Object]` where the page should be, or throwing and taking the whole render down with it.

Demonstrated rather than assumed:

```
truthiness check lets through: constructor, toString, __defineGetter__, hasOwnProperty
hasOwnProperty check lets through: (none)
and calling one of them: TypeError
```

Nothing attacker-supplied can become a function here - the table is a fixed object of five known views - so the impact is a crafted link breaking the page for whoever opens it, not code execution. Fixed with an own-property check at the point of use, which is also the only place it can live: `fromHash` runs while the module is still initialising and cannot see the tab table without a temporal-dead-zone error, the same trap that moved `SETTAB` to the globals block in the first place.

Portal 397 green. Chart 0.16.2, appVersion 0.16.2.