### PR TITLE
release: 0.20.0, a sign-in somebody actually did

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.19.1
+version: 0.20.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.19.1"
+appVersion: "0.20.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.19.1
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.20.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.19.1
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.20.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.19.1
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.20.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
A minor rather than a patch, because everybody notices it on upgrade: an account chooser now appears where a sign-in used to complete in silence.

Somebody already signed in to Microsoft in their browser was being returned straight into the portal with no interaction at all. The authorization request carries `prompt` and `max_age` now, and the callback checks the token's `auth_time` rather than trusting the provider honoured what it was asked. Twelve hours by default; an owner can set it from every time to thirty days.

Also released here, from the work merged since 0.19.1: invites when an account is made, an SMTP wizard that says where each provider's credential comes from, and a notification centre for the setup a deployment skipped.

## The bump

`Chart.yaml` (version and appVersion), `receiver/deploy/receiver.yaml`, `docs/deployment/kubernetes.md`. A repo-wide grep leaves nothing on 0.19.1.

Tag after merge; the tag is what builds the images and publishes the chart.