### PR TITLE
release: 0.18.1, the sign-in screen after a sign-out

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.18.0
+version: 0.18.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.18.0"
+appVersion: "0.18.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.18.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.18.1
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.18.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.18.1
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.18.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.18.1
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Release on top of #216. All three fixes came from 0.18.0 being driven against a real identity provider rather than the stand-in one.

- **Signing out took the Microsoft button off the screen.** `AUTH` was composed by hand and missing two fields added since. Where single sign-on is required, that left a password form only the break-glass account can use, offered to everybody.
- **A real sign-in was mistaken for the wizard's test**, because the callback asked `window.opener` - which is set by any link opened in a new tab. The marker now travels with the sign-in that started it.
- **The sign-in card centres**, which is the state the old layout looked accidental in: with single sign-on required the provider button is the only control on the card.

## The bump

- `charts/ai-guard/Chart.yaml` - `version` and `appVersion` to 0.18.1
- `receiver/deploy/receiver.yaml` - image pin
- `docs/deployment/kubernetes.md` - both image references

A repo-wide grep leaves nothing on 0.18.0.

## Upgrading

Nothing to do beyond the version. No setting changes shape and no migration runs.

Tag after merge; the tag is what builds the images and publishes the chart.