### PR TITLE
release: 0.17.1, so the sign-on wizard can save

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.17.0
+version: 0.17.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.17.0"
+appVersion: "0.17.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.1
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.1
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.1
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Patch release on top of #212.

The portal's `SettingsWrite` is `extra=forbid` and never gained the five `sso_*` keys, `webhook_url` or `extension_crx_url`. Three things the page offers could not be saved at all: the sign-on wizard's fourth step, the notification webhook row and the packed .crx row. The portal refused the body before it reached the receiver, and a 422 whose `detail` is a list falls through to the page's generic `check the values` - which points at the value somebody has just typed, so the redirect step read as a rejected URI when no URI was going to work.

Single sign-on stays beta. This is what stopped it being configurable, not evidence it has met a real app registration.

## The bump

- `charts/ai-guard/Chart.yaml` - `version` and `appVersion` to 0.17.1
- `receiver/deploy/receiver.yaml` - image pin
- `docs/deployment/kubernetes.md` - both image references

A repo-wide grep leaves one `0.17.0` behind on purpose: a test docstring naming the release the body was refused by.

Tag after merge; the tag is what builds the images and publishes the chart.