### PR TITLE
release: 0.18.0, single sign-on you can require

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.17.1
+version: 0.18.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.17.1"
+appVersion: "0.18.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.1
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.18.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.1
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.18.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.17.1
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.18.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Release on top of #214.

Federated sign-in stopped being a thing you configure and became a thing you can rely on.

- **Single sign-on can be required.** A password stops being enough for every account but one, which is how a tenant's multi-factor policy ends up in front of this portal rather than beside it.
- **A break-glass account**, marked at creation rather than nominated later, that cannot be deleted or demoted while it is load-bearing.
- **Enforcement will not switch on** until an owner has actually completed a sign-in through the provider.
- **The sign-in screen offers Microsoft**, and the wizard grew a first step for the addresses a federated sign-in matches on.
- **The demo stack ships a stand-in identity provider**, so the whole flow can be walked from a fresh clone with no tenant.

Single sign-on stays beta: it has completed a sign-in against a provider written for the demo, which is not the same claim as having met a real app registration.

## The bump

- `charts/ai-guard/Chart.yaml` - `version` and `appVersion` to 0.18.0
- `receiver/deploy/receiver.yaml` - image pin
- `docs/deployment/kubernetes.md` - both image references

A repo-wide grep leaves nothing on 0.17.1.

## Upgrading

Additive. The migration marks the earliest owner as the break-glass account, so an existing deployment needs no action - enforcement stays off until an owner turns it on, and cannot be turned on until a real sign-in has completed.

Tag after merge; the tag is what builds the images and publishes the chart.