### PR TITLE
Identity map and budget: say what is missing, not nothing

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.16.3
+version: 0.16.4
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.16.3"
+appVersion: "0.16.4"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/budget.md
+++ b/docs/budget.md
@@ -175,14 +175,16 @@ straight to it for anyone with a login.
 
 Each subscription records its own currency - the one the vendor actually
 invoices in - and those per-currency totals are always shown. Set a
-**preferred currency** (Settings, or step 3 of the setup wizard) and the
-headline additionally converts into it using the ECB's daily reference
+**preferred currency** (Settings > Display and alerting, or step 3 of the
+setup wizard) and the headline additionally converts into it using the ECB's daily reference
 rate, fetched by the receiver from the keyless Frankfurter API and
 cached for half a day. The conversion never hides its working: the rate
 date and the unconverted per-currency figures sit right beside the
 converted number, and if the rate source cannot answer - or a
 subscription uses a currency the ECB does not fix - the headline simply
-falls back to the per-currency breakdown. Newly linked tools default to
+falls back to the per-currency breakdown, and says which of those it
+is: no preferred currency set, a rate source the deployment cannot
+reach, or a currency the ECB does not fix. Newly linked tools default to
 the preferred currency.
 
 ## Seat tiers

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.3
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.4
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.3
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.4
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -2401,6 +2401,24 @@ def api_identity_map_csv(request: Request,
                 u["device_name"] or "no machine name",
                 " · local users: %s" % hint if hint else ""))
 
+    # The other half of the same gap, and the half this file could not
+    # show: people the cloud sources know with no machine attached. They
+    # cannot be rows - the map is keyed on a device or a username, and
+    # these have neither - but the work is matching them against the
+    # machines above, and doing that from two separate screens is how
+    # the join stays undone. A service account or someone on leave
+    # belongs here permanently, which is a real answer rather than a gap.
+    orphans = sorted(k for k, i in identities.items()
+                     if not (i.get("devices") or ()))
+    if orphans:
+        out += ["#",
+                "# --- people with no machine attached (for reference) ---",
+                "# Not rows: the map is keyed on a machine or a username,",
+                "# and these have neither. If one of them owns a machine",
+                "# listed above, put their name against it there."]
+        for name in orphans:
+            out.append("# %s" % derive.csv_safe(name))
+
     return PlainTextResponse(
         "\n".join(out) + "\n",
         headers={"Content-Disposition":

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2580,7 +2580,7 @@ function connectionSettings() {
 }
 
 function alertingSettings() {
-  return `<div class="wcard" style="margin-bottom:10px"><h3>Alerting and Grafana</h3>
+  return `<div class="wcard" style="margin-bottom:10px"><h3>Display and alerting</h3>
   <dl class="kv">
     ${settingRow('alertmanager_url', 'Alertmanager URL',
       'http://alertmanager.<namespace>.svc:9093',
@@ -2785,7 +2785,7 @@ async function settings() {
                    alerting: alertingSettings, account: accountSettings,
                    diagnostics: diagnosticsCards};
   const STABS = [['fleet', 'Fleet'], ['connection', 'Receiver & log store'],
-                 ['alerting', 'Alerting & Grafana'], ['account', 'Account'],
+                 ['alerting', 'Display & alerting'], ['account', 'Account'],
                  ['diagnostics', 'Diagnostics']];
   // Own properties only. SETTAB became reachable from the URL when the
   // settings sub-tab moved into the fragment, and a truthiness check
@@ -3283,6 +3283,35 @@ function bConverted(subs) {
     else return null;
   }
   return {total, date: BFX.date || ''};
+}
+
+// Why the headline is showing two currencies instead of one. Silence
+// here was the wrong kind of graceful: an operator who never set a
+// preferred currency, and one whose cluster cannot reach the rate
+// source, saw exactly the same thing - two figures and no explanation.
+function bConversionNote(subs) {
+  const curs = new Set((subs || []).map(s => (s.currency || '').toUpperCase())
+    .filter(Boolean));
+  if (curs.size < 2) return '';
+  const pref = bPrefCur();
+  if (!pref) {
+    return `Set a preferred currency under Settings to see one total: these
+      are counted separately because nothing says which to convert into.`;
+  }
+  if (!BFX || !BFX.ok) {
+    return `Not converted into ${esc(pref)}: the exchange-rate source could
+      not be reached${BFX && BFX.detail ? ` (${esc(BFX.detail)})` : ''}. The
+      receiver fetches the ECB's daily rates from api.frankfurter.dev - if
+      this deployment restricts outbound traffic, that host needs to be
+      reachable.`;
+  }
+  const missing = [...curs].filter(c =>
+    c !== pref && !((BFX.rates || {})[c]));
+  if (missing.length) {
+    return `Not converted: the ECB publishes no reference rate for
+      ${missing.map(esc).join(', ')}.`;
+  }
+  return '';
 }
 
 async function bFetchFx() {
@@ -4039,6 +4068,8 @@ async function budget() {
   vendor's admin API where one exists, or a CSV export where one does not -
   the numbers work the same either way and each card says which it is.</p>
   ${BMSG ? `<div class="note">${esc(BMSG)}</div>` : ''}
+  ${(() => { const n = conv ? '' : bConversionNote(subs);
+     return n ? `<p class="src-note" style="margin-bottom:10px">${n}</p>` : ''; })()}
   ${subs.length ? `<dl class="stats" style="margin-bottom:14px">
     <div><dt>${spend}</dt><dd>tracked spend / month${conv
       ? ` · ${spendParts.join(' + ')} at ECB ${esc(conv.date)}` : ''}</dd></div>

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.3
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.4
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Both from an operator working through a real estate and reasonably asking why the product was being quiet.

**The identity map download showed half the gap.** It listed devices with nobody attached; the other half - people the cloud sources know with no machine attached - appeared nowhere, and matching one list against the other is the actual work. They cannot be rows, because the map is keyed on a machine or a username and these have neither, so they are listed for reference beneath the machines, where the join can be made in one file:

```
# --- no person known: fill in and uncomment ---
# NIX-BULBA,  # no machine name · local users: bulbasaur
#
# --- people with no machine attached (for reference) ---
# Not rows: the map is keyed on a machine or a username,
# and these have neither. If one of them owns a machine
# listed above, put their name against it there.
# eevee
# psyduck
```

A service account, or somebody on leave, lives in that list permanently - which is a real answer rather than a gap.

**The Budget headline showed two currencies with no explanation.** Three quite different situations produced an identical screen: no preferred currency set, a rate source the cluster cannot reach, and a currency the ECB does not publish a rate for. It now says which - including naming `api.frankfurter.dev` when the fetch failed, since a deployment that restricts outbound traffic is the likely cause and nothing else on the page would tell you.

Verified in the demo across both states: with no preferred currency, "£172 + $390" plus the note; with GBP set, "£459 · £172 + $390 at ECB 2026-08-27".

**Also:** the settings tab holding Grafana embedding, overview widgets and the preferred currency is renamed from "Alerting & Grafana" to "Display & alerting". Nobody hunting for a currency setting would look under Alerting, which is exactly how this came up.

Portal 398 green. Chart 0.16.4, appVersion 0.16.4.