### PR TITLE
Identities: merge after attribution, and keep the name you chose

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.16.2
+version: 0.16.3
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.16.2"
+appVersion: "0.16.3"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.2
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.3
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.2
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.3
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -668,19 +668,6 @@ def build(findings, domain_map=None, identity_map=None):
                 b["devices"].discard(bare)
                 b["devices"].add(canon)
 
-    # One person, one identity. Do this before devices are attributed,
-    # so a device mapped to either spelling lands on the same person.
-    for variant, canon in _identity_aliases(identities).items():
-        src, dst = identities.pop(variant), identities[canon]
-        for field in ("tools", "surfaces", "sources", "accounts", "devices"):
-            dst[field] = (dst.get(field) or set()) | (src.get(field) or set())
-        dst["findings"] += src["findings"]
-        dst["aliases"].add(variant)
-        for t in tools.values():
-            if variant in t["identities"]:
-                t["identities"].discard(variant)
-                t["identities"].add(canon)
-
     # Attach a person to each device, if the deployer supplied a mapping.
     # Device key first, then any local username: an MDM keys on the serial, a
     # spreadsheet is more likely to key on the name someone logs in with.
@@ -699,6 +686,29 @@ def build(findings, domain_map=None, identity_map=None):
             i["tools"] |= d["tools"]
             i["surfaces"] |= d["surfaces"]
 
+    # One person, one identity - AFTER attribution, not before. A cloud
+    # sign-in creates an identity directly; the other spelling of the
+    # same colleague often exists only because the identity map attached
+    # it to a device just above, so merging any earlier compares one
+    # spelling against a name that does not exist yet and leaves the two
+    # rows the merge was written to collapse.
+    for variant, canon in _identity_aliases(
+            identities, set(identity_map.values())).items():
+        src, dst = identities.pop(variant), identities[canon]
+        for field in ("tools", "surfaces", "sources", "accounts", "devices"):
+            dst[field] = (dst.get(field) or set()) | (src.get(field) or set())
+        dst["findings"] += src["findings"]
+        dst["aliases"].add(variant)
+        for t in tools.values():
+            if variant in t["identities"]:
+                t["identities"].discard(variant)
+                t["identities"].add(canon)
+        # A device attributed to the variant now names the person the
+        # rest of the product shows.
+        for d in devices.values():
+            if d.get("person") == variant:
+                d["person"] = canon
+
     return devices, identities, tools, bridges, unattributed
 
 
@@ -710,7 +720,7 @@ _MIN_ALIAS_KEY = 6
 _ALIAS_SEPARATORS = ("-", "_", ".", ":")
 
 
-def _identity_aliases(identities):
+def _identity_aliases(identities, preferred=()):
     """{variant: canonical} where two identity strings are the same
     person spelled differently.
 
@@ -725,6 +735,7 @@ def _identity_aliases(identities):
     identical. Two genuinely different people would have to share a name
     exactly, and no source could tell them apart either.
     """
+    preferred = set(preferred or ())
     by_norm = {}
     for name in identities:
         norm = _norm_person(name)
@@ -734,11 +745,14 @@ def _identity_aliases(identities):
     for names in by_norm.values():
         if len(names) < 2:
             continue
-        # The spelling the estate saw most wins, so the name on screen is
-        # the one most sources use; alphabetical to keep it deterministic
-        # when they tie.
-        canon = sorted(names,
-                       key=lambda n: (-identities[n]["findings"], n))[0]
+        # A spelling somebody typed into the identity map wins: that is a
+        # deliberate choice about what to call a colleague, and a source's
+        # spelling is an accident of how the source stores names. After
+        # that, the spelling seen most often, then alphabetically so the
+        # answer does not move between reads.
+        canon = sorted(names, key=lambda n: (n not in preferred,
+                                             -identities[n]["findings"],
+                                             n))[0]
         for n in names:
             if n != canon:
                 out[n] = canon

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -508,3 +508,30 @@ def test_the_settings_tab_from_the_url_cannot_dispatch_into_the_prototype():
     assert "Object.prototype.hasOwnProperty.call(SGROUPS, SETTAB)" in html
     # The truthiness form must not come back.
     assert "if (!SGROUPS[SETTAB])" not in html
+
+
+def test_a_spelling_that_exists_only_via_the_map_still_merges():
+    """The shape that survived the first attempt at this fix. One
+    spelling comes from a cloud sign-in and becomes an identity
+    directly; the other exists ONLY because the identity map attaches it
+    to a device. Merging before attribution compared the first against a
+    name that did not exist yet, and left both rows on People - one of
+    them showing "unmapped" while its owner's machine sat on the other.
+    """
+    findings = [
+        _f(tool="claude", surface="cloud", device="", user="jeff.gillings"),
+        _f(tool="chatgpt", surface="browser", device="WIN-JEFF",
+           source="browser_extension"),
+    ]
+    graph = derive.graph_from(findings, {}, {"WIN-JEFF": "jeff gillings"})
+    ids = graph["identities"]
+    assert len(ids) == 1
+    # The spelling the operator typed into the map is the one shown: that
+    # is a decision about what to call a colleague, where a source's
+    # spelling is an accident of how it stores names.
+    assert list(ids) == ["jeff gillings"]
+    assert ids["jeff gillings"]["aliases"] == ["jeff.gillings"]
+    assert ids["jeff gillings"]["devices"] == ["WIN-JEFF"]
+    assert set(ids["jeff gillings"]["tools"]) == {"claude", "chatgpt"}
+    # And the device names the same person the rest of the product does.
+    assert graph["devices"]["WIN-JEFF"]["person"] == "jeff gillings"

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.2
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.3
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
0.16.1's identity merge missed the case it was written for, found immediately in live use on the exact person it was meant to help.

The merge ran *before* the identity map attaches people to devices. A cloud sign-in creates an identity directly, but the other spelling of the same colleague usually exists **only** because the map attaches it to a machine in the step below - so the merge compared one spelling against a name that did not exist yet, and both rows stayed on People, one of them reading "unmapped" while its owner's laptop sat on the other.

Reproduced before fixing:

```
before: 'jeff.gillings' devices: []          aliases: []
        'jeff gillings' devices: ['WIN-JEFF'] aliases: []
after:  'jeff gillings' devices: ['WIN-JEFF'] aliases: ['jeff.gillings']
```

- The merge runs after attribution, and a device attributed to a variant spelling now names the person the rest of the product shows.
- The surviving spelling is the one written in the **identity map** where there is one, then the most-seen, then alphabetical. Somebody typing a name into the map is deciding what to call a colleague; a source's spelling is an accident of how that source stores names.

The existing tests passed because both spellings in them came from device-less cloud findings, so both existed before the merge - the new test reproduces the real shape, where one spelling exists only via the map.

Portal 398 green. Chart 0.16.3, appVersion 0.16.3.