### PR TITLE
Identity import: name the rows it drops, and the ones it never counted

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.16.5
+version: 0.16.6
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.16.5"
+appVersion: "0.16.6"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.5
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.6
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.5
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.6
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -1029,12 +1029,22 @@ function identityMapEditor() {
       <button class="mini" data-act="id-cancel">cancel</button>
       ${(p.rows || []).length ? `<button class="mini" data-act="id-save">save ${p.rows.length} ${p.rows.length === 1 ? 'row' : 'rows'}</button>` : ''}
     </div>
-    ${p.rows ? `<p class="src-note">${p.rows.length} rows understood, ${p.skipped}
-      skipped (no key, no person, or a duplicate). Saving REPLACES the map
-      saved here; a mounted file is untouched.
+    ${p.rows ? `<p class="src-note">${p.rows.length} rows understood${
+      (p.skipped || []).length ? ', ' + p.skipped.length + ' skipped' : ''}.
+      Saving REPLACES the map saved here; a mounted file is untouched.
       ${unknown.length ? `<span style="color:var(--warn)">${unknown.length}
         ${unknown.length === 1 ? 'key matches' : 'keys match'} no device or local
         user in the current window - kept, in case the machine reports later.</span>` : ''}</p>
+      ${(p.skipped || []).length ? `<p class="src-note" style="color:var(--warn)">
+        Not saved: ${p.skipped.map(s =>
+          `line ${s.n} <span class="mono">${esc(s.key)}</span> (${esc(s.why)})`)
+          .join(', ')}.</p>` : ''}
+      ${(p.commented || []).length ? `<p class="src-note">
+        ${p.commented.length} commented ${p.commented.length === 1 ? 'row carries' : 'rows carry'}
+        a name and ${p.commented.length === 1 ? 'is' : 'are'} not saved - the download writes
+        proposals and blanks commented out, so remove the leading # from any you meant to keep:
+        ${p.commented.slice(0, 6).map(c => `line ${c.n} <span class="mono">${esc(c.key)}</span>`).join(', ')}${
+          p.commented.length > 6 ? ', and ' + (p.commented.length - 6) + ' more' : ''}.</p>` : ''}
       ${p.rows.length ? `<table><tr><th>key</th><th>person</th><th></th></tr>
       ${p.rows.slice(0, 8).map(r => `<tr><td class="mono">${esc(r.key)}</td><td>${esc(r.identity)}</td>
         <td>${known.has(r.key) ? '<span class="pill p-ok">matches</span>' : '<span class="pill p-mut">not seen yet</span>'}</td></tr>`).join('')}
@@ -1046,20 +1056,39 @@ function identityMapEditor() {
 // straight back in. Comments and the header row are dropped exactly as the
 // server-side loader drops them.
 function parseIdentityCsv(text) {
-  const out = [], seen = new Set();
-  let skipped = 0;
-  String(text || '').replace(/^\uFEFF/, '').split(/\r\n|\r|\n/).forEach(line => {
+  const out = [], seen = new Map();
+  // A count alone sent someone hunting through 62 rows for four of them,
+  // so each dropped row says which line and why. The commented list is
+  // separate and is not a fault: the download writes proposals and blanks
+  // commented out, on purpose. It is here because a row that was filled
+  // in and never uncommented is otherwise invisible - split('#')[0] makes
+  // it an empty line, so it is not saved and was not even counted.
+  const skipped = [], commented = [];
+  const cut = s => bCsvRow(s, s.includes('\t') ? '\t' : ',')
+    .slice(0, 2).map(c => (c || '').trim());
+  String(text || '').replace(/^\uFEFF/, '').split(/\r\n|\r|\n/).forEach((line, i) => {
+    const n = i + 1;
     const bare = line.split('#')[0].trim();
-    if (!bare) return;
-    const cells = bCsvRow(bare, bare.includes('\t') ? '\t' : ',');
-    const [key, identity] = [(cells[0] || '').trim(), (cells[1] || '').trim()];
-    if (!key || !identity) { if (bare) skipped++; return; }
+    if (!bare) {
+      const [k, ident] = cut(line.replace(/^[\s#]+/, '').split('#')[0].trim());
+      if (k && ident) commented.push({n, key: k, identity: ident});
+      return;
+    }
+    const [key, identity] = cut(bare);
     if (['key', 'device', 'local_user'].includes(key.toLowerCase())) return;
-    if (seen.has(key.toLowerCase())) { skipped++; return; }
-    seen.add(key.toLowerCase());
+    if (!key) { skipped.push({n, key: bare, why: 'no key'}); return; }
+    if (!identity) { skipped.push({n, key, why: 'no person'}); return; }
+    const dup = seen.get(key.toLowerCase());
+    if (dup) {
+      // First wins, which is worth saying outright: when the corrected row
+      // is the lower one, the edit is the half that gets dropped.
+      skipped.push({n, key, why: 'same key as line ' + dup});
+      return;
+    }
+    seen.set(key.toLowerCase(), n);
     out.push({key, identity});
   });
-  return {rows: out, skipped};
+  return {rows: out, skipped, commented};
 }
 
 async function people() {

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -528,6 +528,28 @@ def test_the_settings_tab_from_the_url_cannot_dispatch_into_the_prototype():
         assert gone not in html
 
 
+def test_the_identity_import_names_the_rows_it_drops():
+    """A bare count ("58 rows understood, 4 skipped (no key, no person or
+    duplicate)") sent a maintainer hunting through the file for four rows
+    it would not name. Worse, the count was not even complete: the
+    download writes blanks and proposals commented out under "fill in and
+    uncomment", and a row filled in with the # left on becomes an empty
+    line at split('#')[0] - not saved, and not counted either. And where
+    a key appears twice the FIRST wins, so a corrected row below an older
+    one is the half that gets discarded, silently."""
+    index = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    html = open(os.path.join(index, "app", "static", "index.html")).read()
+    # Every dropped row carries a line number and a reason.
+    assert "skipped.push({n, key, why: 'no person'})" in html
+    assert "skipped.push({n, key: bare, why: 'no key'})" in html
+    assert "why: 'same key as line ' + dup" in html
+    # The filled-in-but-still-commented row is surfaced rather than lost.
+    assert "if (k && ident) commented.push({n, key: k, identity: ident});" in html
+    assert "remove the leading # from any you meant to keep" in html
+    # The old count-only phrasing may not come back.
+    assert "skipped (no key, no person, or a duplicate)" not in html
+
+
 def test_a_spelling_that_exists_only_via_the_map_still_merges():
     """The shape that survived the first attempt at this fix. One
     spelling comes from a cloud sign-in and becomes an identity

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.5
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.6
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Hit in live use: a map was edited carefully, re-uploaded, and nothing moved. The preview said `58 rows understood, 4 skipped (no key, no person or duplicate)` - a count that names neither the rows nor which of the three reasons applied to any of them.

Two problems behind it.

**The count was incomplete.** The download writes blanks and proposals commented out, under `# --- no person known: fill in and uncomment ---`. That asks for two edits per row: type the name *and* delete the leading `#`. Do only the first and `line.split('#')[0]` makes the row an empty string - it is not saved, and it is not counted as skipped either. A filled-in row could disappear with nothing said about it at all. Those rows are now listed on their own, phrased as information rather than an error, because a commented row is not a fault - it is how the file is handed over.

**Duplicates needed saying outright.** The first occurrence of a key wins. So when the corrected row sits *below* an older one for the same key, the edit is the half that gets discarded - precisely the shape of "my changes were right and nothing changed". A skipped duplicate now names the line it lost to.

Every dropped row now reports its line number, its key and its reason.

Verified by running the real `parseIdentityCsv` out of `index.html` against the exact shape the portal's own download writes: a corrected duplicate on line 7 is reported as losing to line 2, a row uncommented but left blank reports `no person` on its line, and a row filled in with the `#` still on is named instead of vanishing.

Portal 400 green. Chart 0.16.6, appVersion 0.16.6.