### PR TITLE
Two flat forms become wizards, and five more vendor syncs

### DIFF
--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -210,6 +210,89 @@ button.mini{font:inherit;font-size:12.5px;font-weight:550;padding:4px 11px;borde
 button.mini:hover{border-color:var(--pri)}
 .mfield{font:inherit;font-size:13px;padding:5px 9px;border:1px solid var(--bd);border-radius:7px;
   background:var(--sf2);color:inherit;min-width:260px}
+/* The Settings save bar. Sticks to the bottom of the viewport so it is
+   reachable from any scroll position on a long tab, and is in the flow
+   (not fixed) so it never sits over the drawer or the tour. */
+.setbar{position:sticky;bottom:12px;z-index:40;display:flex;align-items:center;gap:10px;
+  margin:14px 0 4px;padding:10px 14px;background:var(--sf);border:1px solid var(--pri);
+  border-radius:10px;box-shadow:var(--shadow);font-size:12.5px}
+.setbar[hidden]{display:none}
+#setbar-n{font-weight:600}
+#setbar-err{color:var(--warn)}
+.setbar button{margin-left:auto}
+.setbar button+button{margin-left:0}
+button.mini.pri{border-color:var(--pri);background:color-mix(in srgb,var(--pri) 14%,transparent)}
+/* The registry wizard, sharing the SSO wizard's shell above. Only the pieces
+   that shell does not already have live here: the evidence card, the
+   confirm-a-proposal rows and the review table. */
+.eviq{border:1px solid var(--bd);border-left:3px solid var(--pri);border-radius:9px;
+  background:var(--bg);padding:13px 15px;margin:0 0 16px}
+.eviq h5{margin:0 0 8px;font-size:12px;font-weight:600;color:var(--pri);
+  text-transform:uppercase;letter-spacing:.05em}
+.eviq dl{display:grid;grid-template-columns:118px 1fr;gap:5px 14px;margin:0;font-size:13px}
+.eviq dt{color:var(--mut);font-size:12.5px}
+.eviq dd{margin:0}
+.sgroup>h5{margin:16px 0 6px;font-size:11.5px;font-weight:600;color:var(--mut);
+  text-transform:uppercase;letter-spacing:.05em;display:flex;align-items:center;gap:8px}
+.sgroup>h5 .ct{font-weight:500;text-transform:none;letter-spacing:0}
+.sug{display:flex;align-items:center;gap:11px;padding:8px 11px;border:1px solid var(--bd);
+  border-radius:8px;background:var(--bg);margin:0 0 5px;cursor:pointer}
+.sug:hover{border-color:var(--acc)}
+.sug.on{border-color:var(--pri);background:var(--pri-soft)}
+.sug input{margin:0;flex:none;min-width:0}
+.sug .idf{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12.5px;
+  flex:1;min-width:0;word-break:break-all}
+.sug .fld{font-size:11.5px;color:var(--mut);white-space:nowrap}
+.sug .why{font-size:11px;padding:2px 8px;border-radius:99px;white-space:nowrap}
+.sug .why.ev{background:var(--pri-soft);color:var(--pri)}
+.sug .why.vd{background:var(--acc-soft);color:var(--acc)}
+.sug .why.me{background:var(--sf2);color:var(--mut)}
+.addrow{display:flex;gap:7px;margin-top:7px;align-items:center;flex-wrap:wrap}
+.rvw{border:1px solid var(--bd);border-radius:9px;background:var(--bg);
+  overflow:hidden;margin:0 0 14px}
+.rvw table{border-collapse:collapse;width:100%;font-size:13px}
+.rvw th{text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:.05em;
+  color:var(--mut);font-weight:600;padding:9px 14px;border-bottom:1px solid var(--bd)}
+.rvw td{padding:8px 14px;border-bottom:1px solid var(--bd);vertical-align:top}
+.rvw tr:last-child td{border-bottom:0}
+.rvw .sname{font-weight:600;font-size:12.5px}
+.callout{border:1px solid var(--bd);border-left:3px solid var(--acc);border-radius:9px;
+  background:var(--bg);padding:12px 15px;font-size:13px;color:var(--mut);margin:0 0 14px}
+.callout b{color:var(--fg)}
+/* The budget wizard's own pieces: the licence-coverage chips, the member-source
+   cards and the seat-tier table. The tiers used to be three bare inputs whose
+   only labels were placeholders, which disappear as soon as anything is typed. */
+.covers{display:flex;flex-wrap:wrap;gap:7px;margin:2px 0 0}
+.covers label{display:flex;align-items:center;gap:7px;border:1px solid var(--bd);
+  border-radius:8px;padding:6px 11px;cursor:pointer;background:var(--bg);
+  font-size:12.5px}
+.covers label:has(input:checked){border-color:var(--pri);background:var(--pri-soft)}
+.covers label.off{opacity:.55;cursor:not-allowed}
+.covers input{margin:0;min-width:0;accent-color:var(--pri)}
+.covers .tag{font-size:10.5px;padding:1px 6px;border-radius:99px;
+  background:var(--acc-soft);color:var(--acc)}
+.covers .tag.mut{background:var(--sf2);color:var(--mut)}
+.srcpick{display:grid;gap:8px;margin:0 0 12px}
+.srcpick label{display:flex;align-items:flex-start;gap:11px;border:1px solid var(--bd);
+  border-radius:9px;padding:11px 14px;cursor:pointer;background:var(--bg)}
+.srcpick label:hover{border-color:var(--acc)}
+.srcpick label:has(input:checked){border-color:var(--pri);background:var(--pri-soft)}
+.srcpick input{margin:3px 0 0;min-width:0;accent-color:var(--pri)}
+.srcpick .nm{font-weight:600;font-size:13.5px;display:block}
+.srcpick .bl{font-size:12.5px;color:var(--mut)}
+.tiers{width:100%;border-collapse:collapse;margin:0 0 6px}
+.tiers th{text-align:left;font-size:11px;text-transform:uppercase;letter-spacing:.05em;
+  color:var(--mut);font-weight:600;padding:0 8px 6px 0}
+.tiers td{padding:0 8px 7px 0;vertical-align:top}
+.tiers .mfield{min-width:0;width:100%}
+.tiers .num{text-align:right;font-variant-numeric:tabular-nums}
+.tiers .linetot{font-size:12.5px;color:var(--mut);padding-top:11px;
+  font-variant-numeric:tabular-nums;white-space:nowrap}
+.tsum{display:flex;align-items:baseline;gap:10px;border-top:1px solid var(--bd);
+  padding-top:10px;margin-top:4px;font-size:13px}
+.tsum .big{font-size:17px;font-weight:600;font-variant-numeric:tabular-nums}
+.sssum .money{font-size:19px;font-weight:600;font-variant-numeric:tabular-nums;
+  margin:2px 0 1px}
 .tokpane{border:1px solid var(--pri);border-radius:9px;padding:12px 14px;margin:14px 0;background:var(--sf)}
 .tokpane code{word-break:break-all}
 /* The inspector: a device, tool or MCP server opens beside the list rather
@@ -318,6 +401,10 @@ table.plain td{border-bottom:0;padding:4.5px 10px 4.5px 0;vertical-align:middle}
 .sssum .bar{height:100%;background:var(--pri);border-radius:3px;transition:width .35s ease}
 .ssmain{padding:22px 24px}
 .ssmain h4{margin:0 0 8px;font-size:16px}
+/* A wizard column is already narrow; capping the prose again wrapped every
+   sentence two-thirds of the way across and left a ragged margin. */
+.ssmain>p{font-size:13.5px;color:var(--mut);margin:0 0 15px}
+.ssmain .wnote{margin-top:22px}
 .sscopy{display:flex;gap:8px;align-items:center;background:var(--bg);
   border:1px dashed var(--bd);border-radius:8px;padding:9px 11px;margin:0 0 10px}
 .sscopy .mono{flex:1;overflow:auto;white-space:nowrap;user-select:all}
@@ -1018,6 +1105,18 @@ const NAVICONS = {
 // you walk through once, not a place to live.
 const VIEWS = NAV.flatMap(sec => sec.items.map(([id]) => id))
   .concat(['wizard', 'extsetup', 'budget-report']);
+// Where a bare URL lands. Derived from the nav rather than spelled out, so
+// the front door is whatever the sidebar names first and there is no second
+// list to keep in step.
+const HOME = NAV[0].items[0][0];
+// Resolves a fragment to the view it names and, for settings, the sub-tab
+// inside it. The tab is RETURNED rather than assigned: assigning it was a
+// side effect, and the hashchange handler below skips its re-render when the
+// view id has not changed - so #settings -> #settings/account moved SETTAB
+// and drew nothing. The link did nothing, and the tab it had quietly set
+// then surfaced on the NEXT visit to plain #settings, which showed Account
+// under a URL reading #settings. Both halves were wrong; a pure function and
+// a handler that compares both values fixes them together.
 const fromHash = () => {
   const h = (location.hash || '').replace(/^#/, '');
   // #settings/account addresses a sub-tab; the view is still settings.
@@ -1025,12 +1124,27 @@ const fromHash = () => {
     // Checked against the known tabs exactly like the view below it. This
     // is the point the value stops being a fragment and starts being a tab.
     const tab = h.split('/')[1];
-    if (SETTABS.includes(tab)) SETTAB = tab;
-    return 'settings';
+    return {view: 'settings', tab: SETTABS.includes(tab) ? tab : null};
   }
-  return VIEWS.includes(h) ? h : 'setup';
+  // An unknown or empty fragment lands on the Overview. It used to land on
+  // Sources, which is right immediately after the wizard - that sets #setup
+  // itself, deliberately - but it was also where a bare URL took every
+  // operator on every later visit, making a health page the front door.
+  return {view: VIEWS.includes(h) ? h : HOME, tab: null};
 };
-let view = fromHash(), detail = null, filter = '';
+// The fragment for a view, and the inverse of fromHash: settings carries
+// its sub-tab, so a navigation names the tab it is about to show rather
+// than a bare #settings that would describe a different one on a reload.
+const frag = v => '#' + v + (v === 'settings' ? '/' + SETTAB : '');
+const BOOT = fromHash();
+if (BOOT.tab) SETTAB = BOOT.tab;
+// A bare #settings names no tab, but a tab is what gets drawn. Write the
+// one being shown back into the URL rather than leave the address bar
+// describing a different page from the one on screen.
+if (BOOT.view === 'settings' && !BOOT.tab) {
+  history.replaceState(null, '', frag('settings'));
+}
+let view = BOOT.view, detail = null, filter = '';
 
 // Escapes the five characters that matter in HTML text and in a quoted
 // attribute. The apostrophe was missing, and it mattered: values were
@@ -2145,91 +2259,388 @@ const REG_CATEGORIES = ['assistant', 'coding', 'transcription', 'writing',
 const _csv = v => (v || []).join(', ');
 const _uncsv = id => _val(id).split(',').map(x => x.trim()).filter(Boolean);
 
-function regForm() {
-  const e = RPRE || {};
-  const cli = e.cli || {};
-  const ext = e.extension_ids || {};
-  const row = (id, label, val, ph) => `<dt>${esc(label)}</dt>
-    <dd><input id="${id}" class="mfield" style="min-width:340px"
-      value="${esc(val || '')}" placeholder="${esc(ph || '')}"></dd>`;
-  const opt = (v, cur) => `<option value="${v}"${v === cur ? ' selected' : ''}>${v}</option>`;
-  return `<div class="wcard" style="margin-bottom:10px">
-  <h3>${REDIT === '' ? 'Define a tool' : 'Edit ' + esc(REDIT)}</h3>
-  <p class="lede" style="margin-bottom:10px">Identifiers are what the fleet
-  scans for - list only what you have seen or verified. Comma-separated
-  where a list is asked for. The receiver validates everything to the
-  registry's own rules and says exactly what it refuses.</p>
-  ${RERR ? `<div class="note">${esc(RERR)}</div>` : ''}
-  <div style="margin-bottom:8px">
-    <button class="mini" data-act="reg-adv">${RADV ? 'Form editor' : 'Advanced: edit as JSON'}</button>
-  </div>
-  ${RADV ? `<textarea id="re-json" class="mfield" rows="14"
-      style="width:100%;font-family:ui-monospace,monospace"
-      >${esc(JSON.stringify(e, null, 2))}</textarea>`
-  : `<dl class="kv">
-    ${REDIT === '' ? row('re-id', 'id', e.id, 'lowercase-slug, e.g. acme-copilot')
-      : `<dt>id</dt><dd class="mono">${esc(REDIT)}</dd>`}
-    ${row('re-name', 'name', e.name, 'Acme Copilot')}
-    ${row('re-vendor', 'vendor', e.vendor, 'Acme')}
-    <dt>category</dt><dd><select id="re-category" class="mfield">
-      ${REG_CATEGORIES.map(c => opt(c, e.category || 'unreviewed')).join('')}</select></dd>
-    <dt>risk tier</dt><dd><select id="re-risk" class="mfield">
-      ${['high', 'medium', 'low'].map(r => opt(r, e.risk_tier || 'medium')).join('')}</select></dd>
-    ${row('re-domains', 'browser domains', _csv(e.domains), 'copilot.acme.example (lowercase)')}
-    ${row('re-app-names', 'macOS app names', _csv(e.app_names), 'Acme Copilot.app')}
-    ${row('re-bundle-ids', 'macOS bundle ids', _csv(e.bundle_ids), 'com.acme.copilot')}
-    ${row('re-exe-names', 'windows exe names', _csv(e.exe_names), 'acme.exe')}
-    ${row('re-cli-binaries', 'cli binaries', _csv(cli.binaries), 'acme')}
-    ${row('re-cli-config', 'cli config paths (from $HOME)', _csv(cli.config_paths), '.acme')}
-    ${row('re-ext-vscode', 'vscode extension ids', _csv(ext.vscode), 'acme.copilot')}
-    ${row('re-email', 'signup email sender domains', _csv(e.email_senders), 'acme.example')}
-    ${row('re-mcp-ids', 'mcp identifiers', _csv(e.mcp_identifiers), 'acme-copilot')}
-    ${row('re-mcp-any', 'mcp config paths (all OS, from $HOME)', _csv(e.mcp_config_paths), '.acme/mcp.json')}
-    ${row('re-mcp-macos', 'mcp config paths (macOS)', _csv(e.mcp_config_paths_macos), 'Library/Acme/mcp.json')}
-    ${row('re-mcp-windows', 'mcp config paths (Windows)', _csv(e.mcp_config_paths_windows), 'AppData/Acme/mcp.json')}
-    ${row('re-mcp-linux', 'mcp config paths (Linux)', _csv(e.mcp_config_paths_linux), '.config/acme/mcp.json')}
-    ${row('re-notes', 'notes', e.notes, '')}
-  </dl>`}
-  <div style="margin-top:10px">
-    <button class="mini" data-act="reg-save">Save tool</button>
-    <button class="mini" data-act="reg-cancel">Cancel</button>
+// ---- the registry wizard --------------------------------------------------
+// "Define a tool" used to be one card carrying nineteen flat fields, every one
+// optional and ungrouped. The operator does not know a tool's bundle id or CLI
+// binary - working that out is what they run this platform for - so the wizard
+// never asks. It PROPOSES, and they confirm.
+//
+// Where a proposal came from is on screen beside it, because the sources are
+// not equally trustworthy:
+//   seen in your estate    discovery's own evidence, a domain it observed.
+//                          Ticked: something has already matched it.
+//   already saved          an entry being edited. Ticked.
+//   derived from the name  deterministic guesses off the name and vendor.
+//                          NEVER ticked by default, and labelled low
+//                          confidence, because a WRONG identifier is worse
+//                          than a missing one - a blank leaves a tool unseen,
+//                          a wrong one hangs somebody else's findings on it.
+//   you added              typed in by hand. Ticked.
+let RW = null;
+
+const RW_SURFACES = [
+  ['Browser',      ['domains']],
+  ['Desktop apps', ['app_names', 'bundle_ids', 'exe_names']],
+  ['CLI and IDE',  ['cli.binaries', 'cli.config_paths', 'extension_ids.vscode']],
+  ['MCP',          ['mcp_identifiers', 'mcp_config_paths']],
+  ['Email',        ['email_senders']],
+];
+const RW_FIELDLBL = {
+  domains: 'browser domain', app_names: 'macOS app', bundle_ids: 'macOS bundle id',
+  exe_names: 'Windows exe', 'cli.binaries': 'cli binary',
+  'cli.config_paths': 'cli config path', 'extension_ids.vscode': 'vscode extension',
+  mcp_identifiers: 'mcp identifier', mcp_config_paths: 'mcp config path',
+  email_senders: 'email sender domain',
+};
+const RW_WHY = {
+  ev:      ['seen in your estate',   'ev'],
+  saved:   ['already saved',         'ev'],
+  derived: ['derived from the name', 'vd'],
+  me:      ['you added',             'me'],
+};
+const RW_SURFACE_OF = f =>
+  (RW_SURFACES.find(x => x[1].indexOf(f) >= 0) || ['Other'])[0];
+const _slug = s => String(s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-')
+  .replace(/^-+|-+$/g, '');
+
+// Deterministic, and deliberately so: no model, no key, no network call. These
+// are the guesses a person makes first, offered UNTICKED so that one has to be
+// recognised before it can enter detection. A real suggester - the classifier
+// discovery already runs - would add higher-confidence proposals alongside
+// these without changing anything else here.
+function rwDerive(name, vendor, domains) {
+  const nm = String(name || '').trim();
+  if (!nm) return [];
+  const ns = _slug(nm), vs = _slug(vendor) || ns.split('-')[0];
+  const first = ns.split('-')[0];
+  const tail = ns.indexOf(vs + '-') === 0 ? ns.slice(vs.length + 1) : ns;
+  const out = [
+    ['app_names', nm + '.app'],
+    ['bundle_ids', 'com.' + vs + '.' + tail.replace(/-/g, '')],
+    ['exe_names', nm.replace(/[^A-Za-z0-9]/g, '') + '.exe'],
+    ['cli.binaries', first],
+    ['cli.config_paths', '.' + first],
+    ['extension_ids.vscode', vs + '.' + ns],
+    ['mcp_identifiers', ns],
+  ];
+  (domains || []).forEach(d => out.push(['email_senders', d]));
+  return out.filter(x => x[1] && x[1].length > 2)
+    .map(x => ({f: x[0], v: x[1], why: 'derived', conf: 'low', on: false}));
+}
+
+// Recomputed whenever the name or vendor changes. Anything a person put there
+// - evidence, a saved value, a hand-typed one - survives untouched; only the
+// derived guesses are replaced, and a derived value duplicating one of those
+// is dropped rather than shown twice.
+function rwResuggest() {
+  const kept = RW.sugs.filter(s => s.why !== 'derived');
+  const have = {};
+  kept.forEach(s => { have[s.f + ' ' + s.v] = true; });
+  RW.sugs = kept.concat(rwDerive(RW.name, RW.vendor, RW.domains)
+    .filter(s => !have[s.f + ' ' + s.v]));
+}
+
+function rwOpen(seed) {
+  seed = seed || {};
+  RW = {
+    step: 0, editing: seed.editing || '',
+    id: seed.id || '', name: seed.name || '', vendor: seed.vendor || '',
+    category: seed.category || 'unreviewed', risk: seed.risk || 'medium',
+    notes: seed.notes || '', domains: seed.domains || [],
+    evidence: seed.evidence || null, sugs: (seed.sugs || []).slice(),
+  };
+  (seed.domains || []).forEach(d => RW.sugs.push({
+    f: 'domains', v: d, why: seed.editing ? 'saved' : 'ev',
+    conf: 'high', on: true}));
+  rwResuggest();
+  REDIT = seed.editing || ''; RPRE = null; RERR = ''; RADV = false;
+}
+
+// An existing entry arrives with every identifier already confirmed: it is in
+// the registry, so the question is what to change, not what to believe.
+function rwFromEntry(id, e) {
+  const sugs = [];
+  const take = (f, arr) => (arr || []).forEach(v =>
+    sugs.push({f: f, v: v, why: 'saved', conf: 'high', on: true}));
+  take('app_names', e.app_names); take('bundle_ids', e.bundle_ids);
+  take('exe_names', e.exe_names); take('email_senders', e.email_senders);
+  take('mcp_identifiers', e.mcp_identifiers);
+  take('mcp_config_paths', e.mcp_config_paths);
+  take('cli.binaries', (e.cli || {}).binaries);
+  take('cli.config_paths', (e.cli || {}).config_paths);
+  take('extension_ids.vscode', (e.extension_ids || {}).vscode);
+  rwOpen({editing: id, id: id, name: e.name, vendor: e.vendor,
+          category: e.category, risk: e.risk_tier, notes: e.notes,
+          domains: e.domains || [], sugs: sugs});
+}
+
+const rwOn = () => RW.sugs.filter(s => s.on);
+const rwOnIn = s => RW.sugs.filter(x => x.on && RW_SURFACE_OF(x.f) === s);
+const rwCovered = () => RW_SURFACES.filter(x => rwOnIn(x[0]).length).length;
+
+// The entry the wizard currently describes. Empty lists are dropped, because
+// the schema's shapes are optional-or-meaningful and an empty cli object is
+// neither.
+function rwEntry() {
+  // id, name, vendor and category are required by registry/schema.json, so all
+  // four are always present and the first step will not let you past without
+  // them. vendor used to be written only when non-empty, which produced an
+  // entry the receiver refused - found by saving one, not by reading this.
+  const e = {id: RW.editing || RW.id, name: RW.name, vendor: RW.vendor};
+  e.category = RW.category; e.risk_tier = RW.risk;
+  const push = (f, v) => {
+    if (f.indexOf('.') < 0) {
+      e[f] = e[f] || [];
+      if (e[f].indexOf(v) < 0) e[f].push(v);
+      return;
+    }
+    const p = f.split('.');
+    e[p[0]] = e[p[0]] || {};
+    e[p[0]][p[1]] = e[p[0]][p[1]] || [];
+    if (e[p[0]][p[1]].indexOf(v) < 0) e[p[0]][p[1]].push(v);
+  };
+  rwOn().forEach(s => push(s.f, s.v));
+  if (RW.notes) e.notes = RW.notes;
+  return e;
+}
+
+const RW_STEPS = () => [
+  {k: 'found',
+   t: RW.evidence ? 'What we found' : RW.editing ? 'This tool' : 'Which tool',
+   d: RW.evidence ? 'Discovered on your network' : 'Name it to get proposals'},
+  {k: 'ident',  t: 'How else to spot it', d: 'Confirm what to watch for'},
+  {k: 'review', t: 'Review and save',     d: 'What the fleet will watch'},
+];
+
+function rwRailLine(g) {
+  if (g.k === 'found') {
+    if (!RW.name) return {c: 'pend', t: g.d};
+    const ev = RW.evidence;
+    return {c: 'val', t: RW.name + (ev
+      ? ' · ' + ev.devices + ' device' + (ev.devices === 1 ? '' : 's') : '')};
+  }
+  if (g.k === 'ident') {
+    if (!RW.name) return {c: 'pend', t: 'waiting on a name'};
+    const n = rwOn().length, s = rwCovered();
+    return n
+      ? {c: 'val', t: n + ' confirmed across ' + s + ' surface' + (s === 1 ? '' : 's')}
+      : {c: 'pend', t: 'nothing confirmed yet'};
+  }
+  return rwOn().length ? {c: 'val', t: 'ready to save'} : {c: 'pend', t: g.d};
+}
+const rwReady = () => !!(RW.name && RW.vendor && (RW.editing || RW.id));
+const rwDone = g => g.k === 'found' ? rwReady()
+  : g.k === 'ident' ? rwOn().length > 0 : false;
+
+function rwRail() {
+  const steps = RW_STEPS(), cov = rwCovered();
+  return `<div class="ssrail"><h3>${RW.editing ? 'Edit a tool' : 'Add a tool'}</h3>
+  <ol>${steps.map((g, i) => {
+    const d = rwDone(g), on = i === RW.step, ln = rwRailLine(g);
+    return `<li class="ssstep ${d ? 'done' : ''} ${on ? 'on' : ''}"
+      data-act="rw-step" data-key="${i}">
+      <span class="dot">${d ? '&#10003;' : i + 1}</span>
+      <span style="min-width:0"><span class="t">${esc(g.t)}</span>
+      <span class="${ln.c}">${esc(ln.t)}</span></span></li>`;
+  }).join('')}</ol>
+  <div class="sssum">
+    <div class="lede" style="font-size:11.5px">${cov} of ${RW_SURFACES.length}
+      surfaces covered</div>
+    <div class="barwrap"><div class="bar"
+      style="width:${cov / RW_SURFACES.length * 100}%"></div></div>
+    <div class="lede" style="font-size:11.5px">A surface with no identifier is
+      not a gap in your estate - it is a place this tool would go unseen.</div>
   </div></div>`;
 }
 
-// The entry the form currently describes. Empty lists and empty strings
-// are dropped, because the schema's shapes are optional-or-meaningful and
-// an empty cli object is neither.
+function rwBodyFound() {
+  const ev = RW.evidence;
+  const row = (id, label, val, ph) => `<dt>${label}</dt><dd>
+    <input id="${id}" class="mfield" style="min-width:300px"
+      value="${esc(val || '')}" placeholder="${esc(ph || '')}"></dd>`;
+  return `<h4>${ev ? 'What we found'
+    : RW.editing ? esc(RW.name || RW.editing) : 'Which tool'}</h4>
+  <p>${ev
+    ? `Discovery saw this on your network and the classifier read it as an AI
+       service. Confirm it is what you think it is - everything after this hangs
+       off the name.`
+    : RW.editing
+    ? `This tool is already in the registry. Change what you need here; its
+       identifiers are on the next step.`
+    : `Name the tool and identifiers will be proposed for it. Nothing is saved
+       until you have confirmed them.`}</p>
+  ${ev ? `<div class="eviq"><h5>Evidence</h5><dl>
+    <dt>${ev.kind === 'mcp_server' ? 'Server' : 'Domain'}</dt>
+    <dd class="mono">${esc(ev.what)}</dd>
+    <dt>Seen on</dt><dd>${ev.devices} device${ev.devices === 1 ? '' : 's'}</dd>
+    ${ev.confidence ? `<dt>Read as</dt><dd>${esc(ev.category || 'AI tool')}
+      <span class="pill p-ok">${esc(ev.confidence)} confidence</span></dd>` : ''}
+    <dt>Source</dt><dd>Discovery run</dd>
+  </dl></div>` : ''}
+  <dl class="kv">
+    ${row('rw-name', 'name', RW.name, 'Acme Copilot')}
+    ${row('rw-vendor', 'vendor', RW.vendor, 'Acme')}
+    ${RW.editing
+      ? `<dt>id</dt><dd class="mono">${esc(RW.editing)}</dd>`
+      : row('rw-id', 'id', RW.id, 'lowercase-slug, e.g. acme-copilot')}
+    <dt>category</dt><dd><select id="rw-category" class="mfield">
+      ${REG_CATEGORIES.map(c => `<option${RW.category === c ? ' selected' : ''}
+        >${esc(c)}</option>`).join('')}</select></dd>
+    <dt>risk tier</dt><dd><select id="rw-risk" class="mfield">
+      ${['high', 'medium', 'low'].map(r => `<option${RW.risk === r ? ' selected' : ''}
+        >${r}</option>`).join('')}</select></dd>
+  </dl>
+  <p class="src-note" style="margin-top:10px">Name, vendor, id and category are
+  all required: the registry refuses an entry without them.</p>
+  <p class="src-note wnote">${RW.editing
+    ? 'The id is how every other page refers to this tool, so it cannot change.'
+    : ev
+    ? `Dismissing instead? That is the Dismiss button on the review queue - it
+       records that a person decided, so the same domain does not come back
+       next week.`
+    : 'The id is how every other page refers to this tool and cannot change later.'}</p>`;
+}
+
+function rwSugRow(s, i) {
+  const why = RW_WHY[s.why] || RW_WHY.me;
+  return `<label class="sug ${s.on ? 'on' : ''}">
+    <input type="checkbox" data-act="rw-tick" data-key="${i}"${s.on ? ' checked' : ''}>
+    <span class="idf">${esc(s.v)}</span>
+    <span class="fld">${esc(RW_FIELDLBL[s.f] || s.f)}</span>
+    ${s.why === 'derived'
+      ? `<span class="pill p-warn">${esc(s.conf)} confidence</span>` : ''}
+    <span class="why ${why[1]}">${esc(why[0])}</span></label>`;
+}
+
+function rwBodyIdent() {
+  if (!RW.name) return `<h4>How else to spot it</h4>
+    <p>Name the tool on the first step and proposals appear here.</p>`;
+  const anyEv = RW.sugs.some(s => s.why === 'ev' || s.why === 'saved');
+  return `<h4>How else to spot it</h4>
+  <p>What was already seen is ticked. Everything else is a proposal derived from
+  the name - left off, and labelled - because a wrong identifier is worse than a
+  missing one: a blank leaves this tool unseen on a surface, a wrong one hangs
+  somebody else's findings on it. Tick only what you recognise.</p>
+  ${anyEv ? '' : `<div class="note">Nothing here has been seen in your estate
+    yet - you are defining this tool before anything found it, so every line
+    below is a guess until a finding matches it.</div>`}
+  ${RW_SURFACES.map(sf => {
+    const rows = RW.sugs.map((x, i) => [x, i])
+      .filter(p => RW_SURFACE_OF(p[0].f) === sf[0]);
+    if (!rows.length) return '';
+    const n = rows.filter(p => p[0].on).length;
+    return `<div class="sgroup"><h5>${esc(sf[0])}
+      <span class="ct">${n ? n + ' confirmed' : 'none confirmed'}</span></h5>
+      ${rows.map(p => rwSugRow(p[0], p[1])).join('')}</div>`;
+  }).join('')}
+  <div class="sgroup"><h5>Add your own</h5>
+    <div class="addrow">
+      <input id="rw-newv" class="mfield" style="min-width:230px"
+        placeholder="an identifier you know, e.g. Acme.app">
+      <select id="rw-newf" class="mfield" style="min-width:180px">
+        ${Object.keys(RW_FIELDLBL).map(f =>
+          `<option value="${esc(f)}">${esc(RW_FIELDLBL[f])}</option>`).join('')}
+      </select>
+      <button class="mini" data-act="rw-add">Add</button>
+    </div></div>
+  <p class="src-note wnote">A confirmed identifier is still only a guess until something
+  matches it. The next step says which is which.</p>`;
+}
+
+function rwBodyReview() {
+  const rows = RW_SURFACES.map(sf => {
+    const c = rwOnIn(sf[0]);
+    const seen = c.some(x => x.why === 'ev' || x.why === 'saved');
+    return `<tr><td class="sname">${esc(sf[0])}</td>
+      <td>${c.length ? c.map(x => `<div class="mono"
+        style="font-size:12px">${esc(x.v)}</div>`).join('')
+        : '<span style="color:var(--mut)">nothing to match on</span>'}</td>
+      <td>${!c.length ? '<span class="pill p-mut">unseen</span>'
+        : seen ? '<span class="pill p-ok">already matching</span>'
+               : '<span class="pill p-warn">watching</span>'}</td></tr>`;
+  }).join('');
+  return `<h4>Review and save</h4>
+  <p>This is what goes to every collector on its next check-in. No repo, no
+  rebuild, no MDM re-push.</p>
+  ${RERR ? `<div class="note">${esc(RERR)}</div>` : ''}
+  <div class="rvw"><table>
+    <tr><th>surface</th><th>identifiers</th><th>status</th></tr>${rows}
+  </table></div>
+  <div class="callout"><b>Already matching</b> means findings exist for it today.
+  <b>Watching</b> means the identifier is live but nothing has matched yet -
+  which may mean nobody uses it that way, or may mean the identifier is wrong.
+  The tool page keeps that split visible rather than reporting a confident
+  zero.</div>
+  <div style="margin-bottom:10px">
+    <button class="mini" data-act="reg-adv">${RADV
+      ? 'Back to the wizard' : 'Advanced: edit as JSON'}</button></div>
+  ${RADV ? `<textarea id="re-json" class="mfield" rows="14"
+      style="width:100%;font-family:ui-monospace,monospace"
+      >${esc(JSON.stringify(rwEntry(), null, 2))}</textarea>` : ''}`;
+}
+
+function regForm() {
+  if (!RW) rwOpen({});
+  const steps = RW_STEPS(), g = steps[RW.step];
+  const body = g.k === 'found' ? rwBodyFound()
+    : g.k === 'ident' ? rwBodyIdent() : rwBodyReview();
+  const canNext = g.k !== 'found' || rwReady();
+  return `<div class="ssow" style="margin-bottom:14px">${rwRail()}
+    <div class="ssmain">${body}
+      <div class="ssfoot">
+        <button class="mini" data-act="reg-cancel">Cancel</button>
+        <span class="sp"></span>
+        ${RW.step > 0 ? `<button class="mini" data-act="rw-step"
+          data-key="${RW.step - 1}">Back</button>` : ''}
+        ${RW.step < 2
+          ? `<button class="mini pri" data-act="rw-step" data-key="${RW.step + 1}"
+              ${canNext ? '' : 'disabled'}>Next</button>`
+          : `<button class="mini pri" data-act="reg-save">${RW.editing
+              ? 'Save changes' : 'Save and watch'}</button>`}
+      </div></div></div>`;
+}
+
+// Typing a name has to reach the Next button and the rail as it happens. A full
+// re-render would take the focus out of the field mid-word, so this updates the
+// two things that depend on the name and leaves the inputs alone. Without it
+// Next stayed disabled from the first render and the wizard could not be walked
+// at all - found by typing into it rather than by reading it.
+function rwLive() {
+  if (!RW) return;
+  rwSync();
+  const railEl = document.querySelector('.ssrail');
+  if (railEl) railEl.outerHTML = rwRail();
+  const next = document.querySelector('.ssfoot [data-act="rw-step"].pri');
+  if (next) next.disabled = !rwReady();
+}
+app.addEventListener('input', e => {
+  if (e.target && e.target.matches
+      && e.target.matches('#rw-name,#rw-vendor,#rw-id')) rwLive();
+});
+
+// Reads whatever the current step has on screen back into RW, so moving between
+// steps - or saving from the last one - never loses a keystroke.
+function rwSync() {
+  if (!RW) return;
+  const val = id => { const el = document.getElementById(id); return el ? el.value : null; };
+  const nm = val('rw-name');
+  if (nm === null) return;
+  const before = RW.name + ' ' + RW.vendor;
+  RW.name = nm;
+  RW.vendor = val('rw-vendor') || '';
+  if (!RW.editing) RW.id = val('rw-id') || _slug(RW.name);
+  RW.category = val('rw-category') || RW.category;
+  RW.risk = val('rw-risk') || RW.risk;
+  if (RW.name + ' ' + RW.vendor !== before) rwResuggest();
+}
+
 function regEntryFromForm() {
   if (RADV) {
     const t = document.getElementById('re-json');
     return JSON.parse((t && t.value) || '{}');
   }
-  const e = {
-    id: REDIT === '' ? _val('re-id') : REDIT,
-    name: _val('re-name'), vendor: _val('re-vendor'),
-    category: _val('re-category'), risk_tier: _val('re-risk'),
-  };
-  const lists = {
-    domains: _uncsv('re-domains'), app_names: _uncsv('re-app-names'),
-    bundle_ids: _uncsv('re-bundle-ids'), exe_names: _uncsv('re-exe-names'),
-    email_senders: _uncsv('re-email'), mcp_identifiers: _uncsv('re-mcp-ids'),
-    mcp_config_paths: _uncsv('re-mcp-any'),
-    mcp_config_paths_macos: _uncsv('re-mcp-macos'),
-    mcp_config_paths_windows: _uncsv('re-mcp-windows'),
-    mcp_config_paths_linux: _uncsv('re-mcp-linux'),
-  };
-  Object.keys(lists).forEach(k => { if (lists[k].length) e[k] = lists[k]; });
-  const binaries = _uncsv('re-cli-binaries'), config = _uncsv('re-cli-config');
-  if (binaries.length || config.length) {
-    e.cli = {};
-    if (config.length) e.cli.config_paths = config;
-    if (binaries.length) e.cli.binaries = binaries;
-  }
-  const vscode = _uncsv('re-ext-vscode');
-  if (vscode.length) e.extension_ids = {vscode: vscode};
-  const notes = _val('re-notes');
-  if (notes) e.notes = notes;
-  return e;
+  rwSync();
+  return rwEntry();
 }
 
 async function registryView() {
@@ -2750,9 +3161,17 @@ async function iso() {
 // a glance rather than reading.
 const INFO = '<button class="info" data-info type="button" title="about this field">I</button>';
 
-function settingRow(key, label, placeholder, note) {
+// `batch` puts the field under the Settings view's one Save changes bar
+// instead of giving it a Save button of its own. A SECRET never batches,
+// whatever is asked for: its box renders blank by design, and blank means
+// CLEAR - so a batch that swept the secrets up would wipe every one of them
+// the moment somebody edited an unrelated field on the same tab. The wizard
+// and the extension guide pass nothing and keep their per-field saves,
+// which is right there: each step gates on its own value being stored.
+function settingRow(key, label, placeholder, note, batch) {
   const s = (SETTINGS && SETTINGS.settings || {})[key] || {value: '', source: 'unset'};
   const secret = !('value' in s);
+  const batched = batch && !secret;
   const state = secret
     ? (s.set ? '<span class="pill p-ok">set</span>' : '')
     : s.source === 'db' ? '<span class="pill p-mut">saved here</span>'
@@ -2764,12 +3183,14 @@ function settingRow(key, label, placeholder, note) {
     ? (s.set ? 'A value is set (never shown). Leave blank and save to CLEAR it; type and save to replace it.' : 'Not set.')
     : '';
   const more = `${esc(note)}${note ? ' ' : ''}${secretNote || src}`.trim();
+  const val = secret ? '' : (s.value || '');
   return `<dt>${esc(label)}${more ? INFO : ''}</dt><dd>
     <input id="set-${esc(key)}" class="mfield" style="min-width:340px"
       ${secret ? 'type="password" autocomplete="off"' : ''}
+      ${batched ? `data-sfield="${esc(key)}" data-sinit="${esc(val)}"` : ''}
       placeholder="${esc(placeholder)}"
-      value="${secret ? '' : esc(s.value || '')}">
-    <button class="mini" data-act="save-setting" data-key="${esc(key)}">Save</button>
+      value="${esc(val)}">
+    ${batched ? '' : `<button class="mini" data-act="save-setting" data-key="${esc(key)}">Save</button>`}
     ${state}
     ${more ? `<div class="src-note fnote">${more}</div>` : ''}</dd>`;
 }
@@ -2822,7 +3243,7 @@ function widgetPickerRow() {
   </dd>`;
 }
 
-function pasteGuardBehaviourFields() {
+function pasteGuardBehaviourFields(batch) {
   const s = (SETTINGS && SETTINGS.settings) || {};
   const mode = (s.paste_guard_mode || {}).value || '';
   const marksSet = (s.classification_markings || {}).source === 'db';
@@ -2830,19 +3251,22 @@ function pasteGuardBehaviourFields() {
   const opt = (v, label) => `<option value="${v}"${mode === v ? ' selected' : ''}>${label}</option>`;
   return `
     <dt>Paste guard mode${INFO}</dt><dd>
-      <select id="set-paste_guard_mode" class="mfield">
+      <select id="set-paste_guard_mode" class="mfield"
+        ${batch ? `data-sfield="paste_guard_mode" data-sinit="${esc(mode)}"` : ''}>
         <option value=""${mode ? '' : ' selected'}>warn (default)</option>
         ${opt('off', 'off')}${opt('warn', 'warn')}${opt('block', 'block')}
       </select>
-      <button class="mini" data-act="save-setting" data-key="paste_guard_mode">Save</button>
+      ${batch ? '' : '<button class="mini" data-act="save-setting" data-key="paste_guard_mode">Save</button>'}
       <div class="src-note fnote">What happens when someone pastes marked content
       into an AI tool: warn asks them first, block stops it. Baked into the
       policy downloads.</div></dd>
     <dt>Classification markings${INFO}</dt><dd>
       <textarea id="set-classification_markings" class="mfield" rows="4"
         style="min-width:340px;resize:vertical;font-family:inherit"
+        ${batch ? `data-sfield="classification_markings" data-slist="lines"
+          data-sinit="${marks === null ? '' : esc(marks.join('\n'))}"` : ''}
         placeholder="one marking per line (empty = the default set)">${marks === null ? '' : esc(marks.join('\n'))}</textarea>
-      <button class="mini" data-act="save-markings">Save</button>
+      ${batch ? '' : '<button class="mini" data-act="save-markings">Save</button>'}
       ${marksSet ? '<button class="mini" data-act="clear-markings">Clear (default set)</button>' : ''}
       <div class="src-note fnote">Document phrases the guard looks for in pastes,
       one per line. Save an empty box to use no markings; clear to go back
@@ -2850,31 +3274,33 @@ function pasteGuardBehaviourFields() {
       only which detector matched gets reported.</div></dd>`;
 }
 
-function extensionDeliveryFields() {
+function extensionDeliveryFields(batch) {
   return `
     ${settingRow('firefox_extension_id', 'Firefox extension ID (gecko id)',
       'ai-guard@your-org.example',
       'The id you set in the manifest (browser_specific_settings.gecko.id).'
       + ' Not the same as the Chromium id. Needed for the Firefox'
-      + ' downloads.')}
+      + ' downloads.', batch)}
     ${settingRow('extension_crx_url', 'Packed .crx URL (Chromium)',
       'https://files.example.com/ai-guard-1.0.0.crx',
       'Where you host the packed .crx. The generated updates.xml points'
-      + ' browsers at it.')}
+      + ' browsers at it.', batch)}
     ${settingRow('extension_update_url', 'Chromium update manifest URL',
       'https://files.example.com/updates.xml',
       'Where you host the packed extension update manifest (updates.xml).'
-      + ' Needed for the Windows Chromium deploy script.')}
+      + ' Needed for the Windows Chromium deploy script.', batch)}
     ${settingRow('extension_xpi_url', 'Signed .xpi URL (Firefox)',
       'https://files.example.com/ai-guard-1.0.0.xpi',
       'Where you host the SIGNED .xpi from addons.mozilla.org'
       + ' (self-distribution). Firefox only installs Mozilla-signed'
       + ' extensions - the extension setup guide covers the one-time'
-      + ' signing step. Needed for the Firefox downloads.')}`;
+      + ' signing step. Needed for the Firefox downloads.', batch)}`;
 }
 
+// Settings shows these under its one Save changes bar; the extension guide
+// calls pasteGuardBehaviourFields directly and keeps its per-field saves.
 function pasteGuardFields() {
-  return pasteGuardBehaviourFields() + extensionDeliveryFields();
+  return pasteGuardBehaviourFields(true) + extensionDeliveryFields(true);
 }
 
 // The last result of a connection test, rendered where its button lives.
@@ -2895,12 +3321,12 @@ function testNote(which) {
 // The log-store step/card, shared by the wizard and the Settings view. The
 // wizard adds the self-hosted / cloud / none branch; Settings shows all
 // fields flat.
-function logStoreFields(withUsername) {
+function logStoreFields(withUsername, batch) {
   return settingRow('log_store_url', 'Log store base URL',
     'http://loki.<namespace>.svc.cluster.local:3100',
-    'The BASE URL. The receiver derives the push endpoint from it, so the push-vs-base mixup cannot happen here.')
+    'The BASE URL. The receiver derives the push endpoint from it, so the push-vs-base mixup cannot happen here.', batch)
     + (withUsername ? settingRow('log_store_username', 'Log store username',
-        'numeric instance id on Grafana Cloud', '')
+        'numeric instance id on Grafana Cloud', '', batch)
       + settingRow('log_store_password', 'Log store password / token', 'paste to set', '')
       : '');
 }
@@ -3334,9 +3760,10 @@ function fleetSettings() {
   <dl class="kv">
     <dt>Corporate domains${INFO}</dt><dd>
       <input id="set-domains" class="mfield" style="min-width:340px"
+        data-sfield="corp_domains" data-slist="csv"
+        data-sinit="${esc((cd.value || []).join(', '))}"
         placeholder="example.com, example.co.uk"
         value="${esc((cd.value || []).join(', '))}">
-      <button class="mini" data-act="save-domains">Save</button>
       ${cd.source === 'db' ? `<button class="mini" data-act="clear-domains">Clear (fall back)</button>` : ''}
       ${cd.source === 'db' ? '<span class="pill p-mut">saved here</span>'
         : cd.source === 'env' ? '<span class="pill p-mut">from deployment</span>' : ''}
@@ -3344,9 +3771,10 @@ function fleetSettings() {
       as a work account; anything else is flagged personal. ${srcNote}</div></dd>
     <dt>Extension ID${INFO}</dt><dd>
       <input id="set-extid" class="mfield" style="min-width:340px"
+        data-sfield="extension_id"
+        data-sinit="${esc((s.extension_id || {}).value || '')}"
         placeholder="the browser extension's ID"
         value="${esc((s.extension_id || {}).value || '')}">
-      <button class="mini" data-act="save-extid">Save</button>
       <div class="src-note fnote">Used to generate the extension's managed-policy
       artifact. Empty clears it.</div></dd>
     ${pasteGuardFields()}
@@ -3363,7 +3791,7 @@ function connectionSettings() {
   <dl class="kv">
     ${settingRow('receiver_public_url', 'Public receiver URL',
       'https://ai-guard.your-tailnet.ts.net',
-      'The URL endpoints reach from OUTSIDE - it gets baked into every downloaded artifact. Not the internal receiver address the portal proxies to.')}
+      'The URL endpoints reach from OUTSIDE - it gets baked into every downloaded artifact. Not the internal receiver address the portal proxies to.', true)}
   </dl>
   <div style="margin-top:8px">
     <button class="mini" data-act="run-test" data-key="receiver-url">Probe the saved URL</button>
@@ -3375,10 +3803,10 @@ function connectionSettings() {
   moment this is saved - no restart. Credentials follow the URL: a store
   saved here uses only the credentials saved here.</p>
   <dl class="kv">
-    ${logStoreFields(true)}
+    ${logStoreFields(true, true)}
     ${settingRow('log_store_push_url', 'Push endpoint override',
       'only for gateways with a non-standard push path',
-      'Advanced. Leave empty to derive it from the base URL, which is almost always right.')}
+      'Advanced. Leave empty to derive it from the base URL, which is almost always right.', true)}
   </dl>${logStoreTests()}</div>`;
 }
 
@@ -3387,21 +3815,21 @@ function alertingSettings() {
   <dl class="kv">
     ${settingRow('alertmanager_url', 'Alertmanager URL',
       'http://alertmanager.<namespace>.svc:9093',
-      'warn findings page through this. Empty means findings are logged and dashboarded but nothing pages.')}
+      'warn findings page through this. Empty means findings are logged and dashboarded but nothing pages.', true)}
     ${settingRow('webhook_url', 'Notification webhook',
       'https://hooks.slack.com/services/…',
-      'A Slack-compatible incoming webhook. The receiver posts to it when discovery adds a NEW tool or MCP server to the review queue - once per discovery, never per finding. The weekly digest is separate: set DIGEST_WEBHOOK_URL on the portal deployment.')}
+      'A Slack-compatible incoming webhook. The receiver posts to it when discovery adds a NEW tool or MCP server to the review queue - once per discovery, never per finding. The weekly digest is separate: set DIGEST_WEBHOOK_URL on the portal deployment.', true)}
     ${settingRow('grafana_url', 'Grafana URL',
       'the URL a BROWSER reaches Grafana on',
-      'Saving reloads the page: the frame permission lives in this page\u2019s own security policy, which is fixed per load. Grafana must also allow embedding.')}
+      'Saving reloads the page: the frame permission lives in this page\u2019s own security policy, which is fixed per load. Grafana must also allow embedding.', true)}
     ${settingRow('grafana_panels', 'Grafana panels',
-      'dashboardUid:panelId:Title; semicolon separated', '')}
+      'dashboardUid:panelId:Title; semicolon separated', '', true)}
     ${settingRow('grafana_dashboard_uid', 'Grafana dashboard UID',
       'the /d/ segment of the dashboard URL',
-      'Embeds one whole dashboard instead of panels. Pasting the full dashboard URL works: it is trimmed to the UID.')}
+      'Embeds one whole dashboard instead of panels. Pasting the full dashboard URL works: it is trimmed to the UID.', true)}
     ${settingRow('budget_currency', 'Preferred currency',
       'GBP',
-      'The Budget headline converts into it at the ECB daily reference rate, naming the rate date inline; newly linked tools default to it.')}
+      'The Budget headline converts into it at the ECB daily reference rate, naming the rate date inline; newly linked tools default to it.', true)}
     ${widgetPickerRow()}
   </dl></div>`;
 }
@@ -3883,6 +4311,42 @@ function diagnosticsCards() {
   from here.</p></div>`}`;
 }
 
+// ---- the Settings save bar -------------------------------------------
+// Every field on a Settings tab used to carry its own Save, which meant the
+// Fleet tab alone showed eight of them and the four extension-hosting URLs -
+// only meaningful together - were four separate round trips. The fields that
+// can batch now share one bar, and it appears only once something is dirty.
+//
+// Dirty is measured against the value the field was RENDERED with, carried
+// on the element as data-sinit, rather than against SETTINGS: a select and a
+// textarea do not read back the same way, and the rendered value is the one
+// the person is actually looking at.
+const sDirty = () => Array.from(app.querySelectorAll('[data-sfield]'))
+  .filter(el => el.value !== el.getAttribute('data-sinit'));
+
+// The value a field contributes to the POST body. Lists are the two shapes
+// the settings API takes: comma-separated domains and one marking per line.
+function sValue(el) {
+  const v = el.value, list = el.getAttribute('data-slist');
+  if (!list) return v;
+  return v.split(list === 'csv' ? ',' : '\n').map(x => x.trim()).filter(Boolean);
+}
+
+function sBarSync() {
+  const bar = document.getElementById('setbar');
+  if (!bar) return;
+  const n = sDirty().length;
+  bar.hidden = !n;
+  const lbl = document.getElementById('setbar-n');
+  if (lbl) lbl.textContent = n === 1 ? '1 unsaved change' : n + ' unsaved changes';
+  const err = document.getElementById('setbar-err');
+  if (err) err.textContent = '';
+}
+// Both events, because a select fires change and a text field fires input.
+['input', 'change'].forEach(ev => app.addEventListener(ev, e => {
+  if (e.target && e.target.hasAttribute && e.target.hasAttribute('data-sfield')) sBarSync();
+}));
+
 async function settings() {
   if (!DIAG) {
     try { DIAG = await (await fetch('/api/diagnostics')).json(); }
@@ -3928,7 +4392,13 @@ async function settings() {
   ${SETMSG ? `<div class="note">${esc(SETMSG)}</div>` : ''}
   <div class="tabs">${STABS.map(([id, lbl]) =>
     `<button data-settab="${id}" class="${SETTAB===id?'on':''}">${lbl}</button>`).join('')}</div>
-  ${body}`;
+  ${body}
+  <div id="setbar" class="setbar" hidden>
+    <span id="setbar-n"></span>
+    <span id="setbar-err"></span>
+    <button class="mini pri" data-act="settings-save-all">Save changes</button>
+    <button class="mini" data-act="settings-discard">Discard</button>
+  </div>`;
 }
 
 // Repo docs as real links, pinned to the release this portal runs - the
@@ -4540,31 +5010,15 @@ function parseUsersCsv(text) {
                 cols: {email: iEmail, name: iName, role: iRole, tier: iTier}}};
 }
 
-const BPROVIDER_NONE = `ChatGPT Business (Team) has no admin API - OpenAI
-  keeps SCIM and the Compliance API for Enterprise - so its users come in
-  through the guided import below. That is the vendor's boundary, not this
-  page's.`;
-
-function bTierRows(tiers, eff) {
-  const rows = [...(tiers || [])];
-  while (rows.length < Math.min(4, (tiers || []).length + 2)) rows.push({});
-  const covRow = (t, i) => (eff || []).length < 2 ? '' :
-    `<div style="margin:-2px 0 8px 2px;font-size:11.5px;color:var(--mut)">covers:
-      ${eff.map(tool => `<label style="margin-right:12px;cursor:pointer">
-        <input type="checkbox" id="bt-cov-${i}-${esc(tool)}"
-          style="min-width:0;margin:0 4px 0 0;accent-color:var(--pri)"
-          ${!t.covers || !t.covers.length || t.covers.includes(tool) ? 'checked' : ''}>${esc(tool)}</label>`).join('')}
-    </div>`;
-  return rows.map((t, i) => `<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:6px">
-    <input id="bt-name-${i}" class="mfield" style="min-width:140px" placeholder="tier, e.g. premium"
-      value="${esc(t.name || '')}">
-    <input id="bt-seats-${i}" class="mfield" style="min-width:80px" placeholder="seats"
-      value="${t.seats != null ? esc(String(t.seats)) : ''}">
-    <input id="bt-price-${i}" class="mfield" style="min-width:120px" placeholder="price / seat / month"
-      value="${t.unit_price_monthly != null ? esc(String(t.unit_price_monthly)) : ''}">
-  </div>${covRow(t, i)}`).join('');
-}
-
+// The general case, not one vendor's. Automatic sync exists for a vendor only
+// where that vendor ships an admin API the receiver can call, and today that is
+// two of the thirty tools the registry ships with. Naming ChatGPT here made a
+// specific absence look like the only one; every other tool is in the same
+// position and the page never said so.
+const BPROVIDER_NONE = `Automatic sync needs an admin API from the vendor, and
+  most do not have one - or keep it for their top plan. Anything not listed
+  under Automatic uses Import or Manual, and its numbers work the same either
+  way. That is the vendor's boundary, not this page's.`;
 function bReadTiers(eff) {
   const tiers = [];
   for (let i = 0; i < 6; i++) {
@@ -4611,154 +5065,464 @@ function bStash() {
   }
 }
 
+// The seat tiers, as a table with real column headers. They used to be three
+// bare inputs whose only labels were their placeholders, which vanish the
+// moment anything is typed - so a filled-in row said "Standard 1 18" and
+// nothing said which number was the price. The per-row and running totals are
+// here because this is the one wizard whose subject is a number.
+function bTierRows(tiers, eff, cur) {
+  const rows = [...(tiers || [])];
+  while (rows.length < Math.min(4, (tiers || []).length + 2)) rows.push({});
+  const covRow = (t, i) => (eff || []).length < 2 ? '' :
+    `<tr><td colspan="4" style="padding:0 0 9px 2px">
+      <div class="covers">${eff.map(tool => `<label>
+        <input type="checkbox" id="bt-cov-${i}-${esc(tool)}"
+          ${!t.covers || !t.covers.length || t.covers.includes(tool) ? 'checked' : ''}>
+        <span class="mono">${esc(tool)}</span></label>`).join('')}</div></td></tr>`;
+  return `<table class="tiers">
+    <tr><th>Tier</th><th style="width:96px">Seats</th>
+      <th style="width:140px">Price / seat</th>
+      <th style="width:110px">Monthly</th></tr>
+    ${rows.map((t, i) => {
+      const line = (t.seats || 0) * (t.unit_price_monthly || 0);
+      return `<tr>
+      <td><input id="bt-name-${i}" class="mfield" placeholder="tier, e.g. premium"
+        value="${esc(t.name || '')}"></td>
+      <td><input id="bt-seats-${i}" class="mfield num" placeholder="0"
+        value="${t.seats != null ? esc(String(t.seats)) : ''}"></td>
+      <td><input id="bt-price-${i}" class="mfield num" placeholder="0.00"
+        value="${t.unit_price_monthly != null ? esc(String(t.unit_price_monthly)) : ''}"></td>
+      <td class="linetot" id="bt-line-${i}">${line ? bMoney(line, cur) : ''}</td>
+    </tr>${t.name ? covRow(t, i) : ''}`;
+    }).join('')}
+  </table>`;
+}
+
+// What the tiers on screen add up to. Read from the DOM when the seat step is
+// showing, so the rail and the running total move as the number is typed, and
+// from the stashed state otherwise.
+// The currency comes off the screen too while the seat step is showing.
+// Reading it only from the stashed state meant every figure rendered unitless
+// until you left the step - the rail said "216" where it meant GBP 216.
+function bWizCur() {
+  const el = document.getElementById('bw-currency');
+  return (el ? el.value : BWIZ.currency) || BWIZ.currency || '';
+}
+
+function bWizTotals() {
+  const w = BWIZ;
+  const eff = [w.tool_id].concat(w.covers || []);
+  const tiers = document.getElementById('bt-name-0') ? bReadTiers(eff) : (w.tiers || []);
+  return {
+    tiers: tiers,
+    monthly: tiers.reduce((a, t) => a + (t.seats || 0) * (t.unit_price_monthly || 0), 0),
+    seats: tiers.reduce((a, t) => a + (t.seats || 0), 0),
+  };
+}
+
+const BW_STEPS = [
+  {k: 1, t: 'Which tool',        d: 'And what the licence covers'},
+  {k: 2, t: 'Member list',       d: 'Where the names come from'},
+  {k: 3, t: 'Seats and pricing', d: 'What it costs a month'},
+  {k: 4, t: 'Review and link',   d: 'The whole subscription'},
+];
+const BW_SOURCES = [
+  ['api', 'Automatic', "the vendor's admin API, synced on demand"],
+  ['csv', 'Import', "paste the member export from the vendor's admin page"],
+  ['manual', 'Manual', "add members by hand on the tool's card"],
+];
+const bwSrcName = s => (BW_SOURCES.find(x => x[0] === s) || [])[1] || '';
+
+function bwRailLine(st) {
+  const w = BWIZ, tot = bWizTotals();
+  if (st.k === 1) {
+    if (!w.tool_id) return {c: 'pend', t: st.d};
+    const n = (w.covers || []).length;
+    return {c: 'val', t: bToolName(w.tool_id) + (n ? ' +' + n + ' covered' : '')};
+  }
+  if (st.k === 2) return w.source
+    ? {c: 'val', t: bwSrcName(w.source) + (w.source === 'api' && w.provider
+        ? ' · ' + w.provider : '')}
+    : {c: 'pend', t: st.d};
+  if (st.k === 3) return tot.tiers.length
+    ? {c: 'val', t: bMoney(tot.monthly, bWizCur()) + ' / month · '
+        + tot.seats + ' seat' + (tot.seats === 1 ? '' : 's')}
+    : {c: 'pend', t: st.d};
+  return tot.tiers.length ? {c: 'val', t: 'ready to link'} : {c: 'pend', t: st.d};
+}
+const bToolName = id =>
+  ((REGTOOLS || []).find(t => t.id === id) || {}).name || id;
+// Done means "you have been past it", not "it holds a default". Both the tool
+// and the member source are prefilled when the wizard opens, so keying off the
+// value alone ticked steps 1 and 2 green before the operator had looked at
+// either - a rail that congratulates you for arriving is not carrying state.
+// Editing is different: that subscription really is already saved.
+const bwDone = st => {
+  const w = BWIZ;
+  const passed = w.editing || w.step > st.k;
+  if (st.k === 4) return false;
+  if (st.k === 3) return passed && bWizTotals().tiers.length > 0;
+  return passed && (st.k === 1 ? !!w.tool_id : !!w.source);
+};
+
+function bwRail() {
+  const w = BWIZ, tot = bWizTotals();
+  const eff = 1 + (w.covers || []).length;
+  return `<div class="ssrail">
+    <h3>${w.editing ? 'Edit a subscription' : 'Link a tool'}</h3>
+    <ol>${BW_STEPS.map(st => {
+      const d = bwDone(st), on = w.step === st.k, ln = bwRailLine(st);
+      return `<li class="ssstep ${d ? 'done' : ''} ${on ? 'on' : ''}"
+        data-act="b-step" data-key="${st.k}">
+        <span class="dot">${d ? '&#10003;' : st.k}</span>
+        <span style="min-width:0"><span class="t">${esc(st.t)}</span>
+        <span class="${ln.c}">${esc(ln.t)}</span></span></li>`;
+    }).join('')}</ol>
+    <div class="sssum">
+      <div class="lede" style="font-size:11.5px">Monthly spend</div>
+      <div class="money" id="bw-money">${tot.monthly
+        ? bMoney(tot.monthly, bWizCur())
+        : '<span style="color:var(--mut);font-size:13px;font-weight:400">nothing priced yet</span>'}</div>
+      <div class="lede" style="font-size:11.5px">${tot.seats
+        ? tot.seats + ' seat' + (tot.seats === 1 ? '' : 's') + ' across '
+        : 'Covering '}${eff} tool${eff === 1 ? '' : 's'} on one licence.</div>
+    </div></div>`;
+}
+
+function bwBodyTool() {
+  const w = BWIZ;
+  const tools = (REGTOOLS || []).slice().sort((a, b) => a.name.localeCompare(b.name));
+  const linked = new Set((BUDGET.subscriptions || []).map(s => s.tool_id));
+  const picker = w.editing ? `<span class="mono">${esc(w.tool_id)}</span>` : (() => {
+    // Observed tools first: the one being linked is almost always one the
+    // estate already uses, and the whole registry in one flat list buries it.
+    const seen = new Set(Object.keys(G.tools || {}));
+    const coveredBy = {};
+    (BUDGET.subscriptions || []).forEach(o => {
+      bCovers(o).forEach(t => { coveredBy[t] = o.tool_id; });
+    });
+    const opt = t => {
+      const taken = t.id !== w.tool_id && (linked.has(t.id) || coveredBy[t.id]);
+      const label = !taken ? '' : linked.has(t.id) ? ' (linked)'
+        : ` (covered by ${coveredBy[t.id]})`;
+      return `<option value="${esc(t.id)}"${t.id === w.tool_id ? ' selected' : ''}
+        ${taken ? 'disabled' : ''}>${esc(t.name)}${esc(label)}</option>`;
+    };
+    const obs = tools.filter(t => seen.has(t.id));
+    const rest = tools.filter(t => !seen.has(t.id));
+    return `<select id="bw-tool" class="mfield" style="min-width:240px">
+      ${obs.length ? `<optgroup label="Seen in your estate">${obs.map(opt).join('')}</optgroup>
+        <optgroup label="Registry watchlist">${rest.map(opt).join('')}</optgroup>`
+        : tools.map(opt).join('')}</select>`;
+  })();
+  const covers = (() => {
+    // One licence often entitles several tools - a Claude seat covers claude
+    // AND claude-code - and linking them separately bills the same licence
+    // twice while halving every observed-use answer.
+    const primary = w.tool_id, byId = {};
+    (REGTOOLS || []).forEach(t => { byId[t.id] = t; });
+    const group = (byId[primary] || {}).license_group || '';
+    const vendor = (byId[primary] || {}).vendor || '';
+    const coveredBy = {};
+    (BUDGET.subscriptions || []).forEach(o => {
+      if (o.tool_id === primary) return;
+      bCovers(o).forEach(t => { coveredBy[t] = o.tool_id; });
+    });
+    const others = (REGTOOLS || []).filter(t => t.id !== primary);
+    const mates = others.filter(t => group && t.license_group === group);
+    const kin = others.filter(t => !mates.includes(t) && vendor && t.vendor === vendor);
+    const rest = others.filter(t => !mates.includes(t) && !kin.includes(t));
+    const on = new Set(w.covers == null
+      ? mates.filter(t => !coveredBy[t.id]).map(t => t.id) : w.covers);
+    const box = t => `<label${coveredBy[t.id] ? ' class="off"' : ''}>
+      <input type="checkbox" id="bwc-${esc(t.id)}"
+        ${on.has(t.id) ? 'checked' : ''} ${coveredBy[t.id] ? 'disabled' : ''}>
+      <span>${esc(t.name)}</span>${coveredBy[t.id]
+        ? `<span class="tag mut">covered by ${esc(coveredBy[t.id])}</span>`
+        : mates.includes(t) ? '<span class="tag">same licence</span>' : ''}</label>`;
+    const suggested = mates.length + kin.length;
+    return `${suggested
+      ? `<div class="covers">${mates.map(box).join('')}${kin.map(box).join('')}</div>`
+      : `<div class="src-note" style="margin:6px 0 0">Nothing in the registry
+         shares a licence group or vendor with this tool, so there is nothing to
+         suggest. If its licence does entitle others, tick them below.</div>`}
+      ${rest.length ? `<details style="margin-top:8px"><summary
+        style="font-size:12px;color:var(--mut);cursor:pointer">${suggested
+          ? 'more tools…' : 'choose from every tool…'}</summary>
+        <div class="covers" style="margin-top:7px">${rest.map(box).join('')}</div>
+      </details>` : ''}`;
+  })();
+  return `<h4>Which tool</h4>
+  <p>The registry is the menu: a tool that is not in it yet gets added in the
+  Tool registry first, so detection and spend stay one list.</p>
+  <dl class="kv">
+    <dt>Tool</dt><dd>${picker}</dd>
+    <dt>Vendor</dt><dd><input id="bw-vendor" class="mfield"
+      value="${esc(w.vendor || '')}" placeholder="e.g. Anthropic"></dd>
+    <dt>Plan</dt><dd><input id="bw-plan" class="mfield"
+      value="${esc(w.plan || '')}" placeholder="e.g. Team (standard + premium seats)"></dd>
+    <dt>Also covers</dt><dd>${covers}</dd>
+  </dl>
+  <p class="src-note wnote">Every tool this one licence entitles. One
+  subscription per licence: a member seen on any covered tool counts as
+  observed, and the spend is counted once. Getting this wrong bills the same
+  licence twice and halves every observed-use answer.</p>`;
+}
+
+function bwBodySource() {
+  const w = BWIZ;
+  const providers = (BUDGET && BUDGET.providers) || {};
+  const list = ents(providers);
+  // Which vendors can actually be synced, stated up front. It used to be a
+  // bare dropdown, so the only way to learn that a tool had no connector was
+  // to open the list and not find it - and the only plan requirement anywhere
+  // was buried in the key hint of whichever provider happened to be selected.
+  // One table, not two. There used to be a second listing just the built
+  // connectors directly above this, which said nothing this does not and put
+  // a two-row table immediately above a two-entry dropdown - so the dropdown
+  // read as "the vendors that exist" rather than "the ones with code behind
+  // them". "Not supported" is two very different situations - the vendor
+  // offers nothing, or it offers something nobody has connected - and only
+  // the second is worth raising an issue about.
+  const apis = (BUDGET && BUDGET.member_apis) || {};
+  const nameOf = id => ((REGTOOLS || []).find(t => t.id === id) || {}).name || id;
+  const STATUS = {
+    built:   ['Automatic, here', 'p-ok'],
+    vendor:  ['Vendor API, no connector yet', 'p-warn'],
+    none:    ['No seat list exists', 'p-mut'],
+    unknown: ['Not documented', 'p-mut'],
+  };
+  const bucket = a => a.connector ? 'built'
+    : (a.api === 'rest' || a.api === 'scim') ? 'vendor'
+    : a.api === 'none' ? 'none' : 'unknown';
+  const rows = ents(apis)
+    .map(([id, a]) => [id, a, bucket(a)])
+    .sort((x, y) => {
+      const order = {built: 0, vendor: 1, unknown: 2, none: 3};
+      return (order[x[2]] - order[y[2]]) || nameOf(x[0]).localeCompare(nameOf(y[0]));
+    });
+  const counts = {};
+  rows.forEach(r => { counts[r[2]] = (counts[r[2]] || 0) + 1; });
+  const everything = !rows.length ? '' : `<details style="margin:0 0 12px">
+    <summary style="font-size:12.5px;color:var(--mut);cursor:pointer">The
+      dropdown below lists the ${counts.built || 0} tools with a sync written
+      for them. What the ${rows.length} SHIPPED tools' vendors offer${counts.vendor
+        ? ` - ${counts.vendor} have an admin API nobody has connected yet`
+        : ''} (tools you define yourself are not in here)</summary>
+    <div class="rvw" style="margin:9px 0 0"><table>
+      <tr><th>tool</th><th>status</th><th>plan, and how</th></tr>
+      ${rows.map(([id, a, b]) => `<tr>
+        <td class="sname">${esc(nameOf(id))}</td>
+        <td><span class="pill ${STATUS[b][1]}">${STATUS[b][0]}</span></td>
+        <td>${a.plan ? esc(a.plan) + ' ' : ''}<span
+          style="color:var(--mut)">${esc(a.how || '')}</span></td>
+      </tr>`).join('')}
+    </table></div>
+    <p class="src-note">Checked against vendor documentation in August 2026.
+    Vendors move these gates often - if one of these has gone stale, that is
+    worth an issue too.</p>
+  </details>`;
+  return `<h4>Where does the member list come from?</h4>
+  <p>Who actually holds a seat. Without it the spend is a number with nobody
+  attached, and none of the seat-economics questions can be answered.</p>
+  <div id="bw-source" class="srcpick">${BW_SOURCES.map(([v, name, blurb]) => `
+    <label data-act="b-source" data-key="${v}">
+      <input type="radio" name="bw-source" value="${v}"
+        ${w.source === v ? 'checked' : ''}>
+      <span><span class="nm">${name}</span><span class="bl">${blurb}</span></span>
+    </label>`).join('')}</div>
+  ${w.source === 'api' ? `
+    ${everything}
+    <dl class="kv">
+      <dt>Provider</dt><dd><select id="bw-provider" class="mfield"
+        style="min-width:300px">
+        ${list.map(([id, p]) => `<option value="${esc(id)}"
+          ${id === w.provider ? 'selected' : ''}>${esc(p.label)}</option>`).join('')}
+      </select></dd>
+      <dt>API key</dt><dd><input id="bw-key" class="mfield" type="password"
+        style="min-width:300px"
+        placeholder="${w.key_set ? 'saved - paste to replace' : 'paste the vendor API key'}"
+        autocomplete="off" value="${esc(w.api_key || '')}"></dd>
+    </dl>
+    ${((providers[w.provider] || {}).unverified)
+      ? `<div class="note" style="margin-top:22px">This connector is written from
+         ${esc((providers[w.provider] || {}).label || w.provider)}'s documented
+         endpoint and has never been run against a real organisation. If the
+         first sync is refused, the message names the vendor and the status -
+         that is worth an issue rather than an afternoon.</div>` : ''}
+    <p class="src-note wnote">Stored by the receiver and spent server-side; no
+    page ever reads it back. ${esc(((providers[w.provider] || {}).key_hint) || '')}</p>
+  ` : ''}
+  <div class="callout">${w.source === 'api' ? esc(BPROVIDER_NONE) : (() => {
+    // Import and Manual used to carry a paragraph about ChatGPT, whichever
+    // tool you were linking. It was a stale example the moment a ChatGPT
+    // connector existed - it told an Enterprise workspace to use Import when
+    // Automatic had started working for it. Say what is true of THIS tool
+    // instead: the answer is already in member_apis, per tool.
+    const a = apis[w.tool_id] || {};
+    const me = esc(bToolName(w.tool_id));
+    const plan = a.plan ? ' ' + esc(a.plan) : '';
+    // A tool YOU defined has no row in member_apis, and the absence of a row
+    // is not a finding. Falling through to the "not documented" branch made
+    // the page state, about a tool invented five minutes earlier, that its
+    // vendor documents no members API - something nobody had ever looked at.
+    // "We have no record" and "we looked and there is nothing" are different
+    // sentences and only one of them is true here.
+    if (!a.api) {
+      return `<b>${me} is a tool you defined</b>, so there is no record here of
+        what its vendor offers - that list covers the tools this release ships
+        with. Import and Manual work for it exactly as they do for any other.
+        If its vendor does have an admin API worth connecting, that is worth
+        an issue.`;
+    }
+    if (a.connector && providers[a.connector]) {
+      return `<b>${me} can sync automatically.</b>${plan} Import and Manual
+        still work and the numbers are identical - Automatic only saves you
+        keeping the list up to date by hand.`;
+    }
+    if (a.api === 'rest' || a.api === 'scim') {
+      // The plan is a sentence of its own, not an insert: several of them end
+      // in a full stop, so splicing one mid-clause read as
+      // "a members API Enterprise. The Admin API is in preview. - nothing".
+      return `<b>${me}'s vendor does expose a members API</b>, but nothing here
+        connects to it yet - so Import or Manual until it does, and that one is
+        worth an issue.${plan ? ` On the vendor's side:${plan}` : ''}`;
+    }
+    if (a.api === 'none') {
+      return `<b>${me} has no organisation or seat list to read.</b>
+        ${esc(a.how || '')} Import or Manual is the only way, and that is the
+        vendor's boundary rather than this page's.`;
+    }
+    return `<b>${me}'s vendor does not document a members API.</b>
+      ${esc(a.how || '')} Import or Manual.`;
+  })()}
+    ${w.source === 'csv' ? ' The paste box comes right after the review step: '
+      + 'link the tool first, then drop the export in.' : ''}</div>
+  <p class="src-note" style="margin-top:0">Want a vendor connected? Automatic
+    setup lands by request - open an issue at
+    <a href="https://github.com/AmanSK5/shadow-ai-guard/issues"
+      target="_blank" rel="noopener">github.com/AmanSK5/shadow-ai-guard/issues</a>.</p>`;
+}
+
+function bwBodySeats() {
+  const w = BWIZ;
+  const eff = [w.tool_id].concat(w.covers || []);
+  const tot = bWizTotals();
+  return `<h4>Seats and pricing</h4>
+  <p>What the organisation pays. Tier names matter: a member whose seat tier
+  matches a name here is counted against that tier's seats.</p>
+  ${bTierRows(w.tiers, eff, bWizCur())}
+  <div class="tsum"><span class="big" id="bw-tsum">${tot.monthly
+    ? bMoney(tot.monthly, bWizCur())
+    : '<span style="color:var(--mut);font-weight:400;font-size:13px">nothing priced yet</span>'}</span>
+    <span style="color:var(--mut)">per month, <span id="bw-tseats">${tot.seats}</span>
+      seats</span></div>
+  <dl class="kv" style="margin-top:16px">
+    <dt>Currency</dt><dd><input id="bw-currency" class="mfield" style="max-width:110px"
+      value="${esc(w.currency || '')}" placeholder="GBP"></dd>
+    <dt>Renews</dt><dd><input id="bw-renewal" class="mfield" style="max-width:180px"
+      value="${esc(w.renewal || '')}" placeholder="YYYY-MM-DD"></dd>
+    <dt>Owner</dt><dd><input id="bw-owner" class="mfield"
+      value="${esc(w.owner || '')}" placeholder="who holds this budget"></dd>
+  </dl>
+  <p class="src-note wnote">The vendor APIs do not expose per-user tiers, so
+  tiers come from you either way.${eff.length > 1 ? ' Per-tier coverage is how '
+    + '"premium includes claude-code, standard does not" gets said - it powers '
+    + 'the seat-economics findings on the card.' : ''}</p>`;
+}
+
+function bwBodyReview() {
+  const w = BWIZ;
+  const eff = [w.tool_id].concat(w.covers || []);
+  const tot = bWizTotals();
+  return `<h4>Review and link</h4>
+  <p>One subscription, covering ${eff.length} tool${eff.length === 1 ? '' : 's'}.
+  Everything here can be changed later.</p>
+  <div class="rvw"><table>
+    <tr><th>what</th><th>value</th></tr>
+    <tr><td class="sname">Licence</td><td>${esc(w.plan || '—')}
+      <div style="color:var(--mut);font-size:12px">${esc(w.vendor || 'no vendor recorded')}</div></td></tr>
+    <tr><td class="sname">Covers</td><td>
+      ${eff.map(t => `<span class="pill p-mut">${esc(t)}</span>`).join(' ')}
+      <div style="color:var(--mut);font-size:12px">Counted once. A member seen on
+      any of these counts as observed.</div></td></tr>
+    <tr><td class="sname">Members</td><td>${esc(bwSrcName(w.source))}
+      ${w.source === 'api' ? `<span class="pill p-mut">${esc(w.provider || '')}</span>` : ''}
+      ${w.source === 'csv' && !w.editing
+        ? '<span class="pill p-warn">paste due after linking</span>' : ''}</td></tr>
+    <tr><td class="sname">Seats</td><td>${tot.tiers.length
+      ? tot.tiers.map(t => `<div>${esc(t.name)} — ${t.seats || 0}
+          × ${bMoney(t.unit_price_monthly || 0, w.currency)}
+          = ${bMoney((t.seats || 0) * (t.unit_price_monthly || 0), w.currency)} / mo</div>`).join('')
+      : '<span style="color:var(--mut)">none set</span>'}</td></tr>
+    <tr><td class="sname">Monthly</td><td><b>${bMoney(tot.monthly, w.currency)}</b>
+      <div style="color:var(--mut);font-size:12px">Renews ${esc(w.renewal || '—')}
+      · owner ${esc(w.owner || '—')}</div></td></tr>
+  </table></div>
+  <div class="callout"><b>Also covers</b> is the one worth a second look.
+  Linking two tools that share a licence separately bills it twice and halves
+  every observed-use answer, and nothing downstream can tell that happened.</div>`;
+}
+
 function budgetWizard() {
   const w = BWIZ;
-  const tools = (REGTOOLS || []).slice()
-    .sort((a, b) => a.name.localeCompare(b.name));
-  const providers = (BUDGET && BUDGET.providers) || {};
-  const step = n => w.step === n;
-  const linked = new Set((BUDGET.subscriptions || []).map(s => s.tool_id));
+  const body = w.step === 2 ? bwBodySource()
+    : w.step === 3 ? bwBodySeats()
+    : w.step === 4 ? bwBodyReview() : bwBodyTool();
   return `<h2>${w.editing ? 'Edit ' + esc(w.tool_id) : 'Link a tool'}</h2>
-  <p class="lede">Three steps: which tool, where its member list comes
-  from, and what the seats cost. Everything here can be changed later.</p>
   ${BMSG ? `<div class="note">${esc(BMSG)}</div>` : ''}
-  <div class="wcard" style="max-width:760px">
-  <p class="src-note" style="margin-top:0">step ${w.step} of 3</p>
-  ${step(1) ? `
-    <dl class="kv">
-      <dt>Tool</dt><dd>
-        ${w.editing ? `<span class="mono">${esc(w.tool_id)}</span>` : (() => {
-          // Observed tools first: the one being linked is almost always
-          // one the estate already uses, and 38 registry entries in one
-          // flat list buries it.
-          const seen = new Set(Object.keys(G.tools || {}));
-          const coveredBy = {};
-          (BUDGET.subscriptions || []).forEach(o => {
-            bCovers(o).forEach(t => { coveredBy[t] = o.tool_id; });
-          });
-          const opt = t => {
-            const taken = t.id !== w.tool_id
-              && (linked.has(t.id) || coveredBy[t.id]);
-            const label = !taken ? ''
-              : linked.has(t.id) ? ' (linked)'
-              : ` (covered by ${coveredBy[t.id]})`;
-            return `<option value="${esc(t.id)}"
-            ${t.id === w.tool_id ? 'selected' : ''}
-            ${taken ? 'disabled' : ''}>
-            ${esc(t.name)}${esc(label)}</option>`;
-          };
-          const obs = tools.filter(t => seen.has(t.id));
-          const rest = tools.filter(t => !seen.has(t.id));
-          return `<select id="bw-tool" class="mfield" style="min-width:220px">
-          ${obs.length ? `<optgroup label="Seen in your estate">${obs.map(opt).join('')}</optgroup>
-            <optgroup label="Registry watchlist">${rest.map(opt).join('')}</optgroup>`
-            : tools.map(opt).join('')}
-        </select>
-        <div class="src-note">The registry is the menu. A tool that is not
-        in it yet is added in the Tool registry view first, so detection
-        and spend stay one list.</div>`; })()}</dd>
-      <dt>Vendor</dt><dd><input id="bw-vendor" class="mfield" value="${esc(w.vendor || '')}" placeholder="e.g. Anthropic"></dd>
-      <dt>Plan</dt><dd><input id="bw-plan" class="mfield" value="${esc(w.plan || '')}" placeholder="e.g. Team (standard + premium seats)"></dd>
-      ${(() => {
-        // One licence often entitles several tools - a Claude seat covers
-        // claude AND claude-code - and linking them separately bills the
-        // same licence twice while halving every observed-use answer.
-        // Tools sharing the primary's licence group arrive pre-ticked.
-        const primary = w.tool_id;
-        const byId = {};
-        (REGTOOLS || []).forEach(t => { byId[t.id] = t; });
-        const group = (byId[primary] || {}).license_group || '';
-        const vendor = (byId[primary] || {}).vendor || '';
-        const coveredBy = {};
-        (BUDGET.subscriptions || []).forEach(o => {
-          if (o.tool_id === primary) return;
-          bCovers(o).forEach(t => { coveredBy[t] = o.tool_id; });
-        });
-        const others = (REGTOOLS || []).filter(t => t.id !== primary);
-        const mates = others.filter(t => group && t.license_group === group);
-        const kin = others.filter(t => !mates.includes(t) && vendor && t.vendor === vendor);
-        const rest = others.filter(t => !mates.includes(t) && !kin.includes(t));
-        const on = new Set(w.covers == null
-          ? mates.filter(t => !coveredBy[t.id]).map(t => t.id)
-          : w.covers);
-        const box = t => `<label style="display:flex;align-items:baseline;gap:8px;margin-bottom:4px;cursor:pointer">
-          <input type="checkbox" id="bwc-${esc(t.id)}"
-            style="min-width:0;margin:0;accent-color:var(--pri)"
-            ${on.has(t.id) ? 'checked' : ''} ${coveredBy[t.id] ? 'disabled' : ''}>
-          <span><span class="mono">${esc(t.id)}</span>${coveredBy[t.id]
-            ? ` <span style="color:var(--mut)">(covered by ${esc(coveredBy[t.id])})</span>`
-            : mates.includes(t) ? ' <span class="pill p-acc">same licence</span>' : ''}</span>
-        </label>`;
-        return `<dt>Also covers</dt><dd>
-          ${mates.map(box).join('')}${kin.map(box).join('')}
-          ${rest.length ? `<details><summary style="font-size:12px;color:var(--mut);cursor:pointer">more tools…</summary>${rest.map(box).join('')}</details>` : ''}
-          <div class="src-note">Every tool this one licence entitles. One
-          subscription per licence: a member seen on any covered tool
-          counts as observed, and the spend is counted once.</div></dd>`;
-      })()}
-    </dl>
-    <button class="mini" data-act="b-step" data-key="2">Next</button>` : ''}
-  ${step(2) ? `
-    <p style="margin-top:0"><strong>Where does the member list come from?</strong></p>
-    <div id="bw-source" style="margin-bottom:12px">
-    ${[['api', 'Automatic', "the vendor's admin API, synced on demand"],
-       ['csv', 'Import', "paste the member export from the vendor's admin page"],
-       ['manual', 'Manual', "add members by hand on the tool's card"]]
-      .map(([v, name, blurb]) => `
-    <label style="display:flex;align-items:baseline;gap:10px;margin-bottom:8px;cursor:pointer"
-      data-act="b-source" data-key="${v}">
-      <input type="radio" name="bw-source" value="${v}"
-        style="min-width:0;margin:0;accent-color:var(--pri)"
-        ${w.source === v ? 'checked' : ''}>
-      <span><strong>${name}</strong> — ${blurb}</span>
-    </label>`).join('')}
-    <div class="src-note" style="margin-top:4px">${esc(BPROVIDER_NONE)}
-      Automatic setup for more vendors lands by request: if you want a
-      particular tool supported, open an issue at
-      <a href="https://github.com/AmanSK5/shadow-ai-guard/issues" target="_blank" rel="noopener">github.com/AmanSK5/shadow-ai-guard/issues</a>.</div>
-    </div>
-    ${w.source === 'api' ? `<dl class="kv"><dt>Provider</dt><dd>
-      <select id="bw-provider" class="mfield" style="min-width:280px">
-        ${ents(providers).map(([id, p]) => `<option value="${esc(id)}"
-          ${id === w.provider ? 'selected' : ''}>${esc(p.label)}</option>`).join('')}
-      </select>
-    </dd>
-    <dt>API key</dt><dd>
-      <input id="bw-key" class="mfield" type="password" style="min-width:280px"
-        placeholder="${w.key_set ? 'saved - paste to replace' : 'paste the vendor API key'}"
-        autocomplete="off" value="${esc(w.api_key || '')}">
-      <div class="src-note">Stored by the receiver and spent server-side;
-      no page ever reads it back.
-      ${esc(((providers[w.provider] || {}).key_hint) || '')}</div>
-    </dd></dl>` : ''}
-    ${w.source === 'csv' ? `<p class="src-note" style="margin:0 0 10px">The
-      paste box comes right after the last step - link the tool first, then
-      drop the export in.</p>` : ''}
-    <button class="mini" data-act="b-step" data-key="1">Back</button>
-    <button class="mini" data-act="b-step" data-key="3">Next</button>` : ''}
-  ${step(3) ? `
-    <p style="margin-top:0"><strong>Seats and pricing</strong></p>
-    ${bTierRows(w.tiers, [w.tool_id].concat(w.covers || []))}
-    <dl class="kv">
-      <dt>Currency</dt><dd><input id="bw-currency" class="mfield" style="min-width:80px"
-        value="${esc(w.currency || '')}" placeholder="GBP"></dd>
-      <dt>Renews</dt><dd><input id="bw-renewal" class="mfield" style="min-width:140px"
-        value="${esc(w.renewal || '')}" placeholder="YYYY-MM-DD"></dd>
-      <dt>Owner</dt><dd><input id="bw-owner" class="mfield"
-        value="${esc(w.owner || '')}" placeholder="who holds this budget"></dd>
-    </dl>
-    <p class="src-note">Tier names matter: a user row whose seat tier
-    matches a name here is counted against that tier's seats. The vendor
-    APIs do not expose per-user tiers, so tiers come from you either way.
-    ${(w.covers || []).length ? 'Per-tier coverage is how "premium includes '
-      + 'claude-code, standard does not" is said - it powers the '
-      + 'seat-economics findings on the card.' : ''}</p>
-    <button class="mini" data-act="b-step" data-key="2">Back</button>
-    <button class="mini" data-act="b-save">${w.editing ? 'Save changes' : 'Link tool'}</button>` : ''}
-  <p class="src-note" style="margin-bottom:0">
-    <button class="mini" data-act="b-cancel">Cancel</button></p>
-  </div>`;
+  <div class="ssow">${bwRail()}
+    <div class="ssmain">${body}
+      <div class="ssfoot">
+        <button class="mini" data-act="b-cancel">Cancel</button>
+        <span class="sp"></span>
+        ${w.step > 1 ? `<button class="mini" data-act="b-step"
+          data-key="${w.step - 1}">Back</button>` : ''}
+        ${w.step < 4
+          ? `<button class="mini pri" data-act="b-step" data-key="${w.step + 1}"
+              ${w.tool_id ? '' : 'disabled'}>Next</button>`
+          : `<button class="mini pri" data-act="b-save">${w.editing
+              ? 'Save changes' : 'Link tool'}</button>`}
+      </div></div></div>`;
 }
+
+// The money has to move as it is typed: this wizard's whole subject is a
+// number, and a rail quoting a stale total is worse than one quoting none. A
+// full re-render would take focus out of the field mid-digit, so only the rail
+// and the three totals are redrawn.
+function bwLive() {
+  if (!BWIZ || BWIZ.step !== 3) return;
+  const w = BWIZ, tot = bWizTotals();
+  const rail = document.querySelector('.ssrail');
+  if (rail) rail.outerHTML = bwRail();
+  const sum = document.getElementById('bw-tsum');
+  if (sum) sum.innerHTML = tot.monthly ? esc(bMoney(tot.monthly, bWizCur()))
+    : '<span style="color:var(--mut);font-weight:400;font-size:13px">nothing priced yet</span>';
+  // The rail was replaced above, so its money node is the new one.
+  const st = document.getElementById('bw-tseats');
+  if (st) st.textContent = tot.seats;
+  tot.tiers.forEach((t, i) => {
+    const cell = document.getElementById('bt-line-' + i);
+    const line = (t.seats || 0) * (t.unit_price_monthly || 0);
+    if (cell) cell.textContent = line ? bMoney(line, bWizCur()) : '';
+  });
+}
+app.addEventListener('input', e => {
+  if (!e.target || !e.target.matches) return;
+  if (e.target.matches('[id^="bt-"],#bw-currency')) bwLive();
+});
+app.addEventListener('change', e => {
+  if (!e.target || !e.target.matches || !BWIZ) return;
+  // Per-tier coverage only exists for a row that has a name, so naming one has
+  // to draw its checkboxes. On change rather than input: focus has already
+  // left the field by then, so the re-render cannot steal it mid-word.
+  if (e.target.matches('[id^="bt-name-"]')) { bStash(); render(); return; }
+  // Every provider's key is created somewhere different, so the hint under the
+  // field belongs to the provider selected. It was only read when the step was
+  // LEFT, so switching provider left the previous one's instructions standing
+  // - the page said "create it at claude.ai" under a Fireflies key.
+  if (e.target.matches('#bw-provider')) { bStash(); render(); }
+});
 
 // Days since an ISO timestamp, or null. Past this many, a member list
 // is presumed drifting: on plans with no admin API the import is a
@@ -5215,12 +5979,21 @@ async function budget() {
     ${ro ? '' : '<button class="mini" data-act="b-open">Link a tool</button>'}
     ${subs.length ? '<button class="mini" data-act="b-report">Share / export</button>' : ''}</p>
   <p class="src-note">Automatic user sync currently supports
-  ${ents((BUDGET.providers) || {}).map(([, p]) => esc(p.label)).join(' and ') || 'no vendors yet'}.
-  More vendors will be added for automatic configuration - if you want a
+  ${(() => {
+    // Commas and a final "and", not "and" seven times: this list grew from
+    // two vendors to seven and read as one breathless sentence. The trailing
+    // line about ChatGPT Business went too - it is one plan of one vendor,
+    // it stopped being the only notable absence a while ago, and the wizard's
+    // own step says what applies to the tool being linked.
+    const labels = ents((BUDGET.providers) || {}).map(([, p]) => esc(p.label));
+    if (!labels.length) return 'no vendors yet';
+    if (labels.length === 1) return labels[0];
+    return labels.slice(0, -1).join(', ') + ' and ' + labels[labels.length - 1];
+  })()}.
+  Everything else comes in by CSV import or by hand, and the numbers work the
+  same either way. More vendors get added by request - if you want a
   particular tool, please raise an issue on
-  <a href="https://github.com/AmanSK5/shadow-ai-guard/issues" target="_blank" rel="noopener">GitHub</a>.
-  ChatGPT Business has no admin API on that plan, so it uses the CSV
-  import.</p>`;
+  <a href="https://github.com/AmanSK5/shadow-ai-guard/issues" target="_blank" rel="noopener">GitHub</a>.</p>`;
 }
 
 async function budgetAction(act, el) {
@@ -5233,9 +6006,21 @@ async function budgetAction(act, el) {
   if (act === 'b-open') {
     BMSG = '';
     const seen = new Set(Object.keys(G.tools || {}));
-    const first = (REGTOOLS || []).slice()
+    // Skip anything already linked, or already covered by another licence.
+    // The wizard used to open on the first OBSERVED tool whichever it was, so
+    // on a deployment whose busiest tool is already linked it opened on that
+    // one - and pressing through to the end overwrote the subscription that
+    // existed, with nothing on screen saying so. The review step made it
+    // visible; the fix belongs here.
+    const taken = new Set();
+    (BUDGET.subscriptions || []).forEach(o => {
+      taken.add(o.tool_id);
+      bCovers(o).forEach(t => taken.add(t));
+    });
+    const free = (REGTOOLS || []).slice()
       .sort((a, b) => a.name.localeCompare(b.name))
-      .find(t => seen.has(t.id)) || (REGTOOLS || [])[0];
+      .filter(t => !taken.has(t.id));
+    const first = free.find(t => seen.has(t.id)) || free[0];
     BWIZ = {step: 1, tool_id: first ? first.id : '',
             source: 'csv', provider: 'anthropic', tiers: [], api_key: '',
             covers: null, currency: bPrefCur()};
@@ -5285,7 +6070,11 @@ async function budgetAction(act, el) {
     BWIZ.source = el.getAttribute('data-key');
     render(); return;
   }
-  if (act === 'b-step') { bStash(); BWIZ.step = parseInt(key, 10); render(); return; }
+  if (act === 'b-step') {
+    bStash();
+    BWIZ.step = Math.max(1, Math.min(4, parseInt(key, 10) || 1));
+    BMSG = ''; render(); return;
+  }
   if (act === 'b-save') {
     bStash();
     const w = BWIZ;
@@ -5682,8 +6471,34 @@ async function managedAction(act, el) {
     if (offer) await tourStart(TOUR_AFTER_WIZARD);
     return;
   }
-  if (act === 'reg-add') { REDIT = ''; RPRE = null; RERR = ''; RADV = false; render(); return; }
-  if (act === 'reg-cancel') { REDIT = null; RPRE = null; RERR = ''; RADV = false; render(); return; }
+  if (act === 'reg-add') { rwOpen({}); render(); return; }
+  if (act === 'reg-cancel') {
+    RW = null; REDIT = null; RPRE = null; RERR = ''; RADV = false; render(); return;
+  }
+  if (act === 'rw-step') {
+    // Sync before moving: the step being left owns live inputs, and a name
+    // typed and not read back is a name the proposals never saw.
+    rwSync();
+    RW.step = Math.max(0, Math.min(2, parseInt(el.getAttribute('data-key'), 10) || 0));
+    RERR = ''; render(); return;
+  }
+  if (act === 'rw-tick') {
+    const i = parseInt(el.getAttribute('data-key'), 10);
+    if (RW.sugs[i]) RW.sugs[i].on = el.checked;
+    render(); return;
+  }
+  if (act === 'rw-add') {
+    const v = (document.getElementById('rw-newv') || {}).value || '';
+    const f = (document.getElementById('rw-newf') || {}).value || 'domains';
+    const t = v.trim();
+    if (!t) return;
+    // A hand-typed value that duplicates a proposal ticks that proposal rather
+    // than adding a second row saying the same thing.
+    const dup = RW.sugs.find(x => x.f === f && x.v === t);
+    if (dup) dup.on = true;
+    else RW.sugs.push({f: f, v: t, why: 'me', conf: 'high', on: true});
+    render(); return;
+  }
   if (act === 'reg-adv') {
     // Toggling into JSON carries the form's current state with it, so
     // nothing typed is lost; toggling back re-renders the form from the
@@ -5695,7 +6510,7 @@ async function managedAction(act, el) {
   if (act === 'reg-edit') {
     const id = el.getAttribute('data-key');
     const x = (RENTRIES || []).find(r => r.tool_id === id);
-    REDIT = id; RPRE = x ? x.entry : null; RERR = ''; RADV = false;
+    rwFromEntry(id, (x && x.entry) || {});
     render(); return;
   }
   if (act === 'reg-suggest') {
@@ -5704,9 +6519,9 @@ async function managedAction(act, el) {
     const t = el.getAttribute('data-key');
     const slug = t.toLowerCase().replace(/[^a-z0-9-]+/g, '-')
       .replace(/^-+|-+$/g, '').replace(/^[^a-z0-9]+/, '') || 'new-tool';
-    RPRE = {id: slug, name: t};
-    if (t.indexOf('.') > 0 && t.indexOf(' ') < 0) RPRE.domains = [t.toLowerCase()];
-    REDIT = ''; RERR = ''; RADV = false;
+    const domainish = t.indexOf('.') > 0 && t.indexOf(' ') < 0;
+    rwOpen({id: slug, name: t,
+            domains: domainish ? [t.toLowerCase()] : []});
     view = 'registry'; detail = null;
     history.replaceState(null, '', '#registry');
     drawNav(); render(); return;
@@ -5721,11 +6536,17 @@ async function managedAction(act, el) {
     if (!c) return;
     const slug = c.name.toLowerCase().replace(/[^a-z0-9-]+/g, '-')
       .replace(/^-+|-+$/g, '') || 'new-tool';
-    RPRE = {id: slug, name: c.name};
-    if (c.vendor) RPRE.vendor = c.vendor;
-    if (REG_CATEGORIES.indexOf(c.category) >= 0) RPRE.category = c.category;
-    if ((c.domains || []).length) RPRE.domains = c.domains;
-    REDIT = ''; RERR = ''; RADV = false;
+    rwOpen({
+      id: slug, name: c.name, vendor: c.vendor || '',
+      category: REG_CATEGORIES.indexOf(c.category) >= 0 ? c.category : 'unreviewed',
+      domains: c.domains || [],
+      // What discovery actually saw, shown as its own card. It is the only
+      // thing on the next step that is evidence rather than a guess.
+      evidence: {kind: c.kind, what: c.kind === 'mcp_server'
+                   ? (c.evidence || c.name) : (c.domains || []).join(', ') || c.name,
+                 devices: c.devices || 0, confidence: c.confidence || '',
+                 category: c.category || ''},
+    });
     view = 'registry'; detail = null;
     history.replaceState(null, '', '#registry');
     drawNav(); render(); return;
@@ -5821,6 +6642,51 @@ async function managedAction(act, el) {
       alert('Could not clear the decision: ' + d);
     }
     REG = null; EV = null; render(); return;
+  }
+  if (act === 'settings-discard') {
+    // Re-rendering IS the discard: every field is drawn from SETTINGS again.
+    SETMSG = ''; render(); return;
+  }
+  if (act === 'settings-save-all') {
+    const dirty = sDirty();
+    if (!dirty.length) return;
+    const body = {};
+    dirty.forEach(f => { body[f.getAttribute('data-sfield')] = sValue(f); });
+    // People paste the whole dashboard URL, reasonably - the same trim the
+    // per-field save does, kept here because this is now the path Settings
+    // takes and the wizard's is the other one.
+    if (typeof body.grafana_dashboard_uid === 'string'
+        && body.grafana_dashboard_uid.indexOf('/d/') >= 0) {
+      body.grafana_dashboard_uid =
+        body.grafana_dashboard_uid.split('/d/')[1].split('/')[0].split('?')[0];
+    }
+    const keys = Object.keys(body);
+    const r = await mfetch('/api/settings',
+      {method: 'POST', body: JSON.stringify(body)});
+    if (!r.ok) {
+      if (r.status === 401) { sessionLost(); return; }
+      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+      // Reported INTO the bar rather than through SETMSG, because SETMSG
+      // needs a render and a render redraws every field from SETTINGS -
+      // which would throw away the several edits that just failed to save.
+      const err = document.getElementById('setbar-err');
+      const msg = 'Not saved: ' + (typeof d === 'string' ? d : 'check the values.');
+      if (err) err.textContent = msg; else { SETMSG = msg; render(); }
+      return;
+    }
+    SETTINGS = await r.json();
+    SETMSG = keys.length === 1 ? 'Saved. It takes effect immediately.'
+      : 'Saved ' + keys.length + ' changes. They take effect immediately.';
+    if (keys.indexOf('receiver_public_url') >= 0) {
+      const cr = await fetch('/api/config');
+      if (cr.ok) CFG = await cr.json();
+    }
+    // Checked before the log store, and the opposite way round from the
+    // per-field save: a reload re-reads the findings anyway, so a batch
+    // touching both needs the reload and not the load before it.
+    if (keys.some(k => k.indexOf('grafana') === 0)) { location.reload(); return; }
+    if (keys.some(k => k.indexOf('log_store') === 0)) { await load(true); return; }
+    render(); return;
   }
   if (act === 'save-markings' || act === 'clear-markings') {
     const marks = act === 'clear-markings' ? null
@@ -6072,7 +6938,7 @@ function drawNav() {
     view = SECTAB[sec.id] || sec.items[0][0]; detail = null;
     // Replace rather than push: clicking through the nav should not fill the
     // back button with every tab you glanced at.
-    history.replaceState(null, '', '#' + view);
+    history.replaceState(null, '', frag(view));
     drawNav(); render();
   });
   const fv = document.getElementById('footver');
@@ -6201,6 +7067,17 @@ function open_(kind, key) {
   drawDetail();
 }
 
+// Escape closes the inspector, which is what every drawer in every tool the
+// operator already uses does. It was × or a click outside only, and the ×
+// is 500px away from whatever they were reading. Deliberately quiet while
+// the tour is up: the overlay owns the keyboard then, and its own way out
+// is the End tour button, which records that it was skipped.
+document.addEventListener('keydown', e => {
+  if (e.key !== 'Escape' || TOUR) return;
+  if (!document.body.classList.contains('open')) return;
+  open_(null);
+});
+
 // One delegated listener rather than an onclick per row. The handlers used to
 // be inline, which put a finding's own text inside executable script: a device
 // name containing an apostrophe closed the JS string and ran what followed,
@@ -6223,7 +7100,7 @@ app.addEventListener('click', e => {
   const el = e.target.closest('[data-nav]');
   if (!el) return;
   view = el.getAttribute('data-nav'); detail = null;
-  history.replaceState(null, '', '#' + view);
+  history.replaceState(null, '', frag(view));
   drawNav(); render();
 });
 // Changing the wizard's tool re-suggests what the licence covers: the
@@ -6341,7 +7218,7 @@ app.addEventListener('click', e => {
   SETTAB = tab;
   // In the fragment like every other navigation in this page, so a
   // reload keeps the tab and a colleague can be sent the one you mean.
-  history.replaceState(null, '', '#settings/' + SETTAB);
+  history.replaceState(null, '', frag('settings'));
   render();
 });
 // The per-field i: toggles the note in the field's own dd. Delegated on
@@ -6388,7 +7265,18 @@ app.addEventListener('click', e => {
 // Someone editing the fragment, or arriving on a link to a view.
 window.addEventListener('hashchange', () => {
   const h = fromHash();
-  if (h !== view) { view = h; detail = null; drawNav(); render(); }
+  // Before the guard below, which returns early: a bare #settings has to be
+  // normalised even when it changes nothing else.
+  if (h.view === 'settings' && !h.tab) {
+    history.replaceState(null, '', frag('settings'));
+  }
+  // A settings sub-tab changes what is on screen without changing the view
+  // id, so the guard has to ask about both or the tab half never draws.
+  const tabbed = h.tab && h.tab !== SETTAB;
+  if (h.view === view && !tabbed) return;
+  view = h.view; detail = null;
+  if (h.tab) SETTAB = h.tab;
+  drawNav(); render();
 });
 // Enter in a login field is the same as clicking its button. Delegated like
 // the clicks, because the form is re-rendered on every failed attempt.
@@ -6483,7 +7371,7 @@ const TOURS = {
      body: 'One thing worth setting today: your corporate domains, which '
          + 'is what decides whether an account counts as personal. Open '
          + 'Settings.'},
-    {view: 'settings', sel: '#set-domains',
+    {view: 'settings', tab: 'fleet', sel: '#set-domains',
      title: 'Corporate domains',
      body: 'Every domain your people legitimately sign in with. Anything '
          + 'else is a personal account and warns. Get this wrong and the '
@@ -6532,7 +7420,7 @@ const TOURS = {
      body: 'One setting decides what counts as a personal account, and it '
          + 'is worth seeing even though this account cannot change it. '
          + 'Open Settings.'},
-    {view: 'settings', sel: '#set-domains',
+    {view: 'settings', tab: 'fleet', sel: '#set-domains',
      title: 'Corporate domains - read it, do not take it on trust',
      body: 'Anything not on this list is treated as a personal account. '
          + 'Every figure on the Personal accounts page rests on it, so a '
@@ -6657,10 +7545,14 @@ async function tourGo(n) {
 async function tourShow() {
   const st = TOUR.steps[TOUR.i];
   // The step owns where it happens, so Back works across views and a step
-  // never describes a page somebody navigated away from.
-  if (st.view && st.view !== view) {
+  // never describes a page somebody navigated away from. A step on Settings
+  // owns the sub-tab too: #set-domains exists only on Fleet, so a tour taken
+  // by somebody whose last Settings visit was Account used to find nothing
+  // and quietly fall back to the un-aimed card.
+  if (st.view && (st.view !== view || (st.tab && st.tab !== SETTAB))) {
     view = st.view;
-    history.replaceState(null, '', '#' + view);
+    if (st.tab) SETTAB = st.tab;
+    history.replaceState(null, '', frag(view));
     drawNav();
     await render();
   }

--- a/portal/tests/test_budget.py
+++ b/portal/tests/test_budget.py
@@ -142,3 +142,129 @@ def test_printing_drops_the_furniture():
     assert "@media print" in INDEX
     for hidden in ("aside", ".topbar", ".drawer", "[data-act]"):
         assert hidden in INDEX.split("@media print")[1][:600], hidden
+
+
+def test_linking_a_tool_is_four_steps_with_a_review():
+    """The budget wizard was already three steps; what it lacked was the
+    language. Its only progress marker was the italic text "step 1 of 3", the
+    seat tiers were three inputs whose only labels were placeholders that
+    vanish once anything is typed, and it committed straight from the last
+    step with nothing showing the licence, its covered tools and the cost
+    together."""
+    for needle in ("function bwRail(", "function bwBodyReview(",
+                   "const BW_STEPS", "Review and link",
+                   'class="tiers"', "<th>Tier</th>", "Price / seat",
+                   "bw-tsum", "bw-money"):
+        assert needle in INDEX, needle
+    # The rail summary carries the money, not a step count: this is the one
+    # wizard whose subject is a number.
+    assert "Monthly spend" in INDEX
+    assert "function bwLive()" in INDEX
+    # Currency is read off the screen too, or every figure renders unitless
+    # until the step is left.
+    assert "function bWizCur()" in INDEX
+    assert "step 1 of 3" not in INDEX and "step ${w.step} of 3" not in INDEX
+
+
+def test_the_rail_does_not_tick_a_step_nobody_has_visited():
+    """Both the tool and the member source are prefilled when the wizard
+    opens, so keying "done" off the value alone ticked steps 1 and 2 green
+    before the operator had looked at either."""
+    assert "const passed = w.editing || w.step > st.k;" in INDEX
+
+
+def test_linking_does_not_open_on_an_already_linked_tool():
+    """b-open picked the first OBSERVED tool whichever it was, so on a
+    deployment whose busiest tool is already linked it opened on that one -
+    and pressing through to the end overwrote the subscription that existed,
+    with nothing on screen saying so. Caught by driving the wizard and reading
+    the review step, which named a tool the Budget view already listed."""
+    assert "const taken = new Set();" in INDEX
+    assert "const free = (REGTOOLS || []).slice()" in INDEX
+    assert "filter(t => !taken.has(t.id));" in INDEX
+
+
+def test_the_member_step_names_every_connector_and_its_plan():
+    """Automatic sync exists for two of the thirty tools the registry ships,
+    and the only way to find that out was to open the dropdown and not see
+    yours. The step now lists the connectors with the plan each needs.
+
+    The general note replaced a ChatGPT-specific one: naming a single absence
+    made it look like the only one, when every tool without a connector is in
+    exactly the same position."""
+    assert "plan, and how" in INDEX
+    # There used to be a SECOND table listing only the built connectors,
+    # directly above a dropdown containing exactly those same connectors. It
+    # said nothing the full table does not, and having both invited the
+    # reading that the dropdown was the list of vendors rather than the list
+    # of ones with code behind them.
+    assert "The complete list of vendors" not in INDEX
+    assert "plan it needs" not in INDEX
+    assert "Anything not listed" in INDEX
+    assert "under Automatic uses Import or Manual" in INDEX
+    # The old copy spoke only about ChatGPT in the general slot.
+    assert "const BPROVIDER_NONE = `ChatGPT Business" not in INDEX
+
+
+def test_a_tool_with_no_licence_mates_says_so():
+    """Atlassian Rovo shares a licence group with nothing, so "Also covers"
+    rendered an empty chip row and a bare "more tools..." - which reads as a
+    control that failed to load rather than one with nothing to offer."""
+    assert "Nothing in the registry" in INDEX
+    assert "choose from every tool" in INDEX
+
+
+def test_the_member_step_answers_why_a_tool_is_missing():
+    """Naming only the two built connectors left the operator of the other
+    twenty-eight with no answer. The step now separates "the vendor offers
+    nothing" from "the vendor offers something nobody has connected", which is
+    the only one of the two worth opening an issue about."""
+    for needle in ("member_apis", "Vendor API, no connector yet",
+                   "No seat list exists", "Not documented",
+                   "an admin API nobody has connected yet",
+                   "tools with a sync written"):
+        assert needle in INDEX, needle
+    # A connector written from a docs page is not a connector anybody has
+    # run. Being in the dropdown reads as "this works", so the ones that have
+    # never touched a real tenant say so where the key gets pasted.
+    assert "unverified" in INDEX
+    assert "has never been run against a real organisation" in INDEX
+
+
+def test_import_and_manual_speak_about_the_tool_being_linked():
+    """Import and Manual carried a paragraph about ChatGPT whichever tool you
+    were linking. It went stale the moment a ChatGPT connector existed: it
+    told an Enterprise workspace to use Import when Automatic had just started
+    working for it. The answer is per-tool and already in member_apis, so the
+    note is built from that instead of from one vendor's example."""
+    assert "BPROVIDER_CHATGPT" not in INDEX
+    assert "ChatGPT Business (Team) is the usual surprise" not in INDEX
+    for needle in ("can sync automatically",
+                   "vendor does expose a members API",
+                   "has no organisation or seat list to read",
+                   "does not document a members API"):
+        assert needle in INDEX, needle
+
+
+def test_a_tool_you_defined_is_not_reported_as_undocumented():
+    """member_apis covers the tools this release ships with. A tool the
+    operator defined has no row, and an absent row is not a finding - falling
+    through to the "not documented" branch made the page state, about a tool
+    invented five minutes earlier, that its vendor documents no members API.
+    Nobody had looked. "We have no record" and "we looked and there is
+    nothing" are different sentences."""
+    assert "is a tool you defined" in INDEX
+    assert "there is no record here of" in INDEX
+    # And the table says which tools it is actually about.
+    assert "SHIPPED tools" in INDEX
+    assert "tools you define yourself are not in here" in INDEX
+
+
+def test_the_budget_page_lists_providers_as_a_list_not_a_chain():
+    """The empty state joined every provider with " and ". At two vendors that
+    read fine; at seven it was one breathless sentence. The trailing line
+    about ChatGPT Business went with it - it is one plan of one vendor, it
+    stopped being the only notable absence, and the wizard's own step now says
+    what applies to the tool being linked."""
+    assert "ChatGPT Business has no admin API on that plan" not in INDEX
+    assert "labels.slice(0, -1).join(', ')" in INDEX

--- a/portal/tests/test_central_settings.py
+++ b/portal/tests/test_central_settings.py
@@ -187,3 +187,34 @@ def test_the_page_carries_the_editors():
                    "/api/settings", "/api/governance-decisions",
                    "/api/password", "set in the portal"):
         assert needle in html, needle
+
+
+def test_the_settings_tabs_share_one_save_and_secrets_keep_their_own():
+    """The Fleet tab alone carried eight Save buttons, one per field, and
+    the four extension-hosting URLs - only meaningful together - were four
+    separate round trips.
+
+    A SECRET is deliberately left out of the batch. Its box renders blank by
+    design and blank means CLEAR, so sweeping the secrets into a batch would
+    wipe every one of them the moment somebody edited an unrelated field on
+    the same tab."""
+    html = (main.STATIC / "index.html").read_text()
+    # The batch is opt-in per call site, and a secret refuses it.
+    assert "function settingRow(key, label, placeholder, note, batch) {" in html
+    assert "const batched = batch && !secret;" in html
+    # Dirty is measured against the value the field was RENDERED with.
+    assert "const sDirty = () => Array.from(app.querySelectorAll('[data-sfield]'))" in html
+    assert "data-sinit=" in html
+    # The bar and the one save it drives.
+    assert 'data-act="settings-save-all"' in html
+    assert 'data-act="settings-discard"' in html
+    # The two list shapes the settings API takes.
+    assert 'data-slist="csv"' in html and 'data-slist="lines"' in html
+    # A failed save must NOT re-render: a render redraws every field from
+    # SETTINGS and would throw away the several edits that just failed.
+    assert "const err = document.getElementById('setbar-err');" in html
+    # The wizard and the extension guide pass no batch and keep their own
+    # per-field saves - each of their steps gates on its value being stored.
+    assert 'data-act="save-domains"' in html
+    assert 'data-act="save-extid"' in html
+    assert "${batch ? '' : '<button class=\"mini\" data-act=\"save-markings\">Save</button>'}" in html

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -565,12 +565,19 @@ def test_the_settings_tab_from_the_url_cannot_dispatch_into_the_prototype():
     while the view on the very next line always was."""
     index = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     html = open(os.path.join(index, "app", "static", "index.html")).read()
-    # Allow-listed where it enters, like the view beside it.
-    assert "if (SETTABS.includes(tab)) SETTAB = tab;" in html
+    # Allow-listed where it enters, like the view beside it. fromHash now
+    # RETURNS the tab instead of assigning it, so the check and the value
+    # are one expression and there is no unchecked name in between.
+    assert ("return {view: 'settings', tab: SETTABS.includes(tab) ? tab : null};"
+            in html)
+    # The other assignment - the sub-tab buttons - is guarded on the line
+    # immediately above it, against the same list. Pinned as a PAIR: the
+    # assignment on its own is what this test exists to stop.
+    assert ("if (!SETTABS.includes(tab)) return;\n  SETTAB = tab;" in html)
     # And named outright at the point of use - no key, no lookup, no call.
     assert "if (SETTAB === 'connection') body = connectionSettings();" in html
     assert "else { SETTAB = 'fleet'; body = fleetSettings(); }" in html
-    assert "${body}`;" in html
+    assert "\n  ${body}\n" in html
     # The list has to exist before fromHash() runs, or it is a TDZ error
     # on load - the same trap SETTAB itself fell into.
     assert html.index("const SETTABS") < html.index("SETTABS.includes(tab)")
@@ -579,6 +586,55 @@ def test_the_settings_tab_from_the_url_cannot_dispatch_into_the_prototype():
                  "const SGROUPS = new Map([", "${settingsGroup()}",
                  "if (tab) SETTAB = tab;"):
         assert gone not in html
+
+
+def test_a_settings_sub_tab_link_opens_the_tab_it_names():
+    """The fragment carries the Settings sub-tab so a view can be sent to a
+    colleague, but the link only ever worked on a full page LOAD. fromHash()
+    set SETTAB as a side effect and returned only the view, and the
+    hashchange handler re-renders only when the VIEW id changes - so
+    #settings -> #settings/account moved the tab and drew nothing.
+
+    Both halves were wrong. Driven against the running portal: the link was
+    ignored, and the tab it had quietly set then surfaced on the next visit
+    to plain #settings, which showed Account under a URL reading #settings.
+    fromHash is pure now and the handler compares both values."""
+    index = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    html = open(os.path.join(index, "app", "static", "index.html")).read()
+    # Pure: it returns the pair, and assigns nothing.
+    assert "const BOOT = fromHash();" in html
+    assert "if (BOOT.tab) SETTAB = BOOT.tab;" in html
+    # The handler asks about the tab as well as the view, or the tab half
+    # of a fragment never draws.
+    assert "const tabbed = h.tab && h.tab !== SETTAB;" in html
+    assert "if (h.view === view && !tabbed) return;" in html
+    # frag() is fromHash's inverse, so every navigation writes a fragment
+    # that names the tab it is about to show. No caller may go back to
+    # writing a bare '#' + view: that is what left the URL disagreeing
+    # with the screen.
+    assert "const frag = v => '#' + v + (v === 'settings' ? '/' + SETTAB : '');" in html
+    assert "replaceState(null, '', '#' + view)" not in html
+    # A tour step on Settings owns the sub-tab too - #set-domains exists
+    # only on Fleet, and the step found nothing when it did not.
+    assert "{view: 'settings', tab: 'fleet', sel: '#set-domains'," in html
+
+
+def test_a_bare_url_lands_on_the_overview_not_on_sources():
+    """The unknown-fragment fallback doubled as the front door, so a bare
+    URL opened Sources. That is right immediately AFTER the wizard - which
+    sets #setup itself, deliberately - and wrong on every later visit, where
+    it made a health page the first thing an operator saw."""
+    index = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    html = open(os.path.join(index, "app", "static", "index.html")).read()
+    # Derived from the nav, so the front door is whatever the sidebar names
+    # first and there is no second list to keep in step.
+    assert "const HOME = NAV[0].items[0][0];" in html
+    assert "return {view: VIEWS.includes(h) ? h : HOME, tab: null};" in html
+    assert "return VIEWS.includes(h) ? h : 'setup';" not in html
+    # The first-run paths are untouched: the wizard still parks on Sources,
+    # and it still opens itself over an empty fragment.
+    assert "view = 'setup'; detail = null;" in html
+    assert "(!location.hash || location.hash === '#wizard')" in html
 
 
 def test_a_map_keyed_on_the_bare_serial_still_finds_the_machine():

--- a/portal/tests/test_wizard.py
+++ b/portal/tests/test_wizard.py
@@ -244,6 +244,51 @@ def test_the_page_carries_the_tool_registry_view():
         assert needle in html, needle
 
 
+def test_defining_a_tool_proposes_rather_than_asks():
+    """Nineteen flat fields became a three-step wizard, because the operator
+    does not know a tool's bundle id or CLI binary - working that out is what
+    they run the platform for. Discovery only sees DNS
+    (_CANDIDATE_KINDS = domain, mcp_server) and collectors report only what
+    already matches the registry, so the estate cannot answer it either.
+
+    So proposals are DERIVED and offered UNTICKED, and where each one came
+    from is on screen beside it. A wrong identifier is worse than a missing
+    one: a blank leaves a tool unseen on a surface, a wrong one hangs somebody
+    else's findings on it."""
+    html = (main.STATIC / "index.html").read_text()
+    for needle in ("function rwDerive(", "function rwOpen(", "function rwEntry(",
+                   "rw-step", "rw-tick", "rw-add",
+                   "seen in your estate", "derived from the name",
+                   "already saved", "you added"):
+        assert needle in html, needle
+    # Derived guesses are never on by default; evidence and saved values are.
+    assert "why: 'derived', conf: 'low', on: false" in html
+    # The four fields registry/schema.json requires are always written. vendor
+    # was conditional, which produced an entry the receiver refused - found by
+    # saving one, not by reading the code.
+    assert "const e = {id: RW.editing || RW.id, name: RW.name, vendor: RW.vendor};" in html
+    assert "const rwReady = () => !!(RW.name && RW.vendor && (RW.editing || RW.id));" in html
+    # Typing has to reach the Next button, or the wizard cannot be walked at
+    # all: nothing else re-renders while a field has focus.
+    assert "function rwLive()" in html
+    assert "matches('#rw-name,#rw-vendor,#rw-id')" in html
+    # The JSON escape hatch survives the rewrite.
+    assert "reg-adv" in html and "re-json" in html
+
+
+def test_the_review_queue_button_lands_in_the_wizard():
+    """cand-add already opened the same form the Tool registry did, so making
+    that form a wizard puts the review queue's own button into it. What
+    discovery saw rides along as evidence - the one thing on the identifier
+    step that is not a guess."""
+    html = (main.STATIC / "index.html").read_text()
+    assert "if (act === 'cand-add')" in html
+    assert "evidence: {kind: c.kind" in html
+    # An entry being edited arrives already confirmed, not re-proposed.
+    assert "function rwFromEntry(" in html
+    assert "why: 'saved', conf: 'high', on: true" in html
+
+
 def test_the_js_category_list_matches_the_schema():
     """REG_CATEGORIES is a hand-mirror of registry/schema.json's category
     enum; a value added to one and not the other makes the form refuse (or

--- a/receiver/app/budget.py
+++ b/receiver/app/budget.py
@@ -42,6 +42,11 @@ _TIMEOUT = 15.0
 
 ANTHROPIC_URL = "https://api.anthropic.com/v1/organizations/users"
 FIREFLIES_URL = "https://api.fireflies.ai/graphql"
+OPENAI_URL = "https://api.openai.com/v1/organization/users"
+CURSOR_URL = "https://api.cursor.com/teams/members"
+CHATGPT_SCIM_URL = "https://api.openai.com/scim/v2"
+NOTION_SCIM_URL = "https://api.notion.com/scim/v2"
+GRAMMARLY_SCIM_URL = "https://app.grammarly.com/scim/v2"
 
 # What the portal needs to offer the wizard: which providers exist, what
 # each one's key looks like and where an admin creates it. Data, not
@@ -49,6 +54,11 @@ FIREFLIES_URL = "https://api.fireflies.ai/graphql"
 PROVIDERS = {
     "anthropic": {
         "label": "Anthropic (Claude Enterprise / Console)",
+        # What plan the admin API needs. Stated only where it is actually
+        # known: Anthropic documents that Team has no admin keys, so that
+        # one is a fact. Fireflies below does not get a guess.
+        "plan": "Enterprise, or a Console org. Team plans have no admin "
+                "API at all.",
         "key_hint": "Scoped Admin API key with the read:members scope. The "
                     "org's primary owner creates it at claude.ai > "
                     "Organization settings > API (Console orgs: Settings > "
@@ -60,12 +70,269 @@ PROVIDERS = {
         "syncs": "members and roles. Seat tiers are not in the API - "
                  "record them on the subscription.",
     },
+    "chatgpt": {
+        "label": "ChatGPT workspace (Enterprise or Edu)",
+        "plan": "Enterprise or Edu. Business - the plan renamed from Team in "
+                "2025 - has SSO but no SCIM, so it uses Import.",
+        "key_hint": "SCIM API token from the workspace admin console, "
+                    "Settings > Security > SCIM Provisioning. It is issued by "
+                    "OpenAI rather than by your identity provider, and this "
+                    "reads the same endpoint your IdP writes to - no IdP is "
+                    "needed to use it. Codex CLI has no member list of its "
+                    "own: tick it under \"also covers\".",
+        "syncs": "members and whether the account is active. SCIM carries no "
+                 "seat tier or usage - record tiers on the subscription.",
+        "unverified": True,
+    },
+    "notion": {
+        "label": "Notion (Enterprise)",
+        "plan": "Enterprise only - Free, Plus and Business cannot mint a "
+                "SCIM token at all.",
+        "key_hint": "SCIM API token created by an organisation owner under "
+                    "Manage organization. Notion issues it, not your identity "
+                    "provider, and this reads the same endpoint an IdP would "
+                    "write to.",
+        "syncs": "members and whether the account is active. No seat tier or "
+                 "usage - record tiers on the subscription.",
+        "unverified": True,
+    },
+    "grammarly": {
+        "label": "Grammarly (Pro or Enterprise)",
+        "plan": "Pro or Enterprise, and SAML SSO has to be configured first - "
+                "Grammarly will not issue the token before it is.",
+        "key_hint": "SCIM token from the Admin Panel, Settings > SSO & "
+                    "Provisioning.",
+        "syncs": "members and whether the account is active.",
+        "unverified": True,
+    },
+    "openai": {
+        "label": "OpenAI (API platform organisation)",
+        "plan": "Any organisation, with an Admin API key. This is the API "
+                "platform org - a ChatGPT workspace is SCIM-only and uses "
+                "Import.",
+        "key_hint": "Admin API key, created at platform.openai.com > "
+                    "Settings > Organization > Admin keys by an owner. An "
+                    "ordinary project API key will not work: admin keys are "
+                    "the only ones the organization endpoints accept.",
+        "syncs": "members and their org role. Seat tiers are not in the "
+                 "API - record them on the subscription.",
+        # Written from OpenAI's documented endpoint and NOT yet run against a
+        # real organisation. The first operator to point it at one is the
+        # test; a refusal here names the vendor and the status rather than
+        # failing silently.
+        "unverified": True,
+    },
+    "cursor": {
+        "label": "Cursor (Team or Enterprise)",
+        "plan": "Team or Enterprise - both expose it, unusually.",
+        "key_hint": "Team API key from cursor.com > Settings > Cursor "
+                    "Admin API. Sent as HTTP Basic with the key as the "
+                    "username and no password, which is what their curl "
+                    "example shows.",
+        "syncs": "members and their team role. Removed members are dropped "
+                 "rather than counted as seats.",
+        "unverified": True,
+    },
     "fireflies": {
         "label": "Fireflies.ai",
+        # Fireflies' own knowledge base says API access is available on every
+        # plan level, and neither the `users` query nor the API-key article
+        # names a tier or an admin role. The "Business or higher" gate people
+        # quote is on the separate `analytics` query, which this connector
+        # does not use: the per-user counters it reports are fields on
+        # `users` itself.
+        "plan": "Any plan. Fireflies documents API access at every plan "
+                "level, and the team-users query names no tier.",
         "key_hint": "API key from fireflies.ai > Integrations > Fireflies "
                     "API. A team admin's key lists the whole team.",
         "syncs": "members, admin flag, and per-user usage (transcripts, "
                  "minutes).",
+    },
+}
+
+
+# What each SHIPPED registry tool's vendor can tell an administrator about who
+# holds a seat. PROVIDERS above is the subset this receiver has actually
+# implemented; this is the wider map, so the portal can answer the operator's
+# real question - "why is my tool not in the Automatic list?" - with either
+# "its vendor offers nothing" or "its vendor does, and we have not built it
+# yet", which is a far more useful thing to open an issue about.
+#
+# `api` is what the VENDOR offers, not what we support:
+#   rest      a REST/GraphQL admin endpoint that lists members
+#   scim      SCIM 2.0 only, which means provisioning through an IdP
+#   none      no organisation or seat list exists to read
+#   unknown   not documented publicly, or not established
+#
+# `plan` records the tier, and says so honestly where a tier is not documented.
+# Checked against vendor documentation in August 2026. Vendors move these gates
+# often - anything here that starts costing an operator a wasted afternoon
+# should be re-checked rather than trusted because it is written down.
+MEMBER_APIS = {
+    "claude": {
+        "api": "rest", "connector": "anthropic",
+        "plan": "Enterprise, or a Console org. Team plans have no admin API.",
+        "how": "Admin API, GET /v1/organizations/users.",
+    },
+    "claude-code": {
+        "api": "rest", "connector": "anthropic",
+        "plan": "Enterprise, or a Console org.",
+        "how": "Same Anthropic org as Claude - one licence, one member list.",
+    },
+    "chatgpt": {
+        "api": "scim", "connector": "chatgpt",
+        "plan": "Enterprise or Edu only. Business (renamed from Team in 2025) "
+                "has SSO but not SCIM.",
+        "how": "SCIM 2.0 at api.openai.com/scim/v2. The token comes from "
+               "OpenAI's own admin console, so no IdP is involved.",
+    },
+    "codex-cli": {
+        "api": "rest", "connector": "chatgpt",
+        "plan": "Whatever pays for it.",
+        "how": "No member list of its own - it rides the ChatGPT workspace or "
+               "the API platform org. Tick it under \"also covers\".",
+    },
+    "openai-api-platform": {
+        "api": "rest", "connector": "openai",
+        "plan": "Any organisation, with an Admin API key.",
+        "how": "GET /v1/organization/users.",
+    },
+    "gemini": {
+        "api": "rest",
+        "plan": "Google Workspace, Business Standard or higher for Gemini.",
+        "how": "Licences are assigned in Workspace; the Admin SDK Directory "
+               "and Enterprise License Manager APIs list who holds one.",
+    },
+    "gemini-cli": {
+        "api": "rest",
+        "plan": "Google Workspace, or a Google Cloud project for Code Assist.",
+        "how": "Same Workspace licence assignment as Gemini.",
+    },
+    "github-copilot": {
+        "api": "rest",
+        "plan": "Copilot Business or Copilot Enterprise.",
+        "how": "GET /orgs/{org}/copilot/billing/seats. Org owner, with a token "
+               "carrying manage_billing:copilot and read:org.",
+    },
+    "cursor": {
+        "api": "rest", "connector": "cursor",
+        "plan": "Team or Enterprise - both, unusually.",
+        "how": "Admin API, GET /teams/members with a Team API key.",
+    },
+    "codeium": {
+        "api": "rest",
+        "plan": "Enterprise. Teams sees admin analytics in-app; the API and "
+                "SCIM are Enterprise.",
+        "how": "Windsurf enterprise API for team management and analytics.",
+    },
+    "tabnine": {
+        "api": "rest",
+        "plan": "Enterprise, SaaS console or self-hosted.",
+        "how": "Admin APIs for teams and users, plus SCIM IdP sync.",
+    },
+    "cline": {
+        "api": "unknown",
+        "plan": "Enterprise.",
+        "how": "Cline Enterprise manages members in its own dashboard; a "
+               "public members API is not documented.",
+    },
+    "roo-code": {
+        "api": "none", "plan": "",
+        "how": "An open-source extension on your own model keys. There is no "
+               "vendor account, so there is no seat list to read.",
+    },
+    "continue": {
+        "api": "none", "plan": "",
+        "how": "An open-source extension on your own model keys. No vendor "
+               "seat list.",
+    },
+    "otter": {
+        "api": "rest",
+        "plan": "Enterprise. SCIM Directory Sync additionally needs 100+ seats.",
+        "how": "The public API is Enterprise-only, bearer authenticated.",
+    },
+    "grammarly": {
+        "api": "scim", "connector": "grammarly",
+        "plan": "Pro or Enterprise, and SAML SSO has to be on first.",
+        "how": "SCIM 2.0 at app.grammarly.com/scim/v2.",
+    },
+    "wispr-flow": {
+        "api": "scim",
+        "plan": "Enterprise.",
+        "how": "Admin portal at admin.wisprflow.ai with SCIM provisioning; the "
+               "enterprise API covers audit logs rather than a member list.",
+    },
+    "perplexity": {
+        "api": "scim",
+        "plan": "Enterprise Pro at 50+ seats, or Enterprise Max at any size.",
+        "how": "SCIM through your IdP only - there is no admin REST API, and "
+               "the SCIM token is issued during onboarding, not self-served.",
+    },
+    "mistral": {
+        "api": "rest",
+        "plan": "Enterprise. The Admin API is in preview.",
+        "how": "console.mistral.ai/api/admin, x-api-key.",
+    },
+    "grok": {
+        "api": "rest",
+        "plan": "Grok Business, or an xAI organisation.",
+        "how": "Management API at management-api.x.ai with a management key.",
+    },
+    "microsoft-copilot": {
+        "api": "rest",
+        "plan": "Any tenant with a Microsoft 365 admin.",
+        "how": "Microsoft Graph: subscribedSkus and per-user licenseDetails "
+               "say who holds the add-on.",
+    },
+    "microsoft-365-copilot": {
+        "api": "rest",
+        "plan": "An add-on to M365 E3/E5 or Business Standard/Premium.",
+        "how": "Microsoft Graph, the same licence assignment as any other "
+               "M365 service.",
+    },
+    "atlassian-rovo": {
+        "api": "rest",
+        "plan": "Not documented. An organisation API key is what it needs; "
+                "which plans can mint one is not stated publicly.",
+        "how": "Organizations REST API, GET /v2/orgs/{orgId}/directories/"
+               "{directoryId}/users.",
+    },
+    "notion-ai": {
+        "api": "scim", "connector": "notion",
+        "plan": "Enterprise only - Free, Plus and Business cannot use SCIM.",
+        "how": "SCIM for provisioning; the ordinary Notion API's /v1/users "
+               "also lists workspace members with an integration token.",
+    },
+    "fireflies": {
+        "api": "rest", "connector": "fireflies",
+        "plan": "Any plan - API access is documented at every plan level.",
+        "how": "One GraphQL query for the team's users, with per-user usage. "
+               "The separate analytics query needs Business or higher; this "
+               "does not use it.",
+    },
+    "hugging-face": {
+        "api": "rest",
+        "plan": "Any organisation for the members list; SCIM needs Enterprise "
+                "Hub with SSO enabled.",
+        "how": "GET /api/organizations/{org}/members.",
+    },
+    "deepseek": {
+        "api": "unknown", "plan": "",
+        "how": "The open platform issues API keys; no organisation member "
+               "endpoint is documented publicly.",
+    },
+    "midjourney": {
+        "api": "none", "plan": "",
+        "how": "Individual subscriptions. There is no organisation, so there "
+               "is no seat list.",
+    },
+    "ollama": {
+        "api": "none", "plan": "",
+        "how": "Runs locally with no account at all - there is nobody to list.",
+    },
+    "lm-studio": {
+        "api": "none", "plan": "",
+        "how": "A local desktop app with no account.",
     },
 }
 
@@ -203,7 +470,235 @@ async def sync_fireflies(api_key: str) -> list[dict]:
     return members
 
 
-SYNCERS = {"anthropic": sync_anthropic, "fireflies": sync_fireflies}
+async def sync_openai(api_key: str) -> list[dict]:
+    """The organisation's members via the OpenAI Admin API, all pages.
+
+    This is the API PLATFORM organisation - the one that owns API keys and
+    projects - not a ChatGPT workspace. ChatGPT's member list is SCIM-only
+    and Enterprise-only, which is an identity-provider integration rather
+    than a vendor endpoint this could call, so it stays on the Import path.
+
+    Pagination is cursor-based: page with `after` until has_more is false.
+    """
+    members: list[dict] = []
+    after = ""
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        for _ in range(MAX_MEMBERS // 100 + 1):
+            params = {"limit": "100"}
+            if after:
+                params["after"] = after
+            try:
+                r = await client.get(
+                    OPENAI_URL, params=params,
+                    headers={"Authorization": "Bearer " + api_key})
+            except httpx.HTTPError as e:
+                raise SyncError("could not reach the OpenAI API (%s)"
+                                % type(e).__name__)
+            if r.status_code != 200:
+                raise _refusal(r.status_code, "the OpenAI API")
+            try:
+                body = r.json()
+            except json.JSONDecodeError:
+                raise SyncError("the OpenAI API answered 200, but not with "
+                                "JSON")
+            page = body.get("data") or []
+            for u in page:
+                email = str(u.get("email") or "").strip().lower()
+                if not email:
+                    continue
+                members.append({
+                    "email": email,
+                    "name": str(u.get("name") or "")[:200],
+                    "role": str(u.get("role") or "")[:64],
+                    "seat_tier": "",
+                    "usage": {},
+                })
+                if len(members) > MAX_MEMBERS:
+                    raise SyncError("more than %d members: refusing rather "
+                                    "than store a partial member list as if "
+                                    "it were complete" % MAX_MEMBERS)
+            if not body.get("has_more"):
+                return members
+            after = str(body.get("last_id") or "")
+            if not after and page:
+                after = str(page[-1].get("id") or "")
+            if not after:
+                # has_more with no cursor would loop on page one forever.
+                return members
+    raise SyncError("the OpenAI API kept paginating past %d members"
+                    % MAX_MEMBERS)
+
+
+async def sync_cursor(api_key: str) -> list[dict]:
+    """The team's members via the Cursor Admin API.
+
+    One unpaginated call. Authentication is HTTP Basic with the API key as
+    the USERNAME and an empty password - the shape their docs show as
+    `curl -u YOUR_API_KEY:` - not a bearer token.
+
+    Removed members keep appearing with isRemoved set; they are dropped
+    here, because a seat that has been taken away is not a seat somebody
+    holds and counting it would overstate what the licence is paying for.
+    """
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        try:
+            r = await client.get(CURSOR_URL, auth=(api_key, ""))
+        except httpx.HTTPError as e:
+            raise SyncError("could not reach the Cursor API (%s)"
+                            % type(e).__name__)
+    if r.status_code != 200:
+        raise _refusal(r.status_code, "the Cursor API")
+    try:
+        body = r.json()
+    except json.JSONDecodeError:
+        raise SyncError("the Cursor API answered 200, but not with JSON")
+    # Their docs show a bare array; a wrapped object would be a kindness to
+    # accept too rather than a reason to fail the whole sync.
+    rows = body if isinstance(body, list) else (body.get("teamMembers")
+                                                or body.get("members") or [])
+    if not isinstance(rows, list):
+        raise SyncError("the Cursor API answered with JSON this does not "
+                        "recognise as a member list")
+    if len(rows) > MAX_MEMBERS:
+        raise SyncError("more than %d members: refusing rather than store a "
+                        "partial member list as if it were complete"
+                        % MAX_MEMBERS)
+    members = []
+    for u in rows:
+        if not isinstance(u, dict) or u.get("isRemoved"):
+            continue
+        email = str(u.get("email") or "").strip().lower()
+        if not email:
+            continue
+        members.append({
+            "email": email,
+            "name": str(u.get("name") or "")[:200],
+            "role": str(u.get("role") or "")[:64],
+            "seat_tier": "",
+            "usage": {},
+        })
+    return members
+
+async def _scim_users(base_url: str, token: str, vendor: str) -> list[dict]:
+    """Members from any SCIM 2.0 /Users endpoint.
+
+    SCIM was ruled out here at first as "an identity-provider integration
+    rather than a vendor API". That is wrong wherever the VENDOR issues the
+    token from its own admin console and the endpoint answers a plain GET -
+    which is a bearer key like any other, and no IdP is involved. What stays
+    ruled out is a vendor whose token is issued by its support team during
+    onboarding, because there is nothing an operator can paste.
+
+    Pagination is SCIM's own: 1-based startIndex, and totalResults says when
+    to stop. Written once because the three vendors that qualify differ only
+    in their base URL.
+    """
+    members: list[dict] = []
+    start = 1
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        for _ in range(MAX_MEMBERS // 100 + 1):
+            try:
+                r = await client.get(
+                    base_url.rstrip("/") + "/Users",
+                    params={"startIndex": str(start), "count": "100"},
+                    headers={"Authorization": "Bearer " + token,
+                             "Accept": "application/scim+json"})
+            except httpx.HTTPError as e:
+                raise SyncError("could not reach %s (%s)"
+                                % (vendor, type(e).__name__))
+            if r.status_code != 200:
+                raise _refusal(r.status_code, vendor)
+            try:
+                body = r.json()
+            except json.JSONDecodeError:
+                raise SyncError("%s answered 200, but not with JSON" % vendor)
+            page = body.get("Resources")
+            if page is None:
+                raise SyncError("%s answered without a SCIM Resources list - "
+                                "check the base URL is the SCIM one" % vendor)
+            for u in page:
+                if not isinstance(u, dict):
+                    continue
+                # userName is the email on every vendor here, but the emails
+                # array is the spec's own answer, so prefer it and fall back.
+                email = ""
+                for e in (u.get("emails") or []):
+                    if isinstance(e, dict) and e.get("value"):
+                        email = str(e["value"])
+                        if e.get("primary"):
+                            break
+                email = (email or str(u.get("userName") or "")).strip().lower()
+                if not email or "@" not in email:
+                    continue
+                nm = u.get("name") or {}
+                name = str(nm.get("formatted") or
+                           " ".join(x for x in [nm.get("givenName"),
+                                                nm.get("familyName")] if x) or
+                           u.get("displayName") or "")
+                # A deactivated SCIM user is not holding a seat. Counting one
+                # would overstate what the licence pays for, the same way a
+                # removed Cursor member would.
+                if u.get("active") is False:
+                    continue
+                members.append({
+                    "email": email,
+                    "name": name[:200],
+                    "role": "",
+                    "seat_tier": "",
+                    "usage": {},
+                })
+                if len(members) > MAX_MEMBERS:
+                    raise SyncError("more than %d members: refusing rather "
+                                    "than store a partial member list as if "
+                                    "it were complete" % MAX_MEMBERS)
+            total = body.get("totalResults")
+            got = start - 1 + len(page)
+            if not page or (isinstance(total, int) and got >= total):
+                return members
+            start = got + 1
+    raise SyncError("%s kept paginating past %d members"
+                    % (vendor, MAX_MEMBERS))
+
+
+async def sync_chatgpt(api_key: str) -> list[dict]:
+    """The ChatGPT workspace's members, via its SCIM 2.0 endpoint.
+
+    Enterprise and Edu only - Business (renamed from Team in 2025) has SSO
+    but no SCIM, and so stays on the Import path. The token comes from the
+    workspace's own admin console, Settings > Security > SCIM Provisioning,
+    not from an identity provider.
+
+    Codex CLI has no member list of its own: it rides whichever workspace
+    pays for it, so tick it under "also covers" rather than looking for a
+    connector of its own.
+    """
+    return await _scim_users(CHATGPT_SCIM_URL, api_key, "the ChatGPT SCIM API")
+
+
+async def sync_notion(api_key: str) -> list[dict]:
+    """The workspace's members via Notion's SCIM endpoint.
+
+    Enterprise only - Free, Plus and Business cannot mint a SCIM token at
+    all. An organisation owner creates it under Manage organization, so it
+    is a vendor-issued key even though an IdP is the usual consumer.
+    """
+    return await _scim_users(NOTION_SCIM_URL, api_key, "the Notion SCIM API")
+
+
+async def sync_grammarly(api_key: str) -> list[dict]:
+    """The account's members via Grammarly's SCIM endpoint.
+
+    Pro and Enterprise, and SAML SSO has to be configured first - Grammarly
+    will not issue the token before it is. The token comes from the Admin
+    Panel, Settings > SSO & Provisioning.
+    """
+    return await _scim_users(GRAMMARLY_SCIM_URL, api_key,
+                             "the Grammarly SCIM API")
+
+SYNCERS = {"anthropic": sync_anthropic, "fireflies": sync_fireflies,
+           "openai": sync_openai, "cursor": sync_cursor,
+           "chatgpt": sync_chatgpt, "notion": sync_notion,
+           "grammarly": sync_grammarly}
 
 
 # ----------------------------------------------------------------- fx --

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -2474,6 +2474,9 @@ def get_budget(authorization: str = Header(default="")):
     _admin_auth(authorization)
     out = STATE.list_budget()
     out["providers"] = _budget.PROVIDERS
+    # What every shipped tool's vendor offers, so the portal can say
+    # whether a missing connector is our gap or the vendor's.
+    out["member_apis"] = _budget.MEMBER_APIS
     return out
 
 

--- a/receiver/tests/test_budget.py
+++ b/receiver/tests/test_budget.py
@@ -456,3 +456,203 @@ def test_covers_survives_a_database_from_before_it(tmp_path, monkeypatch):
     st2 = state_mod.State(db)
     sub = st2.list_budget()["subscriptions"][0]
     assert sub["covers"] == []
+
+
+def test_every_provider_says_what_plan_it_needs():
+    """The wizard now lists the connectors with their plan requirement, so a
+    provider with no `plan` renders "not recorded" - which is honest but
+    useless. Both entries carry one, and they carry different KINDS of claim:
+    Anthropic documents that Team has no admin keys, so that is stated as
+    fact; Fireflies does not document its tiers, so that one says what was
+    tested rather than inventing a minimum an operator would plan around."""
+    from app import budget
+
+    for name, p in budget.PROVIDERS.items():
+        assert p.get("plan"), name
+        assert p.get("syncs"), name
+        assert p.get("label"), name
+    assert "Team plans have no admin API" in budget.PROVIDERS["anthropic"]["plan"]
+    # Fireflies was first written as "verified on Enterprise, lower plans
+    # untested", which was not research - it was the one plan we happened to
+    # have used. Their knowledge base says API access exists at every plan
+    # level, and the Business gate applies to the analytics query this
+    # connector does not call.
+    ff = budget.PROVIDERS["fireflies"]["plan"]
+    assert "Any plan" in ff
+    assert "untested" not in ff
+
+
+def test_every_shipped_tool_says_what_its_vendor_offers():
+    """"Not supported" is two different situations - the vendor offers
+    nothing, or the vendor offers something and this receiver has not built
+    it - and only the second is worth an operator raising an issue about. The
+    map covers every tool the registry ships, so the wizard can say which.
+
+    It is checked against the registry rather than a hand-count, because the
+    two drifting apart is exactly how a tool ends up with no answer."""
+    import pathlib
+
+    import yaml
+
+    from app import budget
+
+    root = pathlib.Path(__file__).resolve().parents[2]
+    reg = yaml.safe_load((root / "registry" / "registry.yaml").read_text())
+    ids = {t["id"] for t in reg["tools"]}
+    assert set(budget.MEMBER_APIS) == ids
+
+    for tool, m in budget.MEMBER_APIS.items():
+        assert m["api"] in ("rest", "scim", "none", "unknown"), tool
+        assert m.get("how"), tool
+        # A vendor that offers something must say on what plan; one that
+        # offers nothing has no plan to state.
+        if m["api"] in ("rest", "scim") and tool != "codex-cli":
+            assert m.get("plan"), tool
+        if m["api"] == "none":
+            assert not m.get("plan"), tool
+
+    # Every connector this receiver implements is claimed by at least one tool.
+    claimed = {m["connector"] for m in budget.MEMBER_APIS.values()
+               if m.get("connector")}
+    assert claimed == set(budget.PROVIDERS)
+
+
+def test_sync_cursor_uses_basic_auth_and_drops_removed(managed, monkeypatch):
+    """Cursor authenticates with HTTP Basic - the key as the USERNAME with no
+    password, which is what `curl -u YOUR_API_KEY:` means - rather than a
+    bearer token, the one thing easy to get wrong from a docs page. Removed
+    members keep appearing with isRemoved set; counting them would overstate
+    what the licence pays for."""
+    import base64
+
+    def handler(request):
+        assert request.url.host == "api.cursor.com"
+        want = base64.b64encode(b"cur-key-123:").decode()
+        assert request.headers["Authorization"] == "Basic " + want
+        return httpx.Response(200, json=[
+            {"email": "Ash@Corp.example", "name": "Ash", "role": "owner"},
+            {"email": "bo@corp.example", "name": "Bo", "role": "member"},
+            {"email": "gone@corp.example", "name": "Gone", "isRemoved": True},
+            {"name": "no email at all"},
+        ])
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    put = client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "cursor", "provider": "cursor", "api_key": "cur-key-123"})
+    assert put.status_code == 200, put.text
+    r = client.post("/admin/budget/sync", headers=ADMIN,
+                    json={"tool_id": "cursor"})
+    assert r.json() == {"ok": True, "count": 2}
+
+
+def test_sync_openai_pages_with_a_cursor(managed, monkeypatch):
+    """Cursor-paginated on `after`, and the admin key goes in as a bearer.
+    An ordinary project key is refused by the vendor, which is why the hint
+    says admin key rather than API key."""
+    pages = {
+        "": {"data": [{"id": "user_1", "email": "One@Corp.example",
+                       "name": "One", "role": "owner"}],
+             "has_more": True, "last_id": "user_1"},
+        "user_1": {"data": [{"id": "user_2", "email": "two@corp.example",
+                             "name": "Two", "role": "reader"}],
+                   "has_more": False},
+    }
+
+    def handler(request):
+        assert request.url.host == "api.openai.com"
+        assert request.headers["Authorization"] == "Bearer sk-admin-k"
+        return httpx.Response(200, json=pages[request.url.params.get("after", "")])
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "openai-api-platform", "provider": "openai",
+        "api_key": "sk-admin-k"})
+    r = client.post("/admin/budget/sync", headers=ADMIN,
+                    json={"tool_id": "openai-api-platform"})
+    assert r.json() == {"ok": True, "count": 2}
+
+
+def test_a_connector_written_from_docs_says_so():
+    """Anthropic and Fireflies have been run against real orgs. OpenAI and
+    Cursor have not - they are written from the vendors' documented endpoints
+    and nothing more. That belongs in the data rather than in somebody's
+    memory, because "it is in the dropdown" reads as "it works"."""
+    assert budget_mod.PROVIDERS["openai"].get("unverified") is True
+    assert budget_mod.PROVIDERS["cursor"].get("unverified") is True
+    assert not budget_mod.PROVIDERS["anthropic"].get("unverified")
+    assert not budget_mod.PROVIDERS["fireflies"].get("unverified")
+    # Everything offered can be synced, and every syncer is offered.
+    assert set(budget_mod.SYNCERS) == set(budget_mod.PROVIDERS)
+
+
+def test_sync_chatgpt_reads_scim_users_and_pages(managed, monkeypatch):
+    """SCIM was ruled out here at first as "an IdP integration, not a vendor
+    API". That is wrong for ChatGPT: OpenAI issues the token from its own
+    admin console and the endpoint answers a plain GET, so it is a bearer key
+    like any other. What stays out is a vendor whose token is issued by
+    support during onboarding - there is nothing to paste.
+
+    Paging is SCIM's own: 1-based startIndex, totalResults says when to stop.
+    A deactivated user is not holding a seat and must not be counted."""
+    pages = {
+        1: {"totalResults": 3, "startIndex": 1, "itemsPerPage": 2,
+            "Resources": [
+                {"userName": "Ash@Corp.example", "active": True,
+                 "name": {"givenName": "Ash", "familyName": "One"},
+                 "emails": [{"value": "Ash@Corp.example", "primary": True}]},
+                {"userName": "gone@corp.example", "active": False,
+                 "emails": [{"value": "gone@corp.example"}]},
+            ]},
+        3: {"totalResults": 3, "startIndex": 3, "itemsPerPage": 1,
+            "Resources": [
+                {"userName": "bo@corp.example", "active": True,
+                 "name": {"formatted": "Bo Two"}},
+            ]},
+    }
+
+    def handler(request):
+        assert request.url.host == "api.openai.com"
+        assert request.url.path == "/scim/v2/Users"
+        assert request.headers["Authorization"] == "Bearer scim-tok-123"
+        return httpx.Response(
+            200, json=pages[int(request.url.params.get("startIndex", "1"))])
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    put = client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "chatgpt", "provider": "chatgpt",
+        "api_key": "scim-tok-123"})
+    assert put.status_code == 200, put.text
+    r = client.post("/admin/budget/sync", headers=ADMIN,
+                    json={"tool_id": "chatgpt"})
+    # Three resources, one deactivated.
+    assert r.json() == {"ok": True, "count": 2}
+
+
+def test_a_scim_answer_without_resources_is_named_not_guessed(managed,
+                                                              monkeypatch):
+    """Pointing this at a non-SCIM URL returns 200 and JSON that simply has no
+    Resources. Treating that as "zero members" would wipe a member list; it
+    has to refuse and say what it wanted."""
+    def handler(request):
+        return httpx.Response(200, json={"object": "list", "data": []})
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "chatgpt", "provider": "chatgpt", "api_key": "scim-tok-1"})
+    r = client.post("/admin/budget/sync", headers=ADMIN,
+                    json={"tool_id": "chatgpt"})
+    body = r.json()
+    assert body["ok"] is False
+    assert "SCIM Resources" in body["detail"]
+
+
+def test_codex_rides_the_chatgpt_workspace():
+    """Codex CLI has no member list of its own, so it points at the ChatGPT
+    connector rather than getting one - the "also covers" tick is what links
+    the two."""
+    assert budget_mod.MEMBER_APIS["codex-cli"]["connector"] == "chatgpt"
+    assert budget_mod.MEMBER_APIS["chatgpt"]["connector"] == "chatgpt"


### PR DESCRIPTION
Continues the consolidation pass: improve what exists rather than adding surfaces.

## Two wizards

**Define a tool** was one card with nineteen fields, all optional and ungrouped. **Link a tool** was already three steps, but its only progress marker was the italic text `step 1 of 3`. Both now wear the sign-on wizard's rail.

Adding a tool **proposes rather than asks**. An operator does not know a tool's bundle id or CLI binary — working that out is what they run this for — and the estate cannot tell them either: discovery sees DNS only, and collectors report just what already matches the registry, so a tool absent from it is invisible on every other surface. Proposals are derived from the name, offered **unticked** and labelled, because a wrong identifier is worse than a missing one: a blank leaves a tool unseen, a wrong one hangs somebody else's findings on it. The review splits what is **already matching** from what is merely being **watched for**.

Linking a tool gains a review step so both flows end the same way, and its rail carries the running monthly cost rather than a step count. Seat tiers become a table with column headers — they were three inputs whose only labels were placeholders, which vanish as soon as anything is typed.

## What the vendors actually offer

`MEMBER_APIS` records what every shipped tool's vendor exposes, so "not supported" stops hiding two different situations. Of the thirty: eighteen have a REST members endpoint, five are SCIM, five have no account to read at all, two document nothing. A test pins the map to `registry.yaml` by id.

Five syncs added on the back of it — `openai` (API platform org, admin key only), `cursor` (HTTP Basic with the key as the *username*), and `chatgpt`, `notion`, `grammarly` over one shared SCIM reader.

SCIM was ruled out at first as an identity-provider integration rather than a vendor API. That is wrong wherever the vendor issues the token from its own admin console and the endpoint answers a plain GET. What stays out is a vendor whose token is issued by support during onboarding — there is nothing to paste.

**The five new syncs carry `unverified`**: written from documentation, never run against a real organisation. The wizard says so where the key is pasted.

## Fixed on the way through

- `#settings/account` did nothing when clicked from inside the portal, then surfaced on the *next* visit to plain `#settings`
- Escape closes the inspector
- Settings batches its saves — the Fleet tab alone had eight buttons. Secrets keep their own, since blank means clear
- A bare URL lands on the Overview instead of Sources
- **Link a tool opened on a tool that was already linked**, and pressing through overwrote that subscription silently
- The tour's corporate-domains step targets an element that only exists on the Fleet tab

## Testing

489 portal, 244 receiver, 18 registry tests pass. Every screen was driven in a running demo stack rather than reasoned about; several of the fixes above were only visible that way.

Fireflies' recorded plan was corrected: "verified on Enterprise, lower plans untested" was not research, it was the one plan we had used. Their own documentation puts API access at every plan level.