### PR TITLE
release: 0.17.0, with single sign-on flagged beta

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.16.9
+version: 0.17.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.16.9"
+appVersion: "0.17.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.9
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.9
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -4657,8 +4657,13 @@ function accountSettings() {
     ${`${(() => {
       const on = ((SETTINGS && SETTINGS.settings && SETTINGS.settings.sso_enabled
         && SETTINGS.settings.sso_enabled.value) === '1');
+      // Beta, and said where somebody is about to act on it rather than
+      // only in the docs: it has not been run against a real Entra app
+      // registration, and this card is the last screen before a team is
+      // moved onto it.
       return `<p style="margin:0 0 6px"><span class="pill p-ok">${
-        on ? 'On' : 'Off'}</span></p>
+        on ? 'On' : 'Off'}</span> <span class="pill p-amb"
+        title="not yet run against a real Entra app registration">beta</span></p>
       <p class="lede">${on
         ? 'People with an email address on their account can sign in through '
           + 'Microsoft Entra. Passwords keep working, so an account without '

--- a/portal/tests/test_account_email_and_preferences.py
+++ b/portal/tests/test_account_email_and_preferences.py
@@ -230,6 +230,18 @@ def test_the_wizard_is_owner_only():
     assert "AUTH && AUTH.role === 'owner' ? (SSOW ? ssoWizard()" in INDEX
 
 
+def test_the_sso_card_says_it_is_beta():
+    """Beta is stated where somebody is about to act on it, not only in the
+    docs. Single sign-on has not been run against a real Entra app
+    registration, and this card is the last screen before a team is moved
+    onto it - so it belongs beside the On/Off pill rather than in a README
+    the person configuring it may never open."""
+    card = INDEX.split("<h3>Single sign-on</h3>", 1)[1][:900]
+    assert 'class="pill p-amb"' in card
+    assert ">beta</span>" in card
+    assert "real Entra app registration" in card
+
+
 def test_the_redirect_uri_is_offered_not_asked_for():
     """It has to match the app registration exactly, so the page shows the
     one it would actually use rather than asking somebody to compose it."""

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.16.9
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Version bump for 0.17.0, plus the one thing that should ship with it.

## What's in 0.17.0

Thirteen PRs since 0.16.9, and the shape of them is one thing: **the portal became something you can hand to somebody else.**

- **Accounts.** An owner role beside admin and viewer, with a rank rule that makes the tier mean something - you cannot act on an account that outranks you, or grant a role above your own. Roles change in place. Accounts carry an email address, and preferences follow a person between browsers.
- **Single sign-on with Microsoft Entra** (beta), through a five-step wizard.
- **The overview, arranged per person** - drag, stack into columns, resize, hide, and a second form on the cards where the data has more than one honest reading.
- **A guided walkthrough**, now covering every section of the portal in the words of the role taking it.
- **Four wizards sharing one language** - setup, sign-on, define a tool, link a tool - and the first-run setup rebuilt as seven steps with a required/recommended/optional rail.
- **Settings reorganised**: Detection & paste guard, a Getting started tab, and your own password moved to the header menu where a viewer can reach it.
- **Budget**: five more vendor syncs.
- Plus the first-run fixes from #209 and the docs pass from #210.

## The beta flag

Single sign-on ships beta and now **says so on the card that configures it**, not only in the docs:

```
SINGLE SIGN-ON
[ Off ] [ beta ]      ← amber, title="not yet run against a real Entra app registration"
```

It has not been run against a real Entra app registration, and that card is the last screen before a team is moved onto it - a README the person configuring it may never open is the wrong place for the one caveat that matters. It authenticates rather than provisions, and local passwords keep working beside it, so an account without an address stays reachable as a break-glass credential.

## The bump

`chart 0.17.0, appVersion 0.17.0; pins to 0.17.0` - the same three files every previous bump touches:

- `charts/ai-guard/Chart.yaml` (version + appVersion)
- `receiver/deploy/receiver.yaml` (image pin)
- `docs/deployment/kubernetes.md` (two image references)

Verified nothing is left on 0.16.9 anywhere in the tree.

## After this merges

Tagging `v0.17.0` is what actually publishes: CI builds all four images on a tag (tags always build, regardless of which paths changed), tags them `0.17.0` and `latest`, then `publish-chart` packages and pushes the chart as OCI and confirms the published chart resolves.

## Testing

514 portal tests (up from 513 - the new one pins the beta pill beside the other SSO card tests). The pill was checked rendered against the real stylesheet rather than assumed: amber `p-amb` on the existing pill scale, sitting beside `Off`.