### PR TITLE
comments and docstrings: illustrate with shapes, not one estate's numbers

### DIFF
--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -3289,9 +3289,9 @@ const bPrefCur = () => (((SETTINGS && SETTINGS.settings || {})
 const bSubMonthly = s => (s.seat_tiers || []).reduce(
   (x, t) => x + (t.seats || 0) * (t.unit_price_monthly || 0), 0);
 
-// Monthly totals per currency, preferred first: "£934 + $546" is the
-// honest spelling of a mixed estate - one summed number over two
-// currencies would be a figure that lies.
+// Monthly totals per currency, preferred first. Two currencies spelled
+// out beats one summed number over both - that figure would lie, and the
+// invoices it claims to summarise do not move with an exchange rate.
 function bSpendParts(subs) {
   const byCur = {};
   (subs || []).forEach(s => {

--- a/scanner/tests/test_intune_device_map.py
+++ b/scanner/tests/test_intune_device_map.py
@@ -8,9 +8,9 @@ lastSyncDateTime. Nothing errors. A stale-device filter reading that timestamp
 finds every device older than any cutoff and skips the entire fleet, and a
 scanner keyed on that serialNumber gets null for every machine.
 
-Observed: nineteen apps resolved their devices, thirty nine device records came
-back, none survived the filter, and Intune reported two aggregate findings from
-a fleet with fourteen machines that had checked in that morning.
+Observed: apps resolved their devices, device records came back, none survived
+the filter, and Intune reported two aggregate findings from a fleet whose
+machines had checked in that morning.
 
 So device attributes are read from /deviceManagement/managedDevices, fetched
 once into an id-keyed map, and the sub-resource is asked only for the two fields

--- a/scanner/tests/test_sentinelone_device_identity.py
+++ b/scanner/tests/test_sentinelone_device_identity.py
@@ -3,8 +3,8 @@
 Deep Visibility events carry the computer name and nothing else, so findings
 used to be keyed on it. The endpoint collectors and the browser extension both
 report serials. The same machine therefore arrived twice, once as C02XK1ABCDEF
-from its collector and once as JANES-MBP from the scanner, and a fleet of about
-65 counted 73 devices.
+from its collector and once as JANES-MBP from the scanner, so the estate showed
+more device rows than it had machines.
 
 jamf.py had done this correctly since it was written and says why in its module
 docstring. This is the same rule applied to the other two sources.


### PR DESCRIPTION
Three places carried figures observed on a particular deployment rather than illustrative ones:

- `portal/app/static/index.html` — a monthly spend total, in the comment explaining why per-currency totals are printed separately
- `scanner/tests/test_intune_device_map.py` — app, device-record and machine counts in the docstring
- `scanner/tests/test_sentinelone_device_identity.py` — a fleet size in the docstring

None of them needed the numbers to make their point. The comment about two currencies explains itself without naming a sum. A docstring recording that a stale-device filter dropped every device is about the filter, not about how many devices there were — and the part that actually matters, more device rows than machines, is a shape, which is also what the test asserts.

Technical content unchanged; no assertion touched. Portal suite green at 401, scanner suite green at 156.