### PR TITLE
Settings: check the tab from the URL against the tabs that exist

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.16.4
+version: 0.16.5
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.16.4"
+appVersion: "0.16.5"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.4
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.5
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.4
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.5
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -307,6 +307,13 @@ let G = {devices:{},identities:{},tools:{},bridges:{},unattributed:[],counts:{}}
 // is not hoisted, so declaring them lower down is a TDZ error on first
 // refresh.
 let SETTAB = 'fleet';
+// The Settings sub-tabs, up here with SETTAB for the same reason: SETTAB is
+// set from the URL fragment by fromHash(), which runs while the module is
+// still evaluating, so the list it is checked against has to exist by then.
+const STABS = [['fleet', 'Fleet'], ['connection', 'Receiver & log store'],
+               ['alerting', 'Display & alerting'], ['account', 'Account'],
+               ['diagnostics', 'Diagnostics']];
+const SETTABS = STABS.map(([id]) => id);
 let DIAG = null;
 let REG = null;
 let EV = null;
@@ -586,8 +593,10 @@ const fromHash = () => {
   const h = (location.hash || '').replace(/^#/, '');
   // #settings/account addresses a sub-tab; the view is still settings.
   if (h.startsWith('settings/')) {
+    // Checked against the known tabs exactly like the view below it. This
+    // is the point the value stops being a fragment and starts being a tab.
     const tab = h.split('/')[1];
-    if (tab) SETTAB = tab;
+    if (SETTABS.includes(tab)) SETTAB = tab;
     return 'settings';
   }
   return VIEWS.includes(h) ? h : 'setup';
@@ -2788,24 +2797,16 @@ async function settings() {
   if (!managed || !SETTINGS) return `<h2>Settings and diagnostics</h2>
     ${diagnosticsCards()}`;
 
-  // A Map, not an object literal. SETTAB is reachable from the URL
-  // (#settings/<tab>), and an object carries every name it inherits:
-  // constructor, toString and __defineGetter__ all resolved to something
-  // callable, so a crafted link dispatched into Object.prototype and
-  // rendered nonsense or threw. An own-property guard fixed the
-  // behaviour but left the shape - obj[userControlled]() - which is
-  // worth removing rather than annotating: a Map has no inherited keys,
-  // has() answers the question honestly, and what gets called below is a
-  // plain function value rather than a member looked up by name.
-  const SGROUPS = new Map([
-    ['fleet', fleetSettings], ['connection', connectionSettings],
-    ['alerting', alertingSettings], ['account', accountSettings],
-    ['diagnostics', diagnosticsCards]]);
-  const STABS = [['fleet', 'Fleet'], ['connection', 'Receiver & log store'],
-                 ['alerting', 'Display & alerting'], ['account', 'Account'],
-                 ['diagnostics', 'Diagnostics']];
-  if (!SGROUPS.has(SETTAB)) SETTAB = 'fleet';
-  const settingsGroup = SGROUPS.get(SETTAB);
+  // Named outright rather than looked up by a key that came from the URL.
+  // SETTAB is allow-listed where it enters, in fromHash(), so it can only
+  // be one of these; spelling the branches out means there is no name to
+  // dispatch on here at all, and nothing to get wrong twice.
+  let body;
+  if (SETTAB === 'connection') body = connectionSettings();
+  else if (SETTAB === 'alerting') body = alertingSettings();
+  else if (SETTAB === 'account') body = accountSettings();
+  else if (SETTAB === 'diagnostics') body = diagnosticsCards();
+  else { SETTAB = 'fleet'; body = fleetSettings(); }
   return `<h2>Settings</h2>
   <p class="lede">Central settings are editable and reach the fleet at
   runtime - a value saved here overrides the matching environment variable.
@@ -2813,7 +2814,7 @@ async function settings() {
   ${SETMSG ? `<div class="note">${esc(SETMSG)}</div>` : ''}
   <div class="tabs">${STABS.map(([id, lbl]) =>
     `<button data-settab="${id}" class="${SETTAB===id?'on':''}">${lbl}</button>`).join('')}</div>
-  ${settingsGroup()}`;
+  ${body}`;
 }
 
 // Repo docs as real links, pinned to the release this portal runs - the
@@ -4937,7 +4938,9 @@ app.addEventListener('change', e => {
 app.addEventListener('click', e => {
   const el = e.target.closest('[data-settab]');
   if (!el) return;
-  SETTAB = el.getAttribute('data-settab');
+  const tab = el.getAttribute('data-settab');
+  if (!SETTABS.includes(tab)) return;
+  SETTAB = tab;
   // In the fragment like every other navigation in this page, so a
   // reload keeps the tab and a colleague can be sent the one you mean.
   history.replaceState(null, '', '#settings/' + SETTAB);

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2788,21 +2788,24 @@ async function settings() {
   if (!managed || !SETTINGS) return `<h2>Settings and diagnostics</h2>
     ${diagnosticsCards()}`;
 
-  const SGROUPS = {fleet: fleetSettings, connection: connectionSettings,
-                   alerting: alertingSettings, account: accountSettings,
-                   diagnostics: diagnosticsCards};
+  // A Map, not an object literal. SETTAB is reachable from the URL
+  // (#settings/<tab>), and an object carries every name it inherits:
+  // constructor, toString and __defineGetter__ all resolved to something
+  // callable, so a crafted link dispatched into Object.prototype and
+  // rendered nonsense or threw. An own-property guard fixed the
+  // behaviour but left the shape - obj[userControlled]() - which is
+  // worth removing rather than annotating: a Map has no inherited keys,
+  // has() answers the question honestly, and what gets called below is a
+  // plain function value rather than a member looked up by name.
+  const SGROUPS = new Map([
+    ['fleet', fleetSettings], ['connection', connectionSettings],
+    ['alerting', alertingSettings], ['account', accountSettings],
+    ['diagnostics', diagnosticsCards]]);
   const STABS = [['fleet', 'Fleet'], ['connection', 'Receiver & log store'],
                  ['alerting', 'Display & alerting'], ['account', 'Account'],
                  ['diagnostics', 'Diagnostics']];
-  // Own properties only. SETTAB became reachable from the URL when the
-  // settings sub-tab moved into the fragment, and a truthiness check
-  // passes every name an object inherits: #settings/constructor,
-  // #settings/toString and #settings/__defineGetter__ all resolved to
-  // something callable, so the page dispatched into Object.prototype and
-  // rendered nonsense or threw. Nothing attacker-supplied can become a
-  // function here, but a crafted link could break the page for whoever
-  // opened it.
-  if (!Object.prototype.hasOwnProperty.call(SGROUPS, SETTAB)) SETTAB = 'fleet';
+  if (!SGROUPS.has(SETTAB)) SETTAB = 'fleet';
+  const settingsGroup = SGROUPS.get(SETTAB);
   return `<h2>Settings</h2>
   <p class="lede">Central settings are editable and reach the fleet at
   runtime - a value saved here overrides the matching environment variable.
@@ -2810,7 +2813,7 @@ async function settings() {
   ${SETMSG ? `<div class="note">${esc(SETMSG)}</div>` : ''}
   <div class="tabs">${STABS.map(([id, lbl]) =>
     `<button data-settab="${id}" class="${SETTAB===id?'on':''}">${lbl}</button>`).join('')}</div>
-  ${SGROUPS[SETTAB]()}`;
+  ${settingsGroup()}`;
 }
 
 // Repo docs as real links, pinned to the release this portal runs - the

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -502,18 +502,30 @@ def test_the_settings_tab_from_the_url_cannot_dispatch_into_the_prototype():
     truthiness, and every object inherits callable properties, so
     #settings/constructor and #settings/__defineGetter__ dispatched into
     Object.prototype - rendering nonsense, or throwing and taking the
-    page with it."""
+    page with it.
+
+    Two attempted fixes missed. An own-property guard corrected the
+    behaviour but kept the shape; a Map removed the inherited keys but
+    the call was still a value fetched with a key from the URL. The
+    fault was upstream of both: SETTAB was the one fragment-derived
+    value that was never checked against a list of what it may be,
+    while the view on the very next line always was."""
     index = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     html = open(os.path.join(index, "app", "static", "index.html")).read()
-    # A Map has no inherited keys, and what is called is a plain
-    # function value rather than a member looked up by a name from the
-    # URL - the shape is gone, not annotated.
-    assert "const SGROUPS = new Map([" in html
-    assert "if (!SGROUPS.has(SETTAB)) SETTAB = 'fleet';" in html
-    assert "${settingsGroup()}" in html
-    # Neither earlier form may come back.
-    assert "if (!SGROUPS[SETTAB])" not in html
-    assert "SGROUPS[SETTAB]()" not in html
+    # Allow-listed where it enters, like the view beside it.
+    assert "if (SETTABS.includes(tab)) SETTAB = tab;" in html
+    # And named outright at the point of use - no key, no lookup, no call.
+    assert "if (SETTAB === 'connection') body = connectionSettings();" in html
+    assert "else { SETTAB = 'fleet'; body = fleetSettings(); }" in html
+    assert "${body}`;" in html
+    # The list has to exist before fromHash() runs, or it is a TDZ error
+    # on load - the same trap SETTAB itself fell into.
+    assert html.index("const SETTABS") < html.index("SETTABS.includes(tab)")
+    # No earlier form may come back.
+    for gone in ("if (!SGROUPS[SETTAB])", "SGROUPS[SETTAB]()",
+                 "const SGROUPS = new Map([", "${settingsGroup()}",
+                 "if (tab) SETTAB = tab;"):
+        assert gone not in html
 
 
 def test_a_spelling_that_exists_only_via_the_map_still_merges():

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -505,9 +505,15 @@ def test_the_settings_tab_from_the_url_cannot_dispatch_into_the_prototype():
     page with it."""
     index = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     html = open(os.path.join(index, "app", "static", "index.html")).read()
-    assert "Object.prototype.hasOwnProperty.call(SGROUPS, SETTAB)" in html
-    # The truthiness form must not come back.
+    # A Map has no inherited keys, and what is called is a plain
+    # function value rather than a member looked up by a name from the
+    # URL - the shape is gone, not annotated.
+    assert "const SGROUPS = new Map([" in html
+    assert "if (!SGROUPS.has(SETTAB)) SETTAB = 'fleet';" in html
+    assert "${settingsGroup()}" in html
+    # Neither earlier form may come back.
     assert "if (!SGROUPS[SETTAB])" not in html
+    assert "SGROUPS[SETTAB]()" not in html
 
 
 def test_a_spelling_that_exists_only_via_the_map_still_merges():

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.4
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.5
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Code-scanning alert #42, `js/unvalidated-dynamic-method-call`, on the settings sub-tab in the URL fragment.

Two earlier attempts missed, both aimed at the point of use. 0.16.2's own-property guard corrected the behaviour and left the shape. A `Map` removed the inherited keys, but what was called was still a value fetched with a key that came from the URL, and the scan raised it again — as a *new* alert (#43) rather than the old one, which is what made the pattern visible.

The fault was upstream of the dispatch. `fromHash()` derives two things from the fragment:

```js
if (tab) SETTAB = tab;          // taken as given
...
return VIEWS.includes(h) ? h : 'setup';   // checked, always has been
```

`SETTAB` was the only fragment-derived value in the page that was never checked against a list of what it may be — one line above the value that always is. That asymmetry, not the lookup, was the bug.

**The fix**

- `SETTAB` is allow-listed where it enters, in `fromHash()`, and in the tab-strip click handler that also writes it.
- The renderers are named outright instead of looked up, so there is no name to dispatch on at all.
- The tab list moves up beside `SETTAB`: `fromHash()` runs during module evaluation, so a list declared lower down would be a TDZ error on load — the same trap `SETTAB` itself fell into earlier.

**Verified against the file's own source**, not a paraphrase — the harness extracts the real declaration, the real guard and the real dispatch chain out of `index.html` and runs them: the fourteen fragments worth trying (`constructor`, `__proto__`, `__defineGetter__`, `__lookupSetter__`, `toString`, `valueOf`, `hasOwnProperty`, the empty one, a case-variant, a trailing space) all land on `fleet` and render the fleet body; the five real tabs each still select their own renderer. Confirmed in the browser too: `#settings/constructor` leaves `SETTAB` as `fleet`.

Portal 399 green. Chart 0.16.5, appVersion 0.16.5.