### PR TITLE
keep internal naming out of published text

### DIFF
--- a/.githooks/check-identifiers.sh
+++ b/.githooks/check-identifiers.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env sh
+# Fail if any input names a deployment this project is run against.
+#
+# Two callers, because the two halves leak differently:
+#   check-identifiers.sh files            - tracked files, run in CI
+#   check-identifiers.sh text <file>...   - commit messages, run by the hook
+#
+# The file check is the one CI can do. The text check is the one that
+# matters most: CI never sees a commit message, and a message cannot be
+# corrected later without rewriting history.
+set -eu
+
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+list="$here/deny-list.txt"
+if [ ! -f "$list" ]; then
+  # No list configured. A fork has nothing of ours to protect, and a
+  # check that invents patterns would only fail on other people's words.
+  echo "check-identifiers: no $list; skipping (see deny-list.example.txt)" >&2
+  exit 0
+fi
+patterns=$(grep -vE '^\s*(#|$)' "$list")
+[ -n "$patterns" ] || exit 0
+mode=${1:-files}
+shift 2>/dev/null || true
+
+status=0
+report() {
+  status=1
+  echo "$1" >&2
+}
+
+case "$mode" in
+  files)
+    # Tracked files only: the working tree may hold a deployer's own
+    # notes, and this is a check on what gets published.
+    for p in $patterns; do
+      hits=$(git grep -InEi -- "$p" -- \
+               ':!.githooks/deny-list.example.txt' \
+               ':!.githooks/check-identifiers.sh' \
+               2>/dev/null || true)
+      [ -n "$hits" ] && report "deployment identifier /$p/ in tracked files:
+$hits"
+    done
+    ;;
+  text)
+    for f in "$@"; do
+      [ -f "$f" ] || continue
+      for p in $patterns; do
+        hits=$(grep -InEi -- "$p" "$f" || true)
+        [ -n "$hits" ] && report "deployment identifier /$p/ in $f:
+$hits"
+      done
+    done
+    ;;
+  *)
+    echo "usage: $0 [files|text <file>...]" >&2
+    exit 2
+    ;;
+esac
+
+if [ "$status" -ne 0 ]; then
+  cat >&2 <<'MSG'
+
+Describe the behaviour, not the estate it was seen in: "a live
+deployment", "an asset-tagged serial (ASSET-<serial>)", "four figures of
+findings in a week". What was observed is what makes a change worth
+reading; where it was observed is not needed to make the point.
+
+If a match is a false positive, narrow the pattern in the list rather
+than skipping the check.
+MSG
+fi
+exit "$status"

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+# Installed by: git config core.hooksPath .githooks
+exec "$(dirname -- "$0")/check-identifiers.sh" text "$1"

--- a/.githooks/deny-list.example.txt
+++ b/.githooks/deny-list.example.txt
@@ -1,0 +1,18 @@
+# Naming that should not appear in published text: internal shorthands,
+# customer or deployment names, and the asset-tag prefixes device keys
+# carry in a particular estate. One extended-regex pattern per line;
+# blank lines and # comments ignored; matching is case-insensitive.
+#
+# Copy this to deny-list.txt and add your own. That file is not tracked -
+# a list of the things you do not want published is itself a list of the
+# things you do not want published, and it does not belong in a public
+# repository. CI reads the same content from a repository secret named
+# IDENTIFIER_DENY_LIST, one pattern per line; with no secret set the
+# check passes, which is the right answer for a fork.
+#
+# Prefer patterns that are bare rather than anchored to a character
+# class: a prefix is often written in prose in placeholder form, and
+# "<" or "*" will fall outside [a-z0-9].
+acme
+example-corp
+asset-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,21 @@ jobs:
             || { echo "::error::Windows collector token placeholder was replaced"; exit 1; }
           grep -q 'FALLBACK_AUTH_TOKEN = ""' extension/src/background.js \
             || { echo "::error::extension fallback token is not empty"; exit 1; }
+      - name: internal naming stays out of tracked files
+        # The other side of the same job: one catches a placeholder that
+        # went missing, this catches internal shorthand that arrived.
+        # Patterns come from a repository secret rather than the repo, since
+        # a list of strings you would rather not publish is itself one; with
+        # no secret set this passes, which is right for a fork. The same
+        # list runs over commit messages via .githooks/commit-msg, which is
+        # the half CI cannot see.
+        env:
+          DENY_LIST: ${{ secrets.IDENTIFIER_DENY_LIST }}
+        run: |
+          if [ -n "$DENY_LIST" ]; then
+            printf '%s\n' "$DENY_LIST" > .githooks/deny-list.txt
+          fi
+          .githooks/check-identifiers.sh files
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ identity-map.csv
 
 # Tooling
 .claude/
+# Local, untracked: see .githooks/deny-list.example.txt
+.githooks/deny-list.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,22 @@ Present tense, and say why rather than what: the diff already says what. The
 existing history is the style guide, particularly the commits that explain a
 decision that could have gone the other way.
 
+The best of them cite what was actually observed - the finding count that
+exposed a throttling bug, the export that would not import. Describe the
+observation, not the estate it came from: "a live deployment", and an
+asset-tag prefix written as `ASSET-<serial>`. Naming a particular
+deployment adds nothing to the reasoning and is not yours to publish.
+
+A commit message is the one thing here that cannot be corrected afterwards
+without rewriting history, so there is a hook for it:
+
+    git config core.hooksPath .githooks
+
+Copy `.githooks/deny-list.example.txt` to `deny-list.txt` and add any
+shorthand you would not want published. That file is untracked on purpose;
+CI reads the same patterns from a repository secret. With neither present
+the check passes, so a fork needs no setup.
+
 ## The bar for changes
 
 This project's argument is that you can read it and decide for yourself

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -633,7 +633,7 @@ def build(findings, domain_map=None, identity_map=None):
             })
 
     # One machine, one device. Sources disagree about the key: an
-    # endpoint collector reports an asset-tagged serial (TGT-XXXX) and a
+    # endpoint collector reports an asset-tagged serial (ASSET-XXXX) and a
     # browser extension reports the bare one (XXXX), so the same laptop
     # arrived as two devices - two cards under one hostname, its tools
     # split across both, and a personal-account row that could not find
@@ -676,7 +676,7 @@ def build(findings, domain_map=None, identity_map=None):
         if not person:
             # Then the keys this device was merged from. The canonical key
             # is the longer, prefixed one, so a machine the collector calls
-            # TGT-C02ABCD swallows the C02ABCD the extension reports - and
+            # ASSET-C02ABCD swallows the C02ABCD the extension reports - and
             # an MDM export lists the bare serial, which is what a deployer
             # builds the map from. Mapping the serial looked right, matched
             # in the preview, and attached to nothing.
@@ -725,7 +725,7 @@ def build(findings, domain_map=None, identity_map=None):
 
 # Long enough that a shared suffix means something. Six characters of
 # serial matching by accident is a stretch; two or three is not, and
-# merging a junk key like "A" into "TGT-A" would be worse than the split
+# merging a junk key like "A" into "ASSET-A" would be worse than the split
 # it fixes.
 _MIN_ALIAS_KEY = 6
 _ALIAS_SEPARATORS = ("-", "_", ".", ":")

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -187,20 +187,20 @@ def test_a_machine_reported_under_two_keys_is_one_device():
     devices: two cards under one hostname, tools split across both, and
     the review counted 69 cards over 65 distinct names."""
     findings = [
-        _f(device="TGT-ABC123", device_name="LAPTOP-1", tool="claude-code",
+        _f(device="ASSET-ABC123", device_name="LAPTOP-1", tool="claude-code",
            surface="cli", source="collector-macos"),
         _f(device="ABC123", device_name="LAPTOP-1", tool="chatgpt",
            surface="browser", source="browser_extension"),
     ]
     devices, identities, tools, _b, _u = derive.build(findings, {}, {})
-    assert list(devices) == ["TGT-ABC123"]
-    d = devices["TGT-ABC123"]
+    assert list(devices) == ["ASSET-ABC123"]
+    d = devices["ASSET-ABC123"]
     assert d["tools"] == {"claude-code", "chatgpt"}
     assert d["aliases"] == {"ABC123"}
     assert d["findings"] == 2
     # The tool edges follow the surviving key, or a tool page would link
     # to a device that no longer exists.
-    assert tools["chatgpt"]["devices"] == {"TGT-ABC123"}
+    assert tools["chatgpt"]["devices"] == {"ASSET-ABC123"}
 
 
 def test_the_person_the_estate_already_knows_is_not_no_identity():
@@ -208,33 +208,33 @@ def test_the_person_the_estate_already_knows_is_not_no_identity():
     Devices view named on the row above - the browser extension reports
     no user, and the join never asked the device."""
     findings = [
-        _f(device="TGT-ABC123", user="alice", tool="claude-code",
+        _f(device="ASSET-ABC123", user="alice", tool="claude-code",
            surface="cli", source="collector-macos"),
         _f(device="ABC123", tool="chatgpt", surface="browser",
            severity="warn", account_domain="gmail.example",
            source="browser_extension"),
     ]
-    graph = derive.graph_from(findings, {}, {"TGT-ABC123": "alice"})
+    graph = derive.graph_from(findings, {}, {"ASSET-ABC123": "alice"})
     rows = graph["personal_accounts"]
     assert len(rows) == 1
     assert rows[0]["user"] == "alice"
     # And it says the attribution came from the machine, not the source.
     assert rows[0]["user_via"] == "device"
-    assert rows[0]["device"] == "TGT-ABC123"
+    assert rows[0]["device"] == "ASSET-ABC123"
 
 
 def test_an_ambiguous_or_short_key_is_left_alone():
     """Merging the wrong two machines is worse than showing two cards."""
     findings = [
         _f(device="AB1", tool="claude"),          # too short to be an id
-        _f(device="TGT-AB1", tool="claude"),
+        _f(device="ASSET-AB1", tool="claude"),
         _f(device="SERIAL7", tool="claude"),      # tail of two prefixed keys
-        _f(device="TGT-SERIAL7", tool="claude"),
-        _f(device="TNG-SERIAL7", tool="claude"),
+        _f(device="ASSET-SERIAL7", tool="claude"),
+        _f(device="ESTATE-SERIAL7", tool="claude"),
     ]
     devices, _i, _t, _b, _u = derive.build(findings, {}, {})
-    assert set(devices) == {"AB1", "TGT-AB1", "SERIAL7",
-                            "TGT-SERIAL7", "TNG-SERIAL7"}
+    assert set(devices) == {"AB1", "ASSET-AB1", "SERIAL7",
+                            "ASSET-SERIAL7", "ESTATE-SERIAL7"}
 
 
 # ---------------------------------------- one definition of a tool in use --
@@ -530,14 +530,14 @@ def test_the_settings_tab_from_the_url_cannot_dispatch_into_the_prototype():
 
 def test_a_map_keyed_on_the_bare_serial_still_finds_the_machine():
     """Found while explaining why a mapped person still read as unmapped.
-    One machine reported twice - TGT-<serial> by the collector, the bare
+    One machine reported twice - ASSET-<serial> by the collector, the bare
     serial by the extension - merges onto the longer key, and the shorter
     one survives only in aliases. Attribution checked the canonical key
     and local usernames, never the aliases. An MDM export lists the bare
     serial, so a map built from one looked right, said "matches" in the
     preview because the preview does count aliases, and attached to
     nobody."""
-    finds = [_f(device="TGT-C02ABCD", source="collector-macos",
+    finds = [_f(device="ASSET-C02ABCD", source="collector-macos",
                 device_name="sam-mbp", user="sam"),
              _f(device="C02ABCD", source="extension", device_name="sam-mbp")]
     dm = derive.load_domain_map_from(REG)
@@ -548,10 +548,10 @@ def test_a_map_keyed_on_the_bare_serial_still_finds_the_machine():
         return list(devices.values())[0].get("person")
 
     assert person({"C02ABCD": "Sam Patel"}) == "Sam Patel"
-    assert person({"TGT-C02ABCD": "Sam Patel"}) == "Sam Patel"
+    assert person({"ASSET-C02ABCD": "Sam Patel"}) == "Sam Patel"
     assert person({"sam": "Sam Patel"}) == "Sam Patel"
     # The key the device is actually filed under still wins the tie.
-    assert person({"C02ABCD": "Wrong", "TGT-C02ABCD": "Sam Patel"}) == "Sam Patel"
+    assert person({"C02ABCD": "Wrong", "ASSET-C02ABCD": "Sam Patel"}) == "Sam Patel"
 
 
 def test_the_identity_import_names_the_rows_it_drops():


### PR DESCRIPTION
Comments and test fixtures used a device-key prefix taken from one particular estate rather than a neutral one. That is a habit worth stopping rather than a bug: an example is more useful when it illustrates the shape and carries nothing else. `derive.py` and `test_review_findings.py` now read `ASSET-` / `ESTATE-`.

Comments and fixtures only — the alias merge is generic prefix logic and was never keyed on any particular prefix. Portal suite green at 401.

## The check

Two callers, because the two halves behave differently:

- **CI**, folded into the existing `placeholder-guard` job, over tracked files. That job already exists to catch a token placeholder going missing; this is the same idea pointed the other way.
- **A `commit-msg` hook**, over the message. This is the half that matters more: CI never sees a commit message, and unlike a file or an issue body it cannot be corrected afterwards. `git config core.hooksPath .githooks`.

The pattern list is deliberately **not** in the repository — a list of strings you would rather not publish is itself a list of strings you would rather not publish. It lives in an untracked `deny-list.txt` locally and in a repository secret for CI, with `deny-list.example.txt` showing the format. With neither set the check passes, so a fork needs no setup and never fails on someone else's vocabulary.

`CONTRIBUTING.md` says what to do instead: describe the observation, not the estate it came from. The finding count that exposed a throttling bug is what makes a commit worth reading; where it was observed adds nothing to the reasoning.

No behaviour change to the product.