### PR TITLE
portal: the first-run setup becomes seven steps, and the password moves out of Settings

### DIFF
--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -404,6 +404,16 @@ table.plain td{border-bottom:0;padding:4.5px 10px 4.5px 0;vertical-align:middle}
    command in step 2, the zip line in step 5 - pushed the whole panel wider
    than the card, and .ssow's overflow:hidden then cut off the buttons. */
 .ssmain{padding:22px 24px;min-width:0}
+/* The first-run rail groups its steps and says what each one costs to skip. */
+.ssrail .wact{font-size:10.5px;font-weight:700;color:var(--mut);
+  text-transform:uppercase;letter-spacing:.07em;margin:14px 0 4px 2px}
+.ssrail ol:first-of-type .wact:first-child{margin-top:0}
+.wtag{font-size:10px;padding:0 6px;border-radius:99px;margin-left:6px;
+  background:var(--sf2);color:var(--mut);border:1px solid var(--bd);
+  vertical-align:1px;font-weight:500}
+.wtag.req{background:var(--warn-soft);color:var(--warn);border-color:transparent}
+.ssstep .need{font-size:11.5px;color:var(--warn);display:block}
+.ssstep.opt .dot{border-style:dashed}
 .ssmain h4{margin:0 0 8px;font-size:16px}
 /* A wizard column is already narrow; capping the prose again wrapped every
    sentence two-thirds of the way across and left a ragged margin. */
@@ -778,6 +788,15 @@ let REGTOOLS = null, GOVDECS = null, WIZOWNER = '', WIZREVIEW = '';
 // Which log-store shape the wizard's step 2 shows, and the last result of
 // each connection test, keyed by API name, so a result survives re-renders.
 let WIZSTORE = 'self', TESTS = {};
+// Which screen sent you into the extension setup. It is reachable from the
+// first-run wizard's step 5 and from Settings, and the way out is different:
+// somebody mid-setup wants to land back on step 5, and somebody who came from
+// Settings has no setup to return to. Offering both to everybody would send
+// half of them somewhere they were not.
+let EXTFROM = '';
+// Which first-run step is showing. The seven used to render at once on
+// one page, which is how it became 841 lines nobody could scan.
+let WIZSTEP = 1;
 // The budget view: the fetched spend data, the link-a-tool wizard's state
 // (null = closed), the last action's one-line outcome, and a parsed CSV
 // preview waiting for confirmation.
@@ -3588,14 +3607,20 @@ async function extSetup() {
   <div class="ssow">${rail}
     <div class="ssmain">${body}
       <div class="ssfoot">
-        <button class="mini" data-nav="settings">Close</button>
+        ${EXTPAGE === 6 ? '' : EXTFROM === 'wizard'
+          ? `<button class="mini" data-act="ext-back-to-setup">Back to
+              deployment setup</button>`
+          : '<button class="mini" data-nav="settings">Close</button>'}
         <span class="sp"></span>
         ${EXTPAGE > 1 ? `<button class="mini" data-act="ext-page"
           data-key="${EXTPAGE - 1}">Back</button>` : ''}
         ${EXTPAGE < 6
           ? `<button class="mini pri" data-act="ext-page"
               data-key="${EXTPAGE + 1}">Next</button>`
-          : `<button class="mini pri" data-act="open-wizard">Back to the setup wizard</button>`}
+          : EXTFROM === 'wizard'
+          ? `<button class="mini pri" data-act="ext-back-to-setup">Back to
+              deployment setup</button>`
+          : '<button class="mini pri" data-nav="settings">Done</button>'}
       </div></div></div>`;
 }
 
@@ -3642,31 +3667,123 @@ async function wizard() {
     ${WIZSTORE === k ? 'style="border-color:var(--pri)"' : ''}
     data-act="wiz-store" data-key="${k}">${lbl}</button>`;
 
-  return `<h2>Welcome — set up your deployment</h2>
-  <p class="lede">Work through the steps top to bottom. Everything here can
-  be changed later under Settings, and changes take effect immediately - no
-  redeploys.</p>
-  ${SETMSG ? `<div class="note">${esc(SETMSG)}</div>` : ''}
+    const WIZ_STEPS = [
+    {t: 'Receiver URL',         need: 'req', act: 'Start collecting'},
+    {t: 'Log store',            need: 'rec', act: 'Start collecting'},
+    {t: 'Corporate domains',    need: 'req', act: 'Start collecting'},
+    {t: 'Governance baseline',  need: 'opt', act: 'Make it useful'},
+    {t: 'Browser extension',    need: 'opt', act: 'Make it useful'},
+    {t: 'Alerting and Grafana', need: 'opt', act: 'Make it useful'},
+    {t: 'Deployment downloads', need: 'out', act: 'Make it useful'},
+  ];
+  // A first-run wizard that only counts steps tells you how far down the page
+  // you are. This says what the deployment can do yet, and what it will get
+  // WRONG if you stop here. Corporate domains is "required" not because the
+  // platform refuses to run without it but because it runs wrong: every
+  // account reads as personal, and the Overview headline, the Personal
+  // accounts page and the ISO evidence all inherit that.
+  const wv = k => ((SETTINGS && SETTINGS.settings || {})[k] || {}).value || '';
+  const wDone = n =>
+    n === 1 ? !!wv('receiver_public_url') :
+    n === 2 ? !!wv('log_store_url') :
+    n === 3 ? ((cd.value || []).length > 0) :
+    n === 4 ? (GOVDECS || []).length > 0 :
+    n === 5 ? !!extSettingsState().id :
+    n === 6 ? !!(wv('alertmanager_url') || wv('grafana_url')) : false;
+  const wLine = n => {
+    if (n === 1) return wv('receiver_public_url')
+      ? {c: 'val', t: wv('receiver_public_url').replace(/^https?:\/\//, '')}
+      : {c: 'need', t: 'nothing can deploy without it'};
+    if (n === 2) return wv('log_store_url')
+      ? {c: 'val', t: 'reading from it'}
+      : {c: 'pend', t: 'findings stay in container logs'};
+    if (n === 3) return (cd.value || []).length
+      ? {c: 'val', t: (cd.value || []).join(', ')}
+      : {c: 'need', t: 'every account reads as personal'};
+    if (n === 4) return (GOVDECS || []).length
+      ? {c: 'val', t: (GOVDECS || []).length + ' recorded'}
+      : {c: 'pend', t: 'nothing decided yet'};
+    if (n === 5) return extSettingsState().id
+      ? {c: 'val', t: 'packed and hosted'} : {c: 'pend', t: 'not set up'};
+    if (n === 6) return (wv('alertmanager_url') || wv('grafana_url'))
+      ? {c: 'val', t: wv('alertmanager_url') ? 'alerting on' : 'grafana embedded'}
+      : {c: 'pend', t: 'nothing pages'};
+    return (CFG.managed && CFG.managed.artifacts_ready)
+      ? {c: 'val', t: 'ready'} : {c: 'pend', t: 'needs the receiver URL'};
+  };
+  const reqN = WIZ_STEPS.filter(x => x.need === 'req').length;
+  const reqDone = WIZ_STEPS.filter((x, i) => x.need === 'req' && wDone(i + 1)).length;
+  const canGo = reqDone === reqN;
+  let wact = '';
+  const rail = `<div class="ssrail"><h3>Set up your deployment</h3><ol>${
+    WIZ_STEPS.map((x, i) => {
+      const n = i + 1, dn = wDone(n), ln = wLine(n);
+      const hdr = x.act !== wact
+        ? `</ol><div class="wact">${esc(x.act)}</div><ol>` : '';
+      wact = x.act;
+      const tag = x.need === 'req' ? '<span class="wtag req">required</span>'
+        : x.need === 'rec' ? '<span class="wtag">recommended</span>'
+        : x.need === 'opt' ? '<span class="wtag">optional</span>' : '';
+      return `${hdr}<li class="ssstep ${dn ? 'done' : ''}
+        ${WIZSTEP === n ? 'on' : ''} ${x.need === 'opt' ? 'opt' : ''}"
+        data-act="wiz-step" data-key="${n}">
+        <span class="dot">${dn ? '&#10003;' : n}</span>
+        <span style="min-width:0"><span class="t">${esc(x.t)}${tag}</span>
+        <span class="${ln.c}">${esc(ln.t)}</span></span></li>`;
+    }).join('')}</ol>
+    <div class="sssum">${canGo
+      ? `<div class="lede" style="font-size:11.5px;color:var(--pri);font-weight:600">You can deploy now</div>
+         <div class="barwrap"><div class="bar" style="width:100%"></div></div>
+         <div class="lede" style="font-size:11.5px">Both required steps are in.
+           The rest can wait - collectors start reporting as soon as you push
+           the downloads.</div>
+         <p style="margin:9px 0 0"><button class="mini pri" data-act="wiz-step"
+           data-key="7">Go to downloads</button></p>`
+      : `<div class="lede" style="font-size:11.5px">${reqDone} of ${reqN} required steps done</div>
+         <div class="barwrap"><div class="bar"
+           style="width:${reqDone / reqN * 100}%"></div></div>
+         <div class="lede" style="font-size:11.5px">Optional steps can be left
+           for later; everything stays editable under Settings.</div>`}
+    </div></div>`;
 
-  <div class="wcard" style="margin-bottom:10px"><h3>1 · Where your machines reach the receiver</h3>
+  let body = '';
+  if (WIZSTEP === 1) body = `<h4>Where your machines reach the receiver</h4>
   <p class="lede" style="margin-bottom:10px">The URL your laptops and servers
   will send findings to. It gets baked into every download below, so it has
   to work from those machines - not just from inside the cluster. That means
   a DNS record pointing this name at your ingress or reverse proxy, plus a
   certificate - unless something like a Tailscale operator handles both for
-  you. Save it, then hit probe to check.</p>
+  you.</p>
+  <p class="lede" style="margin-bottom:10px">Not sure which address that is?
+  It is whatever already fronts this portal from outside. To find it:
+  <span class="mono">kubectl get ingress -A</span> for an ingress host,
+  <span class="mono">kubectl get svc -A --field-selector
+  spec.type=LoadBalancer</span> for a load-balancer address, or
+  <span class="mono">tailscale status</span> if a Tailscale operator handles
+  it. Then save it and press probe: the receiver either answers on the address
+  you typed or it does not, and that is the only confirmation worth having.</p>
   <dl class="kv">
     ${settingRow('receiver_public_url', 'Public receiver URL',
       'https://ai-guard.your-tailnet.ts.net', '')}
   </dl>
   <div style="margin-top:8px">
     <button class="mini" data-act="run-test" data-key="receiver-url">Probe the saved URL</button>
-  </div>${testNote('receiver-url')}</div>
-
-  <div class="wcard" style="margin-bottom:10px"><h3>2 · The log store</h3>
+  </div>${testNote('receiver-url')}`;
+  if (WIZSTEP === 2) body = `<h4>The log store</h4>
   <p class="lede" style="margin-bottom:10px">Findings are stored in a
   Loki-compatible log store: the receiver writes to it, this portal reads
   from it. Where is yours?</p>
+  <p class="lede" style="margin-bottom:10px">In practice that means
+  <b>Grafana Loki</b>, self-hosted in any of its deployment modes, or
+  <b>Grafana Cloud Logs</b>, which is the same API hosted. If you already run
+  the Grafana stack, this is the Loki you have.</p>
+  <p class="lede" style="margin-bottom:10px">Anything else has to implement
+  Loki's own HTTP API, and <i>both</i> halves of it: the receiver writes to
+  <span class="mono">/loki/api/v1/push</span> and this portal reads from
+  <span class="mono">/loki/api/v1/query_range</span>. Worth checking before you
+  commit - several log stores advertise Loki-compatible <i>ingest</i> while
+  answering queries in a language of their own, and one of those will take
+  every finding you send it and then show you an empty portal.</p>
   <div style="margin-bottom:10px">
     ${storeBtn('self', 'self-hosted / in-cluster')}
     ${storeBtn('cloud', 'hosted (Grafana Cloud)')}
@@ -3686,9 +3803,8 @@ async function wizard() {
     write-only token is the classic mistake - the test buttons below will
     catch it.</p>`}
   <dl class="kv">${logStoreFields(WIZSTORE === 'cloud')}</dl>
-  ${logStoreTests()}`}</div>
-
-  <div class="wcard" style="margin-bottom:10px"><h3>3 · Corporate domains</h3>
+  ${logStoreTests()}`}`;
+  if (WIZSTEP === 3) body = `<h4>Corporate domains</h4>
   <p class="lede" style="margin-bottom:10px">Your work email domains. An AI
   tool signed into one of these counts as a work account; anything else gets
   flagged as personal. Collectors pick this up automatically on their next
@@ -3706,9 +3822,8 @@ async function wizard() {
     headline converts into it at the ECB's daily reference rate (the rate's
     date is named right beside the number), newly linked tools default to
     it, and the per-currency figures stay visible.</div>
-  </div></div>
-
-  <div class="wcard" style="margin-bottom:10px"><h3>4 · Governance baseline</h3>
+  </div>`;
+  if (WIZSTEP === 4) body = `<h4>Governance baseline</h4>
   <p class="lede" style="margin-bottom:10px">Which AI tools your organisation
   has approved or banned. Only set the ones you actually have a position on -
   leaving the rest undecided is fine. You can refine any of this later on
@@ -3721,9 +3836,8 @@ async function wizard() {
       value="${esc(WIZREVIEW || yearOut)}" title="review due date for approvals">
   </div>
   <table><tr><th>tool</th><th>vendor</th><th>decision</th><th></th></tr>
-  ${REGTOOLS.map(toolRow).join('')}</table></div>
-
-  <div class="wcard" style="margin-bottom:10px"><h3>5 · Browser extension &amp; paste guard</h3>
+  ${REGTOOLS.map(toolRow).join('')}</table>`;
+  if (WIZSTEP === 5) body = `<h4>Browser extension &amp; paste guard</h4>
   <p class="lede" style="margin-bottom:10px">One extension does both jobs:
   it reports which account is signed into each AI site, and its paste guard
   warns or blocks risky pastes. It is a one-time pack-and-host, and the
@@ -3732,14 +3846,12 @@ async function wizard() {
   ready-made policy downloads in step 7. Fine to skip on a first pass and
   come back.</p>
   ${extStatusRows(true)}
-  <div style="margin-top:10px">
-    <button class="mini" style="padding:6px 14px" data-act="ext-open">Open the extension setup</button>
-    <span class="src-note" style="margin-left:8px">Six short steps: download,
-    pack, identity, hosting, Firefox, behaviour. Each value is also editable
-    flat under Settings.</span>
-  </div></div>
-
-  <div class="wcard" style="margin-bottom:10px"><h3>6 · Alerting and Grafana (optional)</h3>
+  <p class="src-note" style="margin:14px 0 8px">Six short steps: download,
+  pack, identity, hosting, Firefox, behaviour. It owns those values - Settings
+  shows where they stand and sends you here to change them.</p>
+  <p style="margin:0"><button class="mini" style="padding:6px 14px"
+    data-act="ext-open">Open the extension setup</button></p>`;
+  if (WIZSTEP === 6) body = `<h4>Alerting and Grafana</h4>
   <dl class="kv">
     ${settingRow('alertmanager_url', 'Alertmanager URL',
       'http://alertmanager.<namespace>.svc:9093',
@@ -3747,9 +3859,8 @@ async function wizard() {
     ${settingRow('grafana_url', 'Grafana URL',
       'the URL a BROWSER reaches Grafana on',
       'Saving reloads the page (the frame permission is baked into each page load). Panels and dashboard UID live under Settings; Grafana must allow embedding.')}
-  </dl></div>
-
-  <div class="wcard" style="margin-bottom:10px"><h3>7 · Deployment downloads</h3>
+  </dl>`;
+  if (WIZSTEP === 7) body = `<h4>Deployment downloads</h4>
   <p class="lede" style="margin-bottom:10px">Ready-to-deploy files with the
   receiver URL and a fresh enrollment token already inside - push them
   through your MDM or run them as-is. Machines enroll themselves and appear
@@ -3766,14 +3877,26 @@ async function wizard() {
     <button class="mini" data-act="artifact" data-key="scanner-cronjob">Scanner CronJob</button>
     <button class="mini" data-act="artifact" data-key="discovery-cronjob">Discovery CronJob</button>
   </div>` : `<div class="note">No public receiver URL yet, so downloads cannot
-  bake a URL agents can reach - save one in step 1 and these appear.</div>`}</div>
-
-  <div style="margin:18px 0">
-    <button class="mini" style="padding:8px 18px" data-act="wiz-finish">Finish setup</button>
-    <span class="src-note" style="margin-left:10px">You can come back:
-    everything above stays editable under Settings, and Settings can reopen
-    this wizard.</span>
-  </div>`;
+  bake a URL agents can reach - save one in step 1 and these appear.</div>`}`;
+  return `<h2>Welcome — set up your deployment</h2>
+  <p class="lede">One step at a time. Everything here can be changed later
+  under Settings, and changes take effect immediately - no redeploys.</p>
+  ${SETMSG ? `<div class="note">${esc(SETMSG)}</div>` : ''}
+  <div class="ssow">${rail}
+    <div class="ssmain">${body}
+      <div class="ssfoot">
+        <button class="mini" data-act="wiz-finish">${canGo
+          ? 'Finish setup' : 'Skip for now'}</button>
+        <span class="sp"></span>
+        ${WIZSTEP > 1 ? `<button class="mini" data-act="wiz-step"
+          data-key="${WIZSTEP - 1}">Back</button>` : ''}
+        ${WIZSTEP < 7
+          ? `<button class="mini pri" data-act="wiz-step"
+              data-key="${WIZSTEP + 1}">Next</button>`
+          : `<button class="mini pri" data-act="wiz-finish">Finish setup</button>`}
+      </div></div></div>
+  <p class="src-note">You can come back: everything above stays editable under
+  Settings, and Settings can reopen this wizard.</p>`;
 }
 
 // The editable deployment settings, managed mode only: what the receiver
@@ -6514,6 +6637,15 @@ async function managedAction(act, el) {
     if (offer) await tourStart(TOUR_AFTER_WIZARD);
     return;
   }
+  if (act === 'wiz-step') {
+    // managedAction takes (act, el) and does NOT have `key` in scope - the
+    // handler that does is a different function. Reading it off el is what
+    // every other branch here does; borrowing the name silently threw a
+    // ReferenceError and the click did nothing at all.
+    const n = parseInt(el ? el.getAttribute('data-key') : '', 10);
+    WIZSTEP = Math.max(1, Math.min(7, n || 1));
+    SETMSG = ''; render(); return;
+  }
   if (act === 'reg-add') { rwOpen({}); render(); return; }
   if (act === 'reg-cancel') {
     RW = null; REDIT = null; RPRE = null; RERR = ''; RADV = false; render(); return;
@@ -6837,13 +6969,21 @@ async function managedAction(act, el) {
     return;
   }
   if (act === 'open-wizard') {
-    view = 'wizard'; detail = null;
+    view = 'wizard'; detail = null; WIZSTEP = 1;
     history.replaceState(null, '', '#wizard');
     drawNav(); render(); return;
   }
   if (act === 'ext-open') {
+    EXTFROM = view === 'wizard' ? 'wizard' : '';
     view = 'extsetup'; detail = null;
     history.replaceState(null, '', '#extsetup');
+    drawNav(); render(); return;
+  }
+  if (act === 'ext-back-to-setup') {
+    EXTFROM = '';
+    WIZSTEP = 5;
+    view = 'wizard'; detail = null;
+    history.replaceState(null, '', '#wizard');
     drawNav(); render(); return;
   }
   if (act === 'ext-page') {
@@ -6978,7 +7118,7 @@ function drawNav() {
   }).join('');
   n.querySelectorAll('button').forEach(b => b.onclick = () => {
     const sec = NAV.find(s => s.id === b.dataset.s);
-    view = SECTAB[sec.id] || sec.items[0][0]; detail = null;
+    view = SECTAB[sec.id] || sec.items[0][0]; detail = null; EXTFROM = '';
     // Replace rather than push: clicking through the nav should not fill the
     // back button with every tab you glanced at.
     history.replaceState(null, '', frag(view));
@@ -7142,7 +7282,7 @@ app.addEventListener('click', e => {
 app.addEventListener('click', e => {
   const el = e.target.closest('[data-nav]');
   if (!el) return;
-  view = el.getAttribute('data-nav'); detail = null;
+  view = el.getAttribute('data-nav'); detail = null; EXTFROM = '';
   history.replaceState(null, '', frag(view));
   drawNav(); render();
 });
@@ -7317,7 +7457,7 @@ window.addEventListener('hashchange', () => {
   // id, so the guard has to ask about both or the tab half never draws.
   const tabbed = h.tab && h.tab !== SETTAB;
   if (h.view === view && !tabbed) return;
-  view = h.view; detail = null;
+  view = h.view; detail = null; EXTFROM = '';
   if (h.tab) SETTAB = h.tab;
   drawNav(); render();
 });

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -293,6 +293,42 @@ button.mini.pri{border-color:var(--pri);background:color-mix(in srgb,var(--pri) 
 .tsum .big{font-size:17px;font-weight:600;font-variant-numeric:tabular-nums}
 .sssum .money{font-size:19px;font-weight:600;font-variant-numeric:tabular-nums;
   margin:2px 0 1px}
+/* The account menu, anchored under the name in the header. A menu of
+   items, not a form: see #pwdlg below for why the password moved out. */
+#usermenu{position:absolute;right:0;top:calc(100% + 8px);z-index:60;width:240px;
+  background:var(--sf);border:1px solid var(--bd);border-radius:10px;
+  box-shadow:0 6px 24px rgba(0,0,0,.18);padding:7px;text-align:left}
+#usermenu[hidden]{display:none}
+#usermenu .umhead{font-size:12.5px;font-weight:600;padding:5px 9px 9px;
+  margin-bottom:6px;border-bottom:1px solid var(--bd)}
+#usermenu .umitem{display:block;width:100%;text-align:left;font:inherit;
+  font-size:13px;color:var(--fg);background:none;border:0;border-radius:7px;
+  padding:8px 9px;cursor:pointer}
+#usermenu .umitem:hover{background:var(--pri-soft);color:var(--pri)}
+#who{cursor:pointer}
+/* Changing your own password is a modal rather than a form inside the menu.
+   A menu closes on any click outside it and on Escape, and umClose() would
+   take half-typed fields with it; a password manager rarely offers to save
+   from a panel that disappears on blur. The modal also has the room for a
+   confirm field, which a 240px dropdown does not - and a typo in the new
+   password is otherwise not discovered until the next sign-in, by which
+   time every other session has been signed out with the old one. */
+#pwdlg{border:1px solid var(--bd);border-radius:12px;background:var(--sf);
+  color:var(--fg);padding:20px 22px;width:min(400px,92vw);
+  box-shadow:0 18px 50px rgba(0,0,0,.28)}
+#pwdlg::backdrop{background:rgba(15,18,20,.45)}
+#pwdlg h3{margin:0 0 2px;font-size:15px}
+#pwdlg .pwsub{font-size:12px;color:var(--mut);margin:0 0 15px}
+#pwdlg .pwsub[hidden]{display:none}
+#pwdlg .pwlbl{display:block;font-size:11.5px;color:var(--mut);margin:0 0 5px}
+#pwdlg .mfield{width:100%;margin-bottom:11px}
+#pwdlg .pwmsg{font-size:12px;margin:0 0 11px;padding:7px 9px;border-radius:7px}
+#pwdlg .pwmsg.ok{background:var(--pri-soft);color:var(--pri)}
+#pwdlg .pwmsg.bad{background:var(--warn-soft);color:var(--warn)}
+#pwdlg .pwmsg[hidden]{display:none}
+#pwdlg .src-note[hidden]{display:none}
+#pwdlg .pwfoot{display:flex;gap:8px;align-items:center}
+#pwdlg .pwfoot [hidden]{display:none}
 .tokpane{border:1px solid var(--pri);border-radius:9px;padding:12px 14px;margin:14px 0;background:var(--sf)}
 .tokpane code{word-break:break-all}
 /* The inspector: a device, tool or MCP server opens beside the list rather
@@ -739,7 +775,15 @@ table.plain td{border-bottom:0;padding:4.5px 10px 4.5px 0;vertical-align:middle}
       </div>
       <span id="freshness" class="mono" style="font-size:11px;color:var(--mut)"></span>
       <button id="refresh" class="back" style="margin:0">Refresh</button>
-      <span id="who" class="mono" style="font-size:11px;color:var(--mut);margin-left:auto"></span>
+      <span id="whowrap" style="margin-left:auto;position:relative">
+        <button id="who" class="back mono" style="margin:0;font-size:11px;
+          color:var(--mut);display:none" aria-haspopup="true"
+          aria-expanded="false"></button>
+        <div id="usermenu" hidden>
+          <div class="umhead" id="um-who"></div>
+          <button class="umitem" data-act="open-password">Change password</button>
+        </div>
+      </span>
       <button id="signout" class="back" style="margin:0;display:none">Sign out</button>
       <button id="themebtn" class="back" style="margin:0" title="light / dark">◐</button>
     </div>
@@ -751,6 +795,29 @@ table.plain td{border-bottom:0;padding:4.5px 10px 4.5px 0;vertical-align:middle}
   <div id="tour-ring"></div>
   <div id="tour-card"></div>
 </div>
+<dialog id="pwdlg" aria-labelledby="pw-title">
+  <form id="pwform">
+    <h3 id="pw-title">Change password</h3>
+    <p class="pwsub" id="pw-who"></p>
+    <label class="pwlbl" for="set-curpass">Current password</label>
+    <input id="set-curpass" class="mfield" type="password"
+      autocomplete="current-password">
+    <label class="pwlbl" for="set-newpass">New password</label>
+    <input id="set-newpass" class="mfield" type="password"
+      placeholder="12 characters or more" autocomplete="new-password">
+    <label class="pwlbl" for="set-confpass">Confirm new password</label>
+    <input id="set-confpass" class="mfield" type="password"
+      autocomplete="new-password">
+    <div id="pw-msg" class="pwmsg" hidden></div>
+    <p id="pw-note" class="src-note" style="margin:0 0 15px">Every other
+    session is signed out with the old password; this one stays.</p>
+    <div class="pwfoot">
+      <button id="pw-submit" class="mini pri" type="submit">Change password</button>
+      <button id="pw-cancel" class="back" type="button" style="margin:0"
+        data-act="close-password">Cancel</button>
+    </div>
+  </form>
+</dialog>
 <script>
 let G = {devices:{},identities:{},tools:{},bridges:{},unattributed:[],counts:{}};
 // Views that read a second endpoint, cached until refresh clears them.
@@ -763,9 +830,14 @@ let SETTAB = 'fleet';
 // The Settings sub-tabs, up here with SETTAB for the same reason: SETTAB is
 // set from the URL fragment by fromHash(), which runs while the module is
 // still evaluating, so the list it is checked against has to exist by then.
-const STABS = [['fleet', 'Fleet'], ['connection', 'Receiver & log store'],
+// 'fleet' keeps its id so existing #settings/fleet links still land: the tab
+// was renamed because "Fleet" also names a whole nav section (enrolled devices
+// and enrollment tokens), and two different things called Fleet in one product
+// is a coin toss every time somebody says it.
+const STABS = [['fleet', 'Detection & paste guard'],
+               ['connection', 'Receiver & log store'],
                ['alerting', 'Display & alerting'], ['account', 'Account'],
-               ['diagnostics', 'Diagnostics']];
+               ['start', 'Getting started'], ['diagnostics', 'Diagnostics']];
 const SETTABS = STABS.map(([id]) => id);
 let DIAG = null;
 let REG = null;
@@ -896,9 +968,127 @@ function chrome(on) {
   const so = document.getElementById('signout'), who = document.getElementById('who');
   const login = AUTH && AUTH.mode === 'login';
   so.style.display = on && login ? '' : 'none';
-  who.textContent = on && login && AUTH.username
+  const label = on && login && AUTH.username
     ? AUTH.username + (AUTH.role === 'viewer' ? ' · read-only' : '') : '';
+  who.textContent = label;
+  // A button only when there is a menu behind it. Signed out, or on a
+  // no-login deployment, it would open an empty panel.
+  who.style.display = label ? '' : 'none';
+  const um = document.getElementById('usermenu');
+  if (!label) { if (um) um.hidden = true; who.setAttribute('aria-expanded', 'false');
+                pwHide(); }
+  const umw = document.getElementById('um-who');
+  if (umw) umw.textContent = label;
 }
+
+// The account menu. It carries the one thing a person changes about
+// themselves rather than about the deployment, so it lives in the header
+// beside their name rather than under Settings > Account, which is where
+// OTHER people's accounts are managed. It matters most for a viewer: that tab
+// is read-only for them, and their password was the single editable field on
+// it, three blocks down.
+function umClose() {
+  const um = document.getElementById('usermenu');
+  const who = document.getElementById('who');
+  if (um) um.hidden = true;
+  if (who) who.setAttribute('aria-expanded', 'false');
+}
+
+// The password modal. It clears itself on the way in and on the way out -
+// including the way out the dialog element provides for free, Escape and
+// the backdrop - so a password never sits in a field behind a closed dialog
+// waiting for the next person at the machine.
+const PWFIELDS = ['set-curpass', 'set-newpass', 'set-confpass'];
+const pwWipe = () => PWFIELDS.forEach(id => {
+  const f = document.getElementById(id); if (f) f.value = '';
+});
+const pwIsOpen = () => {
+  const dlg = document.getElementById('pwdlg');
+  return !!(dlg && dlg.open);
+};
+
+function pwShow() {
+  umClose();
+  const dlg = document.getElementById('pwdlg');
+  if (!dlg) return;
+  pwWipe();
+  const msg = document.getElementById('pw-msg');
+  if (msg) { msg.hidden = true; msg.textContent = ''; }
+  // A second visit after a successful change gets the form back, not the
+  // Done button the last one ended on.
+  const sub = document.getElementById('pw-submit');
+  if (sub) sub.hidden = false;
+  const can = document.getElementById('pw-cancel');
+  if (can) can.textContent = 'Cancel';
+  const note = document.getElementById('pw-note');
+  if (note) note.hidden = false;
+  // Whose password this is. Hidden rather than blank when there is no
+  // name to show, or the modal opens with an empty line under its title.
+  const who = document.getElementById('pw-who');
+  if (who) {
+    who.textContent = (AUTH && AUTH.username) || '';
+    who.hidden = !who.textContent;
+  }
+  if (!dlg.open) dlg.showModal();
+  const f = document.getElementById('set-curpass');
+  if (f) f.focus();
+}
+
+function pwHide() {
+  const dlg = document.getElementById('pwdlg');
+  if (dlg && dlg.open) dlg.close();
+  pwWipe();
+}
+document.addEventListener('click', e => {
+  const btn = e.target.closest('#who');
+  const um = document.getElementById('usermenu');
+  if (!um) return;
+  if (btn) {
+    const open = um.hidden;
+    um.hidden = !open;
+    document.getElementById('who').setAttribute('aria-expanded', String(open));
+    if (open) { const f = document.getElementById('set-curpass'); if (f) f.focus(); }
+    return;
+  }
+  // The menu lives outside #app, so the delegated data-act listeners never
+  // see it. Its own listener, and a click anywhere else closes it.
+  const act = e.target.closest('#usermenu [data-act]');
+  if (act) { managedAction(act.getAttribute('data-act'), act); return; }
+  if (!e.target.closest('#usermenu')) umClose();
+});
+window.addEventListener('keydown', e => {
+  if (e.key !== 'Escape') return;
+  // Escape is closed HERE rather than left to the dialog element, which
+  // closes itself but - measured in Chrome 151, main world - fires neither
+  // 'cancel' nor 'close', so the listener below never runs and a typed
+  // password would sit in the field behind a dismissed dialog. Closing it
+  // ourselves is deterministic; dlg.close() on a closed dialog is a no-op,
+  // so it costs nothing where the events do arrive.
+  //
+  // The modal owns the keystroke outright, because the drawer's own Escape
+  // handler is a LATER window listener and by the time it runs pwHide() has
+  // already made pwIsOpen() false - so guarding it on live state is not
+  // enough, and one Escape would dismiss the modal and the drawer behind it.
+  if (pwIsOpen()) { pwHide(); e.stopImmediatePropagation(); return; }
+  const um = document.getElementById('usermenu');
+  if (um && !um.hidden) umClose();
+});
+// The dialog is outside #app for the same reason the menu is, and needs the
+// same treatment. Cancel goes through data-act; the primary button is the
+// form's SUBMIT so that Enter in any field does what the button does, and it
+// deliberately carries no data-act - a click would otherwise both submit and
+// delegate, and change the password twice.
+document.getElementById('pwform').addEventListener('submit', e => {
+  e.preventDefault();
+  managedAction('change-password', document.getElementById('pw-submit'));
+});
+document.getElementById('pwdlg').addEventListener('click', e => {
+  const el = e.target.closest('[data-act]');
+  if (el) managedAction(el.getAttribute('data-act'), el);
+});
+// Kept as well as the Escape handler above, for the dismissals the element
+// owns that this page never initiates, and for browsers that do fire it.
+document.getElementById('pwdlg').addEventListener('close', pwWipe);
 
 function showLogin(msg) {
   // Same reason as the pane below: nothing from the last session belongs on
@@ -3923,7 +4113,7 @@ function fleetSettings() {
       ? `From the deployment's <span class="mono">CORP_DOMAINS</span>;
          saving here overrides it without touching the deployment.`
       : 'Not set anywhere yet.';
-  return `<div class="wcard" style="margin-bottom:10px"><h3>Fleet</h3>
+  return `<div class="wcard" style="margin-bottom:10px"><h3>Detection and paste guard</h3>
   <p class="lede" style="margin-bottom:10px">Saved in the receiver and picked
   up by the fleet automatically - collectors get changes on their next
   check-in, nothing needs re-pushing through the MDM.</p>
@@ -3945,9 +4135,9 @@ function fleetSettings() {
     <h3>Browser extension</h3>
     ${extStatusRows()}
     <div style="margin-top:12px">
+      <p class="src-note" style="margin:0 0 8px">Six steps, and the rail goes
+      straight to the one you need.</p>
       <button class="mini" data-act="ext-open">Open the extension setup</button>
-      <span class="src-note" style="margin-left:8px">Six steps, and the rail
-      goes straight to the one you need.</span>
     </div>
   </div></div>`;
 }
@@ -4270,6 +4460,36 @@ function ssoWizard() {
     </div></div>`;
 }
 
+// The two ways back into the guided paths. They used to sit at the bottom of
+// the Account tab, under the accounts table and single sign-on - nowhere
+// anybody would look, since neither has anything to do with accounts. The
+// first UX pass on this portal found the tour re-entry 1,002 pixels down an
+// 1,105-pixel page; this is that fix.
+function gettingStarted() {
+  const done = SETTINGS && SETTINGS.settings
+    && SETTINGS.settings.onboarding_done
+    && SETTINGS.settings.onboarding_done.value;
+  return `<div class="wcard" style="margin-bottom:10px"><h3>Getting started</h3>
+  <p class="lede" style="margin-bottom:16px">${done
+    ? `Setup is marked done. Both of these are safe to repeat - neither resets
+       anything.`
+    : `Setup has not been finished yet. Neither of these changes anything on
+       its own.`}</p>
+  <p class="src-note" style="margin:0 0 8px">Every step is one of these
+  settings, prefilled with what is already saved - so running it again is a
+  review rather than a reset.</p>
+  <p style="margin:0 0 20px">
+    <button class="mini" style="padding:6px 14px" data-act="open-wizard">${done
+      ? 'Run the setup wizard again' : 'Finish setting up'}</button></p>
+  <p class="src-note" style="margin:0 0 8px">The walkthrough from your first
+  sign-in. It shows the pages your account can act on, so an admin and a viewer
+  see different tours.</p>
+  <p style="margin:0">
+    <button class="mini" style="padding:6px 14px" data-act="take-tour">Take the
+      tour again</button></p>
+  </div>`;
+}
+
 function accountSettings() {
   const viewer = AUTH && AUTH.role === 'viewer';
   const users = USERS === null ? '' : `
@@ -4346,18 +4566,6 @@ function accountSettings() {
   return `${viewer ? `<div class="note">This account is read-only: every
     page works, saving does not. An admin manages accounts from this tab.</div>` : ''}
   ${users}
-  <div class="wcard" style="margin-bottom:10px"><h3>Your account</h3>
-  <dl class="kv">
-    <dt>Change password</dt><dd>
-      <input id="set-curpass" class="mfield" type="password"
-        placeholder="current password" autocomplete="current-password">
-      <input id="set-newpass" class="mfield" type="password"
-        placeholder="new password (12+ characters)" autocomplete="new-password">
-      <button class="mini" data-act="change-password">Change</button>
-      <div class="src-note">Every other session is signed out with the old
-      password; this one stays.</div></dd>
-  </dl></div>
-
   ${AUTH && AUTH.role === 'owner' ? (SSOW ? ssoWizard() : `<div class="wcard"
     style="margin-bottom:10px">
     <h3>Single sign-on</h3>
@@ -4378,14 +4586,7 @@ function accountSettings() {
           && SETTINGS.settings.sso_enabled.value) === '1')
         ? 'Review the configuration' : 'Set it up'}</button></p>`}
   </div>`) : ''}
-  <p class="src-note" style="margin:4px 0 14px">
-    <button class="mini" data-act="open-wizard">Run the setup wizard again</button>
-    — safe to repeat: every step is one of these settings, prefilled
-    with what is saved.</p>
-  <p class="src-note" style="margin:4px 0 14px">
-    <button class="mini" data-act="take-tour">Take the tour again</button>
-    — the walkthrough from your first sign-in. It shows the pages your
-    account can act on, so an admin and a viewer see different tours.</p>`;
+`;
 }
 
 function diagnosticsCards() {
@@ -4549,6 +4750,7 @@ async function settings() {
   if (SETTAB === 'connection') body = connectionSettings();
   else if (SETTAB === 'alerting') body = alertingSettings();
   else if (SETTAB === 'account') body = accountSettings();
+  else if (SETTAB === 'start') body = gettingStarted();
   else if (SETTAB === 'diagnostics') body = diagnosticsCards();
   else { SETTAB = 'fleet'; body = fleetSettings(); }
   return `<h2>Settings</h2>
@@ -7006,21 +7208,55 @@ async function managedAction(act, el) {
     }
     render(); return;
   }
+  if (act === 'open-password') { pwShow(); return; }
+  if (act === 'close-password') { pwHide(); return; }
   if (act === 'change-password') {
-    const r = await mfetch('/api/password', {method: 'POST', body: JSON.stringify(
-      {current: _val('set-curpass'), new: _val('set-newpass')})});
-    if (r.ok) SETMSG = 'Password changed. Every other session was signed out.';
-    else {
-      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
-      // A wrong current password is also a 401, from the receiver rather
-      // than the session gate; only the gate's refusal means signed out.
-      if (r.status === 401 && String(d).indexOf('current password') < 0) {
-        sessionLost(); return;
-      }
-      SETMSG = 'Password unchanged: ' + (typeof d === 'string' ? d
-        : 'the new password needs 12 characters or more.');
+    // The form lives in a modal off the header menu now, reachable from every
+    // view - so the answer goes back into the modal. SETMSG only ever renders
+    // on Settings, and reporting a password change to a page the person is
+    // not looking at is the same as not reporting it.
+    const msg = document.getElementById('pw-msg');
+    const say = (t, ok) => {
+      if (!msg) { SETMSG = t; render(); return; }
+      msg.className = 'pwmsg ' + (ok ? 'ok' : 'bad');
+      msg.textContent = t; msg.hidden = false;
+    };
+    const nw = _val('set-newpass');
+    // Answered here rather than by the receiver, which never sees the second
+    // copy: a mismatch is a typo in one of the two, and the round trip would
+    // report it as whichever one was sent being wrong.
+    if (nw !== _val('set-confpass')) {
+      say('The two new passwords do not match.', false);
+      const f = document.getElementById('set-confpass');
+      if (f) { f.focus(); f.select(); }
+      return;
     }
-    render(); return;
+    const r = await mfetch('/api/password', {method: 'POST', body: JSON.stringify(
+      {current: _val('set-curpass'), new: nw})});
+    if (r.ok) {
+      pwWipe();
+      // The modal stays up to carry the answer, with nothing left to submit.
+      const sub = document.getElementById('pw-submit');
+      if (sub) sub.hidden = true;
+      const can = document.getElementById('pw-cancel');
+      if (can) can.textContent = 'Done';
+      // The note says what WILL happen. The message below now says it
+      // happened, and the two together read as a warning about a change
+      // that is already made.
+      const note = document.getElementById('pw-note');
+      if (note) note.hidden = true;
+      say('Password changed. Every other session was signed out.', true);
+      return;
+    }
+    let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+    // A wrong current password is also a 401, from the receiver rather
+    // than the session gate; only the gate's refusal means signed out.
+    if (r.status === 401 && String(d).indexOf('current password') < 0) {
+      sessionLost(); return;
+    }
+    say('Password unchanged: ' + (typeof d === 'string' ? d
+      : 'the new password needs 12 characters or more.'), false);
+    return;
   }
   if (act === 'dismiss-minted') { MINTED = null; render(); return; }
   if (act === 'copy') {
@@ -7256,7 +7492,7 @@ function open_(kind, key) {
 // the tour is up: the overlay owns the keyboard then, and its own way out
 // is the End tour button, which records that it was skipped.
 document.addEventListener('keydown', e => {
-  if (e.key !== 'Escape' || TOUR) return;
+  if (e.key !== 'Escape' || TOUR || pwIsOpen()) return;
   if (!document.body.classList.contains('open')) return;
   open_(null);
 });
@@ -7436,7 +7672,10 @@ drawerEl.addEventListener('click', e => {
 });
 document.getElementById('overlay').addEventListener('click', () => open_(null));
 window.addEventListener('keydown', e => {
-  if (e.key === 'Escape' && document.body.classList.contains('open')) open_(null);
+  // The modal owns Escape while it is up, or dismissing it would also close
+  // the drawer somebody left open behind it.
+  if (e.key === 'Escape' && !pwIsOpen()
+      && document.body.classList.contains('open')) open_(null);
 });
 // Managed actions, same delegation for the same reason. A separate listener
 // rather than branches in the one above, because data-open is navigation and

--- a/portal/tests/test_central_settings.py
+++ b/portal/tests/test_central_settings.py
@@ -218,3 +218,99 @@ def test_the_settings_tabs_share_one_save_and_secrets_keep_their_own():
     assert 'data-act="save-domains"' in html
     assert 'data-act="save-extid"' in html
     assert "${batch ? '' : '<button class=\"mini\" data-act=\"save-markings\">Save</button>'}" in html
+
+
+def test_getting_started_has_its_own_tab():
+    """"Run the setup wizard again" and "Take the tour again" sat at the
+    bottom of the Account tab, under the accounts table and single sign-on -
+    nowhere anybody would look, since neither has anything to do with
+    accounts. The first UX pass found the tour re-entry 1,002 pixels down an
+    1,105-pixel page."""
+    html = (main.STATIC / "index.html").read_text()
+    assert "['start', 'Getting started']" in html
+    assert "function gettingStarted()" in html
+    assert "else if (SETTAB === 'start') body = gettingStarted();" in html
+
+
+def test_the_fleet_tab_is_renamed_but_keeps_its_id():
+    """"Fleet" also names a whole nav section - enrolled devices and
+    enrollment tokens - and two different things called Fleet in one product
+    is a coin toss every time somebody says it. The id stays so existing
+    #settings/fleet links, and the tour step that targets this tab, still
+    land."""
+    html = (main.STATIC / "index.html").read_text()
+    assert "['fleet', 'Detection & paste guard']" in html
+    assert "{view: 'settings', tab: 'fleet', sel: '#set-domains'," in html
+
+
+def test_your_own_password_lives_in_the_account_menu():
+    """Changing your own password is not an administrative setting, and
+    Settings > Account is about OTHER people's accounts and single sign-on. It
+    matters most for a viewer: that tab is read-only for them, so their
+    password was the one editable field on it, three blocks down.
+
+    The menu sits outside #app, where the delegated data-act listeners never
+    reach - so it carries its own."""
+    html = (main.STATIC / "index.html").read_text()
+    assert 'id="usermenu"' in html
+    assert "function umClose()" in html
+    assert "e.target.closest('#usermenu [data-act]')" in html
+    assert 'data-act="open-password"' in html
+    # Gone from the administrative tab.
+    account = html.split("function accountSettings()")[1].split("\nfunction ")[0]
+    assert "set-curpass" not in account
+
+
+def test_the_password_form_is_a_modal_and_not_the_menu_itself():
+    """The menu offers an ITEM; the form is a dialog. A menu closes on any
+    click outside it and on Escape, and umClose() would take half-typed
+    fields with it - and a password manager rarely offers to save from a
+    panel that disappears on blur.
+
+    The dialog is outside #app for the same reason the menu is, so it needs
+    its own listener, and the result is reported INTO the dialog: SETMSG only
+    ever renders on Settings, and telling a page the person is not looking at
+    is the same as not telling them."""
+    html = (main.STATIC / "index.html").read_text()
+    assert '<dialog id="pwdlg"' in html
+    assert "dlg.showModal()" in html
+    assert 'id="pw-msg"' in html
+    assert "document.getElementById('pwdlg').addEventListener('click'" in html
+    # Every field is cleared on the way out. Escape is closed by hand rather
+    # than left to the dialog element: measured in Chrome 151, main world, it
+    # closes itself but fires neither 'cancel' nor 'close', so the listener
+    # would never run and a typed password would sit in the field behind a
+    # dismissed dialog.
+    # And it takes the keystroke outright: the drawer's Escape handler is a
+    # later window listener, and by the time it runs pwHide() has already made
+    # pwIsOpen() false - so one Escape would dismiss the modal AND the drawer
+    # sitting open behind it.
+    assert "if (pwIsOpen()) { pwHide(); e.stopImmediatePropagation(); return; }" in html
+    assert "document.getElementById('pwdlg').addEventListener('close', pwWipe)" in html
+    # Signing out takes the dialog with it.
+    assert "pwHide(); }" in html
+
+
+def test_the_new_password_is_typed_twice():
+    """Without a confirm field a typo is not discovered until the next
+    sign-in - by which time every other session has been signed out with the
+    old password. The mismatch is answered here rather than by the receiver,
+    which never sees the second copy and would report the typo as whichever
+    password was sent being wrong."""
+    html = (main.STATIC / "index.html").read_text()
+    assert 'id="set-confpass"' in html
+    assert "if (nw !== _val('set-confpass'))" in html
+    assert "The two new passwords do not match." in html
+
+
+def test_the_primary_button_submits_the_form_and_carries_no_act():
+    """Enter in any field has to do what the button does. The button is
+    therefore the form's submit - and it deliberately carries no data-act,
+    because a click would otherwise both submit AND delegate, changing the
+    password twice."""
+    html = (main.STATIC / "index.html").read_text()
+    dlg = html.split('<dialog id="pwdlg"')[1].split("</dialog>")[0]
+    assert 'id="pw-submit"' in dlg and 'type="submit"' in dlg
+    assert "data-act" not in dlg.split('id="pw-submit"')[1].split(">")[0]
+    assert 'data-act="close-password"' in dlg
+    assert "document.getElementById('pwform').addEventListener('submit'" in html

--- a/portal/tests/test_wizard.py
+++ b/portal/tests/test_wizard.py
@@ -391,3 +391,70 @@ def test_a_long_command_cannot_widen_the_wizard_past_its_card():
     html = (main.STATIC / "index.html").read_text()
     assert ".ssmain{padding:22px 24px;min-width:0}" in html
     assert "flex:1;min-width:0;font-size:12px" in html
+
+
+def test_the_first_run_wizard_is_one_step_at_a_time():
+    """Seven numbered sections rendered on one page - the only wizard that
+    never became one, and the first thing a new deployment sees."""
+    html = (main.STATIC / "index.html").read_text()
+    assert "let WIZSTEP = 1;" in html
+    assert "const WIZ_STEPS = [" in html
+    assert 'data-act="wiz-step"' in html
+    # managedAction takes (act, el) and has no `key` in scope. Borrowing the
+    # name threw a silent ReferenceError and every rail click did nothing -
+    # the wizard looked rendered and was simply inert.
+    assert "const n = parseInt(el ? el.getAttribute('data-key') : '', 10);" in html
+
+
+def test_the_rail_says_what_each_step_costs_to_skip():
+    """A first-run wizard that only counts steps says how far down the page
+    you are. Corporate domains is marked required not because the platform
+    refuses to run without it, but because it runs WRONG - every account reads
+    as personal, and the Overview headline, the Personal accounts page and the
+    ISO evidence all inherit that. Once the required steps are in, the summary
+    says so, because the moment it starts working is worth naming."""
+    html = (main.STATIC / "index.html").read_text()
+    for needle in ("required", "recommended", "optional",
+                   "You can deploy now", "Start collecting", "Make it useful",
+                   "every account reads as personal",
+                   "nothing can deploy without it"):
+        assert needle in html, needle
+
+
+def test_the_first_two_steps_say_where_to_look_not_just_what_to_type():
+    """"The one a laptop on someone's kitchen table can resolve" told an
+    operator what the address is FOR, not how to find the one they have. And
+    "Loki-compatible" left open whether Loki itself was required.
+
+    The ingest-versus-query distinction is the trap worth naming: a store that
+    accepts Loki writes but answers queries in its own language will take every
+    finding and then show an empty portal."""
+    html = (main.STATIC / "index.html").read_text()
+    assert "kitchen table" not in html
+    for needle in ("kubectl get ingress -A", "tailscale status",
+                   "Grafana Cloud Logs", "/loki/api/v1/query_range",
+                   "advertise Loki-compatible"):
+        assert needle in html, needle
+
+
+def test_the_extension_setup_offers_the_way_back_it_actually_owes_you():
+    """It is reachable from the first-run wizard's step 5 and from Settings,
+    and the way out differs: somebody mid-setup wants to land back on step 5,
+    somebody who came from Settings has no setup to return to. The last step
+    used to offer "Back to the setup wizard" to everybody, including people
+    who had never been there.
+
+    EXTFROM is cleared by every other navigation, so the offer cannot outlive
+    the journey that earned it. And it appears once per screen - the last step
+    showed it twice, as both the escape and the primary, until the escape was
+    dropped there."""
+    html = (main.STATIC / "index.html").read_text()
+    assert "let EXTFROM = '';" in html
+    assert "EXTFROM = view === 'wizard' ? 'wizard' : '';" in html
+    assert "if (act === 'ext-back-to-setup')" in html
+    # Returning lands on the step that sent you, not the top of the wizard.
+    assert "WIZSTEP = 5;" in html
+    # Cleared on every other route out.
+    assert "view = h.view; detail = null; EXTFROM = '';" in html
+    # One exit per screen.
+    assert "${EXTPAGE === 6 ? '' : EXTFROM === 'wizard'" in html


### PR DESCRIPTION
Two chunks, one per commit.

## The first-run setup wizard

The setup screen was 841 lines rendering seven sections onto one page. The seven are unchanged - their content was always the good part - and now hang off a step counter, with a rail that badges each step **required / recommended / optional** and groups them under "Start collecting" and "Make it useful".

Two steps are required, and the line is drawn where a blank field makes the deployment run *wrong* rather than not run at all:

- **Receiver URL** - the only thing a collector needs, and all a download bakes in.
- **Corporate domains** - blank means every account reads as personal, and the Overview headline, the Personal accounts view and the ISO evidence all inherit that quietly.

Once those two are in, the summary says the deployment can go out and offers the downloads.

Step 1 now says how to *find* the receiver's address rather than assuming the reader knows it, and that the probe button is the only confirmation worth having. Step 2 says plainly that a log store is effectively required and names the two that work - several stores advertise Loki-compatible *ingest* while answering queries in their own language, and one of those accepts every finding and then shows an empty portal.

The extension setup is reachable from step 5 and from Settings, and the way out differs. It records which screen sent you: step 5 gets "Back to deployment setup", Settings gets Close.

## Settings, and where the password lives

- **Fleet -> "Detection & paste guard"**, keeping its id so existing links and the tour's step-8 target still land. Renamed because "Fleet" also names a whole nav section, and two different things called Fleet in one product is a coin toss every time somebody says it. Not "Browser extension", because corporate domains lives there and is not extension config.
- **"Getting started" is a tab of its own**, holding the two ways back into the guided paths. They used to sit at the bottom of Account, 1,002px down an 1,105px page.
- **Changing your own password moves to a menu under the username in the header.** Settings > Account is about *other* people's accounts and single sign-on; for a viewer that tab is read-only and their own password was the single editable field on it.

The menu offers an item and the form is a modal, with a **confirm** field. A menu closes on any click outside it and on Escape, taking half-typed fields with it, and a password manager rarely offers to save from a panel that disappears on blur. Without confirm, a typo is not discovered until the next sign-in - by which point every other session has already been signed out with the old password.

## Found by driving it, not by reading it

- The rail's click handler used a `key` belonging to a different function. Every rail click threw silently while the wizard looked perfectly rendered.
- A grid item's default `min-width` let one long shell command push the panel past its card, where the overflow clips - Copy, Back and Next were gone, with no way to scroll to them.
- The old password handler reported into a variable that only ever renders on Settings, so from any other page a password change reported nothing at all.
- **The `<dialog>` element fires neither `cancel` nor `close` in Chrome 151**, measured in the page's own world. The listener meant to clear the fields never ran, and a typed password sat in the input behind a dismissed dialog. Escape is handled by hand now, with the element's own listener kept as a backstop.
- The modal has to take that keystroke outright: the drawer's Escape handler is a later window listener, and by the time it runs the modal has already closed - so guarding on live state let one Escape dismiss the modal *and* the drawer behind it.

## Testing

503 portal tests (up from 497) and 244 receiver tests pass. Driven in the browser in both themes: the mismatch path sends no request at all, Escape and Cancel each wipe all three fields, and the success state leaves nothing to submit.