### PR TITLE
accounts: an owner role, and signing in with Microsoft Entra

### DIFF
--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1352,7 +1352,8 @@ def esc_attr(v) -> str:
     return html.escape(str(v), quote=True)
 
 
-def _sso_page(title: str, body: str, go: str = "") -> HTMLResponse:
+def _sso_page(title: str, body: str, go: str = "",
+              who: str = "") -> HTMLResponse:
     """The callback's own answer, as a page rather than a redirect.
 
     A redirect would be a cross-site navigation - the chain started at the
@@ -1361,10 +1362,17 @@ def _sso_page(title: str, body: str, go: str = "") -> HTMLResponse:
     back on the sign-in screen holding a valid session. Navigating from
     this page is same-site, which is the difference.
     """
+    # A test sign-in is opened from the wizard in a second tab, so its
+    # result has to travel back to the tab that started it. Same origin
+    # both ways, and the wizard ignores a message from anywhere else.
+    tell = ("<script>try{window.opener&&window.opener.postMessage("
+            + json.dumps({"ssoTest": "ok" if go else "fail",
+                          "username": who, "detail": body})
+            + ",location.origin)}catch(e){}</script>")
     onward = (f'<p><a href="{esc_attr(go)}">Continue</a></p>'
               f'<script>location.replace({json.dumps(go)})</script>') if go \
         else '<p><a href="/">Back to sign in</a></p>'
-    return HTMLResponse(
+    return HTMLResponse(tell + 
         "<!doctype html><meta charset=utf-8>"
         "<meta name=viewport content='width=device-width,initial-scale=1'>"
         f"<title>{esc_attr(title)}</title>"
@@ -1420,7 +1428,8 @@ async def sso_callback(request: Request):
     if not out.get("ok"):
         return _sso_page("Signed in, but not here",
                          str(out.get("detail") or "that sign-in was refused"))
-    resp = _sso_page("Signed in", "Taking you to the portal.", go="/")
+    resp = _sso_page("Signed in", "Taking you to the portal.", go="/",
+                     who=str(out.get("username", "")))
     resp.set_cookie(SESSION_COOKIE, str(out.get("token", "")),
                     httponly=True, samesite="strict",
                     secure=_cookie_secure(request), path="/")

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -74,6 +74,7 @@ encryption.
                     ran, with nothing on screen saying the view was stale.
 """
 
+import html
 import json
 import logging
 import os
@@ -86,8 +87,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from fastapi import Depends, FastAPI, HTTPException, Query, Request
-from fastapi.responses import (FileResponse, JSONResponse, PlainTextResponse,
-                               Response)
+from fastapi.responses import (FileResponse, HTMLResponse, JSONResponse,
+                               PlainTextResponse, RedirectResponse, Response)
 from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from pydantic import BaseModel, Field
 
@@ -1339,6 +1340,93 @@ def api_setup(req: SetupRequest, request: Request):
     return _session_response(out, request)
 
 
+# ----------------------------------------------------- federated sign-in --
+# The browser talks to the portal; the receiver holds the client secret and
+# mints the session. Nothing here reads a token: the code goes straight
+# through and comes back as a session or a refusal.
+
+
+def esc_attr(v) -> str:
+    """The one place this service renders HTML, and provider error text
+    lands in it - so it is escaped rather than trusted."""
+    return html.escape(str(v), quote=True)
+
+
+def _sso_page(title: str, body: str, go: str = "") -> HTMLResponse:
+    """The callback's own answer, as a page rather than a redirect.
+
+    A redirect would be a cross-site navigation - the chain started at the
+    identity provider - and the session cookie is SameSite=Strict, so the
+    browser would decline to send it on arrival and the operator would land
+    back on the sign-in screen holding a valid session. Navigating from
+    this page is same-site, which is the difference.
+    """
+    onward = (f'<p><a href="{esc_attr(go)}">Continue</a></p>'
+              f'<script>location.replace({json.dumps(go)})</script>') if go \
+        else '<p><a href="/">Back to sign in</a></p>'
+    return HTMLResponse(
+        "<!doctype html><meta charset=utf-8>"
+        "<meta name=viewport content='width=device-width,initial-scale=1'>"
+        f"<title>{esc_attr(title)}</title>"
+        "<style>body{font:15px/1.5 -apple-system,'Segoe UI',sans-serif;"
+        "max-width:34rem;margin:14vh auto;padding:0 1.2rem;color:#1c2024}"
+        "@media(prefers-color-scheme:dark){body{background:#14171b;color:#e8eaed}}"
+        "h1{font-size:19px;margin:0 0 .5rem}p{color:#5c636e}"
+        "@media(prefers-color-scheme:dark){p{color:#9aa3ad}}</style>"
+        f"<h1>{esc_attr(title)}</h1><p>{esc_attr(body)}</p>{onward}")
+
+
+@app.get("/sso/start")
+def sso_start(request: Request):
+    """Send the browser to the identity provider."""
+    _login_mode_only()
+    try:
+        out = managed.receiver_request(RECEIVER_URL, "GET", "/admin/sso/start",
+                                       "", None)
+    except managed.ReceiverError as e:
+        if e.status == 404:
+            return _sso_page("Single sign-on is not set up",
+                             "This deployment has not finished configuring an "
+                             "identity provider. Sign in with a password.")
+        return _sso_page("Could not start sign-in", str(e.detail)[:300])
+    return RedirectResponse(out["authorize_url"], status_code=302)
+
+
+@app.post("/sso/callback")
+async def sso_callback(request: Request):
+    """Where the identity provider posts the browser back.
+
+    Deliberately outside /api, so the JSON-only CSRF rule does not refuse
+    the provider's form post. What stands in for that rule here is the
+    state: minted by the receiver minutes ago, single-use, and paired with
+    a PKCE verifier the browser never held.
+    """
+    _login_mode_only()
+    form = await request.form()
+    if form.get("error"):
+        return _sso_page("Sign-in was refused", str(
+            form.get("error_description") or form.get("error"))[:300])
+    code, state = str(form.get("code") or ""), str(form.get("state") or "")
+    if not code or not state:
+        return _sso_page("Sign-in did not complete",
+                         "The identity provider returned no authorization "
+                         "code.")
+    try:
+        out = managed.receiver_request(RECEIVER_URL, "POST",
+                                       "/admin/sso/callback", "",
+                                       {"code": code, "state": state})
+    except managed.ReceiverError as e:
+        return _sso_page("Could not complete sign-in", str(e.detail)[:300])
+    if not out.get("ok"):
+        return _sso_page("Signed in, but not here",
+                         str(out.get("detail") or "that sign-in was refused"))
+    resp = _sso_page("Signed in", "Taking you to the portal.", go="/")
+    resp.set_cookie(SESSION_COOKIE, str(out.get("token", "")),
+                    httponly=True, samesite="strict",
+                    secure=_cookie_secure(request), path="/")
+    return resp
+
+
 @app.post("/api/logout")
 def api_logout(request: Request):
     _login_mode_only()
@@ -1671,6 +1759,20 @@ def api_users_role(uid: str, req: UserRoleWrite, _=Depends(require_auth),
         raise HTTPException(422, "malformed user id")
     return _receiver("POST", "/admin/users/%s/role" % uid, token,
                      req.model_dump())
+
+
+class SSOProbe(BaseModel):
+    model_config = {"extra": "forbid"}
+    tenant_id: str = Field(min_length=1, max_length=120)
+    client_id: str = Field(default="", max_length=64)
+    client_secret: str = Field(default="", max_length=512)
+
+
+@app.post("/api/sso/probe")
+def api_sso_probe(req: SSOProbe, _=Depends(require_auth),
+                  token: str = Depends(_admin_forward)):
+    """The wizard's verification step. Owner-gated at the receiver."""
+    return _receiver("POST", "/admin/sso/probe", token, req.model_dump())
 
 
 @app.post("/api/users/{uid}/email")

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1362,17 +1362,27 @@ def _sso_page(title: str, body: str, go: str = "",
     back on the sign-in screen holding a valid session. Navigating from
     this page is same-site, which is the difference.
     """
-    # A test sign-in is opened from the wizard in a second tab, so its
-    # result has to travel back to the tab that started it. Same origin
-    # both ways, and the wizard ignores a message from anywhere else.
-    tell = ("<script>try{window.opener&&window.opener.postMessage("
-            + json.dumps({"ssoTest": "ok" if go else "fail",
-                          "username": who, "detail": body})
-            + ",location.origin)}catch(e){}</script>")
-    onward = (f'<p><a href="{esc_attr(go)}">Continue</a></p>'
-              f'<script>location.replace({json.dumps(go)})</script>') if go \
+    # Nothing dynamic goes inside a <script> tag. json.dumps escapes for
+    # JSON, which is not the same as escaping for a script context: it
+    # leaves "/" alone, so a provider error_description containing
+    # "</script>" closes the tag early and everything after it is markup.
+    # That text comes from the identity provider, which makes it the one
+    # genuinely untrusted string on this page.
+    #
+    # The values ride in an attribute instead, HTML-escaped like any
+    # other, and a static script reads them back. There is no injection
+    # point left to get the escaping wrong in.
+    payload = json.dumps({"ssoTest": "ok" if go else "fail",
+                          "username": who, "detail": body, "go": go})
+    tell = (f'<div id="ssor" hidden data-r="{esc_attr(payload)}"></div>'
+            '<script>(function(){try{'
+            'var r=JSON.parse(document.getElementById("ssor").dataset.r);'
+            'if(window.opener)window.opener.postMessage(r,location.origin);'
+            'if(r.go)location.replace(r.go);'
+            '}catch(e){}})()</script>')
+    onward = (f'<p><a href="{esc_attr(go)}">Continue</a></p>') if go \
         else '<p><a href="/">Back to sign in</a></p>'
-    return HTMLResponse(tell + 
+    return HTMLResponse(tell +
         "<!doctype html><meta charset=utf-8>"
         "<meta name=viewport content='width=device-width,initial-scale=1'>"
         f"<title>{esc_attr(title)}</title>"
@@ -1410,7 +1420,14 @@ async def sso_callback(request: Request):
     a PKCE verifier the browser never held.
     """
     _login_mode_only()
-    form = await request.form()
+    # Parsed here rather than with request.form(). Starlette's form parser
+    # requires python-multipart even for a urlencoded body, and this
+    # endpoint 500s without it - which is every real sign-in, at the last
+    # step. The provider posts application/x-www-form-urlencoded and
+    # nothing else, so the stdlib is enough and the image gains nothing.
+    raw = (await request.body())[:16384].decode("utf-8", "replace")
+    fields = urllib.parse.parse_qs(raw, keep_blank_values=True)
+    form = {k: v[0] for k, v in fields.items() if v}
     if form.get("error"):
         return _sso_page("Sign-in was refused", str(
             form.get("error_description") or form.get("error"))[:300])

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -605,6 +605,8 @@ let G = {devices:{},identities:{},tools:{},bridges:{},unattributed:[],counts:{}}
 // Declared here rather than beside their views: load() clears them and let
 // is not hoisted, so declaring them lower down is a TDZ error on first
 // refresh.
+// Which account's email is being edited inline, if any.
+let UEFORM = null;
 let SETTAB = 'fleet';
 // The Settings sub-tabs, up here with SETTAB for the same reason: SETTAB is
 // set from the URL fragment by fromHash(), which runs while the module is
@@ -678,6 +680,11 @@ let AUTH = null;
 // they are fetched once with everything else rather than per widget.
 // Managed mode keeps them with the account; classic mode has no account
 // to keep them on and falls back to this browser.
+// The receiver enforces the rank rule; this is the same table so the page
+// does not offer a control whose answer is already a 403.
+const RANK = {owner: 3, admin: 2, viewer: 1};
+const ROLE_ORDER = ['viewer', 'admin', 'owner'];
+
 let PREFS = {};
 const LS_PREFS = 'aiguard-prefs';
 
@@ -3352,21 +3359,40 @@ function accountSettings() {
   const viewer = AUTH && AUTH.role === 'viewer';
   const users = USERS === null ? '' : `
   <div class="wcard" style="margin-bottom:10px"><h3>Accounts</h3>
-    <p class="lede" style="margin-bottom:10px">An admin runs the platform; a
-    viewer reads every page and can change nothing - made for the auditor
-    and the exec. Changing a role applies to that account's next request,
-    not its next sign-in: nobody has to sign out, though a page already
-    open shows its old buttons until it is reloaded.</p>
+    <p class="lede" style="margin-bottom:10px">An owner decides who may sign
+    in; an admin runs the platform; a viewer reads every page and can change
+    nothing - made for the auditor and the exec. Nobody can act on an
+    account that outranks them, or grant a role above their own. Changing a
+    role applies to that account's next request rather than its next
+    sign-in: nobody has to sign out, though a page already open shows its
+    old buttons until it is reloaded.</p>
     ${USERR ? `<div class="note">${esc(USERR)}</div>` : ''}
-    <table><tr><th>username</th><th>role</th><th>created</th><th>last sign-in</th><th></th></tr>
-    ${USERS.map(u => `<tr>
+    <table><tr><th>username</th><th>email</th><th>role</th><th>created</th><th>last sign-in</th><th></th></tr>
+    ${USERS.map(u => {
+      // The same rank rule the receiver enforces, so the page does not
+      // offer a control that is going to come back 403. Equal rank is not
+      // above it: two owners manage each other.
+      const mine = RANK[(AUTH && AUTH.role) || 'viewer'] || 0;
+      const overRank = (RANK[u.role] || 0) > mine;
+      const may = !viewer && !overRank;
+      return `<tr>
       <td>${esc(u.username)}${AUTH && AUTH.username === u.username ? ' <span class="pill p-acc">you</span>' : ''}</td>
-      <td>${viewer
-        ? `<span class="pill ${u.role === 'admin' ? 'p-ok' : 'p-mut'}">${esc(u.role)}</span>`
-        : `<select class="mfield" data-role-for="${esc(u.id)}" style="min-width:100px">
-             <option value="viewer"${u.role === 'viewer' ? ' selected' : ''}>viewer</option>
-             <option value="admin"${u.role === 'admin' ? ' selected' : ''}>admin</option>
-           </select>`}</td>
+      <td>${UEFORM === u.id
+        ? `<input id="ue-new" class="mfield" style="min-width:190px"
+             placeholder="name@example.com" value="${esc(u.email || '')}"
+             autocomplete="off">
+           <button class="mini" data-act="user-email" data-key="${esc(u.id)}">set</button>
+           <button class="mini" data-act="user-email-cancel">cancel</button>`
+        : `${u.email ? `<span class="mono">${esc(u.email)}</span>`
+                     : '<span style="color:var(--mut)">not set</span>'}${may
+            ? ` <button class="mini" data-act="user-email-form"
+                 data-key="${esc(u.id)}">edit</button>` : ''}`}</td>
+      <td>${may
+        ? `<select class="mfield" data-role-for="${esc(u.id)}" style="min-width:100px">
+             ${ROLE_ORDER.filter(r => (RANK[r] || 0) <= mine).map(r =>
+               `<option value="${r}"${u.role === r ? ' selected' : ''}>${r}</option>`).join('')}
+           </select>`
+        : `<span class="pill ${u.role === 'viewer' ? 'p-mut' : 'p-ok'}">${esc(u.role)}</span>`}</td>
       <td style="color:var(--mut)">${esc((u.created_at || '').slice(0, 10))}</td>
       <td style="color:var(--mut)">${esc((u.last_login_at || '').slice(0, 10)) || '—'}</td>
       <td class="nw">${URFORM === u.id
@@ -3374,9 +3400,9 @@ function accountSettings() {
              placeholder="new password (12+)" autocomplete="new-password">
            <button class="mini" data-act="user-reset" data-key="${esc(u.id)}">set</button>
            <button class="mini" data-act="user-reset-cancel">cancel</button>`
-        : `<button class="mini" data-act="user-reset-form" data-key="${esc(u.id)}">reset password</button>
-           <button class="mini" data-act="user-delete" data-key="${esc(u.id)}">delete</button>`}</td>
-    </tr>`).join('')}</table>
+        : may ? `<button class="mini" data-act="user-reset-form" data-key="${esc(u.id)}">reset password</button>
+           <button class="mini" data-act="user-delete" data-key="${esc(u.id)}">delete</button>` : ''}</td>
+    </tr>`;}).join('')}</table>
     <div style="margin-top:12px;display:flex;gap:8px;flex-wrap:wrap;align-items:center">
       <input id="user-name" class="mfield" placeholder="username"
         name="ai-guard-new-account" autocomplete="off"
@@ -3385,13 +3411,20 @@ function accountSettings() {
         placeholder="password (12+ characters)"
         name="ai-guard-new-account-secret" autocomplete="new-password"
         data-lpignore="true" data-1p-ignore data-bwignore>
+      <input id="user-email" class="mfield" placeholder="email (optional)"
+        autocomplete="off" data-lpignore="true" data-1p-ignore data-bwignore>
       <select id="user-role" class="mfield" style="min-width:110px">
-        <option value="viewer">viewer</option><option value="admin">admin</option>
+        ${ROLE_ORDER.filter(r =>
+          (RANK[r] || 0) <= (RANK[(AUTH && AUTH.role) || 'viewer'] || 0)
+        ).map(r => `<option value="${r}">${r}</option>`).join('')}
       </select>
       <button class="mini" data-act="user-create">add account</button>
     </div>
-    <p class="src-note">Deleting an account kills its sessions; the last
-    admin can be neither deleted nor demoted. A role change leaves the
+    <p class="src-note">An email address is what a federated sign-in would
+    match on; an account without one can only be reached with its password,
+    which is what makes it usable as a shared break-glass credential.
+    Deleting an account kills its sessions; the last owner can be neither
+    deleted nor demoted. A role change leaves the
     account's password and sessions alone. Every action here lands in the
     audit trail.</p>
   </div>`;
@@ -5093,7 +5126,8 @@ async function managedAction(act, el) {
   if (act === 'user-create') {
     const role = (document.getElementById('user-role') || {}).value || 'viewer';
     const r = await mfetch('/api/users', {method: 'POST', body: JSON.stringify(
-      {username: _val('user-name'), password: _val('user-pass'), role})});
+      {username: _val('user-name'), password: _val('user-pass'), role,
+       email: _val('user-email')})});
     if (r.status === 401) { sessionLost(); return; }
     USERR = r.ok ? '' : 'Not created: ' + await _refusal(r);
     if (r.ok) USERS = null;
@@ -5158,6 +5192,16 @@ async function managedAction(act, el) {
     render(); return;
   }
   if (act === 'take-tour') { await tourStart(); return; }
+  if (act === 'user-email-form') { UEFORM = el.getAttribute('data-key'); USERR = ''; render(); return; }
+  if (act === 'user-email-cancel') { UEFORM = null; render(); return; }
+  if (act === 'user-email') {
+    const r = await mfetch('/api/users/' + el.getAttribute('data-key') + '/email',
+      {method: 'POST', body: JSON.stringify({email: _val('ue-new')})});
+    if (r.status === 401) { sessionLost(); return; }
+    USERR = r.ok ? '' : 'Not saved: ' + await _refusal(r);
+    if (r.ok) { USERS = null; UEFORM = null; }
+    render(); return;
+  }
   if (act === 'user-reset-form') { URFORM = el.getAttribute('data-key'); USERR = ''; render(); return; }
   if (act === 'user-reset-cancel') { URFORM = null; render(); return; }
   if (act === 'user-reset') {

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -3355,6 +3355,172 @@ function alertingSettings() {
   </dl></div>`;
 }
 
+// ---- the single sign-on wizard ---------------------------------------
+// Owner-only, and a wizard rather than a settings panel because every
+// step here has something real to check. A page of four fields and a save
+// button is a page that reports success over a half-configured provider,
+// and the failure lands on whoever tries to sign in next.
+//
+// Nothing is enabled until a real sign-in has completed. That is the
+// difference between "the settings look right" and "somebody got in".
+let SSOW = null;
+
+const SSO_STEPS = ['register', 'tenant', 'client', 'redirect', 'test'];
+
+function ssoOpen() {
+  const s = (SETTINGS && SETTINGS.settings) || {};
+  const v = k => ((s[k] || {}).value) || '';
+  SSOW = {
+    step: 0, busy: false, err: '', ok: {},
+    tenant: v('sso_tenant_id'), client: v('sso_client_id'),
+    secret: '', redirect: v('sso_redirect_uri') || ssoRedirectGuess(),
+    secretSet: !!((s.sso_client_secret || {}).set),
+  };
+  render();
+}
+
+// The redirect URI has to match the app registration exactly, so the page
+// offers the one it would actually use rather than asking somebody to
+// compose it correctly from memory.
+function ssoRedirectGuess() {
+  return location.origin + '/sso/callback';
+}
+
+async function ssoProbe(withClient) {
+  SSOW.busy = true; SSOW.err = ''; render();
+  const body = {tenant_id: SSOW.tenant.trim()};
+  if (withClient) {
+    body.client_id = SSOW.client.trim();
+    body.client_secret = SSOW.secret;
+  }
+  const r = await mfetch('/api/sso/probe', {method: 'POST',
+    body: JSON.stringify(body)});
+  SSOW.busy = false;
+  if (r.status === 401) { sessionLost(); return false; }
+  if (!r.ok) { SSOW.err = await _refusal(r); render(); return false; }
+  const out = await r.json();
+  SSOW.issuer = out.issuer || '';
+  if (withClient) {
+    SSOW.ok.client = out.client_ok === true;
+    // A tenant can refuse a client-credentials grant for reasons that say
+    // nothing about the credentials - no application permissions
+    // consented, for one. Blocking a correct configuration on that would
+    // be worse than saying what came back.
+    if (!SSOW.ok.client) SSOW.err = 'The pair reached the tenant but it '
+      + 'refused the check: ' + (out.detail || 'no reason given')
+      + '. That can be normal - continue and let the test sign-in decide.';
+  } else {
+    SSOW.ok.tenant = true;
+  }
+  render();
+  return true;
+}
+
+async function ssoSave(enable) {
+  SSOW.busy = true; SSOW.err = ''; render();
+  const body = {sso_tenant_id: SSOW.tenant.trim(),
+                sso_client_id: SSOW.client.trim(),
+                sso_redirect_uri: SSOW.redirect.trim()};
+  if (SSOW.secret) body.sso_client_secret = SSOW.secret;
+  if (enable !== undefined) body.sso_enabled = enable ? '1' : '';
+  const r = await mfetch('/api/settings', {method: 'POST',
+    body: JSON.stringify(body)});
+  SSOW.busy = false;
+  if (r.status === 401) { sessionLost(); return false; }
+  if (!r.ok) { SSOW.err = await _refusal(r); render(); return false; }
+  SETTINGS = await r.json();
+  SSOW.secretSet = SSOW.secretSet || !!SSOW.secret;
+  render();
+  return true;
+}
+
+function ssoWizard() {
+  const step = SSO_STEPS[SSOW.step];
+  const nav = (back, next, nextLabel) => `<div style="margin-top:14px;
+    display:flex;gap:8px;align-items:center">
+    <button class="mini" data-act="sso-close">close</button>
+    <span style="margin-left:auto"></span>
+    ${back ? '<button class="mini" data-act="sso-back">back</button>' : ''}
+    ${next ? `<button class="mini" data-act="${next}"${SSOW.busy
+      ? ' disabled' : ''}>${SSOW.busy ? 'checking…' : nextLabel}</button>` : ''}
+  </div>`;
+  const err = SSOW.err ? `<div class="note" style="border-color:var(--warn)"
+    >${esc(SSOW.err)}</div>` : '';
+  const dots = `<div id="tour-dots" style="margin-bottom:12px">${
+    SSO_STEPS.map((_, i) => `<i class="${i === SSOW.step ? 'on' : ''}"></i>`
+    ).join('')}</div>`;
+
+  const body = {
+    register: `<h3>1 · Register an application</h3>
+      <p class="lede">In the Microsoft Entra admin center, go to
+      <span class="mono">Entra ID → App registrations → New registration</span>.
+      Give it any name, leave the account types on single tenant, and add a
+      <b>Web</b> platform with this exact redirect URI:</p>
+      <p><span class="mono" style="user-select:all">${esc(ssoRedirectGuess())}</span></p>
+      <p class="src-note">Then open <span class="mono">Certificates &amp;
+      secrets</span> and create a client secret. Copy its <b>value</b> now -
+      Entra shows it once. You will need the directory (tenant) ID and the
+      application (client) ID from the overview page as well.</p>`,
+
+    tenant: `<h3>2 · Your tenant</h3>
+      <p class="lede">The directory (tenant) ID from the app registration's
+      overview page, or your tenant's domain. This is checked against the
+      provider before anything is saved.</p>
+      <p><input id="sso-tenant" class="mfield" style="min-width:340px"
+        placeholder="00000000-0000-0000-0000-000000000000"
+        value="${esc(SSOW.tenant)}"></p>
+      ${SSOW.ok.tenant ? `<div class="note">Reached it. Tokens will be
+        issued by <span class="mono">${esc(SSOW.issuer || '')}</span>.</div>`
+        : ''}`,
+
+    client: `<h3>3 · The application</h3>
+      <p class="lede">The application (client) ID, and the secret value you
+      copied. The pair is checked against the tenant now, so a wrong secret
+      is found here rather than by the first person who tries to sign in.</p>
+      <p><input id="sso-client" class="mfield" style="min-width:340px"
+        placeholder="application (client) ID"
+        value="${esc(SSOW.client)}"></p>
+      <p><input id="sso-secret" class="mfield" type="password"
+        style="min-width:340px" autocomplete="new-password"
+        placeholder="${SSOW.secretSet ? 'stored - leave blank to keep it'
+                                      : 'client secret value'}"></p>
+      ${SSOW.ok.client ? '<div class="note">That pair works.</div>' : ''}`,
+
+    redirect: `<h3>4 · Where sign-ins come back to</h3>
+      <p class="lede">This has to match the redirect URI on the app
+      registration exactly. It is filled in with the address this portal is
+      being used on.</p>
+      <p><input id="sso-redirect" class="mfield" style="min-width:340px"
+        value="${esc(SSOW.redirect)}"></p>
+      <p class="src-note">If people reach the portal on more than one
+      address, register every one of them and set the one you want sign-ins
+      to land on.</p>`,
+
+    test: `<h3>5 · Prove it works</h3>
+      <p class="lede">Saved, and off. The last step is a real sign-in: this
+      opens the provider in a new tab and comes back with an account, or
+      with the reason it could not. Nothing is switched on until that
+      succeeds - a misconfigured provider that is already enabled is a
+      deployment nobody can sign in to.</p>
+      <p class="src-note">Your account needs an email address set on it
+      first, matching the one you sign in with. An account with no address
+      is reachable only by password, which is how a shared break-glass
+      credential stays out of the provider's reach.</p>
+      <p><button class="mini" data-act="sso-try">open a test sign-in</button>
+        <button class="mini" data-act="sso-enable">turn it on</button></p>`,
+  }[step];
+
+  return `<div class="wcard" style="margin-bottom:10px">
+    ${dots}${err}${body}
+    ${nav(SSOW.step > 0,
+          step === 'tenant' ? 'sso-check-tenant'
+          : step === 'client' ? 'sso-check-client'
+          : step === 'redirect' ? 'sso-save'
+          : step === 'test' ? '' : 'sso-next',
+          step === 'redirect' ? 'save' : 'next')}
+  </div>`;
+}
+
 function accountSettings() {
   const viewer = AUTH && AUTH.role === 'viewer';
   const users = USERS === null ? '' : `
@@ -3443,6 +3609,22 @@ function accountSettings() {
       password; this one stays.</div></dd>
   </dl></div>
 
+  ${AUTH && AUTH.role === 'owner' ? `<div class="wcard" style="margin-bottom:10px">
+    <h3>Single sign-on</h3>
+    ${SSOW ? '' : `<p class="lede">${
+      ((SETTINGS && SETTINGS.settings && SETTINGS.settings.sso_enabled
+        && SETTINGS.settings.sso_enabled.value) === '1')
+      ? 'On. People with an email address on their account can sign in '
+        + 'through Microsoft Entra. Passwords keep working, so an account '
+        + 'without an address stays reachable as a break-glass credential.'
+      : 'Off. Sign in with Microsoft Entra instead of a portal password. '
+        + 'Five steps, each one checked, ending in a real sign-in - nothing '
+        + 'is switched on until that works.'}</p>
+      <p><button class="mini" data-act="sso-open">${
+        ((SETTINGS && SETTINGS.settings && SETTINGS.settings.sso_enabled
+          && SETTINGS.settings.sso_enabled.value) === '1')
+        ? 'review the configuration' : 'set it up'}</button></p>`}
+  </div>${SSOW ? ssoWizard() : ''}` : ''}
   <p class="src-note" style="margin:4px 0 14px">
     <button class="mini" data-act="open-wizard">run the setup wizard again</button>
     — safe to repeat: every step is one of these settings, prefilled
@@ -5192,6 +5374,45 @@ async function managedAction(act, el) {
     render(); return;
   }
   if (act === 'take-tour') { await tourStart(); return; }
+  if (act === 'sso-open') { ssoOpen(); return; }
+  if (act === 'sso-close') { SSOW = null; render(); return; }
+  if (act === 'sso-back') { SSOW.step--; SSOW.err = ''; render(); return; }
+  if (act === 'sso-next') { SSOW.step++; SSOW.err = ''; render(); return; }
+  if (act === 'sso-check-tenant') {
+    SSOW.tenant = _val('sso-tenant');
+    if (await ssoProbe(false)) { SSOW.step++; render(); }
+    return;
+  }
+  if (act === 'sso-check-client') {
+    SSOW.client = _val('sso-client');
+    const typed = _val('sso-secret');
+    if (typed) SSOW.secret = typed;
+    if (!SSOW.secret && !SSOW.secretSet) {
+      SSOW.err = 'A client secret is needed to check the pair.';
+      render(); return;
+    }
+    // With a stored secret and nothing typed there is nothing to check
+    // against - the receiver never hands a secret back - so the step
+    // passes through and the test sign-in is what proves it.
+    if (!SSOW.secret) { SSOW.step++; render(); return; }
+    await ssoProbe(true);
+    SSOW.step++; render(); return;
+  }
+  if (act === 'sso-save') {
+    SSOW.redirect = _val('sso-redirect');
+    // Saved OFF. Enabling is the last step and needs a real sign-in.
+    if (await ssoSave(false)) { SSOW.step++; SSOW.err = ''; render(); }
+    return;
+  }
+  if (act === 'sso-try') { window.open('/sso/start', '_blank', 'noopener'); return; }
+  if (act === 'sso-enable') {
+    if (await ssoSave(true)) {
+      SSOW = null; SETMSG = 'Single sign-on is on. Local passwords keep '
+        + 'working, so a break-glass account is still a way in.';
+      render();
+    }
+    return;
+  }
   if (act === 'user-email-form') { UEFORM = el.getAttribute('data-key'); USERR = ''; render(); return; }
   if (act === 'user-email-cancel') { UEFORM = null; render(); return; }
   if (act === 'user-email') {

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -287,6 +287,57 @@ table.plain td{border-bottom:0;padding:4.5px 10px 4.5px 0;vertical-align:middle}
   dt, dd, td, th, p, li, span { color: #111 !important; }
   .src-note { color: #555 !important; }
 }
+/* ---- the single sign-on wizard ------------------------------------- */
+.ssow{display:grid;grid-template-columns:290px 1fr;border:1px solid var(--bd);
+  border-radius:12px;overflow:hidden;background:var(--sf);margin-bottom:10px}
+@media(max-width:760px){.ssow{grid-template-columns:1fr}
+  .ssow .ssrail{border-right:0;border-bottom:1px solid var(--bd)}}
+.ssrail{background:var(--sf2);border-right:1px solid var(--bd);padding:18px 16px}
+.ssrail ol{list-style:none;margin:0;padding:0}
+.ssstep{display:flex;gap:10px;padding:9px 8px;border-radius:8px;cursor:pointer;
+  align-items:flex-start;position:relative}
+.ssstep:hover{background:var(--bg)}
+.ssstep.on{background:var(--sf)}
+.ssstep .dot{width:22px;height:22px;border-radius:50%;flex:0 0 22px;display:grid;
+  place-items:center;font-size:11px;font-weight:700;border:1.5px solid var(--bd);
+  color:var(--mut);background:var(--sf)}
+.ssstep.on .dot{border-color:var(--acc);color:var(--acc)}
+.ssstep.done .dot{background:var(--pri);border-color:var(--pri);color:#fff}
+.ssstep .t{font-size:13px;font-weight:600}
+.ssstep .val{font-size:11.5px;color:var(--pri);word-break:break-all;display:block}
+.ssstep .pend{font-size:11.5px;color:var(--mut);display:block}
+.ssstep.locked{opacity:.5;cursor:not-allowed}
+/* The connector, so the rail reads as one sequence rather than five rows. */
+.ssstep::after{content:'';position:absolute;left:19px;top:33px;bottom:-4px;
+  width:1.5px;background:var(--bd)}
+.ssstep:last-child::after{display:none}
+.ssstep.done::after{background:var(--pri)}
+.sssum{margin-top:16px;padding-top:13px;border-top:1px solid var(--bd)}
+.sssum .barwrap{height:5px;border-radius:3px;background:var(--bd);overflow:hidden;
+  margin:7px 0 6px}
+.sssum .bar{height:100%;background:var(--pri);border-radius:3px;transition:width .35s ease}
+.ssmain{padding:22px 24px}
+.ssmain h4{margin:0 0 8px;font-size:16px}
+.sscopy{display:flex;gap:8px;align-items:center;background:var(--bg);
+  border:1px dashed var(--bd);border-radius:8px;padding:9px 11px;margin:0 0 10px}
+.sscopy .mono{flex:1;overflow:auto;white-space:nowrap;user-select:all}
+.sshelp{border:0;background:none;color:var(--acc);cursor:pointer;font:inherit;
+  font-size:12.5px;padding:0;text-decoration:underline;text-underline-offset:3px;
+  display:inline-block;margin:0 0 4px}
+.sshelpbody{border-left:2px solid var(--bd);padding:2px 0 2px 12px;margin:0 0 12px;
+  color:var(--mut);font-size:13px}
+.sshelpbody ol{margin:6px 0 0;padding-left:18px}
+.ssacts{margin-top:20px;display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.ssfoot{display:flex;gap:8px;align-items:center;margin-top:18px;padding-top:14px;
+  border-top:1px solid var(--bd)}
+.ssfoot .sp{margin-left:auto}
+.ssspin{width:11px;height:11px;border:2px solid currentColor;
+  border-right-color:transparent;border-radius:50%;display:inline-block;
+  animation:ssspin .7s linear infinite;margin-right:5px}
+@keyframes ssspin{to{transform:rotate(360deg)}}
+@media(prefers-reduced-motion:reduce){.ssspin{animation:none}
+  .sssum .bar{transition:none}}
+
 /* ---- the guided tour ------------------------------------------------
    A spotlight rather than a modal: the page underneath stays legible, so
    what is being described is the real thing and not a picture of it. The
@@ -426,7 +477,7 @@ table.plain td{border-bottom:0;padding:4.5px 10px 4.5px 0;vertical-align:middle}
 /* The form switch on a card that has more than one honest reading. */
 .wform { float: right; display: inline-flex; gap: 2px; margin: -2px 0 0; }
 .wform button {
-  font: inherit; font-size: 10px; text-transform: lowercase;
+  font: inherit; font-size: 10px;
   padding: 2px 8px; border-radius: 6px; cursor: pointer;
   border: 1px solid var(--bd); background: transparent; color: var(--mut);
 }
@@ -586,9 +637,9 @@ table.plain td{border-bottom:0;padding:4.5px 10px 4.5px 0;vertical-align:middle}
         <input id="q" placeholder="filter this view…">
       </div>
       <span id="freshness" class="mono" style="font-size:11px;color:var(--mut)"></span>
-      <button id="refresh" class="back" style="margin:0">refresh</button>
+      <button id="refresh" class="back" style="margin:0">Refresh</button>
       <span id="who" class="mono" style="font-size:11px;color:var(--mut);margin-left:auto"></span>
-      <button id="signout" class="back" style="margin:0;display:none">sign out</button>
+      <button id="signout" class="back" style="margin:0;display:none">Sign out</button>
       <button id="themebtn" class="back" style="margin:0" title="light / dark">◐</button>
     </div>
     <main id="app"></main>
@@ -1091,7 +1142,7 @@ function formToggle(kind) {
     `<button class="${f === cur ? 'on' : ''}" data-act="widget-form"
       data-key="${esc(kind)}" data-form="${esc(f)}"
       aria-pressed="${f === cur}" title="draw this as a ${esc(f)}"
-      >${esc(f)}</button>`).join('') + '</span>';
+      >${esc(f[0].toUpperCase() + f.slice(1))}</button>`).join('') + '</span>';
 }
 
 // ---- chart parts -----------------------------------------------------
@@ -1247,7 +1298,7 @@ const WIDGETS = {
       return `<div class="wcard w6"><h3>AI spend</h3>
       <p class="lede">Nothing linked yet. The Budget view records what
       each AI tool costs and joins it against observed use.</p>
-      <p class="src-note"><button class="mini" data-nav="budget">open Budget</button></p></div>`;
+      <p class="src-note"><button class="mini" data-nav="budget">Open Budget</button></p></div>`;
     }
     const next = subs.filter(s => s.renewal_date)
       .sort((a, b) => a.renewal_date.localeCompare(b.renewal_date))[0];
@@ -1262,7 +1313,7 @@ const WIDGETS = {
       <div><dt>${subs.length}</dt><dd>tools linked</dd></div>
       <div><dt${unob ? ' style="color:var(--warn)"' : ''}>${unob}</dt><dd>paid seats never observed</dd></div>
     </dl>
-    <p class="src-note">${next ? `next renewal: ${esc(next.tool_id)} ${when(next.renewal_date)} · ` : ''}<button class="mini" data-nav="budget">open Budget</button></p></div>`;
+    <p class="src-note">${next ? `next renewal: ${esc(next.tool_id)} ${when(next.renewal_date)} · ` : ''}<button class="mini" data-nav="budget">Open Budget</button></p></div>`;
   },
 
   top_tools: () => {
@@ -1624,8 +1675,8 @@ function overview() {
               title="${SIZE_NAME[z]}">${SIZE_LABEL[z]}</button>`).join('')
         : ''}${isStacked ? `<button data-act="w-unstack" data-key="${esc(k)}"
         title="give this card a column of its own again"
-        >unstack</button>` : ''}<button data-act="w-hide" data-key="${esc(k)}"
-        >${off ? 'show' : 'hide'}</button></span>` : ''}${body}</div>`;
+        >Unstack</button>` : ''}<button data-act="w-hide" data-key="${esc(k)}"
+        >${off ? 'Show' : 'Hide'}</button></span>` : ''}${body}</div>`;
   };
 
   const colOf = (col, i) => {
@@ -1648,9 +1699,9 @@ function overview() {
       AUTH && AUTH.role !== 'viewer'
         ? ' - the widgets a deployment offers are set under Settings' : ''}.</span>
     <span class="sp"></span>
-    <button class="ghost" data-act="ov-reset">reset to default</button>
-    <button class="ghost" data-act="ov-cancel">cancel</button>
-    <button class="pri" data-act="ov-save">save</button>
+    <button class="ghost" data-act="ov-reset">Reset to default</button>
+    <button class="ghost" data-act="ov-cancel">Cancel</button>
+    <button class="pri" data-act="ov-save">Save</button>
   </div>` : ''}
   <div class="grid${editing ? ' editing' : ''}">${cols.map(colOf).join('')}</div>`;
 }
@@ -1698,9 +1749,9 @@ function identityMapPanel(unattributed) {
       ? ` · a file is also mounted, and rows saved here win over it` : ''}.
   ${unattributed} device${unattributed === 1 ? '' : 's'} still ${unattributed === 1 ? 'has' : 'have'} no person attached.</p>
   <div style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:8px">
-    <button class="mini" data-act="id-export">download map in use (CSV)</button>
-    ${ro ? '' : `<button class="mini" data-act="id-open">${IDPARSE ? 'editing…' : 'upload or paste a map'}</button>`}
-    ${!ro && saved.length ? `<button class="mini" data-act="id-clear">clear the saved map</button>` : ''}
+    <button class="mini" data-act="id-export">Download map in use (CSV)</button>
+    ${ro ? '' : `<button class="mini" data-act="id-open">${IDPARSE ? 'Editing…' : 'Upload or paste a map'}</button>`}
+    ${!ro && saved.length ? `<button class="mini" data-act="id-clear">Clear the saved map</button>` : ''}
   </div>
   ${IDMSG ? `<div class="note">${esc(IDMSG)}</div>` : ''}
   <p class="src-note" style="margin-top:0">The download is the working
@@ -1732,8 +1783,8 @@ function identityMapEditor() {
       placeholder="key,identity&#10;C02XXXX,jo.bloggs&#10;jo.bloggs,Jo Bloggs">${esc(p.text || '')}</textarea>
     <div style="margin-top:8px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
       <input type="file" id="id-file" accept=".csv,text/csv,text/plain" class="mfield" style="min-width:0">
-      <button class="mini" data-act="id-parse">preview</button>
-      <button class="mini" data-act="id-cancel">cancel</button>
+      <button class="mini" data-act="id-parse">Preview</button>
+      <button class="mini" data-act="id-cancel">Cancel</button>
       ${(p.rows || []).length ? `<button class="mini" data-act="id-save">save ${p.rows.length} ${p.rows.length === 1 ? 'row' : 'rows'}</button>` : ''}
     </div>
     ${p.rows ? `<p class="src-note">${p.rows.length} rows understood${
@@ -2001,16 +2052,16 @@ const paStatus = r => (PSTAT || {})[paKey(r)] || null;
 function paActions(r) {
   const st = paStatus(r);
   const key = esc(paKey(r));
-  if (st) return `<button class="mini" data-act="pa-reopen" data-key="${key}">reopen</button>`;
+  if (st) return `<button class="mini" data-act="pa-reopen" data-key="${key}">Reopen</button>`;
   if (PAFORM === paKey(r)) return `
     <input id="pa-reason" class="mfield" style="min-width:180px"
       placeholder="why this is acceptable" autocomplete="off">
-    <button class="mini" data-act="pa-accept" data-key="${key}">accept</button>
-    <button class="mini" data-act="pa-cancel">cancel</button>`;
+    <button class="mini" data-act="pa-accept" data-key="${key}">Accept</button>
+    <button class="mini" data-act="pa-cancel">Cancel</button>`;
   return `<button class="mini" data-act="pa-ack" data-key="${key}"
-      title="spoken to - stays visible, stops being new">ack</button>
+      title="spoken to - stays visible, stops being new">Ack</button>
     <button class="mini" data-act="pa-accept-form" data-key="${key}"
-      title="accepted with a reason - drops out of the open count">accept…</button>`;
+      title="accepted with a reason - drops out of the open count">Accept…</button>`;
 }
 
 const paChip = st => !st ? ''
@@ -2073,8 +2124,8 @@ function govForm(r) {
     <input id="gov-reason" class="mfield" placeholder="reason (optional)"
       value="${esc(pre.reason ?? '')}">
     <div>
-      <button class="mini" data-act="gov-save" data-key="${esc(r.id)}">save decision</button>
-      <button class="mini" data-act="gov-cancel">cancel</button>
+      <button class="mini" data-act="gov-save" data-key="${esc(r.id)}">Save decision</button>
+      <button class="mini" data-act="gov-cancel">Cancel</button>
     </div>
   </div>`;
 }
@@ -2110,7 +2161,7 @@ function regForm() {
   registry's own rules and says exactly what it refuses.</p>
   ${RERR ? `<div class="note">${esc(RERR)}</div>` : ''}
   <div style="margin-bottom:8px">
-    <button class="mini" data-act="reg-adv">${RADV ? 'form editor' : 'advanced: edit as JSON'}</button>
+    <button class="mini" data-act="reg-adv">${RADV ? 'Form editor' : 'Advanced: edit as JSON'}</button>
   </div>
   ${RADV ? `<textarea id="re-json" class="mfield" rows="14"
       style="width:100%;font-family:ui-monospace,monospace"
@@ -2140,8 +2191,8 @@ function regForm() {
     ${row('re-notes', 'notes', e.notes, '')}
   </dl>`}
   <div style="margin-top:10px">
-    <button class="mini" data-act="reg-save">save tool</button>
-    <button class="mini" data-act="reg-cancel">cancel</button>
+    <button class="mini" data-act="reg-save">Save tool</button>
+    <button class="mini" data-act="reg-cancel">Cancel</button>
   </div></div>`;
 }
 
@@ -2201,7 +2252,7 @@ async function registryView() {
   that on the AI register.</p>
 
   ${REDIT !== null ? regForm() : `<div style="margin-bottom:14px">
-    <button class="mini" style="padding:6px 14px" data-act="reg-add">define a tool</button>
+    <button class="mini" style="padding:6px 14px" data-act="reg-add">Define a tool</button>
   </div>`}
 
   <h2 style="font-size:16px">Your tools (${RENTRIES.length})</h2>
@@ -2218,8 +2269,8 @@ async function registryView() {
     <td>${esc(e.name || '')}</td><td>${esc(e.vendor || '')}</td>
     <td>${n}</td>
     <td>${when(x.updated_at)} <span style="color:var(--mut)">${esc(x.updated_by || '')}</span></td>
-    <td><button class="mini" data-act="reg-edit" data-key="${esc(x.tool_id)}">edit</button>
-        <button class="mini" data-act="reg-delete" data-key="${esc(x.tool_id)}">delete</button></td>
+    <td><button class="mini" data-act="reg-edit" data-key="${esc(x.tool_id)}">Edit</button>
+        <button class="mini" data-act="reg-delete" data-key="${esc(x.tool_id)}">Delete</button></td>
   </tr>`; }).join('')}</table>`
   : `<p class="lede">None yet. A tool observed on the register that the
   registry does not know has an "add to registry" button - or define one
@@ -2272,8 +2323,8 @@ function watchlistBlock(observedIds) {
     return `<tr><td>${esc(t.name)}</td>
       <td style="color:var(--mut)">${esc(t.vendor)}</td>
       <td>${state}</td>
-      <td><button class="mini" data-act="wiz-approve" data-key="${esc(t.id)}">approve</button>
-          <button class="mini" data-act="wiz-notapprove" data-key="${esc(t.id)}">not approved</button></td>
+      <td><button class="mini" data-act="wiz-approve" data-key="${esc(t.id)}">Approve</button>
+          <button class="mini" data-act="wiz-notapprove" data-key="${esc(t.id)}">Not approved</button></td>
     </tr>`;
   }).join('')}</table></details>`;
 }
@@ -2495,11 +2546,11 @@ async function register() {
       <dt>review</dt><dd>${review(r)}</dd>
     </dl>
     ${CFG.managed && CFG.managed.enabled ? `<div style="margin-top:8px">
-      <button class="mini" data-act="gov-edit" data-key="${esc(r.id)}">edit</button>
+      <button class="mini" data-act="gov-edit" data-key="${esc(r.id)}">Edit</button>
       ${r.status_source === 'portal' ? `<button class="mini" data-act="gov-clear"
-        data-key="${esc(r.id)}">clear decision</button>` : ''}
+        data-key="${esc(r.id)}">Clear decision</button>` : ''}
       ${!r.in_registry ? `<button class="mini" data-act="reg-suggest"
-        data-key="${esc(r.id)}">add to registry</button>` : ''}</div>` : ''}`}
+        data-key="${esc(r.id)}">Add to registry</button>` : ''}</div>` : ''}`}
     ${exceptionBlock(r)}
   </div>`).join('')}
   </div>` : !dataOk() ? `<p class="lede">No AI tools to show: the findings
@@ -2697,7 +2748,7 @@ async function iso() {
 // so a row is label + input + save - what someone changing a value scans
 // for. What stays visible is state (set, and from where), because that is
 // a glance rather than reading.
-const INFO = '<button class="info" data-info type="button" title="about this field">i</button>';
+const INFO = '<button class="info" data-info type="button" title="about this field">I</button>';
 
 function settingRow(key, label, placeholder, note) {
   const s = (SETTINGS && SETTINGS.settings || {})[key] || {value: '', source: 'unset'};
@@ -2718,7 +2769,7 @@ function settingRow(key, label, placeholder, note) {
       ${secret ? 'type="password" autocomplete="off"' : ''}
       placeholder="${esc(placeholder)}"
       value="${secret ? '' : esc(s.value || '')}">
-    <button class="mini" data-act="save-setting" data-key="${esc(key)}">save</button>
+    <button class="mini" data-act="save-setting" data-key="${esc(key)}">Save</button>
     ${state}
     ${more ? `<div class="src-note fnote">${more}</div>` : ''}</dd>`;
 }
@@ -2764,7 +2815,7 @@ function widgetPickerRow() {
     ${orphans.map((r, i) => box('owo-' + i, true, r,
       `<span class="mono">grafana:${esc(r)}</span>`,
       'saved panel reference (no longer in the panels list)')).join('')}
-    <button class="mini" data-act="save-widgets" style="margin-top:4px">save</button>
+    <button class="mini" data-act="save-widgets" style="margin-top:4px">Save</button>
     <div class="src-note fnote">What the overview draws, in this order.
     Unticking everything is refused rather than saved: an empty list falls
     back to the default set, which is probably not what you meant.</div>
@@ -2783,7 +2834,7 @@ function pasteGuardBehaviourFields() {
         <option value=""${mode ? '' : ' selected'}>warn (default)</option>
         ${opt('off', 'off')}${opt('warn', 'warn')}${opt('block', 'block')}
       </select>
-      <button class="mini" data-act="save-setting" data-key="paste_guard_mode">save</button>
+      <button class="mini" data-act="save-setting" data-key="paste_guard_mode">Save</button>
       <div class="src-note fnote">What happens when someone pastes marked content
       into an AI tool: warn asks them first, block stops it. Baked into the
       policy downloads.</div></dd>
@@ -2791,8 +2842,8 @@ function pasteGuardBehaviourFields() {
       <textarea id="set-classification_markings" class="mfield" rows="4"
         style="min-width:340px;resize:vertical;font-family:inherit"
         placeholder="one marking per line (empty = the default set)">${marks === null ? '' : esc(marks.join('\n'))}</textarea>
-      <button class="mini" data-act="save-markings">save</button>
-      ${marksSet ? '<button class="mini" data-act="clear-markings">clear (default set)</button>' : ''}
+      <button class="mini" data-act="save-markings">Save</button>
+      ${marksSet ? '<button class="mini" data-act="clear-markings">Clear (default set)</button>' : ''}
       <div class="src-note fnote">Document phrases the guard looks for in pastes,
       one per line. Save an empty box to use no markings; clear to go back
       to the default five. What people paste never leaves their device -
@@ -2855,8 +2906,8 @@ function logStoreFields(withUsername) {
 }
 
 const logStoreTests = () => `<div style="margin-top:8px">
-  <button class="mini" data-act="run-test" data-key="log-store-push">test: receiver can write</button>
-  <button class="mini" data-act="run-test" data-key="log-store-read">test: portal can read</button>
+  <button class="mini" data-act="run-test" data-key="log-store-push">Test: receiver can write</button>
+  <button class="mini" data-act="run-test" data-key="log-store-read">Test: portal can read</button>
 </div>${testNote('log-store-push')}${testNote('log-store-read')}`;
 
 // ------------------------------------------------- extension setup guide --
@@ -2894,7 +2945,7 @@ function extStatusRows() {
 
 const extCmd = c => `<div style="display:flex;gap:8px;align-items:flex-start;margin:8px 0">
   <pre class="mono" style="margin:0;padding:8px 10px;background:var(--sf2);border:1px solid var(--bd);border-radius:6px;overflow-x:auto;flex:1;font-size:12px">${esc(c)}</pre>
-  <button class="mini" data-act="copy" data-copy="${esc(c)}">copy</button></div>`;
+  <button class="mini" data-act="copy" data-copy="${esc(c)}">Copy</button></div>`;
 
 async function extSetup() {
   const gate = CFG.managed && CFG.managed.enabled
@@ -2977,7 +3028,7 @@ async function extSetup() {
       <dt>Chromium extension ID</dt><dd>
         <input id="set-extid" class="mfield" style="min-width:340px"
           placeholder="the 32-letter id, a-p only" value="${esc(st.id)}">
-        <button class="mini" data-act="save-extid">save</button>
+        <button class="mini" data-act="save-extid">Save</button>
         <div class="src-note">32 letters a-p. Anything else means the id was
         read from the wrong place - it is not the key, and not a hash.</div></dd>
     </dl>`;
@@ -3008,7 +3059,7 @@ async function extSetup() {
         'Where you put updates.xml. The install policies point every browser at this URL, and it is how future releases roll out - pack, upload, replace updates.xml, done.')}
     </dl>
     ${st.upd ? `<div style="margin-top:8px">
-      <button class="mini" data-act="run-test" data-key="extension-updates">probe the hosted manifest</button>
+      <button class="mini" data-act="run-test" data-key="extension-updates">Probe the hosted manifest</button>
     </div>${testNote('extension-updates')}` : ''}`;
   if (EXTPAGE === 5) body = `
     <h3>Firefox (skip if you do not deploy it)</h3>
@@ -3047,7 +3098,7 @@ async function extSetup() {
       next to it, at the update_url you put in the manifest:</p>
       ${dlBtn('firefox-updates-json', 'download firefox-updates.json')}
       <div style="margin-top:8px">
-        <button class="mini" data-act="run-test" data-key="extension-xpi">probe the hosted .xpi (checks the Mozilla signature)</button>
+        <button class="mini" data-act="run-test" data-key="extension-xpi">Probe the hosted .xpi (checks the Mozilla signature)</button>
       </div>${testNote('extension-xpi')}` : ''}`;
   if (EXTPAGE === 6) body = `
     <h3>What the guard does</h3>
@@ -3060,7 +3111,7 @@ async function extSetup() {
     The policy downloads - pre-filled with all of this plus a fresh
     enrollment token each - are in the wizard's step 7, and pushing those
     through your MDM is the actual rollout.</p>
-    <button class="mini" style="padding:6px 14px" data-act="open-wizard">back to the setup wizard</button>`;
+    <button class="mini" style="padding:6px 14px" data-act="open-wizard">Back to the setup wizard</button>`;
 
   return `<h2>Extension setup</h2>
   <p class="lede">The browser extension, from source to hosted package, one
@@ -3071,7 +3122,7 @@ async function extSetup() {
   <div class="wcard" style="margin-bottom:10px">${body}</div>
   <div style="margin:14px 0">
     ${EXTPAGE > 1 ? `<button class="mini" data-act="ext-page" data-key="${EXTPAGE - 1}">← back</button>` : ''}
-    ${EXTPAGE < 6 ? `<button class="mini" data-act="ext-page" data-key="${EXTPAGE + 1}">next →</button>` : ''}
+    ${EXTPAGE < 6 ? `<button class="mini" data-act="ext-page" data-key="${EXTPAGE + 1}">Next →</button>` : ''}
   </div>`;
 }
 
@@ -3109,8 +3160,8 @@ async function wizard() {
     return `<tr><td>${esc(t.name)}</td>
       <td style="color:var(--mut)">${esc(t.vendor)}</td>
       <td>${state}</td>
-      <td><button class="mini" data-act="wiz-approve" data-key="${esc(t.id)}">approve</button>
-          <button class="mini" data-act="wiz-notapprove" data-key="${esc(t.id)}">not approved</button></td>
+      <td><button class="mini" data-act="wiz-approve" data-key="${esc(t.id)}">Approve</button>
+          <button class="mini" data-act="wiz-notapprove" data-key="${esc(t.id)}">Not approved</button></td>
     </tr>`;
   };
 
@@ -3136,7 +3187,7 @@ async function wizard() {
       'https://ai-guard.your-tailnet.ts.net', '')}
   </dl>
   <div style="margin-top:8px">
-    <button class="mini" data-act="run-test" data-key="receiver-url">probe the saved URL</button>
+    <button class="mini" data-act="run-test" data-key="receiver-url">Probe the saved URL</button>
   </div>${testNote('receiver-url')}</div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>2 · The log store</h3>
@@ -3172,12 +3223,12 @@ async function wizard() {
   <input id="set-domains" class="mfield" style="min-width:340px"
     placeholder="example.com, example.co.uk"
     value="${esc((cd.value || []).join(', '))}">
-  <button class="mini" data-act="save-domains">save</button>
+  <button class="mini" data-act="save-domains">Save</button>
   <div style="margin-top:12px">
     <input id="set-budget_currency" class="mfield" style="min-width:120px"
       placeholder="GBP"
       value="${esc(((s.budget_currency || {}).value) || '')}">
-    <button class="mini" data-act="save-setting" data-key="budget_currency">save</button>
+    <button class="mini" data-act="save-setting" data-key="budget_currency">Save</button>
     <div class="src-note">Preferred currency, for the Budget view: the
     headline converts into it at the ECB's daily reference rate (the rate's
     date is named right beside the number), newly linked tools default to
@@ -3209,7 +3260,7 @@ async function wizard() {
   come back.</p>
   ${extStatusRows()}
   <div style="margin-top:10px">
-    <button class="mini" style="padding:6px 14px" data-act="ext-open">open the extension setup</button>
+    <button class="mini" style="padding:6px 14px" data-act="ext-open">Open the extension setup</button>
     <span class="src-note" style="margin-left:8px">Six short steps: download,
     pack, identity, hosting, Firefox, behaviour. Each value is also editable
     flat under Settings.</span>
@@ -3232,15 +3283,15 @@ async function wizard() {
   under Fleet. Each download gets its own token, so you can revoke one
   rollout without touching the others.</p>
   ${CFG.managed && CFG.managed.artifacts_ready ? `<div style="display:flex;gap:8px;flex-wrap:wrap">
-    <button class="mini" data-act="artifact" data-key="collector-macos">macOS collector</button>
+    <button class="mini" data-act="artifact" data-key="collector-macos">MacOS collector</button>
     <button class="mini" data-act="artifact" data-key="collector-linux">Linux collector</button>
     <button class="mini" data-act="artifact" data-key="collector-windows">Windows collector</button>
     <button class="mini" data-act="artifact" data-key="extension-policy">extension policy · Chromium macOS${eid ? '' : ' (needs step 5)'}</button>
-    <button class="mini" data-act="artifact" data-key="extension-windows">extension deploy · Chromium Windows</button>
-    <button class="mini" data-act="artifact" data-key="firefox-policy">extension policy · Firefox macOS</button>
-    <button class="mini" data-act="artifact" data-key="firefox-windows">extension deploy · Firefox Windows</button>
-    <button class="mini" data-act="artifact" data-key="scanner-cronjob">scanner CronJob</button>
-    <button class="mini" data-act="artifact" data-key="discovery-cronjob">discovery CronJob</button>
+    <button class="mini" data-act="artifact" data-key="extension-windows">Extension deploy · Chromium Windows</button>
+    <button class="mini" data-act="artifact" data-key="firefox-policy">Extension policy · Firefox macOS</button>
+    <button class="mini" data-act="artifact" data-key="firefox-windows">Extension deploy · Firefox Windows</button>
+    <button class="mini" data-act="artifact" data-key="scanner-cronjob">Scanner CronJob</button>
+    <button class="mini" data-act="artifact" data-key="discovery-cronjob">Discovery CronJob</button>
   </div>` : `<div class="note">No public receiver URL yet, so downloads cannot
   bake a URL agents can reach - save one in step 1 and these appear.</div>`}</div>
 
@@ -3285,8 +3336,8 @@ function fleetSettings() {
       <input id="set-domains" class="mfield" style="min-width:340px"
         placeholder="example.com, example.co.uk"
         value="${esc((cd.value || []).join(', '))}">
-      <button class="mini" data-act="save-domains">save</button>
-      ${cd.source === 'db' ? `<button class="mini" data-act="clear-domains">clear (fall back)</button>` : ''}
+      <button class="mini" data-act="save-domains">Save</button>
+      ${cd.source === 'db' ? `<button class="mini" data-act="clear-domains">Clear (fall back)</button>` : ''}
       ${cd.source === 'db' ? '<span class="pill p-mut">saved here</span>'
         : cd.source === 'env' ? '<span class="pill p-mut">from deployment</span>' : ''}
       <div class="src-note fnote">An AI tool signed into one of these counts
@@ -3295,13 +3346,13 @@ function fleetSettings() {
       <input id="set-extid" class="mfield" style="min-width:340px"
         placeholder="the browser extension's ID"
         value="${esc((s.extension_id || {}).value || '')}">
-      <button class="mini" data-act="save-extid">save</button>
+      <button class="mini" data-act="save-extid">Save</button>
       <div class="src-note fnote">Used to generate the extension's managed-policy
       artifact. Empty clears it.</div></dd>
     ${pasteGuardFields()}
   </dl>
   <div style="margin-top:10px">
-    <button class="mini" data-act="ext-open">open the extension setup</button>
+    <button class="mini" data-act="ext-open">Open the extension setup</button>
     <span class="src-note" style="margin-left:8px">The guided version of
     these fields: pack, host and sign, one step at a time.</span>
   </div></div>`;
@@ -3315,7 +3366,7 @@ function connectionSettings() {
       'The URL endpoints reach from OUTSIDE - it gets baked into every downloaded artifact. Not the internal receiver address the portal proxies to.')}
   </dl>
   <div style="margin-top:8px">
-    <button class="mini" data-act="run-test" data-key="receiver-url">probe the saved URL</button>
+    <button class="mini" data-act="run-test" data-key="receiver-url">Probe the saved URL</button>
   </div>${testNote('receiver-url')}</div>
 
   <div class="wcard" style="margin-bottom:10px"><h3>Log store</h3>
@@ -3365,67 +3416,102 @@ function alertingSettings() {
 // difference between "the settings look right" and "somebody got in".
 let SSOW = null;
 
-const SSO_STEPS = ['register', 'tenant', 'client', 'redirect', 'test'];
+const SSO_STEPS = [
+  {k:'register', t:'Register an application', d:'In the Entra admin center'},
+  {k:'tenant',   t:'Your tenant',             d:'Checked against the provider'},
+  {k:'client',   t:'Application and secret',  d:'Proved before anyone signs in'},
+  {k:'redirect', t:'Where sign-ins return',   d:'Must match the registration'},
+  {k:'test',     t:'Verify and enable',       d:'A real sign-in, then enable'},
+];
 
 function ssoOpen() {
   const s = (SETTINGS && SETTINGS.settings) || {};
   const v = k => ((s[k] || {}).value) || '';
   SSOW = {
-    step: 0, busy: false, err: '', ok: {},
+    step: 0, busy: '', err: '', done: {},
     tenant: v('sso_tenant_id'), client: v('sso_client_id'),
     secret: '', redirect: v('sso_redirect_uri') || ssoRedirectGuess(),
     secretSet: !!((s.sso_client_secret || {}).set),
   };
+  // A deployment that has been through this before starts with what it
+  // already proved, rather than asking for it all again.
+  if (SSOW.tenant) SSOW.done.tenant = 'Saved · ' + SSOW.tenant;
+  if (SSOW.client) SSOW.done.client = 'Saved · ' + SSOW.client;
+  if (v('sso_redirect_uri')) SSOW.done.redirect = 'Saved · ' + v('sso_redirect_uri');
+  if (SSOW.tenant) SSOW.done.register = 'done';
   render();
 }
 
 // The redirect URI has to match the app registration exactly, so the page
 // offers the one it would actually use rather than asking somebody to
 // compose it correctly from memory.
-function ssoRedirectGuess() {
-  return location.origin + '/sso/callback';
+function ssoRedirectGuess() { return location.origin + '/sso/callback'; }
+
+function ssoGo(i) {
+  const reach = ssoReach();
+  if (i > reach) return;
+  ssoStash(); SSOW.step = i; SSOW.err = ''; render();
+}
+function ssoReach() {
+  let n = 0;
+  for (const s of SSO_STEPS) { if (SSOW.done[s.k]) n++; else break; }
+  return Math.min(n, SSO_STEPS.length - 1);
+}
+function ssoStash() {
+  const g = id => { const e = document.getElementById(id); return e ? e.value : null; };
+  const t = g('sso-tenant'); if (t !== null) SSOW.tenant = t;
+  const c = g('sso-client'); if (c !== null) SSOW.client = c;
+  const k = g('sso-secret'); if (k) SSOW.secret = k;
+  const r = g('sso-redirect'); if (r !== null) SSOW.redirect = r;
 }
 
 async function ssoProbe(withClient) {
-  SSOW.busy = true; SSOW.err = ''; render();
-  const body = {tenant_id: SSOW.tenant.trim()};
+  ssoStash();
+  SSOW.busy = withClient ? 'client' : 'tenant'; SSOW.err = ''; render();
+  const body = {tenant_id: (SSOW.tenant || '').trim()};
   if (withClient) {
-    body.client_id = SSOW.client.trim();
+    body.client_id = (SSOW.client || '').trim();
     body.client_secret = SSOW.secret;
   }
   const r = await mfetch('/api/sso/probe', {method: 'POST',
     body: JSON.stringify(body)});
-  SSOW.busy = false;
+  SSOW.busy = '';
   if (r.status === 401) { sessionLost(); return false; }
   if (!r.ok) { SSOW.err = await _refusal(r); render(); return false; }
   const out = await r.json();
-  SSOW.issuer = out.issuer || '';
   if (withClient) {
-    SSOW.ok.client = out.client_ok === true;
-    // A tenant can refuse a client-credentials grant for reasons that say
-    // nothing about the credentials - no application permissions
-    // consented, for one. Blocking a correct configuration on that would
-    // be worse than saying what came back.
-    if (!SSOW.ok.client) SSOW.err = 'The pair reached the tenant but it '
-      + 'refused the check: ' + (out.detail || 'no reason given')
-      + '. That can be normal - continue and let the test sign-in decide.';
+    if (out.client_ok === true) {
+      SSOW.done.client = 'Verified · ' + SSOW.client;
+    } else {
+      // A tenant can refuse a client-credentials grant for reasons that
+      // say nothing about the credentials - unconsented application
+      // permissions, for one. Blocking a correct configuration on that
+      // would be worse than saying what came back.
+      SSOW.done.client = 'Accepted · ' + SSOW.client;
+      SSOW.err = 'The tenant took the pair but refused the check: '
+        + (out.detail || 'no reason given')
+        + ' That can be normal. The test sign-in at the end decides.';
+    }
   } else {
-    SSOW.ok.tenant = true;
+    SSOW.done.tenant = 'Reached · ' + SSOW.tenant;
+    SSOW.issuer = out.issuer || '';
   }
+  if (SSOW.step < SSO_STEPS.length - 1) SSOW.step++;
   render();
   return true;
 }
 
 async function ssoSave(enable) {
-  SSOW.busy = true; SSOW.err = ''; render();
-  const body = {sso_tenant_id: SSOW.tenant.trim(),
-                sso_client_id: SSOW.client.trim(),
-                sso_redirect_uri: SSOW.redirect.trim()};
+  ssoStash();
+  SSOW.busy = 'save'; SSOW.err = ''; render();
+  const body = {sso_tenant_id: (SSOW.tenant || '').trim(),
+                sso_client_id: (SSOW.client || '').trim(),
+                sso_redirect_uri: (SSOW.redirect || '').trim()};
   if (SSOW.secret) body.sso_client_secret = SSOW.secret;
   if (enable !== undefined) body.sso_enabled = enable ? '1' : '';
   const r = await mfetch('/api/settings', {method: 'POST',
     body: JSON.stringify(body)});
-  SSOW.busy = false;
+  SSOW.busy = '';
   if (r.status === 401) { sessionLost(); return false; }
   if (!r.ok) { SSOW.err = await _refusal(r); render(); return false; }
   SETTINGS = await r.json();
@@ -3434,91 +3520,160 @@ async function ssoSave(enable) {
   return true;
 }
 
-function ssoWizard() {
-  const step = SSO_STEPS[SSOW.step];
-  const nav = (back, next, nextLabel) => `<div style="margin-top:14px;
-    display:flex;gap:8px;align-items:center">
-    <button class="mini" data-act="sso-close">close</button>
-    <span style="margin-left:auto"></span>
-    ${back ? '<button class="mini" data-act="sso-back">back</button>' : ''}
-    ${next ? `<button class="mini" data-act="${next}"${SSOW.busy
-      ? ' disabled' : ''}>${SSOW.busy ? 'checking…' : nextLabel}</button>` : ''}
-  </div>`;
+// The test sign-in happens in a second tab, so its result comes back by
+// message rather than by return value. Same origin both ways; anything
+// from anywhere else is ignored.
+window.addEventListener('message', e => {
+  if (e.origin !== location.origin || !SSOW) return;
+  const d = e.data || {};
+  if (d.ssoTest === 'ok') {
+    SSOW.done.test = 'Signed in as ' + (d.username || 'your account');
+    SSOW.err = '';
+  } else if (d.ssoTest === 'fail') {
+    SSOW.err = String(d.detail || 'that sign-in was refused');
+  } else { return; }
+  SSOW.busy = ''; render();
+});
+
+function ssoBody(k) {
+  const busy = SSOW.busy === k;
   const err = SSOW.err ? `<div class="note" style="border-color:var(--warn)"
     >${esc(SSOW.err)}</div>` : '';
-  const dots = `<div id="tour-dots" style="margin-bottom:12px">${
-    SSO_STEPS.map((_, i) => `<i class="${i === SSOW.step ? 'on' : ''}"></i>`
-    ).join('')}</div>`;
+  if (k === 'register') return `
+    <h4>Register an application</h4>
+    <p class="lede">First you will need to create an app registration in
+      Microsoft Entra.</p>
+    <p class="lede">In the Entra admin center go to <span class="mono">Entra ID
+      &rarr; App registrations &rarr; New registration</span>. Give it a name
+      your team will recognise, leave the account types on single tenant, and
+      add a <b>Web</b> platform with this redirect URI:</p>
+    <div class="sscopy"><span class="mono">${esc(ssoRedirectGuess())}</span>
+      <button class="mini" data-act="sso-copy">Copy</button></div>
+    <p class="lede" style="font-size:12.5px">Paste it exactly. Entra matches it
+      character for character, and a trailing slash is a different address as
+      far as it is concerned.</p>
+    <button class="sshelp" data-act="sso-help">Where do I find the values I
+      will need?</button>
+    ${SSOW.help ? `<div class="sshelpbody"><ol>
+      <li><b>Directory (tenant) ID</b> - the registration's Overview page.</li>
+      <li><b>Application (client) ID</b> - the same page, just above it.</li>
+      <li><b>Client secret</b> - Certificates &amp; secrets &rarr; New client
+        secret. Copy the <b>Value</b> straight away; Entra shows it once and
+        never again.</li></ol></div>` : ''}
+    ${err}<div class="ssacts">
+      <button class="mini" data-act="sso-registered">Registered</button></div>`;
+  if (k === 'tenant') return `
+    <h4>Your tenant</h4>
+    <p class="lede">Your tenant is your organisation's directory in Entra.
+      Paste its ID here - it is on the Overview page of the registration you
+      just made, labelled <b>Directory (tenant) ID</b>. Your tenant domain
+      works too if you would rather use that.</p>
+    <p><input id="sso-tenant" class="mfield" style="min-width:340px"
+      placeholder="00000000-0000-0000-0000-000000000000"
+      value="${esc(SSOW.tenant)}"></p>
+    <p class="lede" style="font-size:12.5px">We will ask Microsoft about it
+      before anything is saved, so a typo shows up now rather than at the
+      end.</p>
+    ${SSOW.done.tenant && SSOW.issuer ? `<div class="note">Found it. Sign-ins
+      will be issued by <span class="mono">${esc(SSOW.issuer)}</span></div>` : ''}
+    ${err}<div class="ssacts"><button class="mini" data-act="sso-check-tenant"
+      ${busy ? 'disabled' : ''}>${busy
+        ? '<span class="ssspin"></span>Checking with Microsoft…' : 'Verify'}</button></div>`;
+  if (k === 'client') return `
+    <h4>Application and secret</h4>
+    <p class="lede">Two values from the registration you just made: the
+      <b>Application (client) ID</b> from its Overview page, and the client
+      secret you created under Certificates &amp; secrets.</p>
+    <p><input id="sso-client" class="mfield" style="min-width:340px"
+      placeholder="Application (client) ID" value="${esc(SSOW.client)}"></p>
+    <p><input id="sso-secret" class="mfield" type="password"
+      style="min-width:340px" autocomplete="new-password"
+      placeholder="${SSOW.secretSet ? 'Stored - leave blank to keep it'
+                                    : 'Client secret value'}"></p>
+    <p class="lede" style="font-size:12.5px">If you did not copy the secret
+      when you created it, you will need to make a new one - Entra only shows
+      the value once. We will ask Microsoft for a token with these now, so a
+      wrong secret is caught here instead of by the first person who tries to
+      sign in.</p>
+    ${err}<div class="ssacts"><button class="mini" data-act="sso-check-client"
+      ${busy ? 'disabled' : ''}>${busy
+        ? '<span class="ssspin"></span>Checking with Microsoft…'
+        : 'Verify application'}</button></div>`;
+  if (k === 'redirect') return `
+    <h4>Where sign-ins return</h4>
+    <p class="lede">When somebody finishes signing in, Entra sends them back
+      here. This has to be the exact URI you put on the app registration. The
+      address shown below is the one you are using to access the portal
+      currently.</p>
+    <p><input id="sso-redirect" class="mfield" style="min-width:340px"
+      value="${esc(SSOW.redirect)}"></p>
+    <p class="lede" style="font-size:12.5px">If your team reaches the portal on
+      more than one address, add every one of them to the registration and put
+      the one you want sign-ins to land on here.</p>
+    <div class="note">Saving does not switch single sign-on on. That is the
+      last step, and only after a real sign-in has worked.</div>
+    ${err}<div class="ssacts"><button class="mini" data-act="sso-save"
+      ${SSOW.busy === 'Save' ? 'disabled' : ''}>${SSOW.busy === 'Save'
+        ? '<span class="ssspin"></span>Saving…' : 'Save and continue'}</button></div>`;
+  return `
+    <h4>Verify and enable</h4>
+    <p class="lede">Config saved. Single sign-on is still disabled. To enable
+      it, complete the verification by clicking Test sign-in.</p>
+    <p class="lede">This opens Microsoft in a new tab. Come back here and you
+      will either see who you signed in as, or the reason it did not work.</p>
+    <div class="note">Your account needs an email address on it matching the
+      one you sign in with. An account with no address can only be reached with
+      its password - which is how you would keep a shared break-glass login out
+      of Entra's reach.</div>
+    ${SSOW.done.test ? `<div class="note" style="border-color:var(--pri)"
+      >${esc(SSOW.done.test)}</div>` : ''}
+    ${err}<div class="ssacts">
+      <button class="mini" data-act="sso-try" ${busy ? 'disabled' : ''}>${busy
+        ? '<span class="ssspin"></span>Waiting for Microsoft…' : 'Test sign-in'}</button>
+      <button class="mini" data-act="sso-enable"
+        ${SSOW.done.test && SSOW.busy !== 'Save' ? '' : 'disabled'}>${
+        SSOW.busy === 'Save' ? '<span class="ssspin"></span>Turning it on…'
+                             : 'Turn on single sign-on'}</button>
+      ${SSOW.done.test ? '' : `<span class="lede" style="font-size:12.5px"
+        >unlocks once a sign-in works</span>`}</div>`;
+}
 
-  const body = {
-    register: `<h3>1 · Register an application</h3>
-      <p class="lede">In the Microsoft Entra admin center, go to
-      <span class="mono">Entra ID → App registrations → New registration</span>.
-      Give it any name, leave the account types on single tenant, and add a
-      <b>Web</b> platform with this exact redirect URI:</p>
-      <p><span class="mono" style="user-select:all">${esc(ssoRedirectGuess())}</span></p>
-      <p class="src-note">Then open <span class="mono">Certificates &amp;
-      secrets</span> and create a client secret. Copy its <b>value</b> now -
-      Entra shows it once. You will need the directory (tenant) ID and the
-      application (client) ID from the overview page as well.</p>`,
-
-    tenant: `<h3>2 · Your tenant</h3>
-      <p class="lede">The directory (tenant) ID from the app registration's
-      overview page, or your tenant's domain. This is checked against the
-      provider before anything is saved.</p>
-      <p><input id="sso-tenant" class="mfield" style="min-width:340px"
-        placeholder="00000000-0000-0000-0000-000000000000"
-        value="${esc(SSOW.tenant)}"></p>
-      ${SSOW.ok.tenant ? `<div class="note">Reached it. Tokens will be
-        issued by <span class="mono">${esc(SSOW.issuer || '')}</span>.</div>`
-        : ''}`,
-
-    client: `<h3>3 · The application</h3>
-      <p class="lede">The application (client) ID, and the secret value you
-      copied. The pair is checked against the tenant now, so a wrong secret
-      is found here rather than by the first person who tries to sign in.</p>
-      <p><input id="sso-client" class="mfield" style="min-width:340px"
-        placeholder="application (client) ID"
-        value="${esc(SSOW.client)}"></p>
-      <p><input id="sso-secret" class="mfield" type="password"
-        style="min-width:340px" autocomplete="new-password"
-        placeholder="${SSOW.secretSet ? 'stored - leave blank to keep it'
-                                      : 'client secret value'}"></p>
-      ${SSOW.ok.client ? '<div class="note">That pair works.</div>' : ''}`,
-
-    redirect: `<h3>4 · Where sign-ins come back to</h3>
-      <p class="lede">This has to match the redirect URI on the app
-      registration exactly. It is filled in with the address this portal is
-      being used on.</p>
-      <p><input id="sso-redirect" class="mfield" style="min-width:340px"
-        value="${esc(SSOW.redirect)}"></p>
-      <p class="src-note">If people reach the portal on more than one
-      address, register every one of them and set the one you want sign-ins
-      to land on.</p>`,
-
-    test: `<h3>5 · Prove it works</h3>
-      <p class="lede">Saved, and off. The last step is a real sign-in: this
-      opens the provider in a new tab and comes back with an account, or
-      with the reason it could not. Nothing is switched on until that
-      succeeds - a misconfigured provider that is already enabled is a
-      deployment nobody can sign in to.</p>
-      <p class="src-note">Your account needs an email address set on it
-      first, matching the one you sign in with. An account with no address
-      is reachable only by password, which is how a shared break-glass
-      credential stays out of the provider's reach.</p>
-      <p><button class="mini" data-act="sso-try">open a test sign-in</button>
-        <button class="mini" data-act="sso-enable">turn it on</button></p>`,
-  }[step];
-
-  return `<div class="wcard" style="margin-bottom:10px">
-    ${dots}${err}${body}
-    ${nav(SSOW.step > 0,
-          step === 'tenant' ? 'sso-check-tenant'
-          : step === 'client' ? 'sso-check-client'
-          : step === 'redirect' ? 'sso-save'
-          : step === 'test' ? '' : 'sso-next',
-          step === 'redirect' ? 'save' : 'next')}
-  </div>`;
+function ssoWizard() {
+  const reach = ssoReach();
+  const n = SSO_STEPS.filter(s => SSOW.done[s.k]).length;
+  return `<div class="ssow">
+    <div class="ssrail">
+      <h3>Setup</h3>
+      <ol>${SSO_STEPS.map((s, i) => {
+        const d = SSOW.done[s.k], on = i === SSOW.step;
+        const locked = i > reach && !on, busy = SSOW.busy === s.k;
+        return `<li class="ssstep ${d ? 'done' : ''} ${on ? 'on' : ''}
+          ${locked ? 'locked' : ''}"${locked ? '' : ` data-act="sso-step"
+          data-key="${i}"`}>
+          <span class="dot">${busy
+            ? '<span class="ssspin" style="margin:0"></span>'
+            : d ? '&#10003;' : i + 1}</span>
+          <span style="min-width:0"><span class="t">${esc(s.t)}</span>
+          ${d && d !== 'done'
+            ? `<span class="val">${esc(d)}</span>`
+            : `<span class="pend">${busy ? 'checking…' : esc(s.d)}</span>`}</span>
+        </li>`;
+      }).join('')}</ol>
+      <div class="sssum">
+        <div class="lede" style="font-size:11.5px">${n} of ${SSO_STEPS.length} verified</div>
+        <div class="barwrap"><div class="bar"
+          style="width:${n / SSO_STEPS.length * 100}%"></div></div>
+        <div class="lede" style="font-size:11.5px">Single sign-on turns on only
+          when every step is ticked.</div>
+      </div>
+    </div>
+    <div class="ssmain">${ssoBody(SSO_STEPS[SSOW.step].k)}
+      <div class="ssfoot"><button class="mini" data-act="sso-close">Close</button>
+        <span class="sp"></span>
+        ${SSOW.step > 0 ? `<button class="mini" data-act="sso-step"
+          data-key="${SSOW.step - 1}">Back</button>` : ''}
+      </div>
+    </div></div>`;
 }
 
 function accountSettings() {
@@ -3547,12 +3702,12 @@ function accountSettings() {
         ? `<input id="ue-new" class="mfield" style="min-width:190px"
              placeholder="name@example.com" value="${esc(u.email || '')}"
              autocomplete="off">
-           <button class="mini" data-act="user-email" data-key="${esc(u.id)}">set</button>
-           <button class="mini" data-act="user-email-cancel">cancel</button>`
+           <button class="mini" data-act="user-email" data-key="${esc(u.id)}">Set</button>
+           <button class="mini" data-act="user-email-cancel">Cancel</button>`
         : `${u.email ? `<span class="mono">${esc(u.email)}</span>`
                      : '<span style="color:var(--mut)">not set</span>'}${may
             ? ` <button class="mini" data-act="user-email-form"
-                 data-key="${esc(u.id)}">edit</button>` : ''}`}</td>
+                 data-key="${esc(u.id)}">Edit</button>` : ''}`}</td>
       <td>${may
         ? `<select class="mfield" data-role-for="${esc(u.id)}" style="min-width:100px">
              ${ROLE_ORDER.filter(r => (RANK[r] || 0) <= mine).map(r =>
@@ -3564,10 +3719,10 @@ function accountSettings() {
       <td class="nw">${URFORM === u.id
         ? `<input id="ur-new" class="mfield" type="password" style="min-width:190px"
              placeholder="new password (12+)" autocomplete="new-password">
-           <button class="mini" data-act="user-reset" data-key="${esc(u.id)}">set</button>
-           <button class="mini" data-act="user-reset-cancel">cancel</button>`
-        : may ? `<button class="mini" data-act="user-reset-form" data-key="${esc(u.id)}">reset password</button>
-           <button class="mini" data-act="user-delete" data-key="${esc(u.id)}">delete</button>` : ''}</td>
+           <button class="mini" data-act="user-reset" data-key="${esc(u.id)}">Set</button>
+           <button class="mini" data-act="user-reset-cancel">Cancel</button>`
+        : may ? `<button class="mini" data-act="user-reset-form" data-key="${esc(u.id)}">Reset password</button>
+           <button class="mini" data-act="user-delete" data-key="${esc(u.id)}">Delete</button>` : ''}</td>
     </tr>`;}).join('')}</table>
     <div style="margin-top:12px;display:flex;gap:8px;flex-wrap:wrap;align-items:center">
       <input id="user-name" class="mfield" placeholder="username"
@@ -3584,7 +3739,7 @@ function accountSettings() {
           (RANK[r] || 0) <= (RANK[(AUTH && AUTH.role) || 'viewer'] || 0)
         ).map(r => `<option value="${r}">${r}</option>`).join('')}
       </select>
-      <button class="mini" data-act="user-create">add account</button>
+      <button class="mini" data-act="user-create">Add account</button>
     </div>
     <p class="src-note">An email address is what a federated sign-in would
     match on; an account without one can only be reached with its password,
@@ -3604,33 +3759,37 @@ function accountSettings() {
         placeholder="current password" autocomplete="current-password">
       <input id="set-newpass" class="mfield" type="password"
         placeholder="new password (12+ characters)" autocomplete="new-password">
-      <button class="mini" data-act="change-password">change</button>
+      <button class="mini" data-act="change-password">Change</button>
       <div class="src-note">Every other session is signed out with the old
       password; this one stays.</div></dd>
   </dl></div>
 
-  ${AUTH && AUTH.role === 'owner' ? `<div class="wcard" style="margin-bottom:10px">
+  ${AUTH && AUTH.role === 'owner' ? (SSOW ? ssoWizard() : `<div class="wcard"
+    style="margin-bottom:10px">
     <h3>Single sign-on</h3>
-    ${SSOW ? '' : `<p class="lede">${
-      ((SETTINGS && SETTINGS.settings && SETTINGS.settings.sso_enabled
-        && SETTINGS.settings.sso_enabled.value) === '1')
-      ? 'On. People with an email address on their account can sign in '
-        + 'through Microsoft Entra. Passwords keep working, so an account '
-        + 'without an address stays reachable as a break-glass credential.'
-      : 'Off. Sign in with Microsoft Entra instead of a portal password. '
-        + 'Five steps, each one checked, ending in a real sign-in - nothing '
-        + 'is switched on until that works.'}</p>
+    ${`${(() => {
+      const on = ((SETTINGS && SETTINGS.settings && SETTINGS.settings.sso_enabled
+        && SETTINGS.settings.sso_enabled.value) === '1');
+      return `<p style="margin:0 0 6px"><span class="pill p-ok">${
+        on ? 'On' : 'Off'}</span></p>
+      <p class="lede">${on
+        ? 'People with an email address on their account can sign in through '
+          + 'Microsoft Entra. Passwords keep working, so an account without '
+          + 'an address stays reachable as a break-glass credential.'
+        : 'Sign in with Microsoft Entra instead of a portal password. Five '
+          + 'step process through an interactive wizard.'}</p>`;
+    })()}
       <p><button class="mini" data-act="sso-open">${
         ((SETTINGS && SETTINGS.settings && SETTINGS.settings.sso_enabled
           && SETTINGS.settings.sso_enabled.value) === '1')
-        ? 'review the configuration' : 'set it up'}</button></p>`}
-  </div>${SSOW ? ssoWizard() : ''}` : ''}
+        ? 'Review the configuration' : 'Set it up'}</button></p>`}
+  </div>`) : ''}
   <p class="src-note" style="margin:4px 0 14px">
-    <button class="mini" data-act="open-wizard">run the setup wizard again</button>
+    <button class="mini" data-act="open-wizard">Run the setup wizard again</button>
     — safe to repeat: every step is one of these settings, prefilled
     with what is saved.</p>
   <p class="src-note" style="margin:4px 0 14px">
-    <button class="mini" data-act="take-tour">take the tour again</button>
+    <button class="mini" data-act="take-tour">Take the tour again</button>
     — the walkthrough from your first sign-in. It shows the pages your
     account can act on, so an admin and a viewer see different tours.</p>`;
 }
@@ -3836,7 +3995,7 @@ function setup() {
     return `It does not cover <strong>${un.length}</strong> of
       ${ents(G.devices || {}).length} devices, which show as unattributed -
       a legitimate answer, and one you can shorten:
-      <button class="mini" data-nav="people">edit the map on People</button>`;
+      <button class="mini" data-nav="people">Edit the map on People</button>`;
   })()}</p>`
   : `<details class="how" style="margin:0 0 14px"><summary>how to build the map</summary><div>
   <ol style="padding-left:18px;line-height:2;margin:6px 0">
@@ -3983,9 +4142,9 @@ async function fleet() {
                        : '<span class="pill p-mut">revoked</span>')
                        : '<span class="pill p-ok">active</span>'}</td>
     <td>${!d.revoked_at
-            ? `<button class="mini" data-act="revoke-device" data-key="${esc(d.id)}">revoke</button>`
+            ? `<button class="mini" data-act="revoke-device" data-key="${esc(d.id)}">Revoke</button>`
             : (d.reenroll_allowed_at ? ''
-               : `<button class="mini" data-act="allow-reenroll" data-key="${esc(d.id)}">allow re-enrollment</button>`)}</td>
+               : `<button class="mini" data-act="allow-reenroll" data-key="${esc(d.id)}">Allow re-enrollment</button>`)}</td>
   </tr>`).join('')}</table>`
   : `<div class="note">${(() => {
       // An empty enrollment list beside a reporting fleet is not a
@@ -4021,12 +4180,12 @@ async function tokens() {
   Revoke it here when a rollout is done or a token leaks.</p>
   ${MINTED ? (MINTED.error
     ? `<div class="note">${esc(MINTED.error)}
-       <button class="mini" data-act="dismiss-minted">dismiss</button></div>`
+       <button class="mini" data-act="dismiss-minted">Dismiss</button></div>`
     : `<div class="tokpane"><strong>Token ${esc(MINTED.id)} minted.</strong>
        This is the only time it is shown — the receiver stores a hash.
        <br><code>${esc(MINTED.token)}</code><br>
-       <button class="mini" data-act="copy" data-copy="${esc(MINTED.token)}">copy</button>
-       <button class="mini" data-act="dismiss-minted">done, I've saved it</button>
+       <button class="mini" data-act="copy" data-copy="${esc(MINTED.token)}">Copy</button>
+       <button class="mini" data-act="dismiss-minted">Done, I've saved it</button>
        </div>`) : ''}
   <div style="margin:10px 0 16px">
     <input id="mint-note" class="mfield" placeholder="note, e.g. macOS Jamf rollout">
@@ -4040,7 +4199,7 @@ async function tokens() {
     <td class="mono">${esc(t.id)}</td><td>${esc(t.note || '—')}</td>
     <td>${when(t.created_at)}</td><td>${when(t.expires_at)}</td>
     <td><span class="pill ${cls}">${lbl}</span></td>
-    <td>${lbl === 'active' ? `<button class="mini" data-act="revoke-token" data-key="${esc(t.id)}">revoke</button>` : ''}</td>
+    <td>${lbl === 'active' ? `<button class="mini" data-act="revoke-token" data-key="${esc(t.id)}">Revoke</button>` : ''}</td>
   </tr>`; }).join('')}</table>` : '<div class="note">No enrollment tokens yet.</div>'}`;
 }
 
@@ -4538,7 +4697,7 @@ function budgetWizard() {
           counts as observed, and the spend is counted once.</div></dd>`;
       })()}
     </dl>
-    <button class="mini" data-act="b-step" data-key="2">next</button>` : ''}
+    <button class="mini" data-act="b-step" data-key="2">Next</button>` : ''}
   ${step(2) ? `
     <p style="margin-top:0"><strong>Where does the member list come from?</strong></p>
     <div id="bw-source" style="margin-bottom:12px">
@@ -4575,8 +4734,8 @@ function budgetWizard() {
     ${w.source === 'csv' ? `<p class="src-note" style="margin:0 0 10px">The
       paste box comes right after the last step - link the tool first, then
       drop the export in.</p>` : ''}
-    <button class="mini" data-act="b-step" data-key="1">back</button>
-    <button class="mini" data-act="b-step" data-key="3">next</button>` : ''}
+    <button class="mini" data-act="b-step" data-key="1">Back</button>
+    <button class="mini" data-act="b-step" data-key="3">Next</button>` : ''}
   ${step(3) ? `
     <p style="margin-top:0"><strong>Seats and pricing</strong></p>
     ${bTierRows(w.tiers, [w.tool_id].concat(w.covers || []))}
@@ -4594,10 +4753,10 @@ function budgetWizard() {
     ${(w.covers || []).length ? 'Per-tier coverage is how "premium includes '
       + 'claude-code, standard does not" is said - it powers the '
       + 'seat-economics findings on the card.' : ''}</p>
-    <button class="mini" data-act="b-step" data-key="2">back</button>
-    <button class="mini" data-act="b-save">${w.editing ? 'save changes' : 'link tool'}</button>` : ''}
+    <button class="mini" data-act="b-step" data-key="2">Back</button>
+    <button class="mini" data-act="b-save">${w.editing ? 'Save changes' : 'Link tool'}</button>` : ''}
   <p class="src-note" style="margin-bottom:0">
-    <button class="mini" data-act="b-cancel">cancel</button></p>
+    <button class="mini" data-act="b-cancel">Cancel</button></p>
   </div>`;
 }
 
@@ -4679,7 +4838,7 @@ function budgetCard(sub) {
     <td>${esc(m.role || '—')}</td><td>${esc(m.seat_tier || '—')}</td>
     <td>${esc(usageBits(m)) || '<span class="src-note">—</span>'}</td>
     <td>${m.source === 'manual' && !ro
-      ? `<button class="mini" data-act="b-mdel" data-tool="${esc(sub.tool_id)}" data-key="${esc(m.email)}">remove</button>`
+      ? `<button class="mini" data-act="b-mdel" data-tool="${esc(sub.tool_id)}" data-key="${esc(m.email)}">Remove</button>`
       : `<span class="pill p-mut">${esc(m.source)}</span>`}</td></tr>`;
   // The same licence linked twice, from before covers existed: name the
   // fold-together steps on the card rather than leave the double count
@@ -4782,15 +4941,15 @@ function budgetCard(sub) {
     with no person attached - not counted anywhere
     above. An identity map (Sources view) links them.</p>` : ''}
   ${ro ? '' : `<div style="margin-top:10px;display:flex;gap:6px;flex-wrap:wrap">
-    ${conn ? `<button class="mini" data-act="b-sync" data-key="${esc(sub.tool_id)}">sync users now</button>` : ''}
-    <button class="mini" data-act="b-edit" data-key="${esc(sub.tool_id)}">edit</button>
-    <button class="mini" data-act="b-import" data-key="${esc(sub.tool_id)}">import users</button>
-    <button class="mini" data-act="b-unlink" data-key="${esc(sub.tool_id)}">unlink</button>
+    ${conn ? `<button class="mini" data-act="b-sync" data-key="${esc(sub.tool_id)}">Sync users now</button>` : ''}
+    <button class="mini" data-act="b-edit" data-key="${esc(sub.tool_id)}">Edit</button>
+    <button class="mini" data-act="b-import" data-key="${esc(sub.tool_id)}">Import users</button>
+    <button class="mini" data-act="b-unlink" data-key="${esc(sub.tool_id)}">Unlink</button>
   </div>
   <div style="margin-top:8px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
     <input id="bm-email-${esc(sub.tool_id)}" class="mfield" placeholder="add member: email" autocomplete="off">
     <input id="bm-tier-${esc(sub.tool_id)}" class="mfield" style="min-width:110px" placeholder="seat tier">
-    <button class="mini" data-act="b-madd" data-key="${esc(sub.tool_id)}">add</button>
+    <button class="mini" data-act="b-madd" data-key="${esc(sub.tool_id)}">Add</button>
   </div>`}
   </div>`;
 }
@@ -4809,8 +4968,8 @@ function budgetImport() {
   <textarea id="b-csv" class="mfield" style="width:100%;min-height:140px;font-family:var(--monofont,monospace)"
     placeholder="email,role,seat type&#10;jane@corp.example,member,premium">${esc(BCSV.text || '')}</textarea>
   <div style="margin-top:8px;display:flex;gap:6px">
-    <button class="mini" data-act="b-csv-parse">preview</button>
-    <button class="mini" data-act="b-csv-cancel">cancel</button>
+    <button class="mini" data-act="b-csv-parse">Preview</button>
+    <button class="mini" data-act="b-csv-cancel">Cancel</button>
     ${parsed && parsed.members.length ? `<button class="mini" data-act="b-csv-save">import ${parsed.members.length} members</button>` : ''}
   </div>
   ${parsed ? `${parsed.headerless ? `<p class="src-note" style="color:var(--warn)">These
@@ -4973,10 +5132,10 @@ function budgetReport() {
   };
 
   return `<div class="noprint" style="display:flex;gap:6px;flex-wrap:wrap;margin-bottom:14px;align-items:center">
-    <button class="mini" data-act="b-report-back">back to Budget</button>
-    <button class="mini" data-act="b-report-print">print / save as PDF</button>
-    <button class="mini" data-act="b-report-csv">download CSV</button>
-    <button class="mini" data-act="b-report-names">${BRNAMES ? 'withhold names' : 'show names'}</button>
+    <button class="mini" data-act="b-report-back">Back to Budget</button>
+    <button class="mini" data-act="b-report-print">Print / save as PDF</button>
+    <button class="mini" data-act="b-report-csv">Download CSV</button>
+    <button class="mini" data-act="b-report-names">${BRNAMES ? 'Withhold names' : 'Show names'}</button>
     <span class="src-note" style="margin:0">${BRNAMES
       ? 'Names are shown. Withhold them for wider circulation - the counts stay.'
       : 'Names are withheld: counts only, in the page and in the CSV.'}</span>
@@ -5054,7 +5213,7 @@ async function budget() {
     detection data already holds.</div>`}
   <p style="margin-top:10px">
     ${ro ? '' : '<button class="mini" data-act="b-open">Link a tool</button>'}
-    ${subs.length ? '<button class="mini" data-act="b-report">share / export</button>' : ''}</p>
+    ${subs.length ? '<button class="mini" data-act="b-report">Share / export</button>' : ''}</p>
   <p class="src-note">Automatic user sync currently supports
   ${ents((BUDGET.providers) || {}).map(([, p]) => esc(p.label)).join(' and ') || 'no vendors yet'}.
   More vendors will be added for automatic configuration - if you want a
@@ -5376,17 +5535,21 @@ async function managedAction(act, el) {
   if (act === 'take-tour') { await tourStart(); return; }
   if (act === 'sso-open') { ssoOpen(); return; }
   if (act === 'sso-close') { SSOW = null; render(); return; }
-  if (act === 'sso-back') { SSOW.step--; SSOW.err = ''; render(); return; }
-  if (act === 'sso-next') { SSOW.step++; SSOW.err = ''; render(); return; }
-  if (act === 'sso-check-tenant') {
-    SSOW.tenant = _val('sso-tenant');
-    if (await ssoProbe(false)) { SSOW.step++; render(); }
+  if (act === 'sso-help') { SSOW.help = !SSOW.help; render(); return; }
+  if (act === 'sso-step') { ssoGo(+el.getAttribute('data-key')); return; }
+  if (act === 'sso-copy') {
+    try { await navigator.clipboard.writeText(ssoRedirectGuess());
+      el.textContent = 'copied';
+      setTimeout(() => { el.textContent = 'copy'; }, 1400);
+    } catch (e) { el.textContent = 'select it and copy'; }
     return;
   }
+  if (act === 'sso-registered') {
+    SSOW.done.register = 'done'; SSOW.step = 1; SSOW.err = ''; render(); return;
+  }
+  if (act === 'sso-check-tenant') { await ssoProbe(false); return; }
   if (act === 'sso-check-client') {
-    SSOW.client = _val('sso-client');
-    const typed = _val('sso-secret');
-    if (typed) SSOW.secret = typed;
+    ssoStash();
     if (!SSOW.secret && !SSOW.secretSet) {
       SSOW.err = 'A client secret is needed to check the pair.';
       render(); return;
@@ -5394,21 +5557,32 @@ async function managedAction(act, el) {
     // With a stored secret and nothing typed there is nothing to check
     // against - the receiver never hands a secret back - so the step
     // passes through and the test sign-in is what proves it.
-    if (!SSOW.secret) { SSOW.step++; render(); return; }
-    await ssoProbe(true);
-    SSOW.step++; render(); return;
+    if (!SSOW.secret) {
+      SSOW.done.client = 'Saved · ' + SSOW.client;
+      SSOW.step = 3; SSOW.err = ''; render(); return;
+    }
+    await ssoProbe(true); return;
   }
   if (act === 'sso-save') {
-    SSOW.redirect = _val('sso-redirect');
     // Saved OFF. Enabling is the last step and needs a real sign-in.
-    if (await ssoSave(false)) { SSOW.step++; SSOW.err = ''; render(); }
+    if (await ssoSave(false)) {
+      SSOW.done.redirect = 'Saved · ' + SSOW.redirect;
+      SSOW.step = 4; SSOW.err = ''; render();
+    }
     return;
   }
-  if (act === 'sso-try') { window.open('/sso/start', '_blank', 'noopener'); return; }
+  if (act === 'sso-try') {
+    // Not noopener: the new tab reports its result back by postMessage,
+    // and that needs an opener to report to. Same origin both ways.
+    SSOW.busy = 'test'; SSOW.err = ''; render();
+    window.open('/sso/start', 'aiguard-sso-test');
+    return;
+  }
   if (act === 'sso-enable') {
     if (await ssoSave(true)) {
-      SSOW = null; SETMSG = 'Single sign-on is on. Local passwords keep '
-        + 'working, so a break-glass account is still a way in.';
+      SSOW = null;
+      SETMSG = 'Single sign-on is on. Local passwords keep working, so a '
+        + 'break-glass account is still a way in.';
       render();
     }
     return;
@@ -5924,7 +6098,7 @@ function overviewTools() {
   const hidden = overviewWidgets().hidden.length;
   return `${hidden ? `<button class="mini" data-act="ov-showall"
     >show all (${hidden} hidden)</button>` : ''}
-    <button class="mini" data-act="ov-edit">edit</button>`;
+    <button class="mini" data-act="ov-edit">Edit</button>`;
 }
 
 // Did the estate data actually arrive? Every "none seen, and that is a
@@ -6277,7 +6451,7 @@ const TOURS = {
      body: 'This is every AI tool your estate is actually using - the '
          + 'browser, laptops, your cloud tenant - and the accounts behind '
          + 'it. Two minutes and you will know where to look for what.',
-     ok: 'start'},
+     ok: 'Start'},
     {view: 'overview', sel: '[data-tour="stats"]',
      title: 'The numbers that matter',
      body: 'Personal accounts first, because that is the one worth acting '
@@ -6325,7 +6499,7 @@ const TOURS = {
      body: 'This account reads every page and changes nothing - made for '
          + 'the auditor and the exec. Same tour as an admin gets, with who '
          + 'to ask where a page needs a change.',
-     ok: 'start'},
+     ok: 'Start'},
     {view: 'overview', sel: '[data-tour="stats"]',
      title: 'The numbers that matter',
      body: 'Personal accounts first, because that is the one worth acting '
@@ -6388,7 +6562,7 @@ const TOUR_AFTER_WIZARD = {
       + 'numbers come from - including which of them depend on what you '
       + 'just configured. It stays in Settings, so not now does not mean '
       + 'never.',
-  ok: 'show me around', no: 'not now'};
+  ok: 'Show me around', no: 'Not now'};
 
 // Shown instead of a welcome to somebody who has taken the other role's
 // tour already: they know the pages, and what they need is the delta.
@@ -6400,7 +6574,7 @@ const TOUR_ROLE_CHANGED = {
         + 'decisions, accounts, and device enrolment. A short walkthrough '
         + 'covers where those live; it is in Settings if you would rather '
         + 'not now.',
-    ok: 'show me', no: 'no thanks'},
+    ok: 'Show me', no: 'No thanks'},
   viewer: {
     title: 'This account is read-only now',
     body: 'Someone changed it from admin to viewer. Every page still works '
@@ -6408,7 +6582,7 @@ const TOUR_ROLE_CHANGED = {
         + 'refuses with a line saying so rather than failing quietly. A '
         + 'short walkthrough covers what you can still do and who to ask '
         + 'for the rest.',
-    ok: 'show me', no: 'no thanks'},
+    ok: 'Show me', no: 'No thanks'},
 };
 
 let TOUR = null;
@@ -6563,10 +6737,10 @@ function tourPaint(el, st) {
     <div id="tour-foot">
       <div id="tour-dots">${TOUR.steps.map((_, n) =>
         `<i class="${n === TOUR.i ? 'on' : ''}"></i>`).join('')}</div>
-      <button class="ghost" data-tour-act="skip">${esc(st.no || 'end tour')}</button>
-      ${TOUR.i > 0 ? '<button data-tour-act="back">back</button>' : ''}
+      <button class="ghost" data-tour-act="skip">${esc(st.no || 'End tour')}</button>
+      ${TOUR.i > 0 ? '<button data-tour-act="back">Back</button>' : ''}
       <button class="${st.click ? '' : 'pri'}" data-tour-act="next">${
-        esc(st.ok || (last ? 'done' : 'next'))}</button>
+        esc(st.ok || (last ? 'Done' : 'Next'))}</button>
     </div>`;
   // Restarted per step so the card animates in each time rather than once.
   card.classList.remove('step-in');

--- a/portal/tests/test_account_email_and_preferences.py
+++ b/portal/tests/test_account_email_and_preferences.py
@@ -196,7 +196,7 @@ def test_the_wizard_saves_disabled_and_enables_only_after_a_sign_in():
 
 
 def test_the_wizard_is_owner_only():
-    assert "AUTH && AUTH.role === 'owner' ? `<div class=\"wcard\"" in INDEX
+    assert "AUTH && AUTH.role === 'owner' ? (SSOW ? ssoWizard()" in INDEX
 
 
 def test_the_redirect_uri_is_offered_not_asked_for():

--- a/portal/tests/test_account_email_and_preferences.py
+++ b/portal/tests/test_account_email_and_preferences.py
@@ -152,3 +152,54 @@ def test_the_accounts_table_shows_and_edits_an_email():
     assert 'data-act="user-email-form"' in INDEX
     assert "id=\"user-email\"" in INDEX, "and on the create row too"
 
+
+
+# ---------------------------------------------------- federated sign-in --
+
+
+def test_the_callback_is_outside_the_json_only_rule():
+    """The identity provider posts a form, so the CSRF rule that refuses
+    non-JSON POSTs under /api would refuse the sign-in. What stands in for
+    it is the state: minted by the receiver minutes earlier, single-use,
+    and paired with a PKCE verifier the browser never held."""
+    src = (Path(__file__).parent.parent / "app" / "main.py").read_text()
+    assert '@app.post("/sso/callback")' in src
+    assert '"/api/sso/callback"' not in src
+
+
+def test_the_callback_answers_with_a_page_not_a_redirect():
+    """The session cookie is SameSite=Strict and this redirect chain began
+    at the identity provider, so a redirect would arrive with the cookie
+    withheld - signed in, and shown the sign-in screen. Navigating from a
+    page we served is same-site, which is the difference."""
+    src = (Path(__file__).parent.parent / "app" / "main.py").read_text()
+    fn = src.split("async def sso_callback(", 1)[1].split("\n@app", 1)[0]
+    assert "_sso_page(" in fn
+    assert "RedirectResponse" not in fn
+
+
+def test_provider_error_text_is_escaped_into_that_page():
+    """It is the one place this service renders HTML, and the text comes
+    from outside."""
+    src = (Path(__file__).parent.parent / "app" / "main.py").read_text()
+    page = src.split("def _sso_page(", 1)[1].split("\n@app", 1)[0]
+    assert "esc_attr(title)" in page and "esc_attr(body)" in page
+
+
+def test_the_wizard_saves_disabled_and_enables_only_after_a_sign_in():
+    """A misconfigured provider that is already enabled is a deployment
+    nobody can sign in to."""
+    save = INDEX.split("if (act === 'sso-save') {", 1)[1].split("\n  }", 1)[0]
+    assert "ssoSave(false)" in save
+    enable = INDEX.split("if (act === 'sso-enable') {", 1)[1].split("\n  }", 1)[0]
+    assert "ssoSave(true)" in enable
+
+
+def test_the_wizard_is_owner_only():
+    assert "AUTH && AUTH.role === 'owner' ? `<div class=\"wcard\"" in INDEX
+
+
+def test_the_redirect_uri_is_offered_not_asked_for():
+    """It has to match the app registration exactly, so the page shows the
+    one it would actually use rather than asking somebody to compose it."""
+    assert "location.origin + '/sso/callback'" in INDEX

--- a/portal/tests/test_account_email_and_preferences.py
+++ b/portal/tests/test_account_email_and_preferences.py
@@ -9,6 +9,7 @@ which is what keeps a layout from being addressable by anyone else.
 """
 
 import os
+import re
 from pathlib import Path
 
 os.environ.setdefault("PORTAL_AUTH", "none")
@@ -186,6 +187,36 @@ def test_provider_error_text_is_escaped_into_that_page():
     assert "esc_attr(title)" in page and "esc_attr(body)" in page
 
 
+def test_nothing_dynamic_is_written_inside_a_script_tag():
+    """json.dumps escapes for JSON, which is not escaping for a script
+    context - it leaves "/" alone, so a provider error_description
+    containing "</script>" closed the tag early and everything after it
+    became markup. CodeQL caught it as py/reflective-xss.
+
+    The values ride in an attribute now, HTML-escaped like any other, and
+    a static script reads them back: there is no injection point left to
+    get the escaping wrong in."""
+    src = (Path(__file__).parent.parent / "app" / "main.py").read_text()
+    page = src.split("def _sso_page(", 1)[1].split("\n@app", 1)[0]
+    # An f-string is the only way a Python value reaches this markup, so
+    # no f-string may carry a script tag. The JS itself is a plain literal.
+    for m in re.finditer(r"""(f?)(['"])(.*?)\2""", page, re.S):
+        is_f, text = m.group(1), m.group(3)
+        if "<script" in text or "</script" in text:
+            assert not is_f, "a script tag is being built by an f-string"
+    assert 'data-r="{esc_attr(payload)}"' in page
+
+
+def test_the_escaping_survives_a_script_closing_tag():
+    """The actual attack string, through the actual helper."""
+    import html as _html
+    import json as _json
+    attr = _html.escape(_json.dumps(
+        {"detail": "x </script><img src=x onerror=alert(1)>"}), quote=True)
+    assert "</script>" not in attr
+    assert "&lt;/script&gt;" in attr
+
+
 def test_the_wizard_saves_disabled_and_enables_only_after_a_sign_in():
     """A misconfigured provider that is already enabled is a deployment
     nobody can sign in to."""
@@ -203,3 +234,21 @@ def test_the_redirect_uri_is_offered_not_asked_for():
     """It has to match the app registration exactly, so the page shows the
     one it would actually use rather than asking somebody to compose it."""
     assert "location.origin + '/sso/callback'" in INDEX
+
+
+def test_the_callback_parses_its_form_without_python_multipart():
+    """Starlette's form parser insists on python-multipart even for a
+    urlencoded body, and this endpoint 500s without it - which is every
+    real sign-in, at the last step. The provider posts
+    application/x-www-form-urlencoded and nothing else, so the stdlib is
+    enough and the image gains no dependency."""
+    src = (Path(__file__).parent.parent / "app" / "main.py").read_text()
+    fn = src.split("async def sso_callback(", 1)[1].split("\n@app", 1)[0]
+    # Comments stripped: the one explaining this names the thing it
+    # replaced, and would trip its own assertion.
+    code = "\n".join(l for l in fn.splitlines()
+                     if not l.strip().startswith("#"))
+    assert "request.form()" not in code
+    assert "urllib.parse.parse_qs" in code
+    # And it does not read an unbounded body from an open endpoint.
+    assert "[:16384]" in code

--- a/portal/tests/test_account_email_and_preferences.py
+++ b/portal/tests/test_account_email_and_preferences.py
@@ -135,10 +135,20 @@ def test_the_accounts_table_ships_the_role_control():
     assert "async function userRole" in INDEX
 
 
-def test_a_viewer_sees_the_role_as_text_not_a_control():
-    """The select is rendered only for an account that could use it - a
-    read-only account offered a dropdown that always 403s is a worse page
-    than one that shows the role plainly."""
-    cell = INDEX.split("data-role-for")[0]
-    assert "${viewer" in cell.rsplit("<td>", 1)[-1]
+def test_the_page_offers_no_control_whose_answer_is_already_403():
+    """A read-only account, and an account looking at one that outranks
+    it, both see the role plainly rather than a dropdown that refuses.
+    The page keeps the receiver's rank table for exactly this - it is a
+    courtesy, not the enforcement, which stays server-side."""
+    assert "const RANK = {owner: 3, admin: 2, viewer: 1};" in INDEX
+    assert "const may = !viewer && !overRank;" in INDEX
+    # And it never offers a role above the viewer's own to grant.
+    assert "ROLE_ORDER.filter(r => (RANK[r] || 0) <= mine)" in INDEX
+
+
+def test_the_accounts_table_shows_and_edits_an_email():
+    """Built in #199 as an API with no way to reach it from the page."""
+    assert "<th>email</th>" in INDEX
+    assert 'data-act="user-email-form"' in INDEX
+    assert "id=\"user-email\"" in INDEX, "and on the create row too"
 

--- a/portal/tests/test_budget.py
+++ b/portal/tests/test_budget.py
@@ -132,7 +132,7 @@ def test_the_shell_ships_the_share_view():
 def test_the_report_can_withhold_names_and_guards_the_csv():
     # The page names individuals and their personal account domains, so
     # withholding them is one control, in the page and in the export.
-    assert "BRNAMES" in INDEX and "withhold names" in INDEX
+    assert "BRNAMES" in INDEX and "Withhold names" in INDEX
     assert "-anonymised.csv" in INDEX or "'-anonymised'" in INDEX
     # An exported address starting with = is a live formula in Excel.
     assert "B_FORMULA_LEAD" in INDEX and "function bCsvCell" in INDEX

--- a/portal/tests/test_guided_tour.py
+++ b/portal/tests/test_guided_tour.py
@@ -120,4 +120,4 @@ def test_every_step_carries_a_way_forward():
         "a step that asks for a click must still offer next"
     assert "st.click ? '' : 'pri'" in card, \
         "next should be secondary on a click step, not absent"
-    assert "'end tour'" in card, "the way out has to say what it does"
+    assert "'End tour'" in card, "the way out has to say what it does"

--- a/portal/tests/test_widget_forms.py
+++ b/portal/tests/test_widget_forms.py
@@ -129,3 +129,12 @@ def test_the_meter_fill_can_actually_render():
     empty track whatever the ratio was."""
     css = INDEX.split(".meterrow .fill {", 1)[1].split("}", 1)[0]
     assert "display: block" in css
+
+
+def test_the_form_switch_shows_a_capitalised_label_but_stores_the_id():
+    """The label is capitalised like every other button; the value written
+    to preferences stays the lowercase form id, so a saved choice keeps
+    resolving."""
+    assert "esc(f[0].toUpperCase() + f.slice(1))" in INDEX
+    assert 'data-form="${esc(f)}"' in INDEX
+

--- a/portal/tests/test_wizard.py
+++ b/portal/tests/test_wizard.py
@@ -232,7 +232,7 @@ def test_the_register_carries_the_watchlist_decisions():
     html = (main.STATIC / "index.html").read_text()
     for needle in ("watchlistBlock", "wl-toggle", "open-wizard",
                    "known, not observed",
-                   "run the setup wizard again"):
+                   "Run the setup wizard again"):
         assert needle in html, needle
 
 

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -70,6 +70,53 @@ shared token off for ingest (see the configuration table).
 | GET  | `/admin/preferences` | admin or viewer | the signed-in account's own display state - layout, chart choices, what it has already been walked through. Scoped to the session, so there is no id to pass and no route to another account's |
 | PUT  | `/admin/preferences` | admin or viewer | merge keys into the account's own preferences; a `null` value deletes one. The single authenticated write a viewer owns - these change what one person sees, never what a page reports. Bounded at 50 keys and 4096 characters a value |
 
+**Federated sign-in (Microsoft Entra).** Owner-gated, off until proven.
+Configured through a five-step wizard in the portal rather than a settings
+panel, because each step has something to check: the tenant is resolved
+against its own OpenID configuration document, the application id and
+secret are proved with a client-credentials grant, and the last step is a
+real sign-in. Nothing is enabled until that sign-in succeeds - an enabled
+provider that does not work is a deployment nobody can sign in to.
+
+| Method | Path | Who | What |
+|---|---|---|---|
+| POST | `/admin/sso/probe` | owner (write) | check a tenant, and optionally an application id and secret, before anything is saved |
+| GET  | `/admin/sso/start` | open | begin a sign-in; 404 until federated sign-in is fully configured, so an estate that has not set it up does not advertise the endpoint |
+| POST | `/admin/sso/callback` | open | redeem the code the provider handed the browser, and mint a session |
+
+The two open endpoints are open for the reason `/admin/login` is: nobody
+has a session yet. What protects the callback is the `state` it must
+quote - minted by `/start` minutes earlier, single-use, and paired with a
+PKCE verifier the browser never held.
+
+**How an account is matched.** On an account's first federated sign-in the
+email address finds it; the account's `oid` and `tid` are written at that
+moment, and every sign-in after that matches on those alone. Microsoft's
+guidance is explicit that an address "isn't guaranteed to be correct and
+is mutable over time. Never use it for authorization" - addresses get
+reassigned, and a joiner inheriting a leaver's address would otherwise
+inherit their account and their role. The address is an invitation, spent
+once.
+
+**No sign-in ever creates an account.** Somebody who can set an address in
+a tenant cannot mint themselves a way in; an owner or admin has to create
+the account first. Local passwords keep working whether or not federated
+sign-in is on, so an account with no address remains reachable only by
+password - which is what makes one usable as a shared break-glass
+credential.
+
+**On the ID token signature.** It is not verified, deliberately. The token
+is fetched by the receiver over TLS directly from the token endpoint named
+by the tenant's own discovery document, and OpenID Connect Core 3.1.3.7
+permits exactly that: "If the ID Token is received via direct
+communication between the Client and the Token Endpoint... the TLS server
+validation MAY be used to validate the issuer in place of checking the
+token signature." Issuer, audience, expiry, nonce and tenant are all
+checked. The alternative is a JWT library and the native cryptography
+stack it brings, on an image this project keeps small, for a guarantee the
+transport already gives in this flow. Revisit it the day a token arrives
+by any other route.
+
 **Roles and the rank rule.** Three roles: `owner`, `admin`, `viewer`. An
 owner decides who may sign in and can appoint another owner; an admin runs
 the platform - fleet, governance, budget, settings and the accounts below

--- a/receiver/README.md
+++ b/receiver/README.md
@@ -62,13 +62,45 @@ shared token off for ingest (see the configuration table).
 | GET  | `/admin/session` | admin | who this session is, its role, and until when; the portal's validity probe |
 | POST | `/admin/password` | admin | change your own password (`current` + `new`) - a viewer owns theirs too. With the `ADMIN_TOKEN` credential, `current` is not required and the reset targets the oldest admin: the break-glass path. Every other session dies with the old password |
 | GET  | `/admin/users` | admin | the accounts: username, email, role, created, last sign-in |
-| POST | `/admin/users` | admin (write) | create an account (`username`, `password`, `role`: `admin` or `viewer`, and an optional `email`) |
-| POST | `/admin/users/{id}/delete` | admin (write) | remove an account and kill its sessions. The last admin cannot be deleted |
+| POST | `/admin/users` | admin (write) | create an account (`username`, `password`, `role`: `owner`, `admin` or `viewer`, and an optional `email`). Subject to the rank rule below |
+| POST | `/admin/users/{id}/delete` | admin (write) | remove an account and kill its sessions. The last owner cannot be deleted |
 | POST | `/admin/users/{id}/password` | admin (write) | set someone else's password - the forgotten-password path. Their old sessions die with it |
-| POST | `/admin/users/{id}/role` | admin (write) | move an account between `admin` and `viewer`. Takes effect on that account's next request, not its next sign-in - the role is read off the account row per request, so a demotion refuses the next write immediately and a promotion costs a page reload. Sessions and passwords are untouched. The last admin cannot be demoted, for the same reason it cannot be deleted |
+| POST | `/admin/users/{id}/role` | admin (write) | move an account between `owner`, `admin` and `viewer`. Takes effect on that account's next request, not its next sign-in - the role is read off the account row per request, so a demotion refuses the next write immediately and a promotion costs a page reload. Sessions and passwords are untouched. The last owner cannot be demoted, for the same reason it cannot be deleted |
 | POST | `/admin/users/{id}/email` | admin (write) | set or clear (empty string) the address an identity provider would map onto this account. Normalised to lowercase and unique across accounts; **not** the login identifier, which stays `username` - so a local account keeps working whatever happens to a provider. Admin-gated: an account able to rewrite its own mapping could point somebody else's federated sign-in at itself |
 | GET  | `/admin/preferences` | admin or viewer | the signed-in account's own display state - layout, chart choices, what it has already been walked through. Scoped to the session, so there is no id to pass and no route to another account's |
 | PUT  | `/admin/preferences` | admin or viewer | merge keys into the account's own preferences; a `null` value deletes one. The single authenticated write a viewer owns - these change what one person sees, never what a page reports. Bounded at 50 keys and 4096 characters a value |
+
+**Roles and the rank rule.** Three roles: `owner`, `admin`, `viewer`. An
+owner decides who may sign in and can appoint another owner; an admin runs
+the platform - fleet, governance, budget, settings and the accounts below
+their own level; a viewer reads every page and writes nothing but its own
+password and display preferences.
+
+Every account action above is subject to one rule: **you cannot act on an
+account that outranks you, and you cannot grant a role above your own.**
+Without it the owner tier exists in name only, because an admin reaches an
+owner through any of three doors - reset their password and sign in as
+them, set the address a federated sign-in matches on, or simply change
+their role. Equal rank is not above it, so two owners manage each other and
+an admin still resets a colleague-admin's password. Kubernetes RBAC calls
+this escalation prevention; Entra enforces the same shape by refusing a
+password reset against a higher-privileged role.
+
+The `ADMIN_TOKEN` credential is outside the rule. It is break-glass, held
+by whoever can set the receiver's environment - who already owns the box -
+and rank-limiting it would only lock an operator out of their own recovery
+path.
+
+The account created by the setup code is the deployment's owner. On a
+deployment that predates the role, the earliest account is promoted on
+first start (`create_admin` refuses once any account exists, so "earliest"
+identifies it exactly) and the promotion lands in the audit trail.
+
+An account with no email address cannot be matched by a federated sign-in
+at all, which is what makes one usable as a shared break-glass credential:
+a password in a password manager, reachable by nobody through the identity
+provider.
+
 | GET  | `/admin/settings` | admin | each central setting with its effective value and its source (`db`, `env`, `unset`), so a saved value shadowing an environment one is visible as such. The log-store password is reported as `{set, source}` only, never its value |
 | PUT  | `/admin/settings` | admin | partial upsert; a saved value wins over the matching env var, an explicit `null` (or empty) deletes the row and falls back to it. Unknown keys are 422. Keys: `corp_domains`, `extension_id`, `onboarding_done`, `receiver_public_url`, `log_store_url` (base - the push endpoint is **derived** as `<base>/loki/api/v1/push`), `log_store_push_url` (explicit override for gateways), `log_store_username`, `log_store_password`, `alertmanager_url`, `grafana_url`, `grafana_panels`, `grafana_dashboard_uid`, `overview_widgets`, `extension_update_url`, `extension_crx_url`, `extension_xpi_url`, `paste_guard_mode`, `firefox_extension_id`, `classification_markings`, `webhook_url` (Slack-compatible; the receiver posts to it when discovery queues a NEW tool or MCP server - once per candidate lifetime, from a thread, so a webhook outage can never bounce ingest. Masked like the log-store password: a webhook URL is a bearer capability) |
 | GET  | `/admin/settings/secrets` | admin (write) | the stored log-store configuration with the password in plaintext - for the portal's server-side reads via its service credential; the portal exposes no route that relays it. Admin-only, because the credential is typically write-capable and a read-only account must not be a path to it. See SECURITY.md |

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -818,20 +818,30 @@ def _touch_device(request: Request):
         )
 
 
-def _admin_auth(authorization: str, write: bool = False):
+def _admin_auth(authorization: str, write: bool = False,
+                owner: bool = False):
     # Defence in depth for /admin/*, like _auth for ingest. 404 when managed
     # mode is off: routes that do not exist should not confirm they exist.
     # write=True is the role gate: a viewer account reads everything and
     # changes nothing, and the refusal names the reason rather than lying
     # with a generic 401 to someone who IS authenticated.
+    #
+    # owner=True is the tier above it, for the settings that decide who may
+    # sign in at all. Returns the caller's role, because the account routes
+    # need it: the rules there are relative to who is asking, not absolute.
+    # The API credential returns "admin" from _admin_role and is treated as
+    # unrestricted by the state layer, which is what break-glass means.
     if STATE is None:
         raise HTTPException(404, "Not Found")
     role = _admin_role(authorization)
     if role is None:
         raise HTTPException(401, "bad token")
-    if write and role != "admin":
+    if owner and role not in ("owner",):
+        raise HTTPException(403, "only an owner account can change this")
+    if write and role not in ("owner", "admin"):
         raise HTTPException(403, "this account is read-only: an admin "
                                  "account has to make this change")
+    return role
 
 
 # What can enroll. The three collector platforms, one browser profile
@@ -1108,7 +1118,8 @@ def post_user(req: UserCreate, authorization: str = Header(default="")):
                                  "digits, . _ @ -")
     try:
         return STATE.create_user(req.username, req.password, req.role,
-                                 _admin_actor(authorization), req.email)
+                                 _admin_actor(authorization), req.email,
+                                 _actor_role(authorization))
     except _state.AuthError as e:
         raise HTTPException(e.status, e.detail)
 
@@ -1119,7 +1130,8 @@ def delete_user(uid: str, authorization: str = Header(default="")):
     if not re.fullmatch(r"[0-9a-f]{16}", uid):
         raise HTTPException(422, "malformed user id")
     try:
-        if not STATE.delete_user(uid, _admin_actor(authorization)):
+        if not STATE.delete_user(uid, _admin_actor(authorization),
+                                 _actor_role(authorization)):
             raise HTTPException(404, "no account with that id")
     except _state.AuthError as e:
         raise HTTPException(e.status, e.detail)
@@ -1141,7 +1153,8 @@ def set_user_role(uid: str, req: UserRoleWrite,
         raise HTTPException(422, "malformed user id")
     try:
         if not STATE.set_user_role(uid, req.role,
-                                   _admin_actor(authorization)):
+                                   _admin_actor(authorization),
+                                   _actor_role(authorization)):
             raise HTTPException(404, "no account with that id")
     except _state.AuthError as e:
         raise HTTPException(e.status, e.detail)
@@ -1160,7 +1173,8 @@ def set_user_email(uid: str, req: UserEmailWrite,
         raise HTTPException(422, "malformed user id")
     try:
         if not STATE.set_user_email(uid, req.email,
-                                    _admin_actor(authorization)):
+                                    _admin_actor(authorization),
+                                    _actor_role(authorization)):
             raise HTTPException(404, "no account with that id")
     except _state.AuthError as e:
         raise HTTPException(e.status, e.detail)
@@ -1176,9 +1190,13 @@ def reset_user_password(uid: str, req: UserPasswordReset,
     _admin_auth(authorization, write=True)
     if not re.fullmatch(r"[0-9a-f]{16}", uid):
         raise HTTPException(422, "malformed user id")
-    if not STATE.reset_user_password(uid, req.new,
-                                     _admin_actor(authorization)):
-        raise HTTPException(404, "no account with that id")
+    try:
+        if not STATE.reset_user_password(uid, req.new,
+                                         _admin_actor(authorization),
+                                         _actor_role(authorization)):
+            raise HTTPException(404, "no account with that id")
+    except _state.AuthError as e:
+        raise HTTPException(e.status, e.detail)
     return {"reset": uid}
 
 
@@ -1239,6 +1257,18 @@ def _session_account(authorization: str) -> str:
             return u["user_id"]
     raise HTTPException(409, "preferences belong to a signed-in account; "
                              "the API credential does not have one")
+
+
+def _actor_role(authorization: str) -> str:
+    """The role to enforce the account rules against, or "" for the API
+    credential - which is the operator's own break-glass and deliberately
+    outside them."""
+    token = _bearer(authorization)
+    if STATE is not None and token.startswith(_state.SESSION_PREFIX):
+        u = STATE.session_user(token)
+        if u is not None:
+            return u.get("role") or "admin"
+    return ""
 
 
 def _admin_actor(authorization: str) -> str:

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -23,6 +23,8 @@ New in v0.1.3:
   - GET /metrics: Prometheus metrics (scraped via ServiceMonitor)
 """
 
+import base64
+import hashlib
 import hmac
 import json
 import logging
@@ -509,10 +511,18 @@ app = FastAPI(title="ai-guard-receiver", version=APP_VERSION)
 _PROTECTED = ("/report", "/flag", "/registry", "/candidates")
 _MANAGED = ("/enroll", "/admin")
 
-# The two doors into admin auth. Exempt from the admin gate - they are how a
+# The doors into admin auth. Exempt from the admin gate - they are how a
 # session comes to exist - but not from the body-size gate, and they answer
 # 404 like everything managed when managed mode is off.
-_ADMIN_OPEN = ("/admin/setup", "/admin/login")
+#
+# The two federated ones are open for the same reason the password one is:
+# nobody has a session yet. What protects the callback is the state it must
+# quote, minted by /sso/start minutes earlier, single-use, and paired with
+# a PKCE verifier the browser never saw. /sso/start itself answers 404
+# until federated sign-in is fully configured, so an estate that has not
+# set it up does not advertise the endpoint.
+_ADMIN_OPEN = ("/admin/setup", "/admin/login",
+               "/admin/sso/start", "/admin/sso/callback")
 
 
 def _admin_role(header: str) -> str | None:
@@ -1235,6 +1245,296 @@ def put_preferences(req: PreferencesWrite,
         raise HTTPException(e.status, e.detail)
 
 
+
+# ----------------------------------------------------- federated sign-in --
+# OpenID Connect against Microsoft Entra, authorization code flow with
+# PKCE. The browser never carries a token: it carries a code, which this
+# receiver exchanges itself over TLS.
+#
+# ON NOT VERIFYING THE ID TOKEN SIGNATURE. The token is fetched by this
+# process, over verified TLS, directly from the token endpoint named by
+# the tenant's own discovery document. OpenID Connect Core 3.1.3.7 permits
+# exactly this: "If the ID Token is received via direct communication
+# between the Client and the Token Endpoint... the TLS server validation
+# MAY be used to validate the issuer in place of checking the token
+# signature." Everything a signature would not have told us is still
+# checked below - issuer, audience, expiry, nonce and tenant.
+#
+# The alternative is a JWT library and the native cryptography stack it
+# pulls in, on an image this project keeps deliberately small, for a
+# guarantee the transport already gives in this flow. That trade is worth
+# revisiting the day a token arrives by any route other than this one.
+
+_MS_AUTHORITY = "https://login.microsoftonline.com"
+# Guessing at endpoint paths is how an integration breaks silently when a
+# cloud instance differs; these come from the tenant's own document.
+_DISCOVERY = _MS_AUTHORITY + "/%s/v2.0/.well-known/openid-configuration"
+# A tenant is a GUID or a verified domain. Anything else is somebody's
+# typo, and refusing it here beats a confusing failure three steps later.
+_TENANT_RE = re.compile(r"^[0-9a-fA-F-]{36}$|^[a-zA-Z0-9.-]{3,120}$")
+_GUID_RE = re.compile(r"^[0-9a-fA-F-]{36}$")
+
+# In-flight sign-ins: state -> what has to match when the browser returns.
+# In memory on purpose. A restart losing them costs somebody a retry,
+# where a table would keep the nonce and verifier of every abandoned
+# attempt indefinitely.
+_SSO_FLIGHT: dict[str, dict] = {}
+SSO_FLIGHT_SECONDS = 600
+SSO_FLIGHT_MAX = 64
+
+
+def _sso_conf() -> dict:
+    g = (lambda k, d="": (STATE.get_setting(k) if STATE else None) or d)
+    return {
+        "tenant": g("sso_tenant_id"),
+        "client_id": g("sso_client_id"),
+        "secret": g("sso_client_secret"),
+        "redirect": g("sso_redirect_uri"),
+        "enabled": g("sso_enabled") == "1",
+    }
+
+
+async def _sso_discover(tenant: str) -> dict:
+    """The tenant's OpenID configuration, or a refusal naming the reason."""
+    if not _TENANT_RE.match(tenant or ""):
+        raise HTTPException(422, "that does not look like a tenant id or "
+                                 "domain")
+    try:
+        async with httpx.AsyncClient(timeout=10) as c:
+            r = await c.get(_DISCOVERY % tenant)
+    except Exception as e:
+        raise HTTPException(502, "could not reach the identity provider: %s"
+                                 % type(e).__name__)
+    if r.status_code != 200:
+        raise HTTPException(400, "the identity provider does not recognise "
+                                 "that tenant (HTTP %d)" % r.status_code)
+    doc = r.json()
+    for key in ("authorization_endpoint", "token_endpoint", "issuer"):
+        if not doc.get(key):
+            raise HTTPException(502, "the provider's configuration document "
+                                     "is missing %s" % key)
+    return doc
+
+
+def _sso_sweep():
+    now = time.time()
+    for k in [k for k, v in _SSO_FLIGHT.items()
+              if now - v["at"] > SSO_FLIGHT_SECONDS]:
+        _SSO_FLIGHT.pop(k, None)
+
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def _jwt_payload(token: str) -> dict:
+    """The claims, without verifying the signature - see the note above."""
+    try:
+        part = token.split(".")[1]
+        return json.loads(base64.urlsafe_b64decode(
+            part + "=" * (-len(part) % 4)))
+    except Exception:
+        raise HTTPException(502, "the identity provider returned a token "
+                                 "this receiver could not read")
+
+
+class SSOProbe(BaseModel):
+    model_config = {"extra": "forbid"}
+    tenant_id: str = Field(min_length=1, max_length=120)
+    client_id: str = Field(default="", max_length=64)
+    client_secret: str = Field(default="", max_length=512)
+
+
+@app.post("/admin/sso/probe")
+async def sso_probe(req: SSOProbe, authorization: str = Header(default="")):
+    """Check a tenant, and optionally an app registration, before anything
+    is saved.
+
+    The wizard's verification step. Each answer names what was actually
+    established, because "it works" over a half-configured provider is
+    what produces a deployment nobody can sign in to.
+    """
+    _admin_auth(authorization, write=True, owner=True)
+    doc = await _sso_discover(req.tenant_id.strip())
+    out = {"tenant_ok": True, "issuer": doc["issuer"],
+           "authorization_endpoint": doc["authorization_endpoint"]}
+    if not (req.client_id and req.client_secret):
+        return out
+    if not _GUID_RE.match(req.client_id.strip()):
+        raise HTTPException(422, "an application (client) id is a GUID")
+    # A client credentials grant proves the id and secret are a real pair
+    # in that tenant, before anybody is asked to sign in with them. It
+    # says nothing about redirect URIs - only a real sign-in does.
+    try:
+        async with httpx.AsyncClient(timeout=10) as c:
+            r = await c.post(doc["token_endpoint"], data={
+                "client_id": req.client_id.strip(),
+                "client_secret": req.client_secret,
+                "scope": "https://graph.microsoft.com/.default",
+                "grant_type": "client_credentials",
+            })
+    except Exception as e:
+        raise HTTPException(502, "could not reach the token endpoint: %s"
+                                 % type(e).__name__)
+    body = {}
+    try:
+        body = r.json()
+    except Exception:
+        pass
+    if r.status_code == 200 and body.get("access_token"):
+        out["client_ok"] = True
+        return out
+    code = body.get("error", "")
+    detail = body.get("error_description", "") or ("HTTP %d" % r.status_code)
+    if code == "unauthorized_client" or "AADSTS700016" in detail:
+        raise HTTPException(400, "no application with that client id exists "
+                                 "in this tenant")
+    if code == "invalid_client" or "AADSTS7000215" in detail:
+        raise HTTPException(400, "that client secret is wrong, or expired")
+    # A tenant can refuse the grant for reasons that say nothing about the
+    # credentials - no application permissions consented, for one. The
+    # pair is real if the refusal is about permissions rather than
+    # identity, and saying so beats blocking a correct configuration.
+    out["client_ok"] = False
+    out["detail"] = detail[:300]
+    return out
+
+
+@app.get("/admin/sso/start")
+async def sso_start(request: Request):
+    """Begin a sign-in, or a test of one.
+
+    Deliberately unauthenticated: this is the door somebody knocks on
+    BEFORE they have a session. It gives away nothing a sign-in page does
+    not - and returns 404 rather than a description when federated
+    sign-in is off, so an estate that has not configured it does not
+    advertise the endpoint.
+    """
+    if STATE is None:
+        raise HTTPException(404, "Not Found")
+    conf = _sso_conf()
+    if not (conf["tenant"] and conf["client_id"] and conf["secret"]
+            and conf["redirect"]):
+        raise HTTPException(404, "Not Found")
+    doc = await _sso_discover(conf["tenant"])
+    _sso_sweep()
+    if len(_SSO_FLIGHT) >= SSO_FLIGHT_MAX:
+        raise HTTPException(429, "too many sign-ins in flight; try again")
+    verifier = _b64u(secrets.token_bytes(48))
+    state = _b64u(secrets.token_bytes(24))
+    nonce = _b64u(secrets.token_bytes(24))
+    _SSO_FLIGHT[state] = {"nonce": nonce, "verifier": verifier,
+                          "at": time.time(), "issuer": doc["issuer"],
+                          "token_endpoint": doc["token_endpoint"]}
+    challenge = _b64u(hashlib.sha256(verifier.encode()).digest())
+    return {"authorize_url": doc["authorization_endpoint"] + "?" + urllib.parse.urlencode({
+        "client_id": conf["client_id"],
+        "response_type": "code",
+        "redirect_uri": conf["redirect"],
+        # form_post keeps the code out of the URL, where it would land in
+        # browser history and any proxy log on the way.
+        "response_mode": "form_post",
+        "scope": "openid profile email",
+        "state": state,
+        "nonce": nonce,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    })}
+
+
+class SSOCallback(BaseModel):
+    model_config = {"extra": "forbid"}
+    code: str = Field(min_length=1, max_length=4096)
+    state: str = Field(min_length=1, max_length=256)
+
+
+def _sso_refuse(why: str):
+    # One shape for every refusal, and never the provider's raw error to a
+    # browser: these are read by whoever is trying to sign in.
+    return {"ok": False, "detail": why}
+
+
+@app.post("/admin/sso/callback")
+async def sso_callback(req: SSOCallback):
+    """Redeem the code the provider handed the browser.
+
+    Unauthenticated, like /start and for the same reason: nobody has a
+    session yet. What protects it is the state it must quote - minted here
+    minutes earlier, single-use, and paired with a PKCE verifier the
+    browser never saw.
+
+    The portal is what the browser talks to; it forwards the code here and
+    turns the answer into its own cookie. The client secret stays in this
+    process and the session is minted where sessions live.
+    """
+    if STATE is None:
+        raise HTTPException(404, "Not Found")
+    _sso_sweep()
+    flight = _SSO_FLIGHT.pop(req.state, None)
+    if flight is None:
+        return _sso_refuse("that sign-in expired or was not started here")
+    conf = _sso_conf()
+    try:
+        async with httpx.AsyncClient(timeout=10) as c:
+            r = await c.post(flight["token_endpoint"], data={
+                "client_id": conf["client_id"],
+                "client_secret": conf["secret"],
+                "code": req.code,
+                "grant_type": "authorization_code",
+                "redirect_uri": conf["redirect"],
+                "code_verifier": flight["verifier"],
+            })
+    except Exception as e:
+        return _sso_refuse("could not reach the token endpoint: %s"
+                           % type(e).__name__)
+    body = {}
+    try:
+        body = r.json()
+    except Exception:
+        pass
+    if r.status_code != 200 or not body.get("id_token"):
+        return _sso_refuse(str(body.get("error_description")
+                               or "the provider refused the sign-in")[:300])
+
+    claims = _jwt_payload(body["id_token"])
+    # Everything a signature check would not have told us anyway. The
+    # issuer is compared against the one this tenant's own discovery
+    # document named, not against a pattern.
+    if claims.get("iss") != flight["issuer"]:
+        return _sso_refuse("the token came from an unexpected issuer")
+    if claims.get("aud") != conf["client_id"]:
+        return _sso_refuse("the token was issued for a different application")
+    if claims.get("nonce") != flight["nonce"]:
+        return _sso_refuse("the token did not answer this sign-in")
+    if int(claims.get("exp") or 0) <= int(time.time()):
+        return _sso_refuse("the token had already expired")
+    tid, sub = claims.get("tid") or "", claims.get("oid") or ""
+    if not tid or not sub:
+        return _sso_refuse("the token carried no tenant or object id")
+    # A guest signing in through this tenant is a different account from
+    # the same person in their home tenant, by Microsoft's own design.
+    # Pinning the tenant is what keeps that true here.
+    if _GUID_RE.match(conf["tenant"] or "") and tid != conf["tenant"]:
+        return _sso_refuse("that account is not in this tenant")
+
+    email = claims.get("email") or claims.get("preferred_username") or ""
+    user = STATE.sso_account(tid, sub, email)
+    if user is None:
+        # No account, and none is created. An address in a tenant is not a
+        # way in here: somebody has to have been given an account first.
+        return _sso_refuse("no account here matches that sign-in. An owner "
+                           "or admin has to create one and set its email "
+                           "address first.")
+    if not user["bound"]:
+        try:
+            STATE.sso_bind(user["id"], tid, sub)
+        except _state.AuthError as e:
+            return _sso_refuse(e.detail)
+    out = STATE.sso_login(user["id"], ttl_hours=SESSION_TTL_HOURS)
+    return {"ok": True, "token": out["token"], "username": out["username"],
+            "role": out["role"], "expires_at": out["expires_at"],
+            "bound_now": not user["bound"]}
+
 # ------------------------------------------------------- central settings --
 # Deployment configuration the portal edits and the fleet hears at runtime.
 # Precedence is DB-wins-when-set: a saved value overrides the matching
@@ -1307,6 +1607,16 @@ _STR_SETTINGS = (
     # Fired on a NEW discovery candidate - the moment a human decision
     # becomes needed - and never per finding, which would be a firehose.
     ("webhook_url", True, 500),
+    # Federated sign-in. Owner-gated in put_settings, because these decide
+    # who may sign in at all rather than what the platform reports.
+    # sso_enabled is deliberately last to matter: nothing here takes effect
+    # until it is "1", and the portal will not set it until a real sign-in
+    # has been completed against the rest.
+    ("sso_tenant_id", False, 64),
+    ("sso_client_id", False, 64),
+    ("sso_client_secret", False, 512),
+    ("sso_redirect_uri", True, 500),
+    ("sso_enabled", False, 1),
     # The currency the Budget view's headline reports in, and the default
     # for newly linked tools. A display preference, not money math: the
     # portal never converts between currencies.
@@ -1317,7 +1627,7 @@ _STR_SETTINGS = (
 # tool. Baked into every extension policy artifact; "warn" is the default
 # when unset, matching the extension's own default.
 _PASTE_GUARD_MODES = ("off", "warn", "block")
-SECRET_SETTINGS = ("log_store_password", "webhook_url")
+SECRET_SETTINGS = ("log_store_password", "webhook_url", "sso_client_secret")
 
 
 class SettingsUpdate(BaseModel):
@@ -1332,6 +1642,11 @@ class SettingsUpdate(BaseModel):
     log_store_push_url: str | None = Field(default=None, max_length=500)
     log_store_username: str | None = Field(default=None, max_length=256)
     log_store_password: str | None = Field(default=None, max_length=512)
+    sso_tenant_id: str | None = Field(default=None, max_length=64)
+    sso_client_id: str | None = Field(default=None, max_length=64)
+    sso_redirect_uri: str | None = Field(default=None, max_length=500)
+    sso_enabled: str | None = Field(default=None, max_length=1)
+    sso_client_secret: str | None = Field(default=None, max_length=512)
     alertmanager_url: str | None = Field(default=None, max_length=500)
     grafana_url: str | None = Field(default=None, max_length=500)
     grafana_panels: str | None = Field(default=None, max_length=2000)
@@ -1420,6 +1735,20 @@ def get_settings(authorization: str = Header(default="")):
             "source": ("db" if stored.get("classification_markings")
                        is not None else "unset"),
         },
+        # Federated sign-in. The tenant, application id and redirect are
+        # not secrets - they are in every authorize URL a browser sees -
+        # so the wizard can show them back and say what is configured.
+        "sso_tenant_id": plain("sso_tenant_id"),
+        "sso_client_id": plain("sso_client_id"),
+        "sso_redirect_uri": plain("sso_redirect_uri"),
+        "sso_enabled": plain("sso_enabled"),
+        # The secret is not. Same treatment as the log-store password: set
+        # -ness and source, never the value.
+        "sso_client_secret": {
+            "set": stored.get("sso_client_secret") is not None,
+            "source": ("db" if stored.get("sso_client_secret") is not None
+                       else "unset"),
+        },
     }}
 
 
@@ -1453,8 +1782,15 @@ def get_settings_secrets(authorization: str = Header(default="")):
 @app.put("/admin/settings")
 def put_settings(req: SettingsUpdate, authorization: str = Header(default="")):
     """Partial upsert: only the keys sent change. An explicit null deletes
-    the row, which is how the environment value comes back into effect."""
+    the row, which is how the environment value comes back into effect.
+
+    The sso_* keys are owner-gated inside. They are not settings about
+    what the platform reports; they decide who may sign in to it at all,
+    which is the one thing the tier above admin exists to hold.
+    """
     _admin_auth(authorization, write=True)
+    if any(k.startswith("sso_") for k in req.model_fields_set):
+        _admin_auth(authorization, write=True, owner=True)
     by = _admin_actor(authorization)
 
     if "corp_domains" in req.model_fields_set:

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -236,12 +236,23 @@ _DEVICE_COLUMNS_ADDED = (
 _ADMIN_COLUMNS_ADDED = (
     ("role", "TEXT NOT NULL DEFAULT 'admin'"),
     # Where an account meets an identity provider. Nullable because a local
-    # account has never needed one and still does not: this is the join key
-    # a future SSO integration would map onto, recorded now while there are
-    # few accounts to fill in. It is deliberately NOT the login identifier -
-    # username stays that, so `admin` remains a usable local account and a
-    # misconfigured provider cannot lock anyone out of their own portal.
+    # account has never needed one and still does not. It is deliberately
+    # NOT the login identifier - username stays that, so `admin` remains a
+    # usable local account and a misconfigured provider cannot lock anyone
+    # out of their own portal.
+    #
+    # It is also not the join key after the first federated sign-in. The
+    # address matches once, to find the account somebody was invited to;
+    # the immutable pair below is written at that moment and every sign-in
+    # after that matches on it alone. Microsoft's own guidance is explicit:
+    # an address "isn't guaranteed to be correct and is mutable over time.
+    # Never use it for authorization", because addresses are reassigned -
+    # a joiner inheriting a leaver's address would otherwise inherit their
+    # account and their role.
     ("email", "TEXT"),
+    ("sso_subject", "TEXT"),
+    ("sso_tenant", "TEXT"),
+    ("sso_bound_at", "TEXT"),
 )
 
 # A subscription from before licence coverage covers exactly its own tool,
@@ -404,6 +415,12 @@ class State:
             self._db.execute(
                 "CREATE UNIQUE INDEX IF NOT EXISTS admin_users_email"
                 " ON admin_users (email) WHERE email IS NOT NULL")
+            # One federated identity, one account. Partial for the same
+            # reason: most accounts have never signed in that way.
+            self._db.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS admin_users_sso"
+                " ON admin_users (sso_tenant, sso_subject)"
+                " WHERE sso_subject IS NOT NULL")
             have = {r["name"] for r in self._db.execute(
                 "PRAGMA table_info(budget_subscriptions)")}
             for name, decl in _BUDGET_SUB_COLUMNS_ADDED:
@@ -798,8 +815,8 @@ class State:
     def list_users(self) -> list[dict]:
         with self._lock:
             rows = self._db.execute(
-                "SELECT id, username, email, role, created_at, last_login_at"
-                " FROM admin_users ORDER BY created_at"
+                "SELECT id, username, email, role, created_at, last_login_at,"
+                " sso_bound_at FROM admin_users ORDER BY created_at"
             ).fetchall()
         return [dict(r) for r in rows]
 
@@ -948,6 +965,116 @@ class State:
             self._event("password_reset", {"user": uid, "by": by})
             self._db.commit()
         return True
+
+    # -------------------------------------------------- federated sign-in --
+
+    def sso_account(self, tenant: str, subject: str, email: str) -> dict | None:
+        """The account this federated identity signs in as, or None.
+
+        Two matches, and the order is the whole design. The immutable pair
+        first: once an account has been bound, that binding is the only
+        thing that signs it in, and nothing about the address can move it.
+        The address second, and only for an account not yet bound - it is
+        an invitation, spent the first time somebody accepts it.
+
+        Never creates an account. Somebody who can set an address in a
+        tenant cannot mint themselves a way in here; every account exists
+        because a person decided it should.
+        """
+        address = (email or "").strip().lower()
+        with self._lock:
+            row = self._db.execute(
+                "SELECT id, username, role FROM admin_users"
+                " WHERE sso_tenant = ? AND sso_subject = ?",
+                (tenant, subject)).fetchone()
+            if row is not None:
+                return dict(row) | {"bound": True}
+            if not address:
+                return None
+            row = self._db.execute(
+                "SELECT id, username, role FROM admin_users"
+                " WHERE email = ? AND sso_subject IS NULL", (address,)
+            ).fetchone()
+            return dict(row) | {"bound": False} if row else None
+
+    def sso_bind(self, uid: str, tenant: str, subject: str) -> bool:
+        """Write the immutable pair onto an account, once.
+
+        Refuses if the account is already bound to a different identity:
+        rebinding is how an address change would move somebody else's
+        account, which is exactly what binding exists to stop. Clearing a
+        binding is deliberate and separate.
+        """
+        with self._lock:
+            row = self._db.execute(
+                "SELECT sso_subject, sso_tenant FROM admin_users WHERE id = ?",
+                (uid,)).fetchone()
+            if row is None:
+                return False
+            if row["sso_subject"]:
+                if (row["sso_subject"], row["sso_tenant"]) != (subject, tenant):
+                    raise AuthError(409, "that account is already linked to a "
+                                         "different federated identity")
+                return True
+            self._db.execute(
+                "UPDATE admin_users SET sso_subject = ?, sso_tenant = ?,"
+                " sso_bound_at = ? WHERE id = ?",
+                (subject, tenant, _now(), uid))
+            # The subject is a GUID, and recorded: an operator asking "who
+            # is this account" needs to be able to answer it.
+            self._event("sso_bound", {"user": uid, "tenant": tenant,
+                                      "subject": subject})
+            self._db.commit()
+        return True
+
+    def sso_unbind(self, uid: str, by: str = "", by_role: str = "") -> bool:
+        """Cut an account loose from its federated identity.
+
+        The way back from a wrong binding, and the way an account is handed
+        to a different person. Subject to the same rank rule as every other
+        account action: unbinding an account above yours would let you
+        re-bind it to yourself on the next sign-in.
+        """
+        with self._lock:
+            row = self._db.execute(
+                "SELECT role, sso_subject FROM admin_users WHERE id = ?",
+                (uid,)).fetchone()
+            if row is None:
+                return False
+            self._may_act_on(by_role, row["role"])
+            self._db.execute(
+                "UPDATE admin_users SET sso_subject = NULL, sso_tenant = NULL,"
+                " sso_bound_at = NULL WHERE id = ?", (uid,))
+            self._event("sso_unbound", {"user": uid, "by": by})
+            self._db.commit()
+        return True
+
+    def sso_login(self, uid: str, ttl_hours: int = 24) -> dict:
+        """Mint a session for an account the provider has vouched for.
+
+        Deliberately not login(): there is no password to verify, and the
+        throttle that guards password guessing has nothing to guard here.
+        """
+        with self._lock:
+            row = self._db.execute(
+                "SELECT username, role FROM admin_users WHERE id = ?",
+                (uid,)).fetchone()
+            if row is None:
+                raise AuthError(404, "no account with that id")
+            token = SESSION_PREFIX + secrets.token_urlsafe(32)
+            expires = (datetime.now(timezone.utc)
+                       + timedelta(hours=ttl_hours)).isoformat()
+            self._db.execute(
+                "INSERT INTO sessions (token_hash, user_id, created_at,"
+                " expires_at) VALUES (?, ?, ?, ?)",
+                (_hash(token), uid, _now(), expires))
+            self._db.execute(
+                "UPDATE admin_users SET last_login_at = ? WHERE id = ?",
+                (_now(), uid))
+            self._event("sso_login", {"user": uid})
+            self._db.commit()
+        return {"token": token, "expires_at": expires,
+                "username": row["username"], "role": row["role"]}
 
     # ---------------------------------------------------- preferences --
     # How one person wants the portal laid out, and what it has already

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -369,6 +369,33 @@ class State:
                 if name not in have:
                     self._db.execute(
                         f"ALTER TABLE admin_users ADD COLUMN {name} {decl}")
+            # A database from before the owner role has accounts and no
+            # owner. The account the setup code created is the earliest
+            # one - create_admin refuses once any account exists, so
+            # "earliest" identifies it exactly - and it is promoted.
+            # Nothing new is recorded to work this out, and a deployment
+            # that has since deleted that account promotes whichever admin
+            # is now oldest rather than leaving nobody able to appoint one.
+            have_any = self._db.execute(
+                "SELECT 1 FROM admin_users LIMIT 1").fetchone()
+            if have_any:
+                has_owner = self._db.execute(
+                    "SELECT 1 FROM admin_users WHERE role = 'owner' LIMIT 1"
+                ).fetchone()
+                if not has_owner:
+                    first = self._db.execute(
+                        "SELECT id FROM admin_users WHERE role = 'admin'"
+                        " ORDER BY created_at, id LIMIT 1").fetchone()
+                    if first is not None:
+                        self._db.execute(
+                            "UPDATE admin_users SET role = 'owner'"
+                            " WHERE id = ?", (first["id"],))
+                        self._db.execute(
+                            "INSERT INTO events (at, kind, detail)"
+                            " VALUES (?, ?, ?)",
+                            (_now(), "owner_promoted_on_upgrade",
+                             json.dumps({"user": first["id"],
+                                         "why": "earliest account, no owner"})))
             # After the ALTER, never in _SCHEMA: on a database that predates
             # the column the index would be built against a column that does
             # not exist yet. Partial, so the many accounts with no address do
@@ -619,7 +646,7 @@ class State:
         return row is not None
 
     def create_admin(self, username: str, password: str) -> dict:
-        """The first account, always an admin.
+        """The first account, and the deployment's owner.
 
         Refuses once any account exists: creating the first account is what
         the one-time setup code authorizes, and after that the door is
@@ -633,7 +660,7 @@ class State:
             self._db.execute(
                 "INSERT INTO admin_users"
                 " (id, username, password_hash, created_at, role)"
-                " VALUES (?, ?, ?, ?, 'admin')",
+                " VALUES (?, ?, ?, ?, 'owner')",
                 (uid, username, _hash_password(password), _now()),
             )
             self._event("admin_created", {"user": uid, "username": username})
@@ -716,7 +743,57 @@ class State:
     # happened, and it cost the account its password to say something the
     # trail can state outright.
 
-    ROLES = ("admin", "viewer")
+    ROLES = ("owner", "admin", "viewer")
+
+    # What a role outranks. The rule every account action below enforces:
+    # you cannot act on an account that outranks you, and you cannot grant
+    # a role above your own. Without it, an admin reaches an owner through
+    # any of three doors - reset their password and sign in as them, set
+    # their email and sign in through the identity provider, or simply
+    # change their role - and the tier above admin would exist in name
+    # only. Kubernetes RBAC names this escalation prevention; Entra
+    # enforces the same shape by refusing a password reset against a
+    # higher-privileged role.
+    RANK = {"owner": 3, "admin": 2, "viewer": 1}
+
+    def _outranks(self, actor: str, target: str) -> bool:
+        return self.RANK.get(actor, 0) > self.RANK.get(target, 0)
+
+    def _may_act_on(self, by_role: str, target_role: str):
+        """Raise unless by_role may act on an account holding target_role.
+
+        by_role empty means the API credential, which is the operator's own
+        break-glass and is not role-limited.
+        """
+        if not by_role:
+            return
+        if self._outranks(target_role, by_role):
+            raise AuthError(403, "that account holds a role above yours")
+
+    def _may_grant(self, by_role: str, role: str):
+        if not by_role:
+            return
+        if self._outranks(role, by_role):
+            raise AuthError(403, "you cannot grant a role above your own")
+
+    def _guard_last(self, was: str, becomes: str = ""):
+        """Refuse to remove the last owner.
+
+        Callers hold the lock. This replaces the old last-admin floor,
+        which existed so a deployment could not lock itself out of its own
+        account management - an owner does everything an admin does, so a
+        deployment with an owner and no admins is not locked out of
+        anything. The owner floor is the one that matters and is stricter
+        than the admin floor ever was: an admin cannot make an owner, so
+        losing the last one cannot be undone from inside at all.
+        """
+        if was != "owner" or becomes == "owner":
+            return
+        n = self._db.execute(
+            "SELECT COUNT(*) AS n FROM admin_users WHERE role = 'owner'"
+        ).fetchone()["n"]
+        if n <= 1:
+            raise AuthError(409, "cannot remove the last owner")
 
     def list_users(self) -> list[dict]:
         with self._lock:
@@ -727,9 +804,11 @@ class State:
         return [dict(r) for r in rows]
 
     def create_user(self, username: str, password: str, role: str,
-                    by: str = "", email: str = "") -> dict:
+                    by: str = "", email: str = "",
+                    by_role: str = "") -> dict:
         if role not in self.ROLES:
-            raise AuthError(422, "role must be admin or viewer")
+            raise AuthError(422, "role must be owner, admin or viewer")
+        self._may_grant(by_role, role)
         address = normalize_email(email)
         uid = secrets.token_hex(8)
         with self._lock:
@@ -759,7 +838,8 @@ class State:
         return {"id": uid, "username": username, "role": role,
                 "email": address}
 
-    def set_user_email(self, uid: str, email: str, by: str = "") -> bool:
+    def set_user_email(self, uid: str, email: str, by: str = "",
+                       by_role: str = "") -> bool:
         """Set or clear the address an identity provider would map onto.
 
         Separate from account creation because the accounts that need one
@@ -768,10 +848,15 @@ class State:
         name."""
         address = normalize_email(email)
         with self._lock:
-            if self._db.execute(
-                "SELECT 1 FROM admin_users WHERE id = ?", (uid,)
-            ).fetchone() is None:
+            row = self._db.execute(
+                "SELECT role FROM admin_users WHERE id = ?", (uid,)
+            ).fetchone()
+            if row is None:
                 return False
+            # The address is what a federated sign-in matches on, so
+            # setting it on an account above yours is that account's
+            # credentials by another route.
+            self._may_act_on(by_role, row["role"])
             if address and self._db.execute(
                 "SELECT 1 FROM admin_users WHERE email = ? AND id != ?",
                 (address, uid),
@@ -785,7 +870,8 @@ class State:
             self._db.commit()
         return True
 
-    def set_user_role(self, uid: str, role: str, by: str = "") -> bool:
+    def set_user_role(self, uid: str, role: str, by: str = "",
+                      by_role: str = "") -> bool:
         """Move an account between trust levels.
 
         Enforcement is live: session_user reads the role off the account row
@@ -795,7 +881,8 @@ class State:
         sign someone out to achieve what the join already achieved.
         """
         if role not in self.ROLES:
-            raise AuthError(422, "role must be admin or viewer")
+            raise AuthError(422, "role must be owner, admin or viewer")
+        self._may_grant(by_role, role)
         with self._lock:
             row = self._db.execute(
                 "SELECT role FROM admin_users WHERE id = ?", (uid,)
@@ -803,20 +890,14 @@ class State:
             if row is None:
                 return False
             was = row["role"]
+            # Both ends: granting a role you do not hold is escalation, and
+            # so is demoting somebody who outranks you out of the way.
+            self._may_act_on(by_role, was)
             if was == role:
                 # Idempotent, and no event: the trail records changes, and a
                 # write that changed nothing is not one.
                 return True
-            if was == "admin" and role != "admin":
-                admins = self._db.execute(
-                    "SELECT COUNT(*) AS n FROM admin_users WHERE role = 'admin'"
-                ).fetchone()["n"]
-                if admins <= 1:
-                    # The same floor delete_user holds, for the same reason:
-                    # a deployment with accounts and no admin cannot manage
-                    # its own accounts, and the API credential that could
-                    # dig it out is optional.
-                    raise AuthError(409, "cannot demote the last admin")
+            self._guard_last(was, role)
             self._db.execute("UPDATE admin_users SET role = ? WHERE id = ?",
                              (role, uid))
             self._event("user_role_changed",
@@ -824,7 +905,7 @@ class State:
             self._db.commit()
         return True
 
-    def delete_user(self, uid: str, by: str = "") -> bool:
+    def delete_user(self, uid: str, by: str = "", by_role: str = "") -> bool:
         """Remove an account and kill its sessions. The last admin cannot be
         deleted: a deployment with accounts and no admin is locked out of
         its own account management, and the API credential that could fix
@@ -835,12 +916,8 @@ class State:
             ).fetchone()
             if row is None:
                 return False
-            if row["role"] == "admin":
-                admins = self._db.execute(
-                    "SELECT COUNT(*) AS n FROM admin_users WHERE role = 'admin'"
-                ).fetchone()["n"]
-                if admins <= 1:
-                    raise AuthError(409, "cannot delete the last admin")
+            self._may_act_on(by_role, row["role"])
+            self._guard_last(row["role"])
             # Sessions reference the account (FK), and a deleted account's
             # sessions have nothing left to say - remove rather than revoke.
             self._db.execute("DELETE FROM sessions WHERE user_id = ?", (uid,))
@@ -850,16 +927,18 @@ class State:
         return True
 
     def reset_user_password(self, uid: str, new_password: str,
-                            by: str = "") -> bool:
+                            by: str = "", by_role: str = "") -> bool:
         """An admin setting someone else's password. Every session that user
         holds dies with the old one - the reset exists because the old
         credential can no longer be trusted, and that distrust extends to
         anything it minted."""
         with self._lock:
-            if self._db.execute(
-                "SELECT 1 FROM admin_users WHERE id = ?", (uid,)
-            ).fetchone() is None:
+            row = self._db.execute(
+                "SELECT role FROM admin_users WHERE id = ?", (uid,)
+            ).fetchone()
+            if row is None:
                 return False
+            self._may_act_on(by_role, row["role"])
             self._db.execute(
                 "UPDATE admin_users SET password_hash = ? WHERE id = ?",
                 (_hash_password(new_password), uid))
@@ -1511,8 +1590,9 @@ class State:
         user_id names whose - the session's own user in the normal path.
         current=None with no user_id is the break-glass path, reached only
         with the API credential (the operator who can set the receiver's
-        environment already owns the box); it targets the oldest admin,
-        which is the account the setup code created. Every session except
+        environment already owns the box); it targets the oldest owner,
+        which is the account the setup code created, falling back to the
+        oldest admin if a deployment has removed its owners. Every session except
         keep_session dies with the old password - a stolen session must not
         outlive the password change that was made because of it.
         """
@@ -1523,12 +1603,20 @@ class State:
                     (user_id,),
                 ).fetchone()
             else:
+                # The oldest account that can run the platform: the owner
+                # the setup code created, or the oldest admin on a
+                # deployment whose owners have all been removed. This used
+                # to name role = 'admin' outright, which stopped finding
+                # anything the moment the setup account became an owner -
+                # breaking the one path that exists for being locked out.
                 row = self._db.execute(
                     "SELECT id, password_hash FROM admin_users"
-                    " WHERE role = 'admin' ORDER BY created_at LIMIT 1"
+                    " WHERE role IN ('owner', 'admin')"
+                    " ORDER BY CASE role WHEN 'owner' THEN 0 ELSE 1 END,"
+                    " created_at, id LIMIT 1"
                 ).fetchone()
             if row is None:
-                raise AuthError(409, "no admin account exists")
+                raise AuthError(409, "no owner or admin account exists")
             if current is not None and not _verify_password(
                 current, row["password_hash"]
             ):

--- a/receiver/tests/test_account_email_and_preferences.py
+++ b/receiver/tests/test_account_email_and_preferences.py
@@ -228,7 +228,10 @@ def test_a_database_written_before_either_gains_both(tmp_path):
     st = state_mod.State(path)
     users = st.list_users()
     assert [u["username"] for u in users] == ["existing"]
-    # Accounts predate roles as well as addresses, and both defaults hold.
-    assert users[0]["role"] == "admin"
+    # Accounts predate roles, addresses AND the owner role. The role
+    # column defaults to admin, and the earliest account - which is the
+    # one the setup code created, since create_admin refuses once any
+    # account exists - is promoted to owner on open.
+    assert users[0]["role"] == "owner"
     assert users[0]["email"] is None
     assert st.set_preferences(users[0]["id"], {"a": "1"}) == {"a": "1"}

--- a/receiver/tests/test_roles.py
+++ b/receiver/tests/test_roles.py
@@ -98,7 +98,7 @@ def test_viewer_writes_nothing_and_is_told_why(viewer):
 
 def test_the_session_probe_names_the_role(viewer, admin):
     assert client.get("/admin/session", headers=viewer).json()["role"] == "viewer"
-    assert client.get("/admin/session", headers=admin).json()["role"] == "admin"
+    assert client.get("/admin/session", headers=admin).json()["role"] == "owner"
 
 
 # ------------------------------------------------------- account management --
@@ -111,7 +111,7 @@ def test_admin_creates_lists_and_deletes_accounts(managed, admin):
     assert r.status_code == 200 and r.json()["role"] == "viewer"
     users = client.get("/admin/users", headers=admin).json()["users"]
     assert [(u["username"], u["role"]) for u in users] == \
-        [("root", "admin"), ("auditor", "viewer")]
+        [("root", "owner"), ("auditor", "viewer")]
     uid = users[1]["id"]
     assert client.post(f"/admin/users/{uid}/delete",
                        headers=admin).status_code == 200
@@ -128,11 +128,24 @@ def test_duplicate_usernames_and_odd_roles_are_refused(managed, admin):
     assert client.post("/admin/users", headers=admin, json=body).status_code == 422
 
 
-def test_the_last_admin_cannot_be_deleted(managed, admin):
+def test_the_last_owner_cannot_be_deleted(managed, admin):
+    """The floor that replaced the last-admin one. It is stricter than
+    that floor ever was: an admin cannot make an owner, so losing the last
+    one cannot be undone from inside at all."""
     uid = client.get("/admin/users", headers=admin).json()["users"][0]["id"]
     r = client.post(f"/admin/users/{uid}/delete", headers=admin)
     assert r.status_code == 409
-    assert "last admin" in r.json()["detail"]
+    assert "last owner" in r.json()["detail"]
+
+
+def test_the_last_admin_may_be_deleted_while_an_owner_remains(managed, admin):
+    """An owner does everything an admin does, so there is nothing to
+    protect - the old floor here would have refused this."""
+    _mk(managed, "operator", "admin")
+    uid = next(u["id"] for u in managed.list_users()
+               if u["username"] == "operator")
+    assert client.post(f"/admin/users/{uid}/delete",
+                       headers=admin).status_code == 200
 
 
 def test_deleting_an_account_kills_its_sessions(managed, admin):
@@ -233,18 +246,16 @@ def test_a_promotion_takes_effect_without_a_sign_out(managed, admin):
                       ).status_code == 200
 
 
-def test_the_last_admin_cannot_be_demoted(managed, admin):
-    """The same floor that stops the last admin being deleted: a deployment
-    with accounts and no admin cannot manage its own accounts."""
+def test_the_last_owner_cannot_be_demoted(managed, admin):
     uid = next(u["id"] for u in managed.list_users() if u["username"] == "root")
     r = client.post(f"/admin/users/{uid}/role", headers=admin,
                     json={"role": "viewer"})
     assert r.status_code == 409
-    assert "last admin" in r.json()["detail"]
+    assert "last owner" in r.json()["detail"]
 
 
-def test_an_admin_may_be_demoted_once_another_exists(managed, admin):
-    _mk(managed, "second", "admin")
+def test_an_owner_may_be_demoted_once_another_exists(managed, admin):
+    _mk(managed, "second", "owner")
     uid = next(u["id"] for u in managed.list_users() if u["username"] == "root")
     assert client.post(f"/admin/users/{uid}/role", headers=admin,
                        json={"role": "viewer"}).status_code == 200
@@ -260,7 +271,7 @@ def test_a_viewer_cannot_change_a_role(managed, viewer):
 def test_an_unknown_role_and_an_unknown_account_are_refused(managed, admin):
     uid = next(u["id"] for u in managed.list_users() if u["username"] == "root")
     assert client.post(f"/admin/users/{uid}/role", headers=admin,
-                       json={"role": "owner"}).status_code == 422
+                       json={"role": "superuser"}).status_code == 422
     assert client.post("/admin/users/0123456789abcdef/role", headers=admin,
                        json={"role": "admin"}).status_code == 404
 
@@ -288,3 +299,119 @@ def test_setting_the_role_it_already_has_records_nothing(managed, admin):
                        json={"role": "viewer"}).status_code == 200
     events = client.get("/admin/events", headers=admin).json()["events"]
     assert [x for x in events if x["kind"] == "user_role_changed"] == []
+
+
+# ------------------------------------------------------------ the rank rule --
+# You cannot act on an account that outranks you, and you cannot grant a
+# role above your own. Without it the tier above admin exists in name
+# only: an admin reaches an owner through any of three doors - reset their
+# password and sign in as them, set the address a federated sign-in
+# matches on, or simply change their role.
+
+
+def _admin_session(managed, name="operator"):
+    _mk(managed, name, "admin")
+    return _session(managed, name), next(
+        u["id"] for u in managed.list_users() if u["username"] == name)
+
+
+def test_an_admin_cannot_reset_an_owners_password(managed, admin):
+    """The most direct door: reset it, then sign in as them."""
+    sess, _ = _admin_session(managed)
+    owner = next(u["id"] for u in managed.list_users() if u["role"] == "owner")
+    r = client.post(f"/admin/users/{owner}/password", headers=sess,
+                    json={"new": "a-brand-new-long-password"})
+    assert r.status_code == 403
+    assert "above yours" in r.json()["detail"]
+
+
+def test_an_admin_cannot_set_an_owners_email(managed, admin):
+    """The quieter door, and the one this rule exists for: the address is
+    what a federated sign-in matches on, so setting it on an account above
+    yours is that account's credentials by another route."""
+    sess, _ = _admin_session(managed)
+    owner = next(u["id"] for u in managed.list_users() if u["role"] == "owner")
+    r = client.post(f"/admin/users/{owner}/email", headers=sess,
+                    json={"email": "attacker@example.com"})
+    assert r.status_code == 403
+
+
+def test_an_admin_cannot_demote_an_owner(managed, admin):
+    sess, _ = _admin_session(managed)
+    owner = next(u["id"] for u in managed.list_users() if u["role"] == "owner")
+    assert client.post(f"/admin/users/{owner}/role", headers=sess,
+                       json={"role": "viewer"}).status_code == 403
+
+
+def test_an_admin_cannot_delete_an_owner(managed, admin):
+    sess, _ = _admin_session(managed)
+    owner = next(u["id"] for u in managed.list_users() if u["role"] == "owner")
+    assert client.post(f"/admin/users/{owner}/delete",
+                       headers=sess).status_code == 403
+
+
+def test_an_admin_cannot_grant_owner(managed, admin):
+    """Not by creating one, and not by promoting one. Either would let a
+    role make a role above itself, which is the whole thing the rule
+    prevents."""
+    sess, uid = _admin_session(managed)
+    assert client.post("/admin/users", headers=sess,
+                       json={"username": "climber", "role": "owner",
+                             "password": "a-long-enough-password"}
+                       ).status_code == 403
+    _mk(managed, "colleague", "viewer")
+    cid = next(u["id"] for u in managed.list_users()
+               if u["username"] == "colleague")
+    assert client.post(f"/admin/users/{cid}/role", headers=sess,
+                       json={"role": "owner"}).status_code == 403
+
+
+def test_an_admin_still_manages_admins_and_viewers(managed, admin):
+    """The rule is about rank, not about account management: an operator
+    keeps the job they had, including resetting a colleague-admin's
+    password. Only the tier above them is out of reach."""
+    sess, _ = _admin_session(managed)
+    assert client.post("/admin/users", headers=sess,
+                       json={"username": "colleague", "role": "admin",
+                             "password": "a-long-enough-password"}
+                       ).status_code == 200
+    cid = next(u["id"] for u in managed.list_users()
+               if u["username"] == "colleague")
+    assert client.post(f"/admin/users/{cid}/password", headers=sess,
+                       json={"new": "another-long-password"}).status_code == 200
+    assert client.post(f"/admin/users/{cid}/email", headers=sess,
+                       json={"email": "colleague@example.com"}
+                       ).status_code == 200
+    assert client.post(f"/admin/users/{cid}/role", headers=sess,
+                       json={"role": "viewer"}).status_code == 200
+    assert client.post(f"/admin/users/{cid}/delete",
+                       headers=sess).status_code == 200
+
+
+def test_an_owner_may_act_on_another_owner(managed, admin):
+    """Equal rank is not above it. Otherwise two owners could never manage
+    each other and the role would need a fourth tier to supervise it."""
+    _mk(managed, "second", "owner")
+    sess = _session(managed, "second")
+    root = next(u["id"] for u in managed.list_users() if u["username"] == "root")
+    assert client.post(f"/admin/users/{root}/email", headers=sess,
+                       json={"email": "root@example.com"}).status_code == 200
+
+
+def test_the_api_credential_is_outside_the_rank_rule(managed, admin):
+    """It is the operator's break-glass, held by whoever can set the
+    receiver's environment - who already owns the box. Rank-limiting it
+    would only lock the operator out of their own recovery path."""
+    owner = next(u["id"] for u in managed.list_users() if u["role"] == "owner")
+    assert client.post(f"/admin/users/{owner}/email", headers=API_ADMIN,
+                       json={"email": "root@example.com"}).status_code == 200
+
+
+def test_break_glass_finds_the_owner_not_a_missing_admin(managed, admin):
+    """It used to name role = 'admin' outright, which stopped finding
+    anything the moment the setup account became an owner - breaking the
+    one path that exists for being locked out."""
+    r = client.post("/admin/password", headers=API_ADMIN,
+                    json={"new": "recovered-long-password"})
+    assert r.status_code == 200
+    assert managed.login("root", "recovered-long-password")["token"]

--- a/receiver/tests/test_roles.py
+++ b/receiver/tests/test_roles.py
@@ -415,3 +415,37 @@ def test_break_glass_finds_the_owner_not_a_missing_admin(managed, admin):
                     json={"new": "recovered-long-password"})
     assert r.status_code == 200
     assert managed.login("root", "recovered-long-password")["token"]
+
+
+# --------------------------------------------------------- the owner tier --
+
+
+def test_only_an_owner_configures_federated_sign_in(managed, admin):
+    """The one thing the tier above admin exists to hold. Everything else
+    on the settings page stays an admin's job."""
+    sess, _ = _admin_session(managed)
+    r = client.put("/admin/settings", headers=sess,
+                   json={"sso_tenant_id": "contoso.onmicrosoft.com"})
+    assert r.status_code == 403
+    assert "owner" in r.json()["detail"]
+    # ...and the rest of the page is untouched by the gate.
+    assert client.put("/admin/settings", headers=sess,
+                      json={"grafana_url": "https://grafana.example.com"}
+                      ).status_code == 200
+
+
+def test_an_owner_configures_federated_sign_in(managed, admin):
+    assert client.put("/admin/settings", headers=admin,
+                      json={"sso_tenant_id": "contoso.onmicrosoft.com"}
+                      ).status_code == 200
+
+
+def test_the_client_secret_is_never_echoed(managed, admin):
+    """Same treatment as the log-store password and the webhook: a stored
+    secret that a GET hands back is a stored secret anybody with a read
+    can walk off with."""
+    client.put("/admin/settings", headers=admin,
+               json={"sso_client_secret": "a-real-looking-secret"})
+    body = client.get("/admin/settings", headers=admin).json()
+    assert "a-real-looking-secret" not in str(body)
+    assert body["settings"]["sso_client_secret"]["set"] is True

--- a/receiver/tests/test_sso.py
+++ b/receiver/tests/test_sso.py
@@ -1,0 +1,150 @@
+"""Federated sign-in: what it refuses, and what it binds to.
+
+The flow itself is ordinary OpenID Connect. What is worth holding here is
+the part that is specific to this product and easy to get wrong: which
+claim an account is matched on, and the fact that no sign-in ever creates
+one.
+
+Microsoft's own guidance is the reason for the first: an address "isn't
+guaranteed to be correct and is mutable over time. Never use it for
+authorization", because addresses get reassigned. A joiner inheriting a
+leaver's address would otherwise inherit their account and their role.
+"""
+
+import os
+import time
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+import pytest
+
+from app import main
+from app import state as state_mod
+
+PASSWORD = "a-long-enough-password"
+TENANT = "11111111-2222-3333-4444-555555555555"
+
+
+@pytest.fixture
+def managed(tmp_path, monkeypatch):
+    st = state_mod.State(str(tmp_path / "state.db"))
+    monkeypatch.setattr(main, "STATE", st)
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"Bearer admin-test-token")
+    st.create_admin("root", PASSWORD)
+    yield st
+
+
+# ------------------------------------------------------------- the match --
+
+
+def test_an_address_matches_only_until_it_is_bound(managed):
+    """The address is an invitation, spent the first time somebody accepts
+    it. After that the immutable pair is the only thing that signs the
+    account in."""
+    managed.create_user("jo", PASSWORD, "viewer", by="t", email="jo@example.com")
+    uid = next(u["id"] for u in managed.list_users() if u["username"] == "jo")
+
+    found = managed.sso_account(TENANT, "oid-jo", "jo@example.com")
+    assert found["id"] == uid and found["bound"] is False
+    managed.sso_bind(uid, TENANT, "oid-jo")
+
+    # Bound: the pair finds it whatever the address now says.
+    again = managed.sso_account(TENANT, "oid-jo", "someone-else@example.com")
+    assert again["id"] == uid and again["bound"] is True
+
+
+def test_a_reused_address_cannot_take_over_a_bound_account(managed):
+    """The failure this design exists to prevent: somebody leaves, a joiner
+    is given their address, and signs in as them."""
+    managed.create_user("jo", PASSWORD, "admin", by="t", email="jo@example.com")
+    uid = next(u["id"] for u in managed.list_users() if u["username"] == "jo")
+    managed.sso_bind(uid, TENANT, "oid-the-leaver")
+
+    # The joiner: same address, different object id.
+    assert managed.sso_account(TENANT, "oid-the-joiner", "jo@example.com") is None
+
+
+def test_an_account_is_never_created_by_a_sign_in(managed):
+    """Somebody who can set an address in a tenant cannot mint themselves a
+    way in here. Every account exists because a person decided it should."""
+    assert managed.sso_account(TENANT, "oid-nobody", "stranger@example.com") is None
+
+
+def test_an_account_with_no_address_cannot_be_reached(managed):
+    """Which is what makes one usable as a shared break-glass credential:
+    a password in a password manager, reachable by nobody through the
+    provider."""
+    assert managed.list_users()[0]["email"] is None
+    assert managed.sso_account(TENANT, "oid-anything", "") is None
+    assert managed.sso_account(TENANT, "oid-anything", "root@example.com") is None
+
+
+def test_one_federated_identity_signs_in_one_account(managed):
+    managed.create_user("a", PASSWORD, "viewer", by="t", email="a@example.com")
+    managed.create_user("b", PASSWORD, "viewer", by="t", email="b@example.com")
+    ids = {u["username"]: u["id"] for u in managed.list_users()}
+    managed.sso_bind(ids["a"], TENANT, "oid-shared")
+    with pytest.raises(Exception):
+        managed.sso_bind(ids["b"], TENANT, "oid-shared")
+
+
+def test_rebinding_a_bound_account_is_refused(managed):
+    """Rebinding is how an address change would move somebody else's
+    account, which is what binding exists to stop."""
+    managed.create_user("jo", PASSWORD, "viewer", by="t", email="jo@example.com")
+    uid = next(u["id"] for u in managed.list_users() if u["username"] == "jo")
+    managed.sso_bind(uid, TENANT, "oid-one")
+    with pytest.raises(state_mod.AuthError) as e:
+        managed.sso_bind(uid, TENANT, "oid-two")
+    assert e.value.status == 409
+
+
+def test_unbinding_obeys_the_rank_rule(managed):
+    """Unbinding an account above yours would let you re-bind it to
+    yourself on the next sign-in."""
+    owner = next(u["id"] for u in managed.list_users() if u["role"] == "owner")
+    managed.sso_bind(owner, TENANT, "oid-owner")
+    with pytest.raises(state_mod.AuthError) as e:
+        managed.sso_unbind(owner, by="operator", by_role="admin")
+    assert e.value.status == 403
+    assert managed.sso_unbind(owner, by="root", by_role="owner") is True
+
+
+# ------------------------------------------------------------ the session --
+
+
+def test_a_federated_session_carries_the_accounts_role(managed):
+    managed.create_user("jo", PASSWORD, "admin", by="t", email="jo@example.com")
+    uid = next(u["id"] for u in managed.list_users() if u["username"] == "jo")
+    out = managed.sso_login(uid)
+    assert out["role"] == "admin" and out["username"] == "jo"
+    assert managed.session_user(out["token"])["user_id"] == uid
+
+
+def test_the_endpoints_are_absent_until_it_is_configured(managed):
+    """An estate that has not configured federated sign-in does not
+    advertise the endpoint."""
+    from fastapi.testclient import TestClient
+    c = TestClient(main.app)
+    assert c.get("/admin/sso/start").status_code == 404
+
+
+def test_a_callback_without_a_live_state_is_refused(managed):
+    """What protects an unauthenticated endpoint: the state it must quote
+    was minted here minutes earlier, is single-use, and is paired with a
+    verifier the browser never saw."""
+    from fastapi.testclient import TestClient
+    c = TestClient(main.app)
+    r = c.post("/admin/sso/callback",
+               json={"code": "anything", "state": "never-minted"})
+    assert r.status_code == 200 and r.json()["ok"] is False
+    assert "expired or was not started here" in r.json()["detail"]
+
+
+def test_a_state_is_single_use(managed):
+    from fastapi.testclient import TestClient
+    c = TestClient(main.app)
+    main._SSO_FLIGHT["s1"] = {"nonce": "n", "verifier": "v", "at": time.time(),
+                              "issuer": "i", "token_endpoint": "http://x"}
+    c.post("/admin/sso/callback", json={"code": "c", "state": "s1"})
+    assert "s1" not in main._SSO_FLIGHT


### PR DESCRIPTION
Two commits: the role that guards identity, then the identity provider it guards.

## The owner role, and the rule that makes it mean something

Three roles — `owner`, `admin`, `viewer`. An owner decides who may sign in and can appoint another owner; an admin runs the platform including the accounts below their own level; a viewer reads.

The role would be decoration without the rule that comes with it:

> **You cannot act on an account that outranks you, and you cannot grant a role above your own.**

Without it an admin reaches an owner through three doors — reset their password and sign in as them, set the address a federated sign-in matches on, or change their role. The email door is the one worth naming: it only opens once SSO exists, and it opens quietly, because the address is a credential by then rather than a contact detail.

**Equal rank is not above it.** Two owners manage each other, and an admin still resets a colleague-admin's password. The rule is about rank, not about taking account management off operators — an admin keeps all 23 write routes they have today. Kubernetes RBAC calls this escalation prevention; Entra enforces the same shape by refusing a password reset against a higher-privileged role.

`ADMIN_TOKEN` stays outside the rule. It's break-glass, held by whoever can set the receiver's environment — who already owns the box.

**Upgrades:** the setup code now creates an owner, and a deployment that predates the role has its earliest account promoted on first start. `create_admin` refuses once any account exists, so "earliest" identifies the setup account exactly, with nothing new recorded to work it out. The promotion lands in the audit trail.

**Two things this broke, both caught by tests:**

- **Break-glass looked for "the oldest admin"** and stopped finding anything the moment the setup account became an owner. That's the one path that exists for being locked out.
- **The last-admin floor was firing wrongly** and is gone. An owner does everything an admin does, so an owner with no admins isn't locked out of anything. The owner floor replaces it and is stricter than the admin floor ever was.

Also: `reset_user_password` was the one account route without an `AuthError` handler, so the rule's 403 escaped as a 500.

**The accounts page gains the email column** the API has had since #199 with no way to reach it — and keeps the receiver's rank table, so a control whose answer is already a 403 isn't offered. An admin looking at an owner sees a role as text and no buttons. That's a courtesy; enforcement is server-side.

## Signing in with Microsoft Entra

OIDC, authorization code flow with PKCE. The browser carries a code, never a token.

**Which claim an account is matched on** — this changed after checking Microsoft's docs, and it matters. The address finds an account *once*, on first sign-in; the account's `oid` and `tid` are written then, and every sign-in after matches on those alone. Microsoft is explicit:

> an address "isn't guaranteed to be correct and is mutable over time. **Never use it for authorization**"

Addresses get reassigned. A joiner inheriting a leaver's address would otherwise inherit their account and their role.

**No sign-in creates an account.** Someone who can set an address in a tenant can't mint a way in — an owner or admin decides the account exists. Local passwords keep working, so an account with **no** address is reachable only by password, which is what makes one usable as a shared break-glass credential.

**A wizard, because every step has something real to check.** The tenant is resolved against its own OpenID configuration document; the client id and secret are proved with a client-credentials grant, so a wrong secret is found before anyone tries to sign in. Where a tenant refuses that check for a reason that isn't about the credentials, the page says what came back and lets the sign-in decide — blocking a correct configuration is the worse failure.

**The settings save disabled.** Enabling is the last step and needs a completed sign-in, because a misconfigured provider that's already enabled is a deployment nobody can sign in to.

**Two things the flow had to work around:**

- **The callback answers with a page, not a redirect.** The session cookie is `SameSite=Strict` and the chain begins at the provider, so a redirect would arrive with the cookie withheld — signed in, looking at the sign-in screen.
- **It sits outside `/api`**, where the JSON-only CSRF rule would refuse the provider's form post. What stands in for that rule is the `state`: minted minutes earlier, single-use, paired with a PKCE verifier the browser never held.

**On the ID token signature** — not verified, deliberately, and documented rather than omitted. The token is fetched by the receiver over TLS directly from the token endpoint named by the tenant's own discovery document, which OIDC Core 3.1.3.7 permits in place of a signature check. Issuer, audience, expiry, nonce and tenant are all verified. The alternative is a JWT library and the native cryptography stack behind it, on an image kept deliberately small, for a guarantee the transport already gives in this flow.

## Verified

The tenant and client checks were driven against Microsoft's live endpoints: a fake tenant is refused and holds the wizard on that step; a real authority resolves and reports its issuer; a bogus client pair returns the provider's own reason and advances with it shown.

Receiver 236 tests, portal 471.