### PR TITLE
enrollment: a revoked device stays revoked

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,9 +57,13 @@ should accept before deploying:
 
 If that is unacceptable in your threat model, use managed mode (the
 default since 0.9.9): the
-endpoint collectors then enroll for per-device credentials, one machine can
-be revoked without touching any other, and an enrollment token in an MDM
-artifact can create auditable device records but never submit findings. The
+endpoint collectors then enroll for per-device credentials, and one machine
+can be revoked without touching any other. An enrollment token in an MDM
+artifact cannot submit findings itself, but it is a credential-minting
+credential and what it mints does report - so treat it as one. Since 0.16.8
+it cannot be used to undo a revocation: a revoked serial is refused at
+`/enroll` until an admin explicitly allows it back, which is what separates
+a reimaged machine from the machine you just cut off. The
 shared token remains valid alongside (the browser extension and scanners
 still use it), so the consequences above shrink to those surfaces rather
 than disappearing - and `REQUIRE_DEVICE_CREDENTIALS=true` closes even that:

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.16.7
+version: 0.16.8
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.16.7"
+appVersion: "0.16.8"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.7
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.8
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.7
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.8
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1458,6 +1458,18 @@ def revoke_device(did: str, _=Depends(require_auth),
     return _receiver("POST", "/admin/devices/%s/revoke" % did, token)
 
 
+@app.post("/api/devices/{did}/allow-reenrollment")
+def allow_reenrollment(did: str, _=Depends(require_auth),
+                       token: str = Depends(_admin_forward)):
+    """The deliberate step that lets a revoked serial enroll once more, for
+    a reimage or a replacement machine. Role-gated by the receiver, like
+    every other write here."""
+    if not _ID_RE.match(did):
+        raise HTTPException(422, "malformed device id")
+    return _receiver(
+        "POST", "/admin/devices/%s/allow-reenrollment" % did, token)
+
+
 # Settings and governance writes. POST rather than PUT on the portal side,
 # because the CSRF rule (JSON-only POSTs) is what protects cookie-carried
 # writes and widening it to more methods is more surface than one verb

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -3040,9 +3040,11 @@ async function fleet() {
   return `<h2>Fleet</h2>
   <p class="lede">Every device holding a credential. (The Devices view is
   different: it shows who has actually reported findings.) Revoke cuts off
-  that one device and nothing else. Re-enrollments - a reimaged laptop, a
-  scanner that enrolls every run - keep their row and are noted under
-  "enrolled".</p>
+  that one device and nothing else, and it holds: a revoked serial is
+  refused at /enroll even by a valid enrollment token, until an admin allows
+  it back for a reimage or a replacement. Re-enrollments of a live device -
+  a reimaged laptop, a scanner that enrolls every run - keep their row and
+  are noted under "enrolled".</p>
   ${ds.length ? `<table><tr><th>device</th><th>platform</th><th>serial</th>
     <th>enrolled</th><th>last seen</th><th>agent</th><th>status</th><th></th></tr>
   ${ds.map(d => `<tr>
@@ -3050,9 +3052,14 @@ async function fleet() {
     <td>${esc(d.platform)}</td><td class="mono">${esc(d.serial)}</td>
     <td>${when(d.enrolled_at)}${d.reenrolled_at ? `<br><span style="font-size:11px;color:var(--mut)">re-enrolled ×${esc(String((d.enrollments || 1) - 1))}, last ${when(d.reenrolled_at)}</span>` : ''}</td><td>${when(d.last_seen)}</td>
     <td>${esc(d.agent_version || '—')}</td>
-    <td>${d.revoked_at ? '<span class="pill p-mut">revoked</span>'
+    <td>${d.revoked_at ? (d.reenroll_allowed_at
+                       ? '<span class="pill p-amb" title="Revoked, but this serial may enroll once more">re-enrollment allowed</span>'
+                       : '<span class="pill p-mut">revoked</span>')
                        : '<span class="pill p-ok">active</span>'}</td>
-    <td>${d.revoked_at ? '' : `<button class="mini" data-act="revoke-device" data-key="${esc(d.id)}">revoke</button>`}</td>
+    <td>${!d.revoked_at
+            ? `<button class="mini" data-act="revoke-device" data-key="${esc(d.id)}">revoke</button>`
+            : (d.reenroll_allowed_at ? ''
+               : `<button class="mini" data-act="allow-reenroll" data-key="${esc(d.id)}">allow re-enrollment</button>`)}</td>
   </tr>`).join('')}</table>`
   : `<div class="note">${(() => {
       // An empty enrollment list beside a reporting fleet is not a
@@ -4762,8 +4769,11 @@ async function managedAction(act, el) {
   if (act === 'revoke-token' || act === 'revoke-device') {
     const id = el.getAttribute('data-key');
     const what = act === 'revoke-token' ? 'enrollment token' : 'device credential';
-    if (!confirm('Revoke ' + what + ' ' + id + '? This cannot be undone; a '
-                 + 'revoked device re-enrolls with a valid enrollment token.')) return;
+    if (!confirm('Revoke ' + what + ' ' + id + '? This cannot be undone. A '
+                 + (act === 'revoke-token'
+                    ? 'revoked token stops minting devices immediately.'
+                    : "revoked device's serial is then refused at /enroll until "
+                      + 'an admin allows it back.'))) return;
     const path = act === 'revoke-token'
       ? '/api/enrollment-tokens/' + encodeURIComponent(id) + '/revoke'
       : '/api/devices/' + encodeURIComponent(id) + '/revoke';
@@ -4774,6 +4784,21 @@ async function managedAction(act, el) {
       alert('Revoke failed: ' + d);
     }
     FLEET = null; TOKENS = null; render(); return;
+  }
+  if (act === 'allow-reenroll') {
+    const id = el.getAttribute('data-key');
+    if (!confirm('Allow device ' + id + ' to enroll once more? Use this for a '
+                 + 'reimage or a replacement machine. The allowance is spent '
+                 + 'by the next enrollment, and the new credential can be '
+                 + 'revoked like any other.')) return;
+    const r = await mfetch('/api/devices/' + encodeURIComponent(id)
+                           + '/allow-reenrollment', {method: 'POST'});
+    if (!r.ok) {
+      if (r.status === 401) { sessionLost(); return; }
+      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+      alert('Could not allow re-enrollment: ' + d);
+    }
+    FLEET = null; render(); return;
   }
   if (act === 'artifact') {
     const kind = el.getAttribute('data-key');

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -33,7 +33,11 @@ script parameters, the browser extension's managed policy, the scanner's
 Secret - and each endpoint collector, browser profile and scanner exchanges
 it once at `/enroll` for its own credential (`aigd_...`). One of them can
 then be revoked without touching any other, and the inventory knows who
-exists rather than inferring it from silence. Platforms are `macos`, `linux`,
+exists rather than inferring it from silence. Revoking is final in the
+direction that matters: the enrollment token is still sitting in the MDM
+artifact on the machine you just cut off, so a revoked serial is refused at
+`/enroll` rather than re-minted, and an admin has to allow it back for a
+genuine reimage or replacement. Platforms are `macos`, `linux`,
 `windows`, `browser` (one row per managed browser profile: serial is the MDM
 device id plus a per-profile install id) and `scanner` (serial is the
 scanner's configured id). Every authenticated request with a device
@@ -44,12 +48,13 @@ shared token off for ingest (see the configuration table).
 
 | method | path | auth | what |
 |--------|------|------|------|
-| POST | `/enroll` | enrollment token | exchange for this device's own credential; a same-serial re-enroll reissues a silent device's credential in place (same id, old credential dead, `reenrolled_at` and `enrollments` say it happened - the reimaged laptop, or a stateless scanner enrolling every run) and 409s a device seen within the hour. Platform `scanner` is exempt from that guard: it enrolls every run by design |
+| POST | `/enroll` | enrollment token | exchange for this device's own credential; a same-serial re-enroll reissues a silent device's credential in place (same id, old credential dead, `reenrolled_at` and `enrollments` say it happened - the reimaged laptop, or a stateless scanner enrolling every run) and 409s a device seen within the hour. Platform `scanner` is exempt from that guard: it enrolls every run by design. A serial whose every row is **revoked** 409s too, until an admin allows it back |
 | POST | `/admin/enrollment-tokens` | admin | mint (`note`, `ttl_days`, default 180) |
 | GET  | `/admin/enrollment-tokens` | admin | list - ids, notes and expiry, never token material |
 | POST | `/admin/enrollment-tokens/{id}/revoke` | admin | |
 | GET  | `/admin/devices` | admin | the fleet: platform, serial, hostname, enrolled / re-enrolled, last seen, agent version |
-| POST | `/admin/devices/{id}/revoke` | admin | that machine's credential stops working on its next request |
+| POST | `/admin/devices/{id}/revoke` | admin | that machine's credential stops working on its next request, and its serial is refused at `/enroll` from then on |
+| POST | `/admin/devices/{id}/allow-reenrollment` | admin | lift that refusal for one enrollment - the reimage, the replacement machine |
 | GET  | `/admin/setup` | none | one bit: does an admin account need creating? The portal chooses its first screen with it |
 | POST | `/admin/setup` | setup code | claim the boot-printed code, create the admin account, leave with a session |
 | POST | `/admin/login` | none | username + password for a session token (`aigt_...`). Throttled: past a per-username or global failure cap in a five-minute window, attempts get a cheap 429 before any password work, and the audit log records a bounded number of failures plus one throttle event |

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -917,6 +917,22 @@ def revoke_device(did: str, authorization: str = Header(default="")):
     return {"ok": True}
 
 
+@app.post("/admin/devices/{did}/allow-reenrollment")
+def allow_reenrollment(did: str, authorization: str = Header(default="")):
+    """Lift the tombstone on a revoked device's serial, for one enrollment.
+
+    A revoked serial is refused at /enroll, because the enrollment token that
+    created it is usually still in the MDM artifact and would otherwise hand
+    the credential back. The reimage and the replacement machine are the real
+    reasons a serial returns, and this is the deliberate step that says so.
+    """
+    _admin_auth(authorization, write=True)
+    if not STATE.allow_reenrollment(did):
+        raise HTTPException(
+            404, "no such revoked device, or re-enrollment is already allowed")
+    return {"ok": True}
+
+
 # ------------------------------------------------------- admin accounts --
 
 

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -18,10 +18,14 @@ presented bearer without trying every table, and so a leaked string is
 identifiable in a log:
 
   aige_...  enrollment token: mints device records at /enroll and does
-            nothing else. Long-lived by default (180 days) because it sits
-            inside an MDM artifact, where a short TTL means the deployment
-            silently breaks for new machines - its safety comes from what it
-            cannot do and from instant revocation, not from a short life.
+            nothing else. It is still a credential-minting credential - what
+            it mints reports - so a revoked serial is refused rather than
+            re-minted, and revocation cannot be undone by the token that
+            created the device. Long-lived by default (180 days) because it
+            sits inside an MDM artifact, where a short TTL means the
+            deployment silently breaks for new machines - its safety comes
+            from that narrow reach and from instant revocation, not from a
+            short life.
   aigd_...  device credential: one machine's bearer for /report and
             /registry, valid until revoked.
   aigt_...  admin session: what a portal login yields, valid for hours
@@ -209,6 +213,10 @@ _DEVICE_COLUMNS_ADDED = (
     # reimaged laptop, the stateless scanner - or a displaced device).
     ("reenrolled_at", "TEXT"),
     ("enrollments", "INTEGER NOT NULL DEFAULT 1"),
+    # Set on a revoked row to let that serial enroll once more. Revocation is
+    # otherwise a tombstone: without this, whoever prompted the revoke could
+    # undo it with the enrollment token they already hold.
+    ("reenroll_allowed_at", "TEXT"),
 )
 
 # Accounts predate roles; a database from before the column gets every
@@ -402,6 +410,32 @@ class State:
                         409, "a device with this serial is actively reporting; revoke it first"
                     )
 
+            # No live row for this serial: either nothing was ever enrolled
+            # under it, or every row was revoked. The second case is an
+            # operator's explicit decision, and the enrollment token that
+            # first created the device is usually still sitting in the same
+            # MDM artifact - so re-enrolling here would hand the credential
+            # straight back and make the revoke advisory. Refuse, and say
+            # what clears it.
+            tomb = None
+            if prior is None:
+                tomb = self._db.execute(
+                    "SELECT id, reenroll_allowed_at FROM devices"
+                    " WHERE platform = ? AND serial = ? AND revoked_at IS NOT NULL"
+                    " ORDER BY revoked_at DESC LIMIT 1",
+                    (platform, serial),
+                ).fetchone()
+                if tomb is not None and tomb["reenroll_allowed_at"] is None:
+                    self._event("enroll_refused_revoked", {
+                        "device": tomb["id"], "platform": platform, "serial": serial,
+                    })
+                    self._db.commit()
+                    raise EnrollError(
+                        409,
+                        "this device was revoked; an admin must allow"
+                        " re-enrollment before it can enroll again",
+                    )
+
             cred = DEVICE_PREFIX + secrets.token_urlsafe(32)
             if prior is not None:
                 # Reissue in place: same device, new credential. The old one
@@ -434,6 +468,18 @@ class State:
                 )
                 self._event("enrolled", {"device": did, "platform": platform,
                                          "serial": serial, "with": row["id"]})
+                if tomb is not None:
+                    # The allowance was for this one enrollment. Spend it, so
+                    # revoking the new row re-arms the tombstone rather than
+                    # leaving the serial permanently open.
+                    self._db.execute(
+                        "UPDATE devices SET reenroll_allowed_at = NULL WHERE id = ?",
+                        (tomb["id"],),
+                    )
+                    self._event("reenroll_allowance_used", {
+                        "device": did, "after": tomb["id"],
+                        "platform": platform, "serial": serial,
+                    })
             self._db.commit()
         return {"device_id": did, "device_token": cred}
 
@@ -469,7 +515,8 @@ class State:
         with self._lock:
             rows = self._db.execute(
                 "SELECT id, platform, serial, hostname, enrolled_at, enrolled_with,"
-                " reenrolled_at, enrollments, last_seen, agent_version, revoked_at"
+                " reenrolled_at, enrollments, last_seen, agent_version, revoked_at,"
+                " reenroll_allowed_at"
                 " FROM devices ORDER BY enrolled_at DESC"
             ).fetchall()
         return [dict(r) for r in rows]
@@ -482,6 +529,26 @@ class State:
             )
             if cur.rowcount:
                 self._event("revoked", {"device": did})
+            self._db.commit()
+        return bool(cur.rowcount)
+
+    def allow_reenrollment(self, did: str) -> bool:
+        """Let a revoked device's serial enroll once more.
+
+        For the reimage and the replacement machine, which are the honest
+        reasons a revoked serial comes back. One enrollment, not a standing
+        permission: enroll() clears this the moment it is used, so the new
+        credential can be revoked with the same finality as the old one.
+        """
+        with self._lock:
+            cur = self._db.execute(
+                "UPDATE devices SET reenroll_allowed_at = ?"
+                " WHERE id = ? AND revoked_at IS NOT NULL"
+                " AND reenroll_allowed_at IS NULL",
+                (_now(), did),
+            )
+            if cur.rowcount:
+                self._event("reenroll_allowed", {"device": did})
             self._db.commit()
         return bool(cur.rowcount)
 

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.7
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.8
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/receiver/tests/test_managed.py
+++ b/receiver/tests/test_managed.py
@@ -261,17 +261,63 @@ def test_a_database_from_before_the_added_columns_is_upgraded(tmp_path):
     assert d["id"] == "d1" and d["enrollments"] == 1 and d["reenrolled_at"] is None
 
 
-def test_a_manually_revoked_device_stays_as_history_when_it_reenrolls(managed):
-    """Revocation is a deliberate record. The stolen-credential recovery path
-    (revoke, then re-enroll from the real machine) keeps the revoked row and
-    makes a fresh one, so the audit trail still shows what was cut off."""
+def test_a_revoked_serial_cannot_enroll_itself_back(managed):
+    """Revocation has to survive the token that created the device.
+
+    The enrollment token lives in an MDM artifact, which is exactly where
+    someone being cut off would still have it. If a revoked serial could
+    enroll again, revoke would mean "until the next check-in"."""
     token = _mint()["token"]
     first = _enroll(token).json()
     client.post(f"/admin/devices/{first['device_id']}/revoke", headers=ADMIN)
+
+    resp = _enroll(token)
+    assert resp.status_code == 409
+    assert "allow" in resp.json()["detail"]
+    # Nothing was minted: the fleet still holds one row, and it is revoked.
+    devices = client.get("/admin/devices", headers=ADMIN).json()["devices"]
+    assert [bool(d["revoked_at"]) for d in devices] == [True]
+    kinds = [r["kind"] for r in managed._db.execute("SELECT kind FROM events")]
+    assert "enroll_refused_revoked" in kinds
+
+
+def test_an_admin_can_let_a_revoked_serial_back_exactly_once(managed):
+    """The reimage and the replacement machine, said deliberately. The
+    allowance is spent by the enrollment it permits, so the new credential
+    is revocable with the same finality as the one it replaces."""
+    token = _mint()["token"]
+    first = _enroll(token).json()
+    did = first["device_id"]
+    client.post(f"/admin/devices/{did}/revoke", headers=ADMIN)
+    assert client.post(f"/admin/devices/{did}/allow-reenrollment",
+                       headers=ADMIN).status_code == 200
+
     second = _enroll(token).json()
-    assert second["device_id"] != first["device_id"]
+    assert second["device_id"] != did
+    # The revoked row stays as history beside the new one.
     devices = client.get("/admin/devices", headers=ADMIN).json()["devices"]
     assert sorted(bool(d["revoked_at"]) for d in devices) == [False, True]
+    # And the allowance is gone: revoking the new row re-arms the tombstone.
+    client.post(f"/admin/devices/{second['device_id']}/revoke", headers=ADMIN)
+    assert _enroll(token).status_code == 409
+
+
+def test_allowing_reenrollment_needs_a_revoked_device(managed):
+    """An active device has nothing to allow, and a standing allowance
+    cannot be stacked up ahead of time."""
+    token = _mint()["token"]
+    did = _enroll(token).json()["device_id"]
+    assert client.post(f"/admin/devices/{did}/allow-reenrollment",
+                       headers=ADMIN).status_code == 404
+    assert client.post("/admin/devices/nope/allow-reenrollment",
+                       headers=ADMIN).status_code == 404
+
+    client.post(f"/admin/devices/{did}/revoke", headers=ADMIN)
+    assert client.post(f"/admin/devices/{did}/allow-reenrollment",
+                       headers=ADMIN).status_code == 200
+    # Twice is not two enrollments.
+    assert client.post(f"/admin/devices/{did}/allow-reenrollment",
+                       headers=ADMIN).status_code == 404
 
 
 def test_an_actively_reporting_device_cannot_be_displaced(managed):
@@ -290,9 +336,12 @@ def test_an_actively_reporting_device_cannot_be_displaced(managed):
     kinds = [r["kind"] for r in managed._db.execute("SELECT kind FROM events")]
     assert "supersede_conflict" in kinds
 
-    # Manual revoke is the documented path through the 409.
+    # Manual revoke is still the documented path through the 409, and since
+    # a revoked serial is a tombstone it takes the second deliberate step.
     did = first["device_id"]
     client.post(f"/admin/devices/{did}/revoke", headers=ADMIN)
+    assert _enroll(token).status_code == 409
+    client.post(f"/admin/devices/{did}/allow-reenrollment", headers=ADMIN)
     assert _enroll(token).status_code == 200
 
 


### PR DESCRIPTION
Per-device revocation could be undone by the enrollment token that created the device.

`enroll()` looked for a prior row with `revoked_at IS NULL`, so a manually revoked serial matched nothing, fell through to the INSERT branch, and was issued a fresh row with a working `aigd_` credential. The supersede guard could not catch it either — it only examines non-revoked rows.

That matters because of where the `aige_` token lives. It is not a backend secret; it is distributed to MDM artifacts and browser policy on the endpoint, so it is still on the machine after that machine is cut off, and it is long-lived by default because a short TTL breaks enrollment silently for new machines. `SECURITY.md` claimed an enrollment token "can create auditable device records but never submit findings" — true of the token itself, but what it minted reported fine.

## What changes

- A revoked serial is a tombstone. `/enroll` returns 409 and names what clears it, instead of minting.
- `POST /admin/devices/{id}/allow-reenrollment` lifts it for **one** enrollment — the reimage, the replacement machine. The allowance is spent by the enrollment it permits, so revoking the new row re-arms the tombstone.
- The Fleet view gains the button and a `re-enrollment allowed` state. The revoke confirm no longer tells operators that "a revoked device re-enrolls with a valid enrollment token" — it did, and now it does not.
- `enroll_refused_revoked`, `reenroll_allowed` and `reenroll_allowance_used` join the audit trail.

Untouched: the supersede guard (a live device still 409s on its own terms), reissue-in-place for a silent device, and stateless scanner enrollment.

## Trade

Recovering from a stolen enrollment token grows a step — revoke, allow, re-enroll — and that is the intended shape: the second step is an operator saying which machine is the real one.

## Verified

Full receiver suite (187) and portal suite (401) green. New coverage in `test_managed.py` for the refusal, the one-shot allowance, the re-armed tombstone, and the 404s on allowing a device that is not revoked. Exercised end to end against a live app: revoked credential 401s, re-enrollment with the still-valid `aige_` token 409s, the admin path restores service, a second revoke closes it again, and unrelated serials enroll normally throughout.