### PR TITLE
diagnostics: count the registry the fleet actually detects on

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.16.8
+version: 0.16.9
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.16.8"
+appVersion: "0.16.9"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.8
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.9
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.8
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.9
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -855,7 +855,7 @@ def _widgets(spec=None):
 
 
 @app.get("/api/diagnostics")
-def diagnostics(_=Depends(require_auth)):
+def diagnostics(request: Request, _=Depends(require_auth)):
     """What the portal can say about itself, for a support conversation.
 
     Everything under "runtime" is observed: the portal either did the thing or
@@ -874,7 +874,15 @@ def diagnostics(_=Depends(require_auth)):
         # 28 - and a review of a live deployment spent real time hunting
         # a stale registry file that did not exist. Both numbers, both
         # named.
-        loaded = derive.load_registry(REGISTRY_PATH)
+        #
+        # _registry(), not the file: a tool defined in the portal is a
+        # tool the fleet detects, and counting only what is mounted made
+        # this page disagree with the AI register on the same estate -
+        # 30 here against 32 there, with nothing saying why. Invisible
+        # until a deployment moved its own entries out of a mounted
+        # ConfigMap and into the portal, which is now the supported way
+        # to add one.
+        loaded = _registry(request)
         tools = (loaded or {}).get("tools") or []
         dm = derive.load_domain_map_from(loaded)
         reg_ok = bool(tools)
@@ -885,6 +893,10 @@ def diagnostics(_=Depends(require_auth)):
         # right thing in a log and the wrong thing in a response body: the path
         # is operator-supplied through REGISTRY_PATH. registry_loaded already
         # carries the signal, so the type is enough to act on.
+        # Includes the receiver being unreachable: without it the custom
+        # entries cannot be known, and reporting the mounted file alone
+        # would be the same quiet under-report this fixed. registry_loaded
+        # and registry_error carry that, rather than a confident number.
         log.warning(
             "registry load failed from %s: %s", REGISTRY_PATH, e, exc_info=True
         )

--- a/portal/tests/test_login.py
+++ b/portal/tests/test_login.py
@@ -326,5 +326,7 @@ def test_the_page_no_longer_carries_an_admin_token_field():
 
 
 def test_diagnostics_report_the_login_mode(login_mode):
-    out = main.diagnostics(_=None)
+    # request=None: in login mode the custom entries need a session cookie
+    # to read, and this test is about auth_mode, not the registry counts.
+    out = main.diagnostics(request=None, _=None)
     assert out["runtime"]["auth_mode"] == "login"

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -398,10 +398,63 @@ def test_diagnostics_counts_tools_not_tools_with_domains(tmp_path, monkeypatch):
         {"id": "claude-code", "name": "Claude Code", "domains": []},
     ]}))
     monkeypatch.setattr(pm, "REGISTRY_PATH", str(reg))
-    runtime = pm.diagnostics(_=None)["runtime"]
+    runtime = pm.diagnostics(request=None, _=None)["runtime"]
     assert runtime["registry_tools"] == 3
     assert runtime["registry_tools_with_domains"] == 2
     assert runtime["registry_loaded"] is True
+
+
+def test_diagnostics_counts_portal_defined_tools_too(tmp_path, monkeypatch):
+    """A tool defined in the portal is a tool the fleet detects, so it
+    belongs in this count. Counting the mounted file alone made this page
+    read 30 while the AI register read 32 on the same estate, with nothing
+    saying why - invisible until a deployment moved its own entries out of
+    a mounted ConfigMap and into the portal, which is the supported way to
+    add one."""
+    from app import main as pm
+
+    reg = tmp_path / "registry.json"
+    reg.write_text(json.dumps({"version": 1, "tools": [
+        {"id": "chatgpt", "name": "ChatGPT", "domains": ["chatgpt.com"]},
+        {"id": "claude-code", "name": "Claude Code", "domains": []},
+    ]}))
+    monkeypatch.setattr(pm, "REGISTRY_PATH", str(reg))
+    monkeypatch.setattr(pm, "_custom_registry_entries", lambda request: [
+        {"id": "warp-terminal", "name": "Warp Terminal",
+         "domains": ["warp.dev"]},
+        {"id": "azure-machine-learning", "name": "Azure Machine Learning",
+         "domains": ["azureml.ms"]},
+    ])
+    runtime = pm.diagnostics(request=object(), _=None)["runtime"]
+    assert runtime["registry_tools"] == 4
+    assert runtime["registry_tools_with_domains"] == 3
+    assert runtime["registry_loaded"] is True
+
+
+def test_diagnostics_says_so_when_the_custom_entries_cannot_be_read(
+        tmp_path, monkeypatch):
+    """The failure this fix must not reintroduce quietly. If the receiver
+    cannot answer, the portal does not know what the portal-defined tools
+    are - and a confident file-only count is the under-report all over
+    again. Report the failure instead."""
+    from fastapi import HTTPException
+
+    from app import main as pm
+
+    reg = tmp_path / "registry.json"
+    reg.write_text(json.dumps({"version": 1, "tools": [
+        {"id": "chatgpt", "name": "ChatGPT", "domains": ["chatgpt.com"]},
+    ]}))
+    monkeypatch.setattr(pm, "REGISTRY_PATH", str(reg))
+
+    def unreachable(request):
+        raise HTTPException(502, "receiver unreachable")
+
+    monkeypatch.setattr(pm, "_custom_registry_entries", unreachable)
+    runtime = pm.diagnostics(request=object(), _=None)["runtime"]
+    assert runtime["registry_loaded"] is False
+    assert runtime["registry_error"] == "HTTPException"
+    assert runtime["registry_tools"] == 0
 
 
 def test_one_person_spelled_two_ways_is_one_identity():

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.8
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.9
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Diagnostics reported **30 tools, 26 with a domain** while the AI register reported **32 watched for**, on the same estate, with nothing explaining the gap.

Both were counting honestly. The Tools row read the mounted registry file directly (`derive.load_registry(REGISTRY_PATH)`), while every other view reasons over `_registry()`, which merges in the portal-defined entries the receiver serves to the fleet. A tool defined in the portal *is* a tool the fleet detects — it belongs in this count.

## Why it stayed hidden

A deployment that keeps its extra tools in a mounted ConfigMap has a file that already agrees with the merged registry, so the two numbers match and the bug is invisible. It surfaces the moment those entries move into the portal — which is the supported way to add a tool, and precisely what the registry ConfigMap cutover asks a deployment to do. Reported from a live upgrade doing exactly that.

## The fix

Diagnostics reads `_registry(request)` like the rest of the portal.

A receiver that cannot answer is now reported rather than quietly worked around: without it the portal genuinely does not know what the portal-defined tools are, and returning a confident file-only count would be the same under-report in a different place. `registry_loaded` goes false and `registry_error` carries the type, which is what that row already exists to say.

## Verified

Portal suite green at 403. Two new tests, both confirmed failing against `main` first:

- `test_diagnostics_counts_portal_defined_tools_too` — fails with `assert 2 == 4`, the same shape as 30 against 32
- `test_diagnostics_says_so_when_the_custom_entries_cannot_be_read` — fails with `assert True is False`, i.e. the old code reporting a healthy registry while unable to read half of it

The existing `test_diagnostics_counts_tools_not_tools_with_domains` still passes unchanged; it and one login test were updated only for the new `request` parameter.

Same shape as the 0.15.2 finding: a count on this page measuring something narrower than its label claims.