### PR TITLE
portal tests: the probe fixture uses the placeholder tailnet

### DIFF
--- a/portal/tests/test_runtime_log_store.py
+++ b/portal/tests/test_runtime_log_store.py
@@ -215,7 +215,7 @@ def test_the_receiver_url_probe_warns_on_a_dotless_host(login_mode, monkeypatch)
     assert out["ok"] is True and out["version"] == "0.9.8"
     assert any("no dot" in w for w in out["warnings"])
 
-    _probe_with_saved_url(monkeypatch, "https://ai-guard.tailfc8950.ts.net")
+    _probe_with_saved_url(monkeypatch, "https://ai-guard.your-tailnet.ts.net")
     out = main.test_receiver_url(_=None, token="t")
     assert out["warnings"] == []
 


### PR DESCRIPTION
`test_runtime_log_store.py` asserted that a fully-qualified host produces no warnings, using a real tailnet name as the fixture. The portal already uses `ai-guard.your-tailnet.ts.net` in two places for the same purpose and the chart's `NOTES.txt` uses `<your-tailnet>`, so this looks like one that got missed rather than a deliberate choice.

Nothing about the test changes — the probe only cares that the host contains a dot, and the placeholder has one. Portal suite green at 401.