### PR TITLE
extension: a finding the receiver refused is not a finding that happened

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -23,6 +23,21 @@ questions:
 
 Both map onto the standard finding schema, so no receiver change is needed.
 
+**Delivery.** The receiver returns 503 when a finding could not be stored,
+so a caller can tell "sent" from "kept". Since 1.5.0 the extension acts on
+that. An account flag's six-hour dedupe window opens when the report lands,
+not when it is attempted, so a refused one is picked up by the next
+five-minute check instead of being silenced for the rest of the window. A
+paste finding cannot be re-derived - the paste happened once - so a refused
+one goes to a bounded queue in `storage.local` (100 events, seven days,
+oldest dropped first) and is retried on a ten-minute alarm, at browser
+startup and alongside the daily heartbeat, oldest first and stopping at the
+first failure. The queue holds the same content-free fields that would have
+been POSTed: tool, surface, source, severity, detector ids and the time it
+happened. The pasted text is never sent to the service worker, so it cannot
+reach the queue either. Protection is unaffected either way - the guard warns
+and blocks locally whether or not anything is recorded.
+
 Before 1.2.0, account flags carried no `source` and nothing carried `os`. The
 receiver defaulted the missing fields, so the findings looked correct while
 being untraceable to a detector: on one fleet that was thousands a week. If

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -44,32 +44,135 @@ function seenStore() {
   return api.storage.session || api.storage.local;
 }
 
-// True if this tool+domain was reported inside the window. Otherwise records
-// it and returns false. Entries past the window are dropped on the way
-// through so the object cannot grow without bound.
-async function alreadyReported(key, now) {
-  const store = seenStore();
-  let seen = {};
+// Paste-guard findings outlive the tab they happened in. The guard warns or
+// blocks locally whether or not anything is recorded, so a failed POST costs
+// no protection - but it costs the audit trail, and "we blocked a card number
+// going into ChatGPT" is the half someone asks about later. Unlike a personal
+// account, which is still true at the next five-minute check, a paste happened
+// once: nothing re-derives it, so a dropped one is gone.
+//
+// storage.local, because this has to survive a browser restart - the receiver
+// being down and the browser being closed overnight are the same evening.
+// Bounded both ways so a long outage cannot grow without limit or replay
+// something stale into next week's dashboard.
+const QUEUE_KEY = "pendingFindings";
+const QUEUE_MAX = 100;
+const QUEUE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const FLUSH_ALARM = "ai-guard-flush";
+const FLUSH_RETRY_MINUTES = 10;
+
+async function readQueue(now) {
   try {
-    const state = await store.get(SEEN_KEY);
-    seen = (state && state[SEEN_KEY]) || {};
-  } catch (e) { /* unreadable state is an empty state: report rather than lose */ }
+    const state = await api.storage.local.get(QUEUE_KEY);
+    const q = (state && state[QUEUE_KEY]) || [];
+    return q.filter((e) => e && e.queued_at && now - e.queued_at < QUEUE_TTL_MS);
+  } catch (e) {
+    return [];
+  }
+}
 
-  if (seen[key] && now - seen[key] < DEDUPE_WINDOW_MS) return true;
+// The payload is built here rather than stored as handed in, so what waits on
+// disk is the same content-free shape that would have been POSTed: tool,
+// surface, source, severity, the detector ids, the time it happened. The
+// matched text never reaches this worker in the first place, and this keeps
+// it that way if anyone ever changes the message.
+async function enqueue(payload, now) {
+  const q = await readQueue(now);
+  q.push({
+    queued_at: now,
+    payload: {
+      tool: payload.tool,
+      surface: payload.surface,
+      source: payload.source,
+      severity: payload.severity,
+      evidence: payload.evidence,
+      reported_at: payload.reported_at,
+    },
+  });
+  // Newest wins. An outage long enough to overflow this has bigger problems
+  // than its oldest hundred events, and the alternative - dropping what just
+  // happened - is the wrong half to lose.
+  const kept = q.slice(-QUEUE_MAX);
+  if (kept.length < q.length) {
+    console.warn("[ai-account-guard] pending queue full, dropped "
+                 + (q.length - kept.length) + " oldest");
+  }
+  try {
+    await api.storage.local.set({ [QUEUE_KEY]: kept });
+  } catch (e) { /* nothing else to fall back to */ }
+  api.alarms.create(FLUSH_ALARM, { delayInMinutes: FLUSH_RETRY_MINUTES });
+}
 
+// Oldest first, stopping at the first failure: the receiver being down is the
+// reason there is a queue, and draining into a dead endpoint just turns one
+// outage into a hundred failed requests. Whatever did not go stays queued.
+async function flushQueue() {
+  const now = Date.now();
+  const q = await readQueue(now);
+  if (!q.length) {
+    try { await api.storage.local.remove(QUEUE_KEY); } catch (e) { /* fine */ }
+    return;
+  }
+  let sent = 0;
+  for (const entry of q) {
+    try {
+      await report({ ...entry.payload });
+      sent++;
+    } catch (e) {
+      break;
+    }
+  }
+  const left = q.slice(sent);
+  try {
+    if (left.length) await api.storage.local.set({ [QUEUE_KEY]: left });
+    else await api.storage.local.remove(QUEUE_KEY);
+  } catch (e) { /* retried on the next flush */ }
+  if (left.length) {
+    api.alarms.create(FLUSH_ALARM, { delayInMinutes: FLUSH_RETRY_MINUTES });
+  }
+}
+
+async function readSeen() {
+  try {
+    const state = await seenStore().get(SEEN_KEY);
+    return (state && state[SEEN_KEY]) || {};
+  } catch (e) {
+    // Unreadable state is an empty state: report rather than lose.
+    return {};
+  }
+}
+
+// True if this tool+domain was reported inside the window. Read-only: the
+// window opens when the finding is delivered, not when it is attempted.
+async function wasRecentlyReported(key, now) {
+  const seen = await readSeen();
+  return Boolean(seen[key] && now - seen[key] < DEDUPE_WINDOW_MS);
+}
+
+// Opens the six-hour window on a finding that actually landed. Entries past
+// the window are dropped on the way through so the object cannot grow
+// without bound.
+async function markReported(key, now) {
+  const seen = await readSeen();
   for (const k of Object.keys(seen)) {
     if (now - seen[k] >= DEDUPE_WINDOW_MS) delete seen[k];
   }
   seen[key] = now;
   try {
-    await store.set({ [SEEN_KEY]: seen });
+    await seenStore().set({ [SEEN_KEY]: seen });
   } catch (e) { /* a write that fails costs one duplicate, not a finding */ }
-  return false;
 }
 
 async function onPersonalAccount(msg) {
   const key = msg.tool + ":" + msg.domain;
-  if (await alreadyReported(key, Date.now())) return;
+  const now = Date.now();
+  if (await wasRecentlyReported(key, now)) return;
+  // Marked only once report() has resolved. It throws when the POST failed -
+  // the receiver 503s precisely so a caller knows the finding is not stored -
+  // and marking first meant a 503 silenced the flag for six hours while
+  // content.js kept re-checking every five minutes. It returns false in
+  // print-only mode, which does count: there was nothing to deliver, and the
+  // window should still stop the console filling up.
   await report({
     tool: msg.tool,
     // Absent until 1.2.0. The receiver defaults surface to "browser" and
@@ -83,6 +186,7 @@ async function onPersonalAccount(msg) {
     account_domain: msg.domain,
     reported_at: msg.ts,
   });
+  await markReported(key, now);
 }
 
 api.runtime.onMessage.addListener((msg) => {
@@ -101,14 +205,18 @@ api.runtime.onMessage.addListener((msg) => {
     // Finding schema so no receiver change is needed: source identifies the
     // guard, evidence carries "<action>: <detector ids>". The matched text
     // never reaches this worker.
-    report({
+    const payload = {
       tool: msg.tool,
       surface: "browser",
       source: "paste_guard",
       severity: "warn",
       evidence: "paste " + msg.action + ": " + msg.detectors.join(","),
       reported_at: msg.ts,
-    }).catch((e) => console.warn("[ai-account-guard] report failed", e));
+    };
+    report(payload).catch((e) => {
+      console.warn("[ai-account-guard] report failed, queued for retry", e);
+      return enqueue(payload, Date.now());
+    });
   }
 });
 
@@ -168,12 +276,20 @@ async function heartbeat(reason) {
   }
 }
 
-api.runtime.onStartup.addListener(() => heartbeat("startup"));
-api.runtime.onInstalled.addListener(() => heartbeat("installed"));
+// The heartbeat is the one thing that runs on a schedule whether or not
+// anyone browses, so it is also when a backlog gets a chance to drain. A
+// heartbeat that succeeds proves the whole chain is up, which is exactly the
+// moment the queue is worth retrying.
+const drain = () => flushQueue()
+  .catch((e) => console.warn("[ai-account-guard] flush failed", e));
+
+api.runtime.onStartup.addListener(() => { heartbeat("startup"); drain(); });
+api.runtime.onInstalled.addListener(() => { heartbeat("installed"); drain(); });
 api.alarms.create(HEARTBEAT_ALARM, { periodInMinutes: 60 * 24 });
 api.alarms.onAlarm.addListener((a) => {
-  if (a.name === HEARTBEAT_ALARM) heartbeat("alarm");
+  if (a.name === HEARTBEAT_ALARM) { heartbeat("alarm"); drain(); }
   if (a.name === HEARTBEAT_RETRY_ALARM) heartbeat("retry");
+  if (a.name === FLUSH_ALARM) drain();
 });
 
 async function getConfig() {

--- a/extension/src/content.js
+++ b/extension/src/content.js
@@ -143,10 +143,12 @@ async function check() {
   // Firefox returns a promise here and rejects it when the background page is
   // not yet awake to receive. Chrome MV3 does the same. Nothing is waiting on
   // the result, so an uncaught rejection would surface in the page console of
-  // a user's browser for no reason. Dedupe lives in background.js, keyed on
-  // tool+domain in storage.session, so a message dropped here is retried at
-  // the next check rather than lost: this check runs every five minutes and
-  // the window is six hours.
+  // a user's browser for no reason. This check is what makes that safe to
+  // swallow: it runs every five minutes and a signed-in account is still
+  // signed in at the next one. Dedupe lives in background.js, keyed on
+  // tool+domain, and its six-hour window opens on delivery rather than on the
+  // attempt - so a POST the receiver refused is retried here too, not
+  // suppressed by a flag recorded for a finding that never landed.
   api.runtime.sendMessage({
     type: "personal-account",
     tool: host,

--- a/extension/src/manifest.json
+++ b/extension/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Guard",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Flags AI tools signed in with a non-corporate account and stops secrets being pasted into them. Reports detector ids and account domains only, never content.",
   "permissions": [
     "storage",

--- a/extension/tests/test_account_dedupe.js
+++ b/extension/tests/test_account_dedupe.js
@@ -7,6 +7,12 @@
 // evaluates it again against the same storage, the way the browser does, and
 // counts what reached the receiver.
 //
+// It also holds the other half of the same invariant: the window opens on
+// delivery, not on the attempt. The receiver returns 503 when the log store
+// would not take a finding, precisely so the caller knows it is not stored;
+// recording the flag before the POST turned that 503 into six hours of
+// silence, on a check that would otherwise have retried five minutes later.
+//
 // No test framework, same as test_payment_card.js. Run it with:
 //     node extension/tests/test_account_dedupe.js
 
@@ -21,20 +27,23 @@ function makeStorage(backing) {
   return {
     get: (key) => Promise.resolve(key in backing ? { [key]: backing[key] } : {}),
     set: (obj) => { Object.assign(backing, obj); return Promise.resolve(); },
+    remove: (key) => { delete backing[key]; return Promise.resolve(); },
   };
 }
 
 // Boot the worker once. Returns the captured onMessage listener and the list
 // of payloads POSTed to the receiver.
-function boot(sessionBacking, localBacking, now) {
+function boot(sessionBacking, localBacking, now, receiver, managed) {
   const posted = [];
+  const alarms = [];
   let listener = null;
+  let onAlarm = null;
   const api = {
     storage: {
       session: sessionBacking && makeStorage(sessionBacking),
       local: makeStorage(localBacking),
-      managed: { get: () => Promise.resolve({ reportEndpoint: "https://r.example/report",
-                                               deviceIdentifier: "DEV1" }) },
+      managed: { get: () => Promise.resolve(managed || {
+        reportEndpoint: "https://r.example/report", deviceIdentifier: "DEV1" }) },
     },
     runtime: {
       onMessage: { addListener: (fn) => { listener = fn; } },
@@ -43,17 +52,33 @@ function boot(sessionBacking, localBacking, now) {
       getManifest: () => ({ version: "test" }),
       getPlatformInfo: () => Promise.resolve({ os: "mac" }),
     },
-    alarms: { create: () => {}, onAlarm: { addListener: () => {} } },
+    alarms: {
+      create: (name) => { alarms.push(name); },
+      onAlarm: { addListener: (fn) => { onAlarm = fn; } },
+    },
   };
   const ctx = {};
   new Function("globalThis", "fetch", "Date", "console",
     src
   ).call(ctx,
     { browser: api },
-    (url, opts) => { posted.push(JSON.parse(opts.body)); return Promise.resolve({ ok: true }); },
+    (url, opts) => {
+      const body = JSON.parse(opts.body);
+      // Default is the old always-up receiver, so every existing case reads
+      // the same. receiver() returning false is the 503 the real one sends
+      // when the log store would not take the finding.
+      const ok = receiver ? receiver(body) : true;
+      posted.push(body);
+      return Promise.resolve({ ok, status: ok ? 200 : 503 });
+    },
     { now: () => now() },
     { warn: () => {}, log: () => {} });
-  return { send: (msg) => listener(msg), posted };
+  return {
+    send: (msg) => listener(msg),
+    posted,
+    alarms,
+    fire: (name) => onAlarm && onAlarm({ name }),
+  };
 }
 
 const tick = () => new Promise((r) => setTimeout(r, 0));
@@ -110,6 +135,45 @@ const flag = { type: "personal-account", tool: "chatgpt.com", domain: "gmail.com
   // guard: a Map would pass every in-lifetime check above and fail this one.
   check("dedupe state is in storage, not module scope",
     typeof session === "object" || "personalAccountSeen" in local, true);
+
+  // ---- the window opens on delivery, not on the attempt ----
+
+  // A receiver that refuses everything: the flag must stay reportable.
+  clock = 3_000_000; session = {}; local = {};
+  const down = () => false;
+  w = boot(session, local, () => clock, down);
+  w.send(flag); await settle();
+  check("a refused report is still attempted", w.posted.length, 1);
+  check("a refused report does not open the window",
+    "chatgpt.com:gmail.com" in (session.personalAccountSeen || {}), false);
+
+  // The next five-minute check, well inside the six-hour window.
+  clock += 5 * 60 * 1000;
+  w = boot(session, local, () => clock, down);
+  w.send(flag); await settle();
+  check("the next check retries it", w.posted.length, 1);
+
+  // The receiver comes back.
+  clock += 5 * 60 * 1000;
+  w = boot(session, local, () => clock, () => true);
+  w.send(flag); await settle();
+  check("it lands once the receiver recovers", w.posted.length, 1);
+  check("and now the window is open",
+    "chatgpt.com:gmail.com" in session.personalAccountSeen, true);
+
+  clock += 5 * 60 * 1000;
+  w = boot(session, local, () => clock, () => true);
+  w.send(flag); await settle();
+  check("a delivered flag is deduped as before", w.posted.length, 0);
+
+  // Print-only mode: no endpoint, nothing to deliver, and the console should
+  // not fill up every five minutes.
+  clock = 4_000_000; session = {}; local = {};
+  w = boot(session, local, () => clock, null, { deviceIdentifier: "DEV1" });
+  w.send(flag); await settle();
+  w = boot(session, local, () => clock + 60_000, null, { deviceIdentifier: "DEV1" });
+  w.send(flag); await settle();
+  check("print-only mode still dedupes", w.posted.length, 0);
 
   console.log(pass + " passed, " + fail + " failed");
   process.exit(fail ? 1 : 0);

--- a/extension/tests/test_pending_queue.js
+++ b/extension/tests/test_pending_queue.js
@@ -1,0 +1,172 @@
+// A paste-guard finding must survive the receiver being down.
+//
+// The guard warns or blocks locally whether or not anything is recorded, so a
+// failed POST costs no protection. It costs the audit trail, and that is the
+// half someone asks about weeks later: "did we stop a card number going into
+// ChatGPT, and when". Unlike a personal account - still true at the next
+// five-minute check, so re-derived for free - a paste happens once. Nothing
+// regenerates it, so report().catch(console.warn) was the finding's last stop.
+//
+// What is asserted, in order:
+//   - a refused paste finding is queued, and a flush alarm is scheduled
+//   - the queue survives a worker restart, and drains when the receiver is back
+//   - a drained queue is removed from storage rather than left as []
+//   - a flush into a still-dead receiver stops at the first failure
+//   - only content-free fields are stored: never the matched text
+//   - the queue is bounded to 100, newest kept, and prunes past seven days
+//   - a personal-account flag is not queued: its retry is the next check
+//
+// No test framework, same as the others. Run it with:
+//     node extension/tests/test_pending_queue.js
+
+const fs = require("fs");
+const path = require("path");
+
+const src = fs.readFileSync(path.join(__dirname, "..", "src", "background.js"), "utf8");
+
+function makeStorage(backing) {
+  return {
+    get: (key) => Promise.resolve(key in backing ? { [key]: backing[key] } : {}),
+    set: (obj) => { Object.assign(backing, obj); return Promise.resolve(); },
+    remove: (key) => { delete backing[key]; return Promise.resolve(); },
+  };
+}
+
+// One storage.local backing shared across "restarts": the queue has to outlive
+// the worker and the browser, which is the whole point of it being on disk.
+function boot(localBacking, now, receiver) {
+  const posted = [];
+  const alarms = [];
+  let onMessage = null, onAlarm = null, onStartup = null;
+  const api = {
+    storage: {
+      session: makeStorage({}),
+      local: makeStorage(localBacking),
+      managed: { get: () => Promise.resolve({
+        reportEndpoint: "https://r.example/report", deviceIdentifier: "DEV1" }) },
+    },
+    runtime: {
+      onMessage: { addListener: (fn) => { onMessage = fn; } },
+      onStartup: { addListener: (fn) => { onStartup = fn; } },
+      onInstalled: { addListener: () => {} },
+      getManifest: () => ({ version: "test" }),
+      getPlatformInfo: () => Promise.resolve({ os: "mac" }),
+    },
+    alarms: {
+      create: (name) => { alarms.push(name); },
+      onAlarm: { addListener: (fn) => { onAlarm = fn; } },
+    },
+  };
+  new Function("globalThis", "fetch", "Date", "console", src).call({},
+    { browser: api },
+    (url, opts) => {
+      const body = JSON.parse(opts.body);
+      posted.push(body);
+      const ok = receiver ? receiver(body) : true;
+      return Promise.resolve({ ok, status: ok ? 200 : 503 });
+    },
+    { now: () => now() },
+    { warn: () => {}, log: () => {} });
+  return {
+    send: (msg) => onMessage(msg),
+    posted,
+    alarms,
+    fire: (name) => onAlarm && onAlarm({ name }),
+    startup: () => onStartup && onStartup(),
+  };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+async function settle() { for (let i = 0; i < 20; i++) await tick(); }
+
+let pass = 0, fail = 0;
+function check(name, got, want) {
+  if (got === want) { pass++; console.log("  ok:   " + name); }
+  else { fail++; console.log("  FAIL: " + name + " (got " + got + ", want " + want + ")"); }
+}
+
+const paste = (n) => ({
+  type: "paste-guard", tool: "chatgpt.com", action: "block",
+  detectors: ["payment-card"], ts: "2026-08-28T09:0" + n + ":00Z",
+});
+const DAY = 24 * 60 * 60 * 1000;
+
+(async () => {
+  console.log("paste-guard pending queue");
+
+  // ---- a refused finding is kept ----
+  let clock = 1_000_000;
+  const local = {};
+  const down = () => false;
+  let w = boot(local, () => clock, down);
+  w.send(paste(1)); await settle();
+  check("the refused finding was attempted", w.posted.length, 1);
+  check("and queued", (local.pendingFindings || []).length, 1);
+  check("with a flush alarm scheduled",
+    w.alarms.includes("ai-guard-flush"), true);
+  check("carrying the detector ids, not the text",
+    local.pendingFindings[0].payload.evidence, "paste block: payment-card");
+  check("and nothing resembling clipboard content",
+    JSON.stringify(local.pendingFindings[0]).includes("4111"), false);
+  check("keeping the time it actually happened",
+    local.pendingFindings[0].payload.reported_at, "2026-08-28T09:01:00Z");
+
+  // ---- it survives the worker, and the browser ----
+  clock += 10 * 60 * 1000;
+  w = boot(local, () => clock, down);
+  w.fire("ai-guard-flush"); await settle();
+  check("a flush into a dead receiver retries it", w.posted.length, 1);
+  check("and keeps it queued", (local.pendingFindings || []).length, 1);
+
+  clock += 10 * 60 * 1000;
+  w = boot(local, () => clock, () => true);
+  w.fire("ai-guard-flush"); await settle();
+  check("it lands once the receiver is back", w.posted.length, 1);
+  check("and the key is removed, not left empty",
+    "pendingFindings" in local, false);
+
+  // ---- a backlog drains in order, and stops at the first failure ----
+  clock += 60 * 1000;
+  let up = false;
+  w = boot(local, () => clock, () => up);
+  w.send(paste(2)); await settle();
+  w.send(paste(3)); await settle();
+  check("two refused findings queue up", local.pendingFindings.length, 2);
+  let n = 0;
+  w = boot(local, () => clock, () => ++n === 1);  // first succeeds, second 503s
+  w.fire("ai-guard-flush"); await settle();
+  check("the flush stops at the first failure", w.posted.length, 2);
+  check("and the undelivered one stays", local.pendingFindings.length, 1);
+  check("oldest first: the one left is the later paste",
+    local.pendingFindings[0].payload.reported_at, "2026-08-28T09:03:00Z");
+  w = boot(local, () => clock, () => true);
+  w.startup(); await settle();
+  check("startup drains the rest", "pendingFindings" in local, false);
+
+  // ---- bounded ----
+  const many = {};
+  w = boot(many, () => clock, down);
+  for (let i = 0; i < 130; i++) { w.send(paste(1)); await settle(); }
+  check("the queue is capped at 100", many.pendingFindings.length, 100);
+
+  const stale = { pendingFindings: [
+    { queued_at: clock - 8 * DAY, payload: { tool: "old", evidence: "e" } },
+    { queued_at: clock - 1 * DAY, payload: { tool: "recent", evidence: "e" } },
+  ] };
+  w = boot(stale, () => clock, down);
+  w.fire("ai-guard-flush"); await settle();
+  check("entries past seven days are dropped", w.posted.length, 1);
+  check("the recent one is the survivor", w.posted[0].tool, "recent");
+
+  // ---- the account path is not the queue's business ----
+  const acct = {};
+  w = boot(acct, () => clock, down);
+  w.send({ type: "personal-account", tool: "chatgpt.com",
+           domain: "gmail.com", ts: "t" });
+  await settle();
+  check("a refused personal-account flag is not queued",
+    "pendingFindings" in acct, false);
+
+  console.log(pass + " passed, " + fail + " failed");
+  process.exit(fail ? 1 : 0);
+})();

--- a/portal/extension-src/background.js
+++ b/portal/extension-src/background.js
@@ -44,32 +44,135 @@ function seenStore() {
   return api.storage.session || api.storage.local;
 }
 
-// True if this tool+domain was reported inside the window. Otherwise records
-// it and returns false. Entries past the window are dropped on the way
-// through so the object cannot grow without bound.
-async function alreadyReported(key, now) {
-  const store = seenStore();
-  let seen = {};
+// Paste-guard findings outlive the tab they happened in. The guard warns or
+// blocks locally whether or not anything is recorded, so a failed POST costs
+// no protection - but it costs the audit trail, and "we blocked a card number
+// going into ChatGPT" is the half someone asks about later. Unlike a personal
+// account, which is still true at the next five-minute check, a paste happened
+// once: nothing re-derives it, so a dropped one is gone.
+//
+// storage.local, because this has to survive a browser restart - the receiver
+// being down and the browser being closed overnight are the same evening.
+// Bounded both ways so a long outage cannot grow without limit or replay
+// something stale into next week's dashboard.
+const QUEUE_KEY = "pendingFindings";
+const QUEUE_MAX = 100;
+const QUEUE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const FLUSH_ALARM = "ai-guard-flush";
+const FLUSH_RETRY_MINUTES = 10;
+
+async function readQueue(now) {
   try {
-    const state = await store.get(SEEN_KEY);
-    seen = (state && state[SEEN_KEY]) || {};
-  } catch (e) { /* unreadable state is an empty state: report rather than lose */ }
+    const state = await api.storage.local.get(QUEUE_KEY);
+    const q = (state && state[QUEUE_KEY]) || [];
+    return q.filter((e) => e && e.queued_at && now - e.queued_at < QUEUE_TTL_MS);
+  } catch (e) {
+    return [];
+  }
+}
 
-  if (seen[key] && now - seen[key] < DEDUPE_WINDOW_MS) return true;
+// The payload is built here rather than stored as handed in, so what waits on
+// disk is the same content-free shape that would have been POSTed: tool,
+// surface, source, severity, the detector ids, the time it happened. The
+// matched text never reaches this worker in the first place, and this keeps
+// it that way if anyone ever changes the message.
+async function enqueue(payload, now) {
+  const q = await readQueue(now);
+  q.push({
+    queued_at: now,
+    payload: {
+      tool: payload.tool,
+      surface: payload.surface,
+      source: payload.source,
+      severity: payload.severity,
+      evidence: payload.evidence,
+      reported_at: payload.reported_at,
+    },
+  });
+  // Newest wins. An outage long enough to overflow this has bigger problems
+  // than its oldest hundred events, and the alternative - dropping what just
+  // happened - is the wrong half to lose.
+  const kept = q.slice(-QUEUE_MAX);
+  if (kept.length < q.length) {
+    console.warn("[ai-account-guard] pending queue full, dropped "
+                 + (q.length - kept.length) + " oldest");
+  }
+  try {
+    await api.storage.local.set({ [QUEUE_KEY]: kept });
+  } catch (e) { /* nothing else to fall back to */ }
+  api.alarms.create(FLUSH_ALARM, { delayInMinutes: FLUSH_RETRY_MINUTES });
+}
 
+// Oldest first, stopping at the first failure: the receiver being down is the
+// reason there is a queue, and draining into a dead endpoint just turns one
+// outage into a hundred failed requests. Whatever did not go stays queued.
+async function flushQueue() {
+  const now = Date.now();
+  const q = await readQueue(now);
+  if (!q.length) {
+    try { await api.storage.local.remove(QUEUE_KEY); } catch (e) { /* fine */ }
+    return;
+  }
+  let sent = 0;
+  for (const entry of q) {
+    try {
+      await report({ ...entry.payload });
+      sent++;
+    } catch (e) {
+      break;
+    }
+  }
+  const left = q.slice(sent);
+  try {
+    if (left.length) await api.storage.local.set({ [QUEUE_KEY]: left });
+    else await api.storage.local.remove(QUEUE_KEY);
+  } catch (e) { /* retried on the next flush */ }
+  if (left.length) {
+    api.alarms.create(FLUSH_ALARM, { delayInMinutes: FLUSH_RETRY_MINUTES });
+  }
+}
+
+async function readSeen() {
+  try {
+    const state = await seenStore().get(SEEN_KEY);
+    return (state && state[SEEN_KEY]) || {};
+  } catch (e) {
+    // Unreadable state is an empty state: report rather than lose.
+    return {};
+  }
+}
+
+// True if this tool+domain was reported inside the window. Read-only: the
+// window opens when the finding is delivered, not when it is attempted.
+async function wasRecentlyReported(key, now) {
+  const seen = await readSeen();
+  return Boolean(seen[key] && now - seen[key] < DEDUPE_WINDOW_MS);
+}
+
+// Opens the six-hour window on a finding that actually landed. Entries past
+// the window are dropped on the way through so the object cannot grow
+// without bound.
+async function markReported(key, now) {
+  const seen = await readSeen();
   for (const k of Object.keys(seen)) {
     if (now - seen[k] >= DEDUPE_WINDOW_MS) delete seen[k];
   }
   seen[key] = now;
   try {
-    await store.set({ [SEEN_KEY]: seen });
+    await seenStore().set({ [SEEN_KEY]: seen });
   } catch (e) { /* a write that fails costs one duplicate, not a finding */ }
-  return false;
 }
 
 async function onPersonalAccount(msg) {
   const key = msg.tool + ":" + msg.domain;
-  if (await alreadyReported(key, Date.now())) return;
+  const now = Date.now();
+  if (await wasRecentlyReported(key, now)) return;
+  // Marked only once report() has resolved. It throws when the POST failed -
+  // the receiver 503s precisely so a caller knows the finding is not stored -
+  // and marking first meant a 503 silenced the flag for six hours while
+  // content.js kept re-checking every five minutes. It returns false in
+  // print-only mode, which does count: there was nothing to deliver, and the
+  // window should still stop the console filling up.
   await report({
     tool: msg.tool,
     // Absent until 1.2.0. The receiver defaults surface to "browser" and
@@ -83,6 +186,7 @@ async function onPersonalAccount(msg) {
     account_domain: msg.domain,
     reported_at: msg.ts,
   });
+  await markReported(key, now);
 }
 
 api.runtime.onMessage.addListener((msg) => {
@@ -101,14 +205,18 @@ api.runtime.onMessage.addListener((msg) => {
     // Finding schema so no receiver change is needed: source identifies the
     // guard, evidence carries "<action>: <detector ids>". The matched text
     // never reaches this worker.
-    report({
+    const payload = {
       tool: msg.tool,
       surface: "browser",
       source: "paste_guard",
       severity: "warn",
       evidence: "paste " + msg.action + ": " + msg.detectors.join(","),
       reported_at: msg.ts,
-    }).catch((e) => console.warn("[ai-account-guard] report failed", e));
+    };
+    report(payload).catch((e) => {
+      console.warn("[ai-account-guard] report failed, queued for retry", e);
+      return enqueue(payload, Date.now());
+    });
   }
 });
 
@@ -168,12 +276,20 @@ async function heartbeat(reason) {
   }
 }
 
-api.runtime.onStartup.addListener(() => heartbeat("startup"));
-api.runtime.onInstalled.addListener(() => heartbeat("installed"));
+// The heartbeat is the one thing that runs on a schedule whether or not
+// anyone browses, so it is also when a backlog gets a chance to drain. A
+// heartbeat that succeeds proves the whole chain is up, which is exactly the
+// moment the queue is worth retrying.
+const drain = () => flushQueue()
+  .catch((e) => console.warn("[ai-account-guard] flush failed", e));
+
+api.runtime.onStartup.addListener(() => { heartbeat("startup"); drain(); });
+api.runtime.onInstalled.addListener(() => { heartbeat("installed"); drain(); });
 api.alarms.create(HEARTBEAT_ALARM, { periodInMinutes: 60 * 24 });
 api.alarms.onAlarm.addListener((a) => {
-  if (a.name === HEARTBEAT_ALARM) heartbeat("alarm");
+  if (a.name === HEARTBEAT_ALARM) { heartbeat("alarm"); drain(); }
   if (a.name === HEARTBEAT_RETRY_ALARM) heartbeat("retry");
+  if (a.name === FLUSH_ALARM) drain();
 });
 
 async function getConfig() {

--- a/portal/extension-src/content.js
+++ b/portal/extension-src/content.js
@@ -143,10 +143,12 @@ async function check() {
   // Firefox returns a promise here and rejects it when the background page is
   // not yet awake to receive. Chrome MV3 does the same. Nothing is waiting on
   // the result, so an uncaught rejection would surface in the page console of
-  // a user's browser for no reason. Dedupe lives in background.js, keyed on
-  // tool+domain in storage.session, so a message dropped here is retried at
-  // the next check rather than lost: this check runs every five minutes and
-  // the window is six hours.
+  // a user's browser for no reason. This check is what makes that safe to
+  // swallow: it runs every five minutes and a signed-in account is still
+  // signed in at the next one. Dedupe lives in background.js, keyed on
+  // tool+domain, and its six-hour window opens on delivery rather than on the
+  // attempt - so a POST the receiver refused is retried here too, not
+  // suppressed by a flag recorded for a finding that never landed.
   api.runtime.sendMessage({
     type: "personal-account",
     tool: host,

--- a/portal/extension-src/manifest.json
+++ b/portal/extension-src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "AI Guard",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Flags AI tools signed in with a non-corporate account and stops secrets being pasted into them. Reports detector ids and account domains only, never content.",
   "permissions": [
     "storage",


### PR DESCRIPTION
The receiver returns 503 when a finding could not be stored, so a caller can distinguish *delivered* from *attempted*. CI already has a job that exists solely to hold the Linux collector to that invariant:

> The throttle timestamp must advance only after confirmed delivery. If it advances on failure, a finding that never reached the receiver is never retried, which is a silent gap in a tool built to not have silent gaps.

The browser surface was not honouring it. `heartbeat()` was fixed for exactly this in #28; the same lesson had not reached the two paths beside it.

## Account flags: the window opened on the attempt

`alreadyReported()` wrote the six-hour dedupe stamp and *then* the caller POSTed. A 503 threw with the flag already marked, so the five-minute re-checks in `content.js` were all suppressed for the rest of the window — the mechanism meant to stop one flag per check turned a brief outage into six hours of silence.

Split into `wasRecentlyReported()` (read-only) and `markReported()`, with the mark after `report()` resolves. Print-only mode still marks: nothing was there to deliver, and the console should stay quiet.

## Paste findings: nothing re-derives them

An account is still signed in at the next check, so a retry is free. A paste happened once — `report(...).catch(console.warn)` was its last stop.

Refused paste findings now go to a bounded queue in `storage.local`: 100 events, seven-day TTL, oldest dropped on overflow, retried on a ten-minute alarm, at browser startup, and alongside the daily heartbeat. Drains oldest-first and stops at the first failure rather than turning one outage into a hundred failed requests.

The queued entry is built field by field from the content-free shape that would have been POSTed — tool, surface, source, severity, detector ids, original timestamp. The matched text never reaches the service worker, and building the entry explicitly keeps it that way even if the message shape changes later.

The guard warns and blocks locally throughout. What was at risk was the audit record, not the protection.

## Verified

All four extension test files pass. The three new dedupe cases were run against `main`'s `background.js` first and fail there — `a refused report does not open the window`, `the next check retries it`, `it lands once the receiver recovers` — reproducing the gap exactly. `test_pending_queue.js` is new (19 cases) and covers the queue, the restart, the ordered drain that stops at a failure, the 100/seven-day bounds, that no clipboard content is stored, and that account flags are deliberately *not* queued.

The CI job globs `extension/tests/test_*.js`, so the new file needs no workflow change. Extension bumped to 1.5.0; no chart bump, since nothing outside `extension/` changes.