### PR TITLE
portal: the first run opens on the wizard, and the walkthrough that follows it

### DIFF
--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -313,6 +313,13 @@ button.mini.pri{border-color:var(--pri);background:color-mix(in srgb,var(--pri) 
    confirm field, which a 240px dropdown does not - and a typo in the new
    password is otherwise not discovered until the next sign-in, by which
    time every other session has been signed out with the old one. */
+#skipdlg{border:1px solid var(--bd);border-radius:12px;background:var(--sf);
+  color:var(--fg);padding:20px 22px;width:min(430px,92vw);
+  box-shadow:0 18px 50px rgba(0,0,0,.28)}
+#skipdlg::backdrop{background:rgba(15,18,20,.45)}
+#skipdlg h3{margin:0 0 2px;font-size:15px}
+#skipdlg .pwsub{font-size:12px;color:var(--mut);margin:0 0 14px}
+#skipdlg .skipbody{font-size:13px;line-height:1.5;margin:0 0 12px}
 #pwdlg{border:1px solid var(--bd);border-radius:12px;background:var(--sf);
   color:var(--fg);padding:20px 22px;width:min(400px,92vw);
   box-shadow:0 18px 50px rgba(0,0,0,.28)}
@@ -795,6 +802,20 @@ table.plain td{border-bottom:0;padding:4.5px 10px 4.5px 0;vertical-align:middle}
   <div id="tour-ring"></div>
   <div id="tour-card"></div>
 </div>
+<dialog id="skipdlg" aria-labelledby="skip-title">
+  <h3 id="skip-title">Skip setup for now?</h3>
+  <p class="pwsub">Nothing is collected until two things are set.</p>
+  <p class="skipbody">The receiver address is all a collector download bakes
+  in, and with no corporate domains every account reads as a personal one -
+  so the Overview headline, Personal accounts and the ISO evidence would all
+  report the wrong thing rather than report nothing.</p>
+  <p class="skipbody">You can pick this up again whenever you like, under
+  <strong>Settings &rsaquo; Getting started</strong>.</p>
+  <div class="pwfoot">
+    <button class="mini pri" data-act="skip-cancel">Keep setting up</button>
+    <button class="back" style="margin:0" data-act="skip-confirm">Skip for now</button>
+  </div>
+</dialog>
 <dialog id="pwdlg" aria-labelledby="pw-title">
   <form id="pwform">
     <h3 id="pw-title">Change password</h3>
@@ -869,6 +890,13 @@ let EXTFROM = '';
 // Which first-run step is showing. The seven used to render at once on
 // one page, which is how it became 841 lines nobody could scan.
 let WIZSTEP = 1;
+// Set the moment the FIRST account on a deployment is created, and read
+// once by load(). The wizard otherwise opens only on a bare fragment, so
+// that an operator who navigated somewhere on purpose is not dragged back
+// - but the very first sign-in has no such intent to respect, and a tab
+// still carrying #settings/start from before the volume was wiped skipped
+// the wizard and handed a brand new deployment the walkthrough instead.
+let FIRSTRUN = false;
 // The budget view: the fetched spend data, the link-a-tool wizard's state
 // (null = closed), the last action's one-line outcome, and a parsed CSV
 // preview waiting for confirmation.
@@ -1034,6 +1062,22 @@ function pwShow() {
   if (f) f.focus();
 }
 
+function skipShow() {
+  const dlg = document.getElementById('skipdlg');
+  if (!dlg) { managedAction('wiz-finish'); return; }
+  if (!dlg.open) dlg.showModal();
+}
+
+function skipHide() {
+  const dlg = document.getElementById('skipdlg');
+  if (dlg && dlg.open) dlg.close();
+}
+
+const skipIsOpen = () => {
+  const dlg = document.getElementById('skipdlg');
+  return !!(dlg && dlg.open);
+};
+
 function pwHide() {
   const dlg = document.getElementById('pwdlg');
   if (dlg && dlg.open) dlg.close();
@@ -1070,6 +1114,7 @@ window.addEventListener('keydown', e => {
   // already made pwIsOpen() false - so guarding it on live state is not
   // enough, and one Escape would dismiss the modal and the drawer behind it.
   if (pwIsOpen()) { pwHide(); e.stopImmediatePropagation(); return; }
+  if (skipIsOpen()) { skipHide(); e.stopImmediatePropagation(); return; }
   const um = document.getElementById('usermenu');
   if (um && !um.hidden) umClose();
 });
@@ -1078,6 +1123,11 @@ window.addEventListener('keydown', e => {
 // form's SUBMIT so that Enter in any field does what the button does, and it
 // deliberately carries no data-act - a click would otherwise both submit and
 // delegate, and change the password twice.
+// Outside #app like the other dialog, so it carries its own listener.
+document.getElementById('skipdlg').addEventListener('click', e => {
+  const el = e.target.closest('[data-act]');
+  if (el) managedAction(el.getAttribute('data-act'), el);
+});
 document.getElementById('pwform').addEventListener('submit', e => {
   e.preventDefault();
   managedAction('change-password', document.getElementById('pw-submit'));
@@ -1230,7 +1280,13 @@ async function load(force) {
     }
     const done = SETTINGS && SETTINGS.settings
       && SETTINGS.settings.onboarding_done.value;
-    if (SETTINGS && !done && (!location.hash || location.hash === '#wizard')) {
+    // A just-created deployment goes to the wizard whatever the fragment
+    // says; after that, a fragment means the operator asked for a page and
+    // a wizard that overrides them traps rather than helps.
+    const first = FIRSTRUN;
+    FIRSTRUN = false;
+    if (SETTINGS && !done
+        && (first || !location.hash || location.hash === '#wizard')) {
       view = 'wizard';
       history.replaceState(null, '', '#wizard');
     }
@@ -3901,6 +3957,12 @@ async function wizard() {
     return (CFG.managed && CFG.managed.artifacts_ready)
       ? {c: 'val', t: 'ready'} : {c: 'pend', t: 'needs the receiver URL'};
   };
+  // A viewer can neither finish the wizard nor skip it: both write
+  // onboarding_done, and the receiver refuses the write. Pressing the only
+  // way out returned "this account is read-only" and left them on the
+  // wizard, reachable from Settings and escapable only through the nav.
+  // Nothing is being saved either way, so for them leaving is navigation.
+  const wizRO = AUTH && AUTH.role === 'viewer';
   const reqN = WIZ_STEPS.filter(x => x.need === 'req').length;
   const reqDone = WIZ_STEPS.filter((x, i) => x.need === 'req' && wDone(i + 1)).length;
   const canGo = reqDone === reqN;
@@ -4075,15 +4137,17 @@ async function wizard() {
   <div class="ssow">${rail}
     <div class="ssmain">${body}
       <div class="ssfoot">
-        <button class="mini" data-act="wiz-finish">${canGo
-          ? 'Finish setup' : 'Skip for now'}</button>
+        <button class="mini" data-act="${wizRO ? 'wiz-close'
+          : canGo ? 'wiz-finish' : 'wiz-skip'}">${wizRO ? 'Close'
+          : canGo ? 'Finish setup' : 'Skip for now'}</button>
         <span class="sp"></span>
         ${WIZSTEP > 1 ? `<button class="mini" data-act="wiz-step"
           data-key="${WIZSTEP - 1}">Back</button>` : ''}
         ${WIZSTEP < 7
           ? `<button class="mini pri" data-act="wiz-step"
               data-key="${WIZSTEP + 1}">Next</button>`
-          : `<button class="mini pri" data-act="wiz-finish">Finish setup</button>`}
+          : `<button class="mini pri" data-act="${wizRO ? 'wiz-close' : 'wiz-finish'}"
+              >${wizRO ? 'Close' : 'Finish setup'}</button>`}
       </div></div></div>
   <p class="src-note">You can come back: everything above stays editable under
   Settings, and Settings can reopen this wizard.</p>`;
@@ -6780,6 +6844,9 @@ async function managedAction(act, el) {
     if (r.ok) {
       const o = await r.json();
       AUTH = {mode: 'login', authenticated: true, username: o.username, setup_needed: false};
+      // Creating the first account IS the first run, whatever the address
+      // bar happens to say.
+      if (act === 'do-setup') FIRSTRUN = true;
       // /api/auth also carries the account's role, which gates the
       // account-management card and labels the read-only state.
       try { AUTH = await (await fetch('/api/auth')).json(); } catch (e) { /* keep the basics */ }
@@ -6817,6 +6884,22 @@ async function managedAction(act, el) {
     }
     render(); return;
   }
+  // Skipping and finishing write the same thing, so somebody who skips has
+  // retired the wizard for good without being told - and the two required
+  // steps are exactly the ones whose absence makes the deployment run WRONG
+  // rather than not run. Said once, here, rather than as prose on a screen
+  // they are in the act of leaving.
+  if (act === 'wiz-skip') { skipShow(); return; }
+  if (act === 'wiz-close') {
+    // No write, so no refusal to report - and back to the tab the button
+    // that opens this wizard lives on.
+    SETMSG = ''; EXTFROM = '';
+    view = 'settings'; SETTAB = 'start'; detail = null;
+    history.replaceState(null, '', frag('settings'));
+    drawNav(); await render(); return;
+  }
+  if (act === 'skip-cancel') { skipHide(); return; }
+  if (act === 'skip-confirm') { skipHide(); await managedAction('wiz-finish'); return; }
   if (act === 'wiz-finish') {
     const r = await mfetch('/api/settings', {method: 'POST',
       body: JSON.stringify({onboarding_done: true})});
@@ -7492,7 +7575,7 @@ function open_(kind, key) {
 // the tour is up: the overlay owns the keyboard then, and its own way out
 // is the End tour button, which records that it was skipped.
 document.addEventListener('keydown', e => {
-  if (e.key !== 'Escape' || TOUR || pwIsOpen()) return;
+  if (e.key !== 'Escape' || TOUR || pwIsOpen() || skipIsOpen()) return;
   if (!document.body.classList.contains('open')) return;
   open_(null);
 });
@@ -7674,7 +7757,7 @@ document.getElementById('overlay').addEventListener('click', () => open_(null));
 window.addEventListener('keydown', e => {
   // The modal owns Escape while it is up, or dismissing it would also close
   // the drawer somebody left open behind it.
-  if (e.key === 'Escape' && !pwIsOpen()
+  if (e.key === 'Escape' && !pwIsOpen() && !skipIsOpen()
       && document.body.classList.contains('open')) open_(null);
 });
 // Managed actions, same delegation for the same reason. A separate listener

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -313,13 +313,13 @@ button.mini.pri{border-color:var(--pri);background:color-mix(in srgb,var(--pri) 
    confirm field, which a 240px dropdown does not - and a typo in the new
    password is otherwise not discovered until the next sign-in, by which
    time every other session has been signed out with the old one. */
-#skipdlg{border:1px solid var(--bd);border-radius:12px;background:var(--sf);
+#skipdlg, #tourdlg{border:1px solid var(--bd);border-radius:12px;background:var(--sf);
   color:var(--fg);padding:20px 22px;width:min(430px,92vw);
   box-shadow:0 18px 50px rgba(0,0,0,.28)}
-#skipdlg::backdrop{background:rgba(15,18,20,.45)}
-#skipdlg h3{margin:0 0 2px;font-size:15px}
-#skipdlg .pwsub{font-size:12px;color:var(--mut);margin:0 0 14px}
-#skipdlg .skipbody{font-size:13px;line-height:1.5;margin:0 0 12px}
+#skipdlg::backdrop, #tourdlg::backdrop{background:rgba(15,18,20,.45)}
+#skipdlg h3, #tourdlg h3{margin:0 0 2px;font-size:15px}
+#skipdlg .pwsub, #tourdlg .pwsub{font-size:12px;color:var(--mut);margin:0 0 14px}
+#skipdlg .skipbody, #tourdlg .skipbody{font-size:13px;line-height:1.5;margin:0 0 12px}
 #pwdlg{border:1px solid var(--bd);border-radius:12px;background:var(--sf);
   color:var(--fg);padding:20px 22px;width:min(400px,92vw);
   box-shadow:0 18px 50px rgba(0,0,0,.28)}
@@ -546,8 +546,17 @@ table.plain td{border-bottom:0;padding:4.5px 10px 4.5px 0;vertical-align:middle}
   color: var(--acc); background: var(--acc-soft);
   border-radius: 999px; padding: 3px 10px;
 }
-#tour-foot { display: flex; align-items: center; gap: 8px; }
-#tour-dots { display: flex; gap: 4px; margin-right: auto; }
+/* The footer wraps, and the buttons never shrink. One dot per step and
+   three buttons came to 322px inside a 322px card at thirteen steps -
+   exact, with nothing spare - so a narrower viewport pushed Next outside
+   the card, where the card does not scroll and nothing clips it. It broke
+   at a 360px viewport by 3px and at 320px by 43px. Dots are the part that
+   should give way, not the way forward. */
+#tour-foot { display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+             row-gap: 10px; }
+#tour-dots { display: flex; gap: 4px; margin-right: auto; flex-wrap: wrap;
+             min-width: 0; }
+#tour-card button { flex: 0 0 auto; }
 #tour-dots i {
   width: 5px; height: 5px; border-radius: 50%; background: var(--bd);
   display: block; transition: background .2s, width .2s;
@@ -802,6 +811,15 @@ table.plain td{border-bottom:0;padding:4.5px 10px 4.5px 0;vertical-align:middle}
   <div id="tour-ring"></div>
   <div id="tour-card"></div>
 </div>
+<dialog id="tourdlg" aria-labelledby="tourdlg-title">
+  <h3 id="tourdlg-title">Tour ended</h3>
+  <p class="skipbody">You can take it again whenever you like, under
+  <strong>Settings &rsaquo; Getting started</strong> - along with the setup
+  wizard.</p>
+  <div class="pwfoot">
+    <button class="mini pri" data-act="tour-notice-close">Got it</button>
+  </div>
+</dialog>
 <dialog id="skipdlg" aria-labelledby="skip-title">
   <h3 id="skip-title">Skip setup for now?</h3>
   <p class="pwsub">Nothing is collected until two things are set.</p>
@@ -1115,6 +1133,7 @@ window.addEventListener('keydown', e => {
   // enough, and one Escape would dismiss the modal and the drawer behind it.
   if (pwIsOpen()) { pwHide(); e.stopImmediatePropagation(); return; }
   if (skipIsOpen()) { skipHide(); e.stopImmediatePropagation(); return; }
+  if (tourDlgIsOpen()) { tourDoneHide(); e.stopImmediatePropagation(); return; }
   const um = document.getElementById('usermenu');
   if (um && !um.hidden) umClose();
 });
@@ -1124,9 +1143,11 @@ window.addEventListener('keydown', e => {
 // deliberately carries no data-act - a click would otherwise both submit and
 // delegate, and change the password twice.
 // Outside #app like the other dialog, so it carries its own listener.
-document.getElementById('skipdlg').addEventListener('click', e => {
-  const el = e.target.closest('[data-act]');
-  if (el) managedAction(el.getAttribute('data-act'), el);
+['skipdlg', 'tourdlg'].forEach(id => {
+  document.getElementById(id).addEventListener('click', e => {
+    const el = e.target.closest('[data-act]');
+    if (el) managedAction(el.getAttribute('data-act'), el);
+  });
 });
 document.getElementById('pwform').addEventListener('submit', e => {
   e.preventDefault();
@@ -6899,6 +6920,7 @@ async function managedAction(act, el) {
     drawNav(); await render(); return;
   }
   if (act === 'skip-cancel') { skipHide(); return; }
+  if (act === 'tour-notice-close') { tourDoneHide(); return; }
   if (act === 'skip-confirm') { skipHide(); await managedAction('wiz-finish'); return; }
   if (act === 'wiz-finish') {
     const r = await mfetch('/api/settings', {method: 'POST',
@@ -7575,7 +7597,8 @@ function open_(kind, key) {
 // the tour is up: the overlay owns the keyboard then, and its own way out
 // is the End tour button, which records that it was skipped.
 document.addEventListener('keydown', e => {
-  if (e.key !== 'Escape' || TOUR || pwIsOpen() || skipIsOpen()) return;
+  if (e.key !== 'Escape' || TOUR || pwIsOpen() || skipIsOpen()
+      || tourDlgIsOpen()) return;
   if (!document.body.classList.contains('open')) return;
   open_(null);
 });
@@ -7757,7 +7780,7 @@ document.getElementById('overlay').addEventListener('click', () => open_(null));
 window.addEventListener('keydown', e => {
   // The modal owns Escape while it is up, or dismissing it would also close
   // the drawer somebody left open behind it.
-  if (e.key === 'Escape' && !pwIsOpen() && !skipIsOpen()
+  if (e.key === 'Escape' && !pwIsOpen() && !skipIsOpen() && !tourDlgIsOpen()
       && document.body.classList.contains('open')) open_(null);
 });
 // Managed actions, same delegation for the same reason. A separate listener
@@ -7851,6 +7874,12 @@ const TOURS = {
          + 'on. Everything here reads the window in the corner - findings '
          + 'age out of it, so a number falling can mean a device went '
          + 'quiet rather than a problem going away.'},
+    {view: 'overview', sel: '[data-act="ov-edit"]',
+     title: 'Read it your way',
+     body: 'Edit lets you drag these cards, stack two into one column, '
+         + 'resize them, or hide what you never look at. It is your own '
+         + 'view and changes nothing for anyone else. A few cards offer a '
+         + 'second form where the data has more than one honest reading.'},
     {view: 'overview', sel: '[data-s="inventory"]', click: true,
      title: 'What was found',
      body: 'Tools, people, devices and the accounts they are signed into. '
@@ -7865,27 +7894,46 @@ const TOURS = {
      title: 'Deciding what is allowed',
      body: 'Nothing is approved or refused until a person says so. Open '
          + 'Governance for where those decisions live.'},
-    {view: 'register', sel: '[data-s="health"]',
+    {view: 'register', sel: '[data-s="spend"]', click: true,
      title: 'Before you trust a number',
-     body: 'The AI register is what you actually use; a tool missing from '
-         + 'the registry is flagged rather than hidden. Health is the '
-         + 'check that belongs with it - a surface nobody is collecting '
-         + 'from looks exactly like a surface with nothing on it.'},
-    {view: 'setup', sel: '[data-s="system"]', click: true,
-     title: 'Making it yours',
-     body: 'One thing worth setting today: your corporate domains, which '
-         + 'is what decides whether an account counts as personal. Open '
-         + 'Settings.'},
+     body: 'The AI register is what you actually use, with what was '
+         + 'decided about each tool: owner, status, review date. A tool '
+         + 'missing from the registry is flagged rather than hidden. What '
+         + 'it all costs is next - open Budget.'},
+    {view: 'budget', sel: '[data-s="health"]', click: true,
+     title: 'What it costs',
+     body: 'Subscriptions set against what the estate is observed doing: '
+         + 'seats nobody uses, people on a tool no seat covers, personal '
+         + 'accounts running beside paid ones. All of it rests on '
+         + 'something still reporting - open Health.'},
+    {view: 'setup', sel: '[data-s="managed"]', click: true,
+     title: 'Is anything actually reporting?',
+     body: 'Which detection sources are reporting, which are set up but '
+         + 'silent, and which you have not enabled. A surface nobody '
+         + 'collects from looks exactly like a surface with nothing on '
+         + 'it. The devices themselves are next - open Fleet.'},
+    {view: 'fleet', sel: '[data-s="system"]', click: true,
+     title: 'Devices and their credentials',
+     body: 'Every device holding an enrollment credential, and the tokens '
+         + 'that invited them. Revoking cuts off one device and it holds: '
+         + 'the serial is refused even by a valid token until you allow '
+         + 'it back. Last stop - open Settings.'},
     {view: 'settings', tab: 'fleet', sel: '#set-domains',
      title: 'Corporate domains',
      body: 'Every domain your people legitimately sign in with. Anything '
          + 'else is a personal account and warns. Get this wrong and the '
          + 'whole platform reports the wrong thing, so it is the first '
          + 'field to fill in.'},
+    {view: 'settings', sel: '#who',
+     title: 'Your own account',
+     body: 'Your name in the corner opens your account, and changing your '
+         + 'own password lives there. Everything else on this screen is '
+         + 'about the deployment, or about other people\u2019s accounts.'},
     {view: 'settings', sel: '#refresh',
      title: 'One last thing',
      body: 'Findings are cached, so this is how you force a fresh read. '
-         + 'You can take this tour again from Settings, under Account.'},
+         + 'You can take this tour again from Settings, under Getting '
+         + 'started.'},
   ],
   viewer: [
     {title: 'Welcome to Shadow AI Guard',
@@ -7899,6 +7947,12 @@ const TOURS = {
          + 'on. Everything here reads the window in the corner - findings '
          + 'age out of it, so a number falling can mean a device went '
          + 'quiet rather than a problem going away.'},
+    {view: 'overview', sel: '[data-act="ov-edit"]',
+     title: 'Read it your way',
+     body: 'Edit lets you drag these cards, stack two into one column, '
+         + 'resize them, or hide what you never look at. This one is '
+         + 'yours: it is a personal view kept with your account, and '
+         + 'read-only does not stop it.'},
     {view: 'overview', sel: '[data-s="inventory"]', click: true,
      title: 'What was found',
      body: 'Tools, people, devices and the accounts they are signed into. '
@@ -7914,17 +7968,30 @@ const TOURS = {
      body: 'Approvals, owners and review dates - the evidence an audit '
          + 'asks for, and all of it readable from this account. Recording '
          + 'a decision is the admin\u2019s half. Open Governance.'},
-    {view: 'register', sel: '[data-s="health"]',
+    {view: 'register', sel: '[data-s="spend"]', click: true,
      title: 'Before you trust a number',
      body: 'The AI register is what you actually use; a tool missing from '
-         + 'the registry is flagged rather than hidden. Health is the '
-         + 'check that belongs with it - a surface nobody is collecting '
-         + 'from looks exactly like a surface with nothing on it.'},
-    {view: 'setup', sel: '[data-s="system"]', click: true,
-     title: 'Where the numbers come from',
-     body: 'One setting decides what counts as a personal account, and it '
-         + 'is worth seeing even though this account cannot change it. '
-         + 'Open Settings.'},
+         + 'the registry is flagged rather than hidden. Reading it is the '
+         + 'half this account does. What it all costs is next - open '
+         + 'Budget.'},
+    {view: 'budget', sel: '[data-s="health"]', click: true,
+     title: 'What it costs',
+     body: 'Unused seats, people on a tool no seat covers, and personal '
+         + 'accounts running beside paid ones - figures worth quoting. '
+         + 'Every one of them rests on something still reporting, which '
+         + 'is the next page - open Health.'},
+    {view: 'setup', sel: '[data-s="managed"]', click: true,
+     title: 'Is anything actually reporting?',
+     body: 'Which detection sources are reporting, which are silent, and '
+         + 'which were never enabled. A surface nobody collects from '
+         + 'looks exactly like one with nothing on it, so read this '
+         + 'before quoting a number that fell. Open Fleet.'},
+    {view: 'fleet', sel: '[data-s="system"]', click: true,
+     title: 'Devices and their credentials',
+     body: 'Every device holding an enrollment credential, and the tokens '
+         + 'that invited them. Revoking one is an admin\u2019s job; seeing '
+         + 'what is enrolled, and what was revoked and when, is not. Last '
+         + 'stop - open Settings.'},
     {view: 'settings', tab: 'fleet', sel: '#set-domains',
      title: 'Corporate domains - read it, do not take it on trust',
      body: 'Anything not on this list is treated as a personal account. '
@@ -7933,11 +8000,18 @@ const TOURS = {
          + 'it. You can read it here; an admin changes it - and if it '
          + 'looks wrong, that is the conversation to have before quoting '
          + 'any of these numbers.'},
+    {view: 'settings', sel: '#who',
+     title: 'The one thing here you can change',
+     body: 'Your name in the corner opens your account. Your own password '
+         + 'is the single thing on this whole screen a read-only account '
+         + 'can change - the rest is the deployment, and an admin\u2019s '
+         + 'to save.'},
     {view: 'settings', sel: '#refresh',
      title: 'That is the tour',
      body: 'Findings are cached, and this forces a fresh read. Saving is '
          + 'the only thing this account cannot do - every page works. You '
-         + 'can take this tour again from Settings, under Account.'},
+         + 'can take this tour again from Settings, under Getting '
+         + 'started.'},
   ],
 };
 
@@ -8020,6 +8094,7 @@ async function tourStart(intro) {
 // failed to load.
 function tourAbort() {
   if (TOUR && TOUR.drop) TOUR.drop();
+  tourRelease();
   TOUR = null;
   const t = document.getElementById('tour');
   if (t) t.className = '';
@@ -8031,6 +8106,7 @@ function tourAbort() {
 }
 
 async function tourEnd(done) {
+  tourRelease();
   TOUR = null;
   document.getElementById('tour').className = '';
   document.getElementById('tour-card').innerHTML = '';
@@ -8038,7 +8114,25 @@ async function tourEnd(done) {
   // decided they did not want it, and reopening it every sign-in would be
   // the tour arguing with them.
   await tourRemember(done ? TOUR_VERSION : 'skipped');
+  // Only when it was left early. The last step says this in its own body,
+  // and repeating it to somebody who read that line is telling them twice.
+  if (!done) tourDoneShow();
 }
+
+function tourDoneShow() {
+  const dlg = document.getElementById('tourdlg');
+  if (dlg && !dlg.open) dlg.showModal();
+}
+
+function tourDoneHide() {
+  const dlg = document.getElementById('tourdlg');
+  if (dlg && dlg.open) dlg.close();
+}
+
+const tourDlgIsOpen = () => {
+  const dlg = document.getElementById('tourdlg');
+  return !!(dlg && dlg.open);
+};
 
 async function tourGo(n) {
   if (!TOUR) return;
@@ -8061,7 +8155,16 @@ async function tourShow() {
     drawNav();
     await render();
   }
+  // The shade and the ring both pass clicks through, so a step could
+  // point at a control and leave it fully working: Edit opened the
+  // arranger behind the card, the corporate domains field took typing
+  // during a walkthrough, and Refresh reloaded the page on the last step.
+  // A step that only DESCRIBES a control makes it inert - which stops the
+  // keyboard reaching it too, not just the mouse - and a step that asks
+  // for a click deliberately does not.
+  tourRelease();
   const el = st.sel ? document.querySelector(st.sel) : null;
+  if (el && !st.click) { el.inert = true; TOUR.inert = el; }
   if (el && el.scrollIntoView) {
     el.scrollIntoView({block: 'center', behavior: 'smooth'});
     // Let the scroll settle before measuring, or the hole lands where the
@@ -8080,6 +8183,15 @@ async function tourShow() {
     document.addEventListener('click', once, true);
     TOUR.drop = () => document.removeEventListener('click', once, true);
   }
+}
+
+// Undo the inert of the step just left. Held on TOUR rather than looked up
+// again, because a render between steps replaces the element and the one
+// that was frozen would no longer be findable. #refresh and the account
+// menu live OUTSIDE #app and survive every render, so failing to release
+// them would leave the topbar dead for the rest of the session.
+function tourRelease() {
+  if (TOUR && TOUR.inert) { TOUR.inert.inert = false; TOUR.inert = null; }
 }
 
 function tourPaint(el, st) {

--- a/portal/tests/test_guided_tour.py
+++ b/portal/tests/test_guided_tour.py
@@ -61,6 +61,48 @@ def test_every_id_target_is_still_rendered():
         assert f'id="{el}"' in INDEX, f"nothing renders #{el}"
 
 
+def test_every_action_target_is_still_rendered():
+    """A step can also aim at a control by its data-act, which is what the
+    overview's Edit button is. Unlike a data-tour hook that exists only for
+    the tour, a data-act is real wiring somebody may rename while doing
+    something else entirely - and the tour would then dim the page and
+    centre its card, which looks like the step meant to do that."""
+    used = set(re.findall(r'sel: \'\[data-act="([a-z-]+)"\]\'', TOURS))
+    assert used, "no data-act steps parsed; this test is guarding nothing"
+    for act in used:
+        assert f'data-act="{act}"' in INDEX, f"nothing renders data-act={act}"
+
+
+def test_the_tour_walks_every_section_of_the_nav():
+    """The tour is the only description of the whole product, and a section
+    it never mentions is one a new colleague does not know exists. Budget
+    and Fleet were both missing for exactly that reason: they shipped after
+    the tour was written, and nothing here noticed.
+
+    'home' is exempt because it is where the tour opens - there is no nav
+    click onto the page you already start on."""
+    nav = INDEX.split("const NAV = [", 1)[1].split("\n];", 1)[0]
+    sections = set(re.findall(r"\{id:'([a-z]+)'", nav)) - {"home"}
+    for role in ("admin", "viewer"):
+        block = TOURS.split(role + ": [", 1)[1].split("\n  ],", 1)[0]
+        reached = set(re.findall(r'sel: \'\[data-s="([a-z]+)"\]\'', block))
+        missing = sections - reached
+        assert not missing, f"{role} tour never reaches: {sorted(missing)}"
+
+
+def test_both_roles_walk_the_same_number_of_steps():
+    """The two tours are deliberately separate copy - a viewer is told who
+    to ask where an admin is told what to change - but they describe one
+    product. A step added to one and forgotten in the other is how the
+    read-only account ends up with a shorter, quietly different tool."""
+    counts = {}
+    for role in ("admin", "viewer"):
+        block = TOURS.split(role + ": [", 1)[1].split("\n  ],", 1)[0]
+        counts[role] = block.count("{title:") + block.count("{view:")
+    assert counts["admin"] == counts["viewer"], counts
+    assert counts["admin"] >= 13, f"steps went missing: {counts}"
+
+
 def test_both_roles_have_a_tour():
     """An admin and a viewer are looking at different products, and a
     missing role would silently fall back to the other one's."""
@@ -121,3 +163,35 @@ def test_every_step_carries_a_way_forward():
     assert "st.click ? '' : 'pri'" in card, \
         "next should be secondary on a click step, not absent"
     assert "'End tour'" in card, "the way out has to say what it does"
+
+
+def test_a_described_control_cannot_be_used_during_the_tour():
+    """The shade and the ring both pass clicks through, deliberately, so a
+    step that asks somebody to press a real control can let them. The cost
+    was that every spotlighted control stayed fully live: Edit opened the
+    arranger behind the card, the corporate domains field took typing in
+    the middle of a walkthrough, and Refresh reloaded the page on the last
+    step. inert rather than pointer-events, because the keyboard reaches a
+    focusable field whatever the mouse is allowed to do."""
+    assert "if (el && !st.click) { el.inert = true; TOUR.inert = el; }" in INDEX
+
+
+def test_the_frozen_control_is_always_released():
+    """#refresh and the account menu live outside #app and survive every
+    render, so a step that froze one and never released it would leave the
+    topbar dead for the rest of the session - long after the tour ended."""
+    assert "function tourRelease()" in INDEX
+    end = INDEX.split("async function tourEnd(", 1)[1][:300]
+    assert "tourRelease()" in end, "ending the tour has to release it"
+    abort = INDEX.split("function tourAbort()", 1)[1][:300]
+    assert "tourRelease()" in abort, "a session going away has to release it"
+    show = INDEX.split("async function tourShow()", 1)[1][:1400]
+    assert "tourRelease()" in show, "each step has to release the last one"
+
+
+def test_leaving_the_tour_early_says_where_it_lives():
+    """Somebody who ends the tour on step two never reaches the last step,
+    which is the only place that says the tour can be taken again."""
+    assert '<dialog id="tourdlg"' in INDEX
+    assert "if (!done) tourDoneShow();" in INDEX
+    assert "Settings &rsaquo; Getting started" in INDEX

--- a/portal/tests/test_review_findings.py
+++ b/portal/tests/test_review_findings.py
@@ -633,8 +633,15 @@ def test_a_bare_url_lands_on_the_overview_not_on_sources():
     assert "return VIEWS.includes(h) ? h : 'setup';" not in html
     # The first-run paths are untouched: the wizard still parks on Sources,
     # and it still opens itself over an empty fragment.
+    #
+    # `first` is the one exemption, and it is not a loophole in this rule:
+    # it is set only where the FIRST account on a deployment is created and
+    # is consumed by the very next load(). Everything this test guards - a
+    # bare URL, and a fragment the operator chose - is unchanged, because by
+    # then there is no first account left to create.
     assert "view = 'setup'; detail = null;" in html
-    assert "(!location.hash || location.hash === '#wizard')" in html
+    assert "(first || !location.hash || location.hash === '#wizard')" in html
+    assert "if (act === 'do-setup') FIRSTRUN = true;" in html
 
 
 def test_a_map_keyed_on_the_bare_serial_still_finds_the_machine():

--- a/portal/tests/test_wizard.py
+++ b/portal/tests/test_wizard.py
@@ -458,3 +458,64 @@ def test_the_extension_setup_offers_the_way_back_it_actually_owes_you():
     assert "view = h.view; detail = null; EXTFROM = '';" in html
     # One exit per screen.
     assert "${EXTPAGE === 6 ? '' : EXTFROM === 'wizard'" in html
+
+
+def test_the_first_account_created_goes_to_the_wizard_not_the_tour():
+    """The wizard otherwise opens only on a bare fragment, so that an
+    operator who navigated somewhere on purpose is not dragged back to it.
+    The very first sign-in has no such intent to respect: a tab still
+    carrying #settings/start from before the volume was wiped skipped the
+    wizard entirely, and maybeTour() then handed a brand new deployment the
+    walkthrough instead of the setup it had not done."""
+    html = (main.STATIC / "index.html").read_text()
+    assert "if (act === 'do-setup') FIRSTRUN = true;" in html
+    assert "const first = FIRSTRUN;" in html
+    assert "FIRSTRUN = false;" in html
+    assert "(first || !location.hash || location.hash === '#wizard')" in html
+
+
+def test_skipping_the_wizard_says_where_it_went():
+    """Skip and Finish wrote the same thing, so skipping retired the wizard
+    for good without a word about it - and the two required steps are the
+    ones whose absence makes the deployment run WRONG rather than not run.
+    Skip is now its own action, and it asks first."""
+    html = (main.STATIC / "index.html").read_text()
+    # The button is Skip only while a required step is outstanding.
+    assert "canGo ? 'wiz-finish' : 'wiz-skip'" in html
+    assert "if (act === 'wiz-skip') { skipShow(); return; }" in html
+    assert '<dialog id="skipdlg"' in html
+    assert "Settings &rsaquo; Getting started" in html
+    # Confirming does exactly what finishing does, rather than a second copy
+    # of it that can drift.
+    assert "await managedAction('wiz-finish')" in html
+
+
+def test_the_skip_dialog_owns_escape_like_the_other_one():
+    """Same trap as the password modal: the drawer's Escape handler is a
+    later window listener, so guarding it on live state alone let one
+    keystroke dismiss the dialog AND whatever was open behind it."""
+    html = (main.STATIC / "index.html").read_text()
+    assert "if (skipIsOpen()) { skipHide(); e.stopImmediatePropagation(); return; }" in html
+    assert "pwIsOpen() || skipIsOpen()" in html
+
+
+def test_a_viewer_can_leave_the_wizard():
+    """Finish and Skip both write onboarding_done, and the receiver refuses
+    the write from a read-only account - so the only way out of a wizard a
+    viewer can reach from Settings answered 'this account is read-only' and
+    left them on it. The nav was the only escape.
+
+    Nothing is being saved either way, so for a viewer leaving is
+    navigation: one button, no write, no refusal to report."""
+    html = (main.STATIC / "index.html").read_text()
+    assert "const wizRO = AUTH && AUTH.role === 'viewer';" in html
+    assert "if (act === 'wiz-close') {" in html
+    # BOTH exits are role-aware: the footer button, and the one step 7
+    # shows in place of Next. Missing either leaves a viewer stuck on that
+    # step instead of on the wizard, which is the same trap in one place.
+    assert html.count("wizRO ? 'wiz-close'") == 2
+    assert html.count("${wizRO ? 'wiz-close' : 'wiz-finish'}") == 1
+    # And it lands back on the tab the button that opens the wizard is on.
+    close = html.split("if (act === 'wiz-close') {", 1)[1][:400]
+    assert "SETTAB = 'start'" in close
+    assert "mfetch" not in close, "a viewer's exit must not attempt a write"


### PR DESCRIPTION
Two commits: what a first run does, and the walkthrough it hands you to. Both found by wiping the volume and doing one.

## A new deployment opens on the wizard

- **First run got the tour instead of the wizard.** The wizard opens only over a bare fragment, so an operator who navigated somewhere on purpose is not dragged back. A brand new deployment has no such intent to respect - and wiping a volume does not wipe the address bar. A tab still carrying `#settings/start` from before the reset skipped the wizard entirely, and the walkthrough, whose only guard is "not while the wizard is up", opened instead: a tour of a portal that had never been configured. Creating the *first* account now sets a flag the next load consumes; the rule is unchanged for every visit after it.
- **Skip and Finish were the same action.** Both wrote `onboarding_done`, so skipping retired the wizard for good without a word about where it went - and the two required steps are exactly the ones whose absence makes a deployment run *wrong* rather than not run. Skip is its own action now and asks first, naming **Settings › Getting started**. Confirming calls the finish path rather than a second copy that can drift.
- **A viewer could not leave.** Both exits write `onboarding_done`, the receiver refuses that write from a read-only account, so the only way out of a wizard reachable from Settings answered *"this account is read-only"* and left them on it - the nav was the only escape. Nothing is being saved either way, so for a viewer leaving is navigation: one **Close**, no write. Step 7's exit is role-aware too; missing it strands them on a step instead of the wizard.

## The walkthrough covers the whole product

Written when there were five nav sections, and not moved since. Budget and Fleet both shipped after it, so a new colleague was never told they existed - and its last step pointed at Settings › Account for a re-entry that moved to Getting started yesterday.

Thirteen steps now, in nav order, each spotlighting the section it hands you to next - the idiom it already used, extended rather than replaced. Four are new: **arranging the overview**, **Budget**, **Fleet**, and **your own account**, where changing a password now lives.

Admin and viewer stay separate copy, because a viewer is told who to ask where an admin is told what to change: arranging the overview is theirs and read-only does not stop it, revoking a device is not, and their own password is titled as the one thing on the Settings screen they *can* change.

## Two bugs the spotlight was hiding

- **You could use what it pointed at.** The shade and ring pass clicks through deliberately, so a step asking you to press a real control can let you - but every other step inherited it. Edit opened the arranger behind the card, the corporate domains field took typing mid-walkthrough, and Refresh would have reloaded the page on the last step. A step that only *describes* a control now makes it `inert` - which stops the keyboard, not just the mouse; a step that asks for a click deliberately does not. Releasing matters as much: `#refresh` and the account menu live outside the rendered view and survive every render, so one left frozen would kill the topbar for the rest of the session.
- **The footer overflowed at thirteen steps.** Thirteen dots and three buttons came to 322px inside a 322px card - exact, nothing spare. The card is `min(360px, 100vw - 32px)`, so a narrow viewport pushed Next outside a card that neither scrolls nor clips: 3px over at 360px, **43px at 320px**. The footer wraps now and the buttons do not shrink, because the dots should give way, not the way forward.

Leaving early also said nothing: the last step is the only place that mentions retaking the tour, so ending early now says it, and only then.

## Testing

513 portal tests (up from 509). New guards for what rots: every step's view, nav section, `data-tour` hook, `id` **and now `data-act`** target must still render; both tours must reach every nav section (Budget and Fleet went missing precisely because nothing checked); both must have the same step count; the frozen control is always released; and a viewer's wizard exit contains no write at all.

One existing test failed and was right to - `test_a_bare_url_lands_on_the_overview_not_on_sources` pins the first-run condition string. It was updated to the new expression with a note on why the first-account flag is not a loophole, rather than loosened.

Verified in the browser: `inert` measured on a rendered button and input (hit-testable and focusable → neither → restored), the footer at 1280/390/360/320, and both dialogs taking Escape without closing a drawer behind them.