### PR TITLE
A sign-in somebody actually did, and a freshness window that is checked

### DIFF
--- a/demo/entra-mock/provider.py
+++ b/demo/entra-mock/provider.py
@@ -103,6 +103,10 @@ def _id_token(person: dict, nonce: str) -> str:
         "nonce": nonce,
         "iat": now,
         "exp": now + 600,
+        # When the person proved who they are, as distinct from when this
+        # token was minted. The receiver checks it against the max_age it
+        # asked for, and refuses a token that omits it.
+        "auth_time": now,
         "name": person["name"],
         "email": person["email"],
         "preferred_username": person["email"],

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1678,6 +1678,7 @@ class SettingsWrite(BaseModel):
     sso_redirect_uri: str | None = Field(default=None, max_length=500)
     sso_enabled: str | None = Field(default=None, max_length=1)
     sso_enforce: str | None = Field(default=None, max_length=1)
+    sso_max_age_hours: str | None = Field(default=None, max_length=4)
     smtp_host: str | None = Field(default=None, max_length=255)
     smtp_port: str | None = Field(default=None, max_length=5)
     smtp_username: str | None = Field(default=None, max_length=255)

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -5604,6 +5604,29 @@ function ssoEnforceBlock() {
       owner has completed a sign-in through Entra yet. Requiring it before
       the door has been opened once would leave only the break-glass
       account, so this stays available until one has.</div>` : ''}
+    <div style="border-top:1px solid var(--bd);margin-top:14px;padding-top:14px">
+      <p style="margin:0 0 6px"><b style="font-size:13px">How recently they
+        must have signed in</b></p>
+      <p class="lede">Somebody already signed in to Microsoft in their
+        browser was being returned straight here with no interaction at all -
+        click a link and you are inside a tool that says who uses which AI.
+        Signing in now always asks them to pick an account, and this decides
+        how stale that sign-in may be before the provider makes them prove it
+        again.</p>
+      <p><select id="sso-maxage" class="mfield" style="min-width:260px">
+        ${[['', 'Every 12 hours (the default)'], ['0', 'Every single time'],
+           ['1', 'Every hour'], ['4', 'Every 4 hours'],
+           ['8', 'Every 8 hours'], ['24', 'Every 24 hours'],
+           ['168', 'Every 7 days']].map(o => `<option value="${o[0]}"${
+          v('sso_max_age_hours') === o[0] ? ' selected' : ''}>${o[1]}</option>`).join('')}
+      </select></p>
+      <p class="src-note" style="margin:0">Twelve hours is a working day:
+      nobody is asked twice before lunch, and a laptop left open overnight
+      cannot be walked up to the next morning. It is sent to Microsoft as
+      max_age and checked again on the way back against what the token says
+      about when they actually signed in, because a control that is only ever
+      asked for is not a control.</p>
+    </div>
     <p style="margin:12px 0 0"><button class="mini" data-act="sso-enforce"
       data-key="${on ? '' : '1'}"
       ${(on || (ready && bg)) ? '' : 'disabled'}>${
@@ -7862,6 +7885,14 @@ async function managedAction(act, el) {
   }
   if (act === 'take-tour') { await tourStart(); return; }
   if (act === 'sso-open') { await ssoOpen(); return; }
+  if (act === 'sso-maxage') {
+    const r = await mfetch('/api/settings', {method: 'POST',
+      body: JSON.stringify({sso_max_age_hours: el.value})});
+    if (r.status === 401) { sessionLost(); return; }
+    SETMSG = r.ok ? '' : 'Not saved: ' + await _refusal(r);
+    if (r.ok) SETTINGS = await r.json();
+    render(); return;
+  }
   if (act === 'sso-enforce') {
     const want = el.getAttribute('data-key') === '1';
     if (want && !confirm('Require single sign-on?\n\nEvery account except '
@@ -8769,6 +8800,9 @@ app.addEventListener('change', e => {
   const roleFor = e.target && e.target.getAttribute
     && e.target.getAttribute('data-role-for');
   if (roleFor) { userRole(roleFor, e.target.value); return; }
+  if (e.target && e.target.id === 'sso-maxage') {
+    managedAction('sso-maxage', e.target); return;
+  }
   if (e.target && e.target.id === 'mw-who') {
     managedAction('mail-who', e.target); return;
   }

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -1403,6 +1403,33 @@ SSO_FLIGHT_SECONDS = 600
 SSO_FLIGHT_MAX = 64
 
 
+# How long a sign-in at the provider stays good for. Twelve hours by
+# default: a working day, so nobody is asked twice before lunch, and a
+# laptop left open overnight cannot be walked up to the next morning.
+#
+# Sent as max_age AND checked on the way back. max_age is a request - a
+# provider is meant to honour it and Entra does, but a control that is only
+# ever asked for is not a control. The token's auth_time is what proves it,
+# and a token that arrives without one when max_age was asked for is
+# refused rather than trusted.
+SSO_MAX_AGE_DEFAULT_HOURS = 12
+# Clocks differ. Two minutes is enough for that and far too little to
+# matter against a window measured in hours.
+SSO_AUTH_TIME_SKEW = 120
+
+
+def _sso_max_age() -> int:
+    """The window in seconds. 0 means re-authenticate every time."""
+    raw = ((STATE.get_setting("sso_max_age_hours") if STATE else None) or "").strip()
+    if raw == "":
+        return SSO_MAX_AGE_DEFAULT_HOURS * 3600
+    try:
+        hours = int(raw)
+    except ValueError:
+        return SSO_MAX_AGE_DEFAULT_HOURS * 3600
+    return max(0, hours) * 3600
+
+
 def _sso_conf() -> dict:
     g = (lambda k, d="": (STATE.get_setting(k) if STATE else None) or d)
     return {
@@ -1548,9 +1575,11 @@ async def sso_start(request: Request):
     # state, because the answer comes back as a cross-site form post
     # carrying nothing but a code and that state - there is no cookie on
     # it and no fragment, so the browser cannot be asked afterwards.
+    max_age = _sso_max_age()
     _SSO_FLIGHT[state] = {"nonce": nonce, "verifier": verifier,
                           "at": time.time(), "issuer": doc["issuer"],
                           "token_endpoint": doc["token_endpoint"],
+                          "max_age": max_age,
                           "test": request.query_params.get("test") == "1"}
     challenge = _b64u(hashlib.sha256(verifier.encode()).digest())
     return {"authorize_url": doc["authorization_endpoint"] + "?" + urllib.parse.urlencode({
@@ -1565,6 +1594,15 @@ async def sso_start(request: Request):
         "nonce": nonce,
         "code_challenge": challenge,
         "code_challenge_method": "S256",
+        # Never a silent redirect. Without this, somebody already signed in
+        # to the provider in that browser is returned straight here with no
+        # interaction at all - click a link and you are inside a tool that
+        # says who uses which AI. select_account is the floor: signing in
+        # has to be something a person did, not something that happened.
+        "prompt": "select_account",
+        # And how recently they proved it. 0 asks the provider to
+        # reauthenticate outright.
+        "max_age": str(max_age),
     })}
 
 
@@ -1634,6 +1672,24 @@ async def sso_callback(req: SSOCallback):
         return _sso_refuse("the token did not answer this sign-in")
     if int(claims.get("exp") or 0) <= int(time.time()):
         return _sso_refuse("the token had already expired")
+    # How recently they actually proved who they are, not how recently a
+    # token was minted. exp says the token is fresh; auth_time says the
+    # PERSON is. Without this max_age is a polite request, and a browser
+    # holding a week-old provider session would be let in on a token
+    # issued a second ago.
+    want = flight.get("max_age")
+    if want is not None:
+        auth_time = int(claims.get("auth_time") or 0)
+        if not auth_time:
+            return _sso_refuse(
+                "the provider did not say when this person last signed in, "
+                "so how recent it was cannot be checked")
+        age = int(time.time()) - auth_time
+        if age > want + SSO_AUTH_TIME_SKEW:
+            return _sso_refuse(
+                "that sign-in is %d minutes old and this deployment asks "
+                "for one within %d. Sign in again."
+                % (age // 60, max(1, want // 60)))
     tid, sub = claims.get("tid") or "", claims.get("oid") or ""
     if not tid or not sub:
         return _sso_refuse("the token carried no tenant or object id")
@@ -1749,6 +1805,10 @@ _STR_SETTINGS = (
     # this on without a federated sign-in ever having completed is how a
     # deployment locks itself down to a single password.
     ("sso_enforce", False, 1),
+    # How stale an existing session at the provider may be before somebody
+    # has to prove who they are again. Hours; empty means the default
+    # below, "0" means every single time. See _sso_max_age.
+    ("sso_max_age_hours", False, 4),
     # The currency the Budget view's headline reports in, and the default
     # for newly linked tools. A display preference, not money math: the
     # portal never converts between currencies.
@@ -1802,6 +1862,7 @@ class SettingsUpdate(BaseModel):
     sso_redirect_uri: str | None = Field(default=None, max_length=500)
     sso_enabled: str | None = Field(default=None, max_length=1)
     sso_enforce: str | None = Field(default=None, max_length=1)
+    sso_max_age_hours: str | None = Field(default=None, max_length=4)
     sso_client_secret: str | None = Field(default=None, max_length=512)
     alertmanager_url: str | None = Field(default=None, max_length=500)
     grafana_url: str | None = Field(default=None, max_length=500)
@@ -1934,6 +1995,9 @@ def get_settings(authorization: str = Header(default="")):
         # What the portal needs to draw the enforcement control honestly:
         # whether it is on, and whether it could be turned on at all.
         "sso_enforce": plain("sso_enforce"),
+        "sso_max_age_hours": plain("sso_max_age_hours"),
+        "sso_max_age_default": {"value": str(SSO_MAX_AGE_DEFAULT_HOURS),
+                                "source": "derived"},
         "sso_enforce_ready": {"value": "1" if STATE.an_owner_is_bound() else "",
                               "source": "derived"},
         "sso_break_glass": {"value": STATE.break_glass_username(),
@@ -2067,6 +2131,13 @@ def put_settings(req: SettingsUpdate, authorization: str = Header(default="")):
                 422, "no owner has completed a single sign-on yet. Sign in "
                      "through the provider once first: requiring a door "
                      "nobody has opened leaves only the break-glass account")
+
+    if "sso_max_age_hours" in req.model_fields_set:
+        raw = (req.sso_max_age_hours or "").strip()
+        if raw and not (raw.isdigit() and 0 <= int(raw) <= 720):
+            raise HTTPException(
+                422, "sso_max_age_hours is a whole number of hours from 0 "
+                     "to 720, or empty for the default")
 
     if "smtp_security" in req.model_fields_set:
         mode = (req.smtp_security or "").strip()

--- a/receiver/tests/test_sso.py
+++ b/receiver/tests/test_sso.py
@@ -11,6 +11,7 @@ authorization", because addresses get reassigned. A joiner inheriting a
 leaver's address would otherwise inherit their account and their role.
 """
 
+import asyncio
 import json
 import os
 import time
@@ -456,3 +457,134 @@ def test_anything_else_is_named_rather_than_quoted(managed, monkeypatch):
     # to relay into an API response.
     assert why == "ConnectionRefusedError"
     assert "10.1.2.3" not in why
+
+
+# ------------------------------------------- how recently they signed in --
+# The weakness this closes: somebody already signed in to the provider in
+# that browser was returned straight here with no interaction. Clicking a
+# link was enough to be inside a tool that says who uses which AI.
+
+
+def _request_with_query(qs):
+    """A bare Request, which is all sso_start reads."""
+    from starlette.requests import Request
+    return Request({"type": "http", "method": "GET", "path": "/",
+                    "scheme": "https", "headers": [(b"host", b"r")],
+                    "query_string": qs.encode()})
+
+
+def _callback_with(st, auth_time, subject="subject-root"):
+    """Drive the callback with a token carrying the auth_time we choose.
+
+    The exchange itself is stubbed: what is under test is what the receiver
+    checks about the claims, not httpx.
+    """
+    from fastapi.testclient import TestClient
+
+    now = int(time.time())
+    claims = {"iss": "https://issuer.example.com", "aud": "c", "nonce": "n",
+              "exp": now + 600, "tid": TENANT, "oid": subject,
+              "email": "root@example.com"}
+    if auth_time is not None:
+        claims["auth_time"] = auth_time
+    token = "%s.%s.x" % (main._b64u(b'{"alg":"none"}'),
+                         main._b64u(json.dumps(claims).encode()))
+
+    class Resp:
+        status_code = 200
+
+        def json(self):
+            return {"id_token": token}
+
+    class FakeClient:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def post(self, *a, **k): return Resp()
+
+    st.set_setting("sso_client_id", "c", "t")
+    st.set_setting("sso_tenant_id", TENANT, "t")
+    st.set_setting("sso_client_secret", "s", "t")
+    st.set_setting("sso_redirect_uri", "https://portal.example.com/sso/callback", "t")
+    _bind_owner(st)
+    orig = main.httpx.AsyncClient
+    main.httpx.AsyncClient = lambda *a, **k: FakeClient()
+    try:
+        c = TestClient(main.app)
+        return c.post("/admin/sso/callback",
+                      json={"code": "c", "state": "state-x"}).json()
+    finally:
+        main.httpx.AsyncClient = orig
+
+
+def _flight(st, **over):
+    """A sign-in in flight, as /admin/sso/start would have recorded it."""
+    f = {"nonce": "n", "verifier": "v", "at": time.time(),
+         "issuer": "https://issuer.example.com", "token_endpoint": "https://t",
+         "max_age": 12 * 3600, "test": False}
+    f.update(over)
+    main._SSO_FLIGHT["state-x"] = f
+    return f
+
+
+def test_the_authorize_request_is_never_silent(managed, monkeypatch):
+    """prompt=select_account is the floor: signing in has to be something a
+    person did, not something that happened to them."""
+    async def fake_discover(tenant):
+        return {"issuer": "https://issuer.example.com",
+                "authorization_endpoint": "https://login.example.com/authorize",
+                "token_endpoint": "https://login.example.com/token"}
+
+    monkeypatch.setattr(main, "_sso_discover", fake_discover)
+    for k, v in [("sso_tenant_id", TENANT), ("sso_client_id", "c"),
+                 ("sso_client_secret", "s"),
+                 ("sso_redirect_uri", "https://portal.example.com/sso/callback")]:
+        managed.set_setting(k, v, "t")
+
+    req = _request_with_query("")
+    out = asyncio.run(main.sso_start(req))
+    url = out["authorize_url"]
+    assert "prompt=select_account" in url
+    assert "max_age=43200" in url        # the twelve hour default
+
+
+def test_a_stale_provider_session_is_refused(managed):
+    """A token minted a second ago off a week-old sign-in. exp says the
+    token is fresh; auth_time says the person is not."""
+    _flight(managed, max_age=12 * 3600)
+    week = int(time.time()) - 7 * 24 * 3600
+    out = _callback_with(managed, auth_time=week)
+    assert out["ok"] is False
+    assert "Sign in again" in out["detail"]
+
+
+def test_a_recent_sign_in_is_allowed(managed):
+    _flight(managed, max_age=12 * 3600)
+    out = _callback_with(managed, auth_time=int(time.time()) - 60)
+    assert out.get("ok") is True
+
+
+def test_a_token_with_no_auth_time_is_refused(managed):
+    """max_age is a request. A provider that ignores it silently must not
+    be indistinguishable from one that honoured it."""
+    _flight(managed, max_age=12 * 3600)
+    out = _callback_with(managed, auth_time=None)
+    assert out["ok"] is False
+    assert "when this person last signed in" in out["detail"]
+
+
+def test_the_window_is_configurable_and_checked(managed):
+    managed.set_setting("sso_max_age_hours", "1", "t")
+    assert main._sso_max_age() == 3600
+    _flight(managed, max_age=3600)
+    out = _callback_with(managed, auth_time=int(time.time()) - 2 * 3600)
+    assert out["ok"] is False
+    managed.set_setting("sso_max_age_hours", "", "t")
+    assert main._sso_max_age() == main.SSO_MAX_AGE_DEFAULT_HOURS * 3600
+
+
+def test_the_window_is_bounded(managed):
+    owner = "Bearer " + managed.login("root", PASSWORD)["token"]
+    with pytest.raises(main.HTTPException) as e:
+        main.put_settings(main.SettingsUpdate(sso_max_age_hours="9999"),
+                          authorization=owner)
+    assert e.value.status_code == 422


### PR DESCRIPTION
Found on a real deployment: somebody already signed in to Microsoft in their browser was returned straight into the portal with **no interaction at all**. Click a link, and you are inside a tool that says who uses which AI on which machine.

The authorization request carried no `prompt`, so the provider was free to answer from an existing session - and it did.

## Two things close it, and only one is the obvious one

**`prompt=select_account`** is the floor. The provider always asks who is signing in, so it is something a person did rather than something that happened to them. On its own that is still one click for a browser holding a week-old session.

**So the request also carries `max_age`, and the callback checks it.** `exp` says the token is fresh; `auth_time` says the *person* is - different claims about different things. A token minted a second ago off a sign-in from last Tuesday satisfies the first and not the second.

`max_age` is a request a provider is meant to honour, and a control that is only ever asked for is not a control. So a token arriving **without** `auth_time` when `max_age` was requested is refused rather than trusted.

## The default

**12 hours**, configurable from every-time to 30 days. A working day: nobody is asked twice before lunch, and a laptop left open overnight cannot be walked up to the next morning. That is the range Microsoft's own sign-in-frequency policies land in for privileged access.

Owners set it on the SSO card, beside requiring single sign-on at all.

## Checked

Portal 527, receiver 269 - six new tests covering the stale session, a missing `auth_time`, the bounds, and that the request is never silent.

Driven end to end against the stand-in provider reporting a three-day-old sign-in:

```
Signed in, but not here
that sign-in is 4320 minutes old and this deployment asks for one within 720.
Sign in again.
```

A fresh sign-in still goes straight through.

## A note on the commit split

The first attempt at splitting these two commits put the new settings key in the receiver without the portal, and **the drift guard added in 0.19.1 failed the build** - the first time that test has earned itself. The two models are one contract and now move in one commit.