### PR TITLE
Portal: links in page content follow the palette

### DIFF
--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -163,6 +163,13 @@ tr[data-open]:hover td{background:color-mix(in srgb,var(--pri-soft) 45%,transpar
 .gov-owner{white-space:nowrap}
 .inputs{margin:0 0 18px;padding-left:20px;font-size:13.5px;line-height:1.9}
 .inputs a{color:var(--warn)}
+/* Links in page content follow the palette, like every control does. A
+   bare anchor was falling back to the browser's default blue, which is
+   near-unreadable on the dark theme and belongs to no part of this
+   design. A rule rather than a style on each link, so the next one
+   added cannot miss it: anything wanting a different colour still says
+   so inline, and the two more specific rules above still win. */
+main a{color:var(--pri)}
 /* No fill, barely-there text. Absence of governance, not a state with equal
    weight to approved or reviewing. */
 .none{color:color-mix(in srgb,var(--mut) 70%,transparent);font-size:12px;white-space:nowrap}

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -535,3 +535,13 @@ def test_a_spelling_that_exists_only_via_the_map_still_merges():
     assert set(ids["jeff gillings"]["tools"]) == {"claude", "chatgpt"}
     # And the device names the same person the rest of the product does.
     assert graph["devices"]["WIN-JEFF"]["person"] == "jeff gillings"
+
+
+def test_content_links_follow_the_palette():
+    """A bare anchor fell back to the browser's default blue, which is
+    near-unreadable on the dark theme and belongs to no part of this
+    design. A rule rather than a style on each link, so the next link
+    added cannot miss it."""
+    index = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    html = open(os.path.join(index, "app", "static", "index.html")).read()
+    assert "main a{color:var(--pri)}" in html


### PR DESCRIPTION
The GitHub link under the Budget page's vendor-sync note rendered in the browser's default blue - near-unreadable on the dark theme, and a colour that appears nowhere else in the design. Every control already uses the theme-aware primary colour.

Fixed as a rule for links inside the main content rather than a style on each link, so the next one added cannot miss it. The two more specific link rules (the sidebar footer, and the inputs block) still win, and anything wanting a different colour still says so inline.

Verified in the demo: the link and the buttons now compute to the same `rgb(70, 192, 127)` in dark mode, and the palette's light-mode green in light.

Portal 399 green. No version change - this rides with 0.16.4, whose pins are already on main.