### PR TITLE
Fix the sign-in screen after a sign-out, and centre the card

### DIFF
--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1366,7 +1366,7 @@ def esc_attr(v) -> str:
 
 
 def _sso_page(title: str, body: str, go: str = "",
-              who: str = "") -> HTMLResponse:
+              who: str = "", test: bool = False) -> HTMLResponse:
     """The callback's own answer, as a page rather than a redirect.
 
     A redirect would be a cross-site navigation - the chain started at the
@@ -1386,20 +1386,25 @@ def _sso_page(title: str, body: str, go: str = "",
     # other, and a static script reads them back. There is no injection
     # point left to get the escaping wrong in.
     payload = json.dumps({"ssoTest": "ok" if go else "fail",
-                          "username": who, "detail": body, "go": go})
-    # An opener means this tab was opened BY the portal - the wizard's test
-    # sign-in, which already has its answer the moment the message lands.
-    # Navigating such a tab into the portal drops somebody into whatever
-    # the app decides a fresh load should show (on a deployment that has
-    # not finished setup, that is the first-run wizard) in a tab they only
-    # opened to prove a configuration. So: report to the opener and stop.
-    # A tab with no opener is a real sign-in from the sign-in screen, and
-    # going to the portal is the whole point of it.
+                          "username": who, "detail": body, "go": go,
+                          "test": test})
+    # Whether this was the wizard proving a configuration, or somebody
+    # actually arriving. The wizard's tab has its answer the moment the
+    # message lands, and navigating it into the portal drops somebody into
+    # whatever a fresh load shows, in a tab they opened only to run a test.
+    # A real sign-in has to go to the portal, which is the whole point.
+    #
+    # This asked window.opener until it was tried in anger. An opener is
+    # set by ANY link opened in a new tab or window, so somebody opening
+    # the sign-in screen that way and then signing in normally was told to
+    # close their tab and go back to a wizard they had never opened - and
+    # was left sitting on the callback page. The flag now travels with the
+    # sign-in itself, from the wizard that started it.
     tell = (f'<div id="ssor" hidden data-r="{esc_attr(payload)}"></div>'
             '<script>(function(){try{'
             'var r=JSON.parse(document.getElementById("ssor").dataset.r);'
-            'if(window.opener){window.opener.postMessage(r,location.origin);'
-            'document.documentElement.dataset.opener="1";return;}'
+            'if(window.opener)window.opener.postMessage(r,location.origin);'
+            'if(r.test){document.documentElement.dataset.test="1";return;}'
             'if(r.go)location.replace(r.go);'
             '}catch(e){}})()</script>')
     # Shown to whoever did not get navigated away: the test tab, and
@@ -1419,7 +1424,7 @@ def _sso_page(title: str, body: str, go: str = "",
         "@media(prefers-color-scheme:dark){p{color:#9aa3ad}}"
         # The test tab keeps the closing line and drops the link that
         # would take it into the portal; a real sign-in does the reverse.
-        "[data-opener] a{display:none}[data-opener] p.t{display:block!important}"
+        "[data-test] a{display:none}[data-test] p.t{display:block!important}"
         "</style>"
         f"<h1>{esc_attr(title)}</h1><p>{esc_attr(body)}</p>{onward}")
 
@@ -1429,8 +1434,13 @@ def sso_start(request: Request):
     """Send the browser to the identity provider."""
     _login_mode_only()
     try:
-        out = managed.receiver_request(RECEIVER_URL, "GET", "/admin/sso/start",
-                                       "", None)
+        # ?test=1 says the sign-on wizard started this, not a person
+        # arriving. It rides to the receiver, which remembers it against
+        # the state, because nothing on the way back could carry it.
+        path = "/admin/sso/start"
+        if request.query_params.get("test") == "1":
+            path += "?test=1"
+        out = managed.receiver_request(RECEIVER_URL, "GET", path, "", None)
     except managed.ReceiverError as e:
         if e.status == 404:
             return _sso_page("Single sign-on is not set up",
@@ -1475,8 +1485,14 @@ async def sso_callback(request: Request):
     if not out.get("ok"):
         return _sso_page("Signed in, but not here",
                          str(out.get("detail") or "that sign-in was refused"))
-    resp = _sso_page("Signed in", "Taking you to the portal.", go="/",
-                     who=str(out.get("username", "")))
+    is_test = bool(out.get("test"))
+    resp = _sso_page("Signed in",
+                     # The test tab is not going anywhere, so it must not
+                     # say it is. The body is the sentence somebody reads
+                     # while deciding whether to wait or to act.
+                     "That is the configuration proved."
+                     if is_test else "Taking you to the portal.",
+                     go="/", who=str(out.get("username", "")), test=is_test)
     resp.set_cookie(SESSION_COOKIE, str(out.get("token", "")),
                     httponly=True, samesite="strict",
                     secure=_cookie_secure(request), path="/")

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -1268,8 +1268,10 @@ function showLogin(msg) {
 // response is the login screen with a line saying why, not a broken view.
 async function sessionLost() {
   if (AUTH) AUTH.authenticated = false;
-  try { AUTH = await (await fetch('/api/auth')).json(); } catch (e) { /* keep what we had */ }
-  showLogin('Signed out — the session expired or was revoked. Sign in again.');
+  // Same reason sign-out re-asks: the screen this is about to draw depends
+  // on fields only the server knows.
+  await refreshAuth();
+  showLogin('Signed out - the session expired or was revoked. Sign in again.');
 }
 
 async function boot() {
@@ -8078,9 +8080,41 @@ fold.onclick = () => {
 try { if (localStorage.getItem('aiguard-side')) fold.onclick(); } catch (e) {}
 document.getElementById('signout').onclick = async () => {
   await mfetch('/api/logout', {method: 'POST'});
-  AUTH = {mode: 'login', authenticated: false, username: '', setup_needed: false};
+  // Re-ask rather than compose one. A hand-written AUTH is missing every
+  // field somebody adds later, and it was: sso and sso_enforced were both
+  // absent, so signing out took the Microsoft button off the screen and a
+  // manual reload was the only way to get it back - on a deployment where
+  // single sign-on is REQUIRED, that left a password form nobody but the
+  // break-glass account could use.
+  await refreshAuth();
   showLogin('Signed out.');
 };
+
+// The one place that knows what the sign-in screen needs. Falls back to a
+// signed-out shape if the receiver cannot be reached, because a sign-out
+// that leaves somebody looking at a stale dashboard is worse than one that
+// offers a password box it is not certain about.
+async function refreshAuth() {
+  try {
+    AUTH = await (await fetch('/api/auth')).json();
+  } catch (e) {
+    AUTH = {mode: 'login', authenticated: false, username: '', role: '',
+            setup_needed: false, sso: false, sso_enforced: false};
+  }
+}
+
+// Coming back to a page the browser kept: a bfcache restore, or a second
+// tab woken up after somebody signed out in the first. Both repaint the
+// last thing rendered, which can be a whole dashboard belonging to a
+// session that no longer exists. Nothing here trusts what is on screen -
+// it asks, and shows the sign-in screen when the answer is nobody.
+window.addEventListener('pageshow', async e => {
+  if (!e.persisted) return;
+  await refreshAuth();
+  if (AUTH && AUTH.mode === 'login' && !AUTH.authenticated) {
+    showLogin('That session has ended. Sign in again.');
+  }
+});
 // ---- the guided tour -------------------------------------------------
 // A first sign-in lands on eleven views with no way to tell which of them
 // answers the question the person came with. This walks them through the

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -7055,7 +7055,7 @@ async function managedAction(act, el) {
     // Not noopener: the new tab reports its result back by postMessage,
     // and that needs an opener to report to. Same origin both ways.
     SSOW.busy = 'test'; SSOW.err = ''; render();
-    window.open('/sso/start', 'aiguard-sso-test');
+    window.open('/sso/start?test=1', 'aiguard-sso-test');
     return;
   }
   if (act === 'sso-enable') {

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -488,6 +488,19 @@ table.plain td{border-bottom:0;padding:4.5px 10px 4.5px 0;vertical-align:middle}
 a.libtn{display:inline-flex;align-items:center;gap:9px;text-decoration:none;
   font:inherit;font-size:12.5px;font-weight:550;padding:7px 16px;
   border:1px solid var(--bd);border-radius:7px;color:var(--pri);cursor:pointer}
+/* The sign-in card centres, and its two buttons go full width. With
+   single sign-on required the provider button is the ONLY control on
+   the card, and a lone left-aligned button in a centred card reads as
+   an accident. Scoped: .wcard is on every page. */
+.licard,.licard .lede,.licard h2,.licard .src-note{text-align:center}
+.licard button.mini{display:block;width:100%;padding:9px 16px}
+.licard a.libtn{display:flex;width:100%;justify-content:center;
+  padding:9px 16px;box-sizing:border-box}
+/* The disclosure summary is width:max-content so its arrow sits by the
+   text; centring it needs the box centred, not the text. */
+.licard details.how{max-width:none}
+.licard details.how summary{margin-left:auto;margin-right:auto}
+.licard details.how>div{text-align:left}
 a.libtn:hover{border-color:var(--pri)}
 .ssfoot{display:flex;gap:8px;align-items:center;margin-top:18px;padding-top:14px;
   border-top:1px solid var(--bd)}
@@ -1224,9 +1237,9 @@ function showLogin(msg) {
       data-act="${create ? 'do-setup' : 'do-login'}">${
       create ? 'Create account' : 'Sign in'}</button>`;
   app.innerHTML = `<div style="max-width:470px;margin:9vh auto 0">
-    <div class="wcard" style="padding:28px 30px">
+    <div class="wcard licard" style="padding:28px 30px">
     <img src="/logo.png" alt="Shadow AI Guard"
-      style="width:230px;max-width:100%;display:block;margin:0 0 20px">
+      style="width:230px;max-width:100%;display:block;margin:0 auto 20px">
     <h2>${create ? 'Create the admin account' : 'Sign in'}</h2>
     <p class="lede">${create
       ? `No admin account exists yet. The receiver printed a one-time setup

--- a/portal/tests/test_login.py
+++ b/portal/tests/test_login.py
@@ -360,25 +360,36 @@ def test_diagnostics_report_the_login_mode(login_mode):
 # --------------------------------------------------- the callback's two jobs --
 
 
-def test_a_test_sign_in_reports_to_its_opener_and_stays_put():
-    """The wizard's test opens a second tab. That tab has told the opener
-    everything the moment its message lands, so navigating it into the
-    portal drops somebody into whatever a fresh load decides to show - on a
-    deployment still mid-setup, the first-run wizard - in a tab they only
-    opened to prove a configuration."""
+def test_the_wizards_test_sign_in_stays_put():
+    """The wizard's test has its answer the moment the message lands, so
+    the tab must not navigate into the portal afterwards."""
     html = main._sso_page("Signed in", "Taking you to the portal.",
-                          go="/", who="gengar").body.decode()
+                          go="/", who="gengar", test=True).body.decode()
     assert 'window.opener.postMessage' in html
+    # The payload is HTML-escaped into an attribute on purpose - see the
+    # note in _sso_page about provider text and script contexts.
+    assert "&quot;test&quot;: true" in html
     # The return is what stops the navigation below it running.
-    assert 'dataset.opener="1";return;' in html
+    assert 'dataset.test="1";return;' in html
     assert "You can close this tab" in html
 
 
-def test_a_real_sign_in_still_goes_to_the_portal():
-    """No opener means the sign-in screen sent them, and arriving at the
-    portal is the entire point."""
+def test_a_real_sign_in_goes_to_the_portal():
+    """Somebody actually arriving must land in the portal, and must not be
+    told to close their tab and go back to a wizard they never opened."""
     html = main._sso_page("Signed in", "Taking you to the portal.",
                           go="/", who="gengar").body.decode()
+    assert "&quot;test&quot;: false" in html
+    assert 'dataset.test' in html          # the branch exists
     assert "if(r.go)location.replace(r.go)" in html
-    # And the link a browser running no script at all would need.
     assert 'href="/"' in html
+
+
+def test_the_marker_does_not_come_from_window_opener():
+    """It used to. An opener is set by ANY link opened in a new tab, so
+    somebody who opened the sign-in screen that way and signed in normally
+    was told to close their tab and left sitting on the callback page.
+    The flag now travels with the sign-in that started it."""
+    html = main._sso_page("Signed in", "x", go="/", who="a").body.decode()
+    assert "if(window.opener){" not in html
+    assert 'dataset.opener' not in html

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -1462,9 +1462,15 @@ async def sso_start(request: Request):
     verifier = _b64u(secrets.token_bytes(48))
     state = _b64u(secrets.token_bytes(24))
     nonce = _b64u(secrets.token_bytes(24))
+    # Whether this is the wizard proving a configuration rather than
+    # somebody actually arriving. It has to be remembered HERE, against the
+    # state, because the answer comes back as a cross-site form post
+    # carrying nothing but a code and that state - there is no cookie on
+    # it and no fragment, so the browser cannot be asked afterwards.
     _SSO_FLIGHT[state] = {"nonce": nonce, "verifier": verifier,
                           "at": time.time(), "issuer": doc["issuer"],
-                          "token_endpoint": doc["token_endpoint"]}
+                          "token_endpoint": doc["token_endpoint"],
+                          "test": request.query_params.get("test") == "1"}
     challenge = _b64u(hashlib.sha256(verifier.encode()).digest())
     return {"authorize_url": doc["authorization_endpoint"] + "?" + urllib.parse.urlencode({
         "client_id": conf["client_id"],
@@ -1572,7 +1578,8 @@ async def sso_callback(req: SSOCallback):
     out = STATE.sso_login(user["id"], ttl_hours=SESSION_TTL_HOURS)
     return {"ok": True, "token": out["token"], "username": out["username"],
             "role": out["role"], "expires_at": out["expires_at"],
-            "bound_now": not user["bound"]}
+            "bound_now": not user["bound"],
+            "test": bool(flight.get("test"))}
 
 # ------------------------------------------------------- central settings --
 # Deployment configuration the portal edits and the fleet hears at runtime.


### PR DESCRIPTION
Three fixes found by driving 0.18.0 against a real identity provider. Each commit is green on its own.

## `sso:` the wizard's test marker travels with the sign-in

The callback page has two jobs and told them apart by asking `window.opener`. That is wrong in a way only real use exposes: **an opener is set by any link opened in a new tab or window.** Somebody who opened the sign-in screen that way and then signed in perfectly normally was told to close their tab and go back to a setup wizard they had never opened, and was left sitting on the callback page instead of arriving at the portal.

The flag now travels with the sign-in that started it: the wizard opens `/sso/start?test=1`, the receiver stores it against the state, and the callback reports it back. It has to live at the receiver because the answer arrives as a cross-site form post carrying nothing but a code and that state - no cookie rides on it and no fragment survives, so the browser cannot be asked afterwards.

A test tab also stopped claiming it was taking anybody to the portal, since it is not going anywhere.

## `portal:` a sign-out leaves the sign-in screen telling the truth

Signing out composed a fresh `AUTH` by hand instead of asking the server:

```js
AUTH = {mode:'login', authenticated:false, username:'', setup_needed:false};
```

Missing `sso` and `sso_enforced`, both added since. So the Microsoft button vanished the moment somebody signed out and only a manual reload brought it back. **On a deployment where single sign-on is required that is worse than cosmetic** - what is left is a password form that only the break-glass account can use, offered to everybody.

Nothing composes that object now; both callers ask, and the expired-session path shares the helper so they cannot drift apart again.

A bfcache restore gets the same treatment. The browser repaints the last thing rendered, which can be a whole dashboard belonging to a session that no longer exists, and it looks live until something is clicked.

## `portal:` the sign-in card centres, and its buttons go full width

Left and shrink-to-fit was defensible while the provider button was one option among two. It is not once single sign-on is required, because then it is the only control on the card. The disclosure keeps its body text left-aligned - a centred paragraph is harder to read than a short centred label. Scoped to a class only the sign-in card carries.

## Checked

Portal 521, receiver 252. All four states driven in a running stack against the demo provider: signed in, signed out, required, and required with the password disclosure open. Both callback paths verified - marked stays put, unmarked lands in the portal.