### PR TITLE
Identity map: a row keyed on the bare serial finds the machine

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.16.6
+version: 0.16.7
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.16.6"
+appVersion: "0.16.7"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.6
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.7
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.6
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.7
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -674,6 +674,17 @@ def build(findings, domain_map=None, identity_map=None):
     for key, d in devices.items():
         person = identity_map.get(key)
         if not person:
+            # Then the keys this device was merged from. The canonical key
+            # is the longer, prefixed one, so a machine the collector calls
+            # TGT-C02ABCD swallows the C02ABCD the extension reports - and
+            # an MDM export lists the bare serial, which is what a deployer
+            # builds the map from. Mapping the serial looked right, matched
+            # in the preview, and attached to nothing.
+            for alias in d["aliases"]:
+                if alias in identity_map:
+                    person = identity_map[alias]
+                    break
+        if not person:
             for lu in d["local_users"]:
                 if lu in identity_map:
                     person = identity_map[lu]

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -528,6 +528,32 @@ def test_the_settings_tab_from_the_url_cannot_dispatch_into_the_prototype():
         assert gone not in html
 
 
+def test_a_map_keyed_on_the_bare_serial_still_finds_the_machine():
+    """Found while explaining why a mapped person still read as unmapped.
+    One machine reported twice - TGT-<serial> by the collector, the bare
+    serial by the extension - merges onto the longer key, and the shorter
+    one survives only in aliases. Attribution checked the canonical key
+    and local usernames, never the aliases. An MDM export lists the bare
+    serial, so a map built from one looked right, said "matches" in the
+    preview because the preview does count aliases, and attached to
+    nobody."""
+    finds = [_f(device="TGT-C02ABCD", source="collector-macos",
+                device_name="sam-mbp", user="sam"),
+             _f(device="C02ABCD", source="extension", device_name="sam-mbp")]
+    dm = derive.load_domain_map_from(REG)
+
+    def person(imap):
+        devices, _i, _t, _b, _u = derive.build(list(finds), dm, imap)
+        assert len(devices) == 1, "the two reports are one machine"
+        return list(devices.values())[0].get("person")
+
+    assert person({"C02ABCD": "Sam Patel"}) == "Sam Patel"
+    assert person({"TGT-C02ABCD": "Sam Patel"}) == "Sam Patel"
+    assert person({"sam": "Sam Patel"}) == "Sam Patel"
+    # The key the device is actually filed under still wins the tie.
+    assert person({"C02ABCD": "Wrong", "TGT-C02ABCD": "Sam Patel"}) == "Sam Patel"
+
+
 def test_the_identity_import_names_the_rows_it_drops():
     """A bare count ("58 rows understood, 4 skipped (no key, no person or
     duplicate)") sent a maintainer hunting through the file for four rows

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.6
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.7
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Found while explaining to a deployer why someone with a correct mapping still read as unmapped.

One machine reported by two collectors arrives as two device keys - an asset-tagged serial (`ASSET-<serial>`) from the collector, the bare serial from the extension - and `_device_aliases` merges them onto the longer, prefixed key. The bare key survives only in `aliases`.

Attribution then read the canonical key and the local usernames, and never the aliases:

```python
person = identity_map.get(key)
if not person:
    for lu in d["local_users"]: ...
```

An MDM export lists bare serials, and that is what a deployer builds the map from. So those rows looked correct, reported `matches` in the upload preview - because the preview *does* count aliases when deciding what is known - and attached to nobody. The two halves disagreed about what counts as knowing a machine, and the half that decides is the one that was wrong.

Reproduced before fixing, with the same shape a real estate produces:

| map keyed on | before | after |
|---|---|---|
| bare serial (an MDM export) | `''` | `Sam Patel` |
| prefixed key | `Sam Patel` | `Sam Patel` |
| local username | `Sam Patel` | `Sam Patel` |

Aliases are checked after the canonical key and before the local usernames, so the key a device is actually filed under still wins a disagreement - asserted, not assumed.

Portal 401 green. Chart 0.16.7, appVersion 0.16.7.
