### PR TITLE
One entry for Codeium, Windsurf and Devin - and an editor being installed is not somebody using it

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.20.0
+version: 0.21.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.20.0"
+appVersion: "0.21.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/files/registry.json
+++ b/charts/ai-guard/files/registry.json
@@ -231,6 +231,10 @@
         "cursor.sh",
         "api2.cursor.sh"
       ],
+      "form": "ide",
+      "inference_domains": [
+        "api2.cursor.sh"
+      ],
       "app_names": [
         "Cursor.app",
         "Cursor"
@@ -306,8 +310,8 @@
     },
     {
       "id": "codeium",
-      "name": "Codeium / Windsurf",
-      "vendor": "Codeium",
+      "name": "Windsurf / Devin (Cognition)",
+      "vendor": "Cognition",
       "category": "coding",
       "approved": false,
       "added_by": "manual",
@@ -315,7 +319,16 @@
         "codeium.com",
         "windsurf.com",
         "server.codeium.com",
-        "codeiumdata.com"
+        "codeiumdata.com",
+        "devin.ai",
+        "app.devin.ai",
+        "api.devin.ai",
+        "cognition.ai"
+      ],
+      "form": "ide",
+      "inference_domains": [
+        "server.codeium.com",
+        "api.devin.ai"
       ],
       "app_names": [
         "Windsurf.app",
@@ -329,7 +342,9 @@
       "risk_tier": "high",
       "email_senders": [
         "codeium.com",
-        "windsurf.com"
+        "windsurf.com",
+        "devin.ai",
+        "cognition.ai"
       ],
       "bundle_ids": [
         "com.codeium.windsurf"

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.20.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.20.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -516,6 +516,15 @@ def build(findings, domain_map=None, identity_map=None):
         "devices": set(), "identities": set(), "surfaces": set(),
         "accounts": set(), "findings": 0,
         "devices_by_surface": defaultdict(set),
+        # Devices where something proved the MODEL ran, as opposed to
+        # devices where the product was merely found installed. The two are
+        # the same set for every tool except a VS Code fork, where an
+        # inventory hit means an editor exists and nothing more. Kept as
+        # devices rather than a finding count because the question people
+        # ask of a licence is "how many of these seats are anyone using",
+        # which is a count of machines, not of DNS lookups.
+        "devices_active": set(),
+        "active_findings": 0,
     })
     # Where an AI tool reached, per the bridge detector. Not a tool inventory.
     bridges = defaultdict(lambda: {"devices": set(), "findings": 0})
@@ -575,6 +584,11 @@ def build(findings, domain_map=None, identity_map=None):
         t = tools[tool]
         t["surfaces"].add(surface)
         t["findings"] += 1
+        active = (f.get("signal") or "active") != "ambient"
+        if active:
+            t["active_findings"] += 1
+            if device:
+                t["devices_active"].add(device)
         if acct:
             t["accounts"].add(acct)
 
@@ -803,6 +817,20 @@ def _device_aliases(devices):
     # B -> C would drop A's findings onto a key that is itself merging
     # away. Rare, but cheap to refuse.
     return {b: c for b, c in out.items() if c not in out}
+
+
+# in-use  something proved a model ran: an account, a sign-in, an MCP config,
+#         or DNS to the completion backend.
+# installed  the product was only ever found sitting on disk. Reachable only
+#         for a registry entry marked `form: ide` - a VS Code fork, useful
+#         all day without calling a model - so every other tool is in-use the
+#         moment it is seen at all, exactly as before.
+#
+# The distinction is what stops "23 tools in use" quietly meaning "23 editors
+# installed", and it is the third column the Budget view needs: seats paid
+# for, seats installed, seats anyone actually used.
+def tool_usage(t) -> str:
+    return "in-use" if t.get("active_findings") else "installed"
 
 
 def jsonable(d):
@@ -1126,6 +1154,7 @@ def graph_from(findings, domain_map=None, identity_map=None, hours=168,
         "identities": {k: jsonable(v) for k, v in identities.items()},
         "tools": {
             k: dict(jsonable(v),
+                    usage=tool_usage(v),
                     devices_by_surface={s2: sorted(d2) for s2, d2
                                         in v["devices_by_surface"].items()})
             for k, v in tools.items()

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2572,9 +2572,15 @@ async function people() {
 function attention(k, t) {
   const personal = (G.personal_accounts || []).filter(r => r.tool === k).length;
   const devs = (t.devices || []).length;
+  // Machines where something proved a model ran. Same as `devs` for every
+  // tool whose presence IS use; smaller only for an editor that bundles AI,
+  // where counting installs as exposure is how a VS Code fork rollout came
+  // to look like an AI rollout.
+  const used = (t.devices_active || []).length;
   const f = [];
   if (personal) f.push(`${personal} personal account${personal === 1 ? '' : 's'}`);
-  if (devs >= 5) f.push(`wide spread (${devs} devices)`);
+  if (used >= 5) f.push(`wide spread (${used} devices)`);
+  if (t.usage === 'installed' && devs) f.push('installed, never used');
   if ((t.surfaces || []).filter(Boolean).length >= 2) f.push('multiple surfaces');
   const fs = ((G.trends || {}).tool_first_seen || {})[k];
   if (fs && Date.parse(fs) > Date.now() - 2 * 86400000) f.push('new this week');
@@ -2602,13 +2608,20 @@ function tools() {
   one - open a tool to see exactly which. "Identities from sources" counts
   people a source named directly; the AI register counts those plus the people
   the identity map attaches through a device, so the two differ for tools found
-  on endpoints.</p>
+  on endpoints. Editors that bundle AI - Cursor, Windsurf/Devin Desktop - are
+  marked <span class="pill p-mut">installed only</span> until something shows a
+  model actually ran, because finding one on a laptop proves an editor is
+  installed and not that anyone sent code to it.</p>
   <div class="tcard"><table><tr><th>tool</th><th></th><th>devices</th>
     <th title="People a SOURCE named on this tool. A cloud sign-in carries a person; an endpoint finding carries a machine, and the person behind it comes from the identity map - so this is lower than the register's user count for tools found on endpoints.">identities from sources</th>
     <th>by surface</th></tr>
   ${rows.map(([k,t,a]) => `<tr data-open="tool" data-key="${esc(k)}" style="cursor:pointer">
-    <td>${esc(k)}</td><td>${attnPill(a)}</td>
-    <td>${(t.devices||[]).length}</td><td>${(t.identities||[]).length}</td>
+    <td>${esc(k)}</td><td>${attnPill(a)}${t.usage === 'installed'
+      ? `<span class="pill p-mut" title="Found installed, but nothing has shown a model actually running - no account, no sign-in, and no traffic to the completion backend. Editors that bundle AI (Cursor, Windsurf/Devin Desktop) are useful all day without it.">installed only</span>`
+      : ''}</td>
+    <td>${(t.devices||[]).length}${(t.devices_active||[]).length < (t.devices||[]).length
+      ? ` <span class="src-note" style="font-style:normal" title="Of the devices this tool was found on, how many show the AI actually being used.">${(t.devices_active||[]).length} using</span>`
+      : ''}</td><td>${(t.identities||[]).length}</td>
     <td>${ents(t.devices_by_surface||{}).sort((a2,b2)=>b2[1].length-a2[1].length)
       .map(([s,v])=>`<span class="pill p-acc">${esc(s||'none')} ${v.length}</span>`).join('')
       || (t.surfaces||[]).filter(Boolean).map(s2 =>
@@ -2679,6 +2692,10 @@ function toolDetail(k) {
   <table><tr><th>by surface</th><td>${ents(t.devices_by_surface||{})
     .sort((a,b)=>b[1].length-a[1].length)
     .map(([s,v])=>`<span class="pill p-acc">${esc(s||'none')} ${v.length}</span>`).join('')}</td></tr>
+  <tr><th title="Installed says the product is on the machine. Used says something proved a model ran: an account, a sign-in, an MCP config, or traffic to the completion backend rather than to the update and telemetry hosts the editor reaches on launch anyway.">installed vs used</th>
+    <td>${(t.devices||[]).length} installed · ${(t.devices_active||[]).length} where the AI ran${
+      t.usage === 'installed' && (t.devices||[]).length
+        ? ' <span class="src-note" style="font-style:normal">nothing has shown this one being used as an AI tool</span>' : ''}</td></tr>
   <tr><th>accounts</th><td>${esc((t.accounts||[]).join(', ')) || '—'}</td></tr></table>
   <h2 style="margin-top:22px;font-size:16px">Devices</h2>
   ${(t.devices||[]).map(dk => G.devices[dk] ? card(dk, G.devices[dk]) : '').join('')}`;

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -902,3 +902,52 @@ class TestLokiUrlScheme:
 
         with pytest.raises(SystemExit, match="LOKI_URL"):
             require_http_url("LOKI_URL", "file:///x")
+def test_an_editor_that_bundles_ai_is_installed_not_in_use():
+    """Windsurf/Devin Desktop and Cursor are VS Code forks: someone can run
+    one all day without ever invoking a model. Counting an inventory hit as
+    AI usage is how "23 tools in use" comes to mean "23 editors installed" -
+    the same mistake as identifying Notion AI by notion.so. The scanner marks
+    those findings ambient; nothing here should read them as use."""
+    g = derive.graph_from([
+        # Found by Intune, and reaching the update/telemetry host on launch.
+        finding(tool="codeium", surface="desktop", device="A",
+                source="intune_app", signal="ambient"),
+        finding(tool="codeium", surface="network", device="B",
+                source="sentinelone_dns", signal="ambient"),
+    ], {})
+
+    t = g["tools"]["codeium"]
+    assert t["usage"] == "installed"
+    assert len(t["devices"]) == 2      # the editor is on two machines
+    assert t["devices_active"] == []   # nobody has been shown using the AI
+
+
+def test_one_hit_on_the_completion_backend_makes_it_in_use():
+    """The whole point of splitting the domains: traffic to the host that
+    only answers when a model runs is the thing that turns "installed" into
+    "used", and it counts the machine it came from - not every machine the
+    editor happens to sit on."""
+    g = derive.graph_from([
+        finding(tool="codeium", surface="desktop", device="A",
+                source="intune_app", signal="ambient"),
+        finding(tool="codeium", surface="network", device="B",
+                source="sentinelone_dns", signal="active"),
+    ], {})
+
+    t = g["tools"]["codeium"]
+    assert t["usage"] == "in-use"
+    assert len(t["devices"]) == 2
+    assert t["devices_active"] == ["B"]
+
+
+def test_a_finding_with_no_signal_still_counts_as_use():
+    """Every finding written before the field existed, and every scanner not
+    yet upgraded, sends no signal at all. Reading that as ambient would empty
+    the in-use column across an entire estate on upgrade day, which looks
+    exactly like everyone stopping work."""
+    g = derive.graph_from([
+        finding(tool="claude", surface="desktop", device="A", source="jamf_app"),
+    ], {})
+
+    assert g["tools"]["claude"]["usage"] == "in-use"
+    assert g["tools"]["claude"]["devices_active"] == ["A"]

--- a/receiver/app/budget.py
+++ b/receiver/app/budget.py
@@ -22,6 +22,11 @@ Providers are deliberately few and honest about what each can do:
   fireflies   Fireflies.ai. One GraphQL query for the team's users, which
               also reports per-user usage (transcripts, minutes) - the
               rare vendor that hands over the usage half too.
+  devin       Cognition, covering Devin and Devin Desktop (the IDE that
+              was Codeium, then Windsurf). GET the org's members with a
+              service-user key. Teams reaches this too, not just
+              Enterprise - one of the few vendors here where that is
+              true - so the wizard does not send a Teams admin to Import.
 
 ChatGPT Business is the named absence: OpenAI exposes no admin API on
 that plan (SCIM and the Compliance API are Enterprise-only), so it is a
@@ -30,6 +35,7 @@ pretending a connector could exist.
 """
 
 import json
+import re
 import time
 
 import httpx
@@ -47,6 +53,11 @@ CURSOR_URL = "https://api.cursor.com/teams/members"
 CHATGPT_SCIM_URL = "https://api.openai.com/scim/v2"
 NOTION_SCIM_URL = "https://api.notion.com/scim/v2"
 GRAMMARLY_SCIM_URL = "https://app.grammarly.com/scim/v2"
+# The only vendor here needing an id in the path. %s is filled from the
+# operator's stored key, never from a request, and only after _DEVIN_ORG
+# has passed it - so the host and path are as fixed as every other URL.
+DEVIN_URL = "https://api.devin.ai/v3beta1/organizations/%s/members/users"
+_DEVIN_ORG = re.compile(r"^org-[A-Za-z0-9_-]{1,64}$")
 
 # What the portal needs to offer the wizard: which providers exist, what
 # each one's key looks like and where an admin creates it. Data, not
@@ -148,6 +159,27 @@ PROVIDERS = {
         "syncs": "members, admin flag, and per-user usage (transcripts, "
                  "minutes).",
     },
+    "devin": {
+        "label": "Devin / Devin Desktop (Cognition)",
+        # Teams genuinely reaches this - the docs give Teams its own API
+        # quick start, and a Teams org admin can mint a service user. That
+        # is worth stating plainly, because the assumption in this file
+        # everywhere else is that a member list means Enterprise.
+        "plan": "Teams or Enterprise. Both can create a service user and "
+                "read their own org's members; Enterprise additionally "
+                "reaches the cross-org endpoints this sync does not use.",
+        "key_hint": "Service user API key (starts with cog_), plus the "
+                    "organisation id, entered as one value: "
+                    "org-xxxx:cog_xxxx. An org admin creates both in the "
+                    "same place - Settings > Service Users - where the "
+                    "org id is shown and Create service user issues the "
+                    "key. The key is shown once. Member role is enough: "
+                    "this sync only reads. Windsurf licences live here "
+                    "too, since Cognition folded Windsurf into Devin.",
+        "syncs": "members and their role names. Seat tiers and usage are "
+                 "not on this endpoint - record tiers on the "
+                 "subscription.",
+    },
 }
 
 
@@ -220,10 +252,17 @@ MEMBER_APIS = {
         "how": "Admin API, GET /teams/members with a Team API key.",
     },
     "codeium": {
-        "api": "rest",
-        "plan": "Enterprise. Teams sees admin analytics in-app; the API and "
-                "SCIM are Enterprise.",
-        "how": "Windsurf enterprise API for team management and analytics.",
+        "api": "rest", "connector": "devin",
+        # This entry used to say Enterprise-only, which was true of the old
+        # Windsurf analytics API and stopped being true when Cognition moved
+        # the product onto Devin's platform: Teams has its own API quick
+        # start and can mint a service user. An operator on Teams was being
+        # told to go and do a CSV import they did not need.
+        "plan": "Teams or Enterprise, via Cognition's Devin API - the "
+                "licence is one and the same since the Windsurf "
+                "acquisition.",
+        "how": "GET /v3beta1/organizations/{org}/members/users with a "
+               "service-user key.",
     },
     "tabnine": {
         "api": "rest",
@@ -695,10 +734,112 @@ async def sync_grammarly(api_key: str) -> list[dict]:
     return await _scim_users(GRAMMARLY_SCIM_URL, api_key,
                              "the Grammarly SCIM API")
 
+
+async def sync_devin(api_key: str) -> list[dict]:
+    """The organisation's members via Cognition's Devin API, all pages.
+
+    Covers Devin and Devin Desktop - the IDE that shipped as Codeium, then
+    as Windsurf - because Cognition folded them onto one platform and one
+    licence. That is why the registry keeps them as one tool, and why this
+    is the connector the `codeium` id links to.
+
+    Teams reaches this, not only Enterprise: an org admin creates a service
+    user under Settings > Service Users and generates a `cog_` key. Member
+    role is enough, since this only reads.
+
+    The stored key is "org-xxxx:cog_xxxx" - the org id and the key, both
+    shown on that same settings page. Devin has no endpoint that resolves a
+    key to its own organisation, so the id has to be carried; it is checked
+    against _DEVIN_ORG before it goes anywhere near a URL.
+
+    Pagination is cursor-based: page with `after` until has_next_page is
+    false. Seat tiers and usage are not on this endpoint, so both stay
+    blank and tiers are recorded on the subscription.
+    """
+    org, _, key = api_key.partition(":")
+    org, key = org.strip(), key.strip()
+    if not key:
+        raise SyncError("the Devin key needs the organisation id with it, as "
+                        "org-xxxx:cog_xxxx - both are on Settings > Service "
+                        "Users")
+    if not _DEVIN_ORG.match(org):
+        raise SyncError("%r is not a Devin organisation id: it should look "
+                        "like org-xxxx, from Settings > Service Users"
+                        % org[:40])
+
+    members: list[dict] = []
+    after = ""
+    url = DEVIN_URL % org
+    async with httpx.AsyncClient(timeout=_TIMEOUT) as client:
+        for _ in range(MAX_MEMBERS // 100 + 1):
+            params = {"first": "100"}
+            if after:
+                params["after"] = after
+            try:
+                r = await client.get(
+                    url, params=params,
+                    headers={"Authorization": "Bearer " + key})
+            except httpx.HTTPError as e:
+                raise SyncError("could not reach the Devin API (%s)"
+                                % type(e).__name__)
+            if r.status_code == 403:
+                # The generic 403 names an Anthropic scope, which would send
+                # a Devin operator looking in the wrong console.
+                raise SyncError("the Devin API answered 403: the service "
+                                "user needs the ViewOrgMembership permission "
+                                "on this organisation")
+            if r.status_code == 404:
+                raise SyncError("the Devin API answered 404: no organisation "
+                                "%s - check the id on Settings > Service "
+                                "Users" % org)
+            if r.status_code != 200:
+                raise _refusal(r.status_code, "the Devin API")
+            try:
+                body = r.json()
+            except json.JSONDecodeError:
+                raise SyncError("the Devin API answered 200, but not with "
+                                "JSON")
+            page = body.get("items") or []
+            for u in page:
+                email = str(u.get("email") or "").strip().lower()
+                if not email:
+                    # Service users are members of the org and have no
+                    # address. They hold no paid seat, so skipping them
+                    # keeps the count to people.
+                    continue
+                # Roles are assignments, not a field: a member can hold more
+                # than one. Join them so the portal shows what the vendor
+                # actually says rather than an arbitrary first pick.
+                roles = []
+                for a in u.get("role_assignments") or []:
+                    nm = str(((a or {}).get("role") or {}).get("role_name")
+                             or "").strip()
+                    if nm and nm not in roles:
+                        roles.append(nm)
+                members.append({
+                    "email": email,
+                    "name": str(u.get("name") or "")[:200],
+                    "role": ", ".join(roles)[:64],
+                    "seat_tier": "",
+                    "usage": {},
+                })
+                if len(members) > MAX_MEMBERS:
+                    raise SyncError("more than %d members: refusing rather "
+                                    "than store a partial member list as if "
+                                    "it were complete" % MAX_MEMBERS)
+            if not page or not body.get("has_next_page"):
+                return members
+            after = str(body.get("end_cursor") or "")
+            if not after:
+                # has_next_page with no cursor would loop on page one.
+                return members
+    raise SyncError("the Devin API kept paginating past %d members"
+                    % MAX_MEMBERS)
+
 SYNCERS = {"anthropic": sync_anthropic, "fireflies": sync_fireflies,
            "openai": sync_openai, "cursor": sync_cursor,
            "chatgpt": sync_chatgpt, "notion": sync_notion,
-           "grammarly": sync_grammarly}
+           "grammarly": sync_grammarly, "devin": sync_devin}
 
 
 # ----------------------------------------------------------------- fx --

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -333,6 +333,11 @@ if REQUIRE_DEVICE_CREDENTIALS and not MANAGED_MODE:
 # a system daemon. It is deliberately distinct from "browser", which means the
 # extension saw an actual page load.
 VALID_SURFACES = {"browser", "network", "cli", "ide", "desktop", "mcp", "cloud"}
+# Whether a finding shows a model ran ("active") or only that the product
+# is installed ("ambient"). Bounded like every other label. Findings from
+# before 0.21 carry neither, and "" is read as active downstream - the
+# meaning they were reported with.
+VALID_SIGNALS = {"active", "ambient"}
 VALID_SEVERITIES = {"info", "warn"}
 # Bounded set: safe as a Loki stream label and a Prometheus metric label.
 # Sources that pre-date the field (older browser extensions) report "unknown".
@@ -482,6 +487,11 @@ class Finding(BaseModel):
     # cannot exclude bridge targets. Empty for pre-0.1.4 lines and for
     # extension flags via /flag.
     source: str = Field(default="", max_length=64)
+    # active | ambient. Only an `ide` registry entry (a VS Code fork, where
+    # the editor is useful without ever calling a model) can report ambient;
+    # every other tool's presence is use. Empty from senders that pre-date
+    # the field, which reads as active - what they always meant.
+    signal: str = Field(default="", max_length=16)
     device_name: str = Field(default="", max_length=256)
     risk_tier: str = Field(default="", max_length=32)
     # How many, and of what. The unit differs per source (sign-ins for Entra,
@@ -702,6 +712,28 @@ def _collector_rows(tools: list[dict]) -> dict:
 # Unknown names pass through untouched. A tool the registry has never heard of
 # is a registry gap worth seeing, not something to quietly fold into a
 # neighbour.
+# Tool ids the registry marks `form: ide` - an editor that bundles AI, where
+# finding the app installed proves an editor is installed and nothing more.
+# The scanner classifies its own findings (it sees the DNS hostname next to
+# the registry entry), but the three endpoint collectors report a plain
+# `surface: desktop` and know nothing about forms. Rather than teach a bash
+# script, a PowerShell script and a Linux script the same rule - and then
+# need all three upgraded before it takes effect - the receiver fills it in
+# on the way past, the same place and for the same reason it already
+# rewrites a hostname to a tool id.
+def _build_ide_tools(reg: dict | None) -> set[str]:
+    if not reg:
+        return set()
+    return {t.get("id") for t in reg.get("tools", [])
+            if t.get("id") and t.get("form") == "ide"}
+
+
+# Surfaces that only ever prove the product is on the machine. `ide` is not
+# here: that surface is an AI EXTENSION someone installed into an editor,
+# which is a deliberate choice to add AI rather than an editor existing.
+_PRESENCE_SURFACES = {"desktop"}
+
+
 def _build_domain_map(reg: dict | None) -> dict[str, str]:
     if not reg:
         return {}
@@ -721,15 +753,17 @@ def _refresh_domain_map():
     domain defined in the portal normalizes findings from that moment and
     an id defined in the portal stops its MCP namesake becoming a
     candidate."""
-    global _DOMAIN_TO_TOOL, _REGISTRY_IDS
+    global _DOMAIN_TO_TOOL, _REGISTRY_IDS, _IDE_TOOLS
     reg = _merged_registry()
     _DOMAIN_TO_TOOL = _build_domain_map(reg)
+    _IDE_TOOLS = _build_ide_tools(reg)
     _REGISTRY_IDS = {t.get("id") for t in (reg or {}).get("tools", [])
                      if t.get("id")}
 
 
 _DOMAIN_TO_TOOL: dict[str, str] = {}
 _REGISTRY_IDS: set[str] = set()
+_IDE_TOOLS: set[str] = set()
 _refresh_domain_map()  # also primes the tools gauge at boot
 
 
@@ -3301,6 +3335,8 @@ async def report(f: Finding, request: Request, authorization: str = Header(defau
         f.severity = "warn"
     if f.os not in VALID_OS:
         f.os = "unknown"
+    if f.signal and f.signal not in VALID_SIGNALS:
+        f.signal = ""
     if not f.reported_at:
         f.reported_at = datetime.now(timezone.utc).isoformat()
 
@@ -3314,6 +3350,13 @@ async def report(f: Finding, request: Request, authorization: str = Header(defau
             f.evidence = "site: %s" % f.tool
         TOOL_NORMALISED.labels(surface=f.surface).inc()
         f.tool = canonical
+
+    # Filled in only where the sender said nothing. A scanner that classified
+    # the finding itself is never second-guessed here: it saw the hostname,
+    # which is the one thing this cannot. Applied AFTER the rewrite above, so
+    # it is matching a registry id rather than whatever name arrived.
+    if not f.signal and f.surface in _PRESENCE_SURFACES and f.tool in _IDE_TOOLS:
+        f.signal = "ambient"
 
     # MCP server names ride in as evidence; unknown ones join the
     # candidates queue (managed mode only - the function gates itself).

--- a/receiver/app/registry-schema.json
+++ b/receiver/app/registry-schema.json
@@ -231,6 +231,21 @@
               "$ref": "#/$defs/relativePath"
             },
             "description": "MCP config paths that exist only on Windows, relative to the user profile."
+          },
+          "form": {
+            "type": "string",
+            "enum": [
+              "ide"
+            ],
+            "description": "The product is a general-purpose tool that BUNDLES AI rather than being one: an editor people use all day whether or not they ever invoke a model (Cursor, Windsurf/Devin Desktop - both VS Code forks). For these, an inventory finding proves the editor is installed, NOT that anyone sent code to a model, so presence alone is reported as installed rather than in use. Absent means presence does imply use, which is true of every other shape here - a Claude desktop app or an AI browser extension has no non-AI purpose. Only `ide` is defined because it is the only shape whose handling is built; do not invent values."
+          },
+          "inference_domains": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9.-]+$"
+            },
+            "description": "The subset of `domains` a host only reaches when a model is actually invoked - the completion/chat backend. Everything else in `domains` is reached on launch anyway for telemetry, updates and licence checks, so a hit there proves the product exists, not that the AI ran. Only meaningful with `form: ide`, where that difference decides installed vs in use; build.py requires every entry to also appear in `domains`. Leave empty when you cannot tell the two apart - an over-claimed inference domain silently turns telemetry into evidence of use."
           }
         }
       }

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.20.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/receiver/tests/test_budget.py
+++ b/receiver/tests/test_budget.py
@@ -656,3 +656,78 @@ def test_codex_rides_the_chatgpt_workspace():
     the two."""
     assert budget_mod.MEMBER_APIS["codex-cli"]["connector"] == "chatgpt"
     assert budget_mod.MEMBER_APIS["chatgpt"]["connector"] == "chatgpt"
+def test_sync_devin_splits_org_from_key_and_joins_roles(managed, monkeypatch):
+    """Devin is the only vendor here that needs an organisation id in the
+    path, and it publishes no endpoint that resolves a key to its own org -
+    so the id travels with the key as "org-xxxx:cog_xxxx" and gets split
+    here. Two things are easy to get wrong: sending the whole stored string
+    as the bearer token, and picking one role when the API returns role
+    ASSIGNMENTS, a list. Service users come back on this endpoint with no
+    email and hold no paid seat, so they are not counted as people."""
+    pages = {
+        "": {"items": [
+            {"user_id": "u1", "email": "Ash@Corp.example", "name": "Ash",
+             "role_assignments": [
+                 {"role": {"role_id": "r1", "role_name": "Admin"}},
+                 {"role": {"role_id": "r2", "role_name": "Member"}}]},
+            {"user_id": "svc", "email": None, "name": "ci-bot",
+             "role_assignments": []},
+        ], "has_next_page": True, "end_cursor": "c1"},
+        "c1": {"items": [
+            {"user_id": "u2", "email": "bo@corp.example", "name": "Bo",
+             "role_assignments": [
+                 {"role": {"role_id": "r2", "role_name": "Member"}}]},
+        ], "has_next_page": False, "end_cursor": None},
+    }
+
+    def handler(request):
+        assert request.url.host == "api.devin.ai"
+        assert request.url.path == (
+            "/v3beta1/organizations/org-abc123/members/users")
+        # The org id must not have ridden along into the token.
+        assert request.headers["Authorization"] == "Bearer cog_secret"
+        return httpx.Response(
+            200, json=pages[request.url.params.get("after", "")])
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "codeium", "provider": "devin",
+        "api_key": "org-abc123:cog_secret"})
+    r = client.post("/admin/budget/sync", headers=ADMIN,
+                    json={"tool_id": "codeium"})
+    assert r.json() == {"ok": True, "count": 2}
+
+    # Members hang off the subscription, so read them back through one.
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=dict(SUB, tool_id="codeium", vendor="Cognition"))
+    sub, = [s for s in client.get("/admin/budget", headers=ADMIN)
+            .json()["subscriptions"] if s["tool_id"] == "codeium"]
+    members = {m["email"]: m for m in sub["members"]}
+    assert set(members) == {"ash@corp.example", "bo@corp.example"}
+    assert members["ash@corp.example"]["role"] == "Admin, Member"
+    assert members["ash@corp.example"]["source"] == "api"
+
+
+@pytest.mark.parametrize("key", ["cog_nokeyatall", "notanorg:cog_key",
+                                 "org-abc/../evil:cog_key", ":cog_keyaa"])
+def test_sync_devin_refuses_a_key_without_a_usable_org_id(managed, monkeypatch,
+                                                          key):
+    """The org id is the one path segment in this module that does not come
+    from a constant, so it is checked before it reaches a URL: a malformed
+    id is refused with an answer, not sent to api.devin.ai to find out."""
+    def handler(request):  # pragma: no cover - must never be reached
+        raise AssertionError("a malformed org id reached the network")
+
+    monkeypatch.setattr(budget_mod.httpx, "AsyncClient",
+                        _mock_async_client(handler))
+    client.put("/admin/budget/connection", headers=ADMIN, json={
+        "tool_id": "codeium", "provider": "devin", "api_key": key})
+    r = client.post("/admin/budget/sync", headers=ADMIN,
+                    json={"tool_id": "codeium"})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is False
+    # The failure is the operator's answer, so it has to name the shape the
+    # key should have taken rather than just refusing.
+    assert "org-xxxx" in body["detail"]

--- a/receiver/tests/test_custom_registry.py
+++ b/receiver/tests/test_custom_registry.py
@@ -6,7 +6,9 @@ appears in /registry, in every /registry/collector surface list, and in the
 receiver's domain normalization - so the fleet detects it with no rebuild.
 """
 
+import contextlib
 import json
+import logging
 import os
 import subprocess
 import sys
@@ -78,6 +80,37 @@ def managed(tmp_path, monkeypatch):
     main._refresh_domain_map()
     yield st
     main._refresh_domain_map()
+
+
+
+@contextlib.contextmanager
+def _capture():
+    """The findings the receiver emitted, parsed. They go out as JSON log
+    lines - that IS the delivery mechanism to Loki, so reading them is
+    reading what a log store would receive."""
+    out = []
+
+    class H(logging.Handler):
+        def emit(self, record):
+            try:
+                line = json.loads(record.getMessage())
+            except (ValueError, TypeError):
+                return
+            if line.get("kind") == "finding":
+                out.append(line)
+
+    h = H()
+    log = logging.getLogger("ai-guard")
+    log.addHandler(h)
+    # A handler alone is not enough: if the logger sits above INFO the record
+    # is dropped before any handler sees it.
+    prev = log.level
+    log.setLevel(logging.INFO)
+    try:
+        yield out
+    finally:
+        log.removeHandler(h)
+        log.setLevel(prev)
 
 
 def _put(**body):
@@ -215,3 +248,36 @@ def test_classic_mode_serves_the_file_untouched():
     assert client.get("/admin/registry-entries", headers=ADMIN).status_code == 404
     assert client.put("/admin/registry-entries", headers=ADMIN,
                       json={}).status_code == 404
+def test_a_collector_reporting_an_editor_gets_the_ambient_signal(managed):
+    """The three endpoint collectors report a plain `surface: desktop` and
+    know nothing about which tools are editors. Without this the whole
+    installed-vs-used split would be defeated on the surface that matters
+    most - a Windsurf.app the macOS collector found would arrive unlabelled
+    and read as someone using AI. Filled in here so the rule lands without
+    upgrading a bash script, a PowerShell script and a Linux script first."""
+    with _capture() as records:
+        assert client.post("/report", headers=AUTH, json={
+            "tool": "codeium", "surface": "desktop", "os": "macos",
+            "device": "MAC-1", "evidence": "Windsurf.app"}).status_code == 200
+        # A tool whose presence IS use must be left alone: Claude.app has no
+        # purpose except the model.
+        assert client.post("/report", headers=AUTH, json={
+            "tool": "claude", "surface": "desktop", "os": "macos",
+            "device": "MAC-1", "evidence": "Claude.app"}).status_code == 200
+
+    by_tool = {r["tool"]: r for r in records}
+    assert by_tool["codeium"]["signal"] == "ambient"
+    assert by_tool["claude"]["signal"] == ""
+
+
+def test_a_scanner_that_classified_itself_is_not_second_guessed(managed):
+    """The scanner saw the DNS hostname; the receiver did not. An explicit
+    active on an editor - traffic to the completion backend - must survive,
+    or the receiver would quietly overwrite the only evidence of real use."""
+    from app.main import Finding, _PRESENCE_SURFACES
+
+    assert "desktop" in _PRESENCE_SURFACES
+    f = Finding(tool="codeium", surface="desktop", signal="active",
+                device="MAC-2")
+    # The ingest rule only fills a blank.
+    assert f.signal == "active"

--- a/registry/build.py
+++ b/registry/build.py
@@ -75,6 +75,26 @@ def validate(registry, schema):
                 print(f"domain {d} claimed by both {seen[d]} and {t['id']}", file=sys.stderr)
                 ok = False
             seen[d] = t["id"]
+    # inference_domains names the hosts that are only reached when a model
+    # actually runs, so it has to be a subset of the domains the tool is
+    # detected on. One that is not in `domains` is either a typo or a host
+    # nothing matches, and both fail silently: the tool would simply never
+    # be credited with being used. JSON Schema cannot express a subset, so
+    # it is checked here.
+    for t in registry.get("tools", []):
+        domains = set(t.get("domains", []))
+        for d in t.get("inference_domains", []):
+            if d not in domains:
+                print(f"{t['id']}: inference_domains entry {d} is not in "
+                      f"domains", file=sys.stderr)
+                ok = False
+        # The reverse pairing: inference_domains only changes how a finding
+        # reads for a tool whose presence does not imply use. On anything
+        # else it is inert, and inert configuration reads as working.
+        if t.get("inference_domains") and t.get("form") != "ide":
+            print(f"{t['id']}: inference_domains needs form: ide - it has no "
+                  f"effect on any other shape", file=sys.stderr)
+            ok = False
     return ok
 
 
@@ -111,6 +131,10 @@ def _scanner_shape(registry) -> dict:
                 if b in ("chrome", "edge")
             },
             "mcp_identifiers": t.get("mcp_identifiers", []),
+            # The scanner resolves a DNS hit to a domain, so it is the only
+            # place that can say whether the hit means the model ran.
+            "form": t.get("form", ""),
+            "inference_domains": t.get("inference_domains", []),
             "notes": t.get("notes", ""),
         }
         for t in tools

--- a/registry/registry.yaml
+++ b/registry/registry.yaml
@@ -140,6 +140,9 @@ tools:
     approved: false
     added_by: manual
     domains: [cursor.com, cursor.sh, api2.cursor.sh]
+    # A VS Code fork: having it installed says an editor is installed.
+    form: ide
+    inference_domains: [api2.cursor.sh]
     app_names: ["Cursor.app", "Cursor"]
     bundle_ids: [com.todesktop.230313mzl4w4u92]
     cli:
@@ -182,18 +185,34 @@ tools:
       vscode: [continue.continue]
     risk_tier: medium
 
+  # One entry, three names. Codeium renamed itself Windsurf in 2025;
+  # Cognition then bought it and folded it into Devin, and windsurf.com
+  # now redirects to devin.ai/desktop. They are one product on one
+  # licence, so they stay one id - splitting them would split the counts
+  # the receiver's domain map exists to merge. The id stays `codeium`
+  # because it is the label on every finding already stored.
   - id: codeium
-    name: Codeium / Windsurf
-    vendor: Codeium
+    name: Windsurf / Devin (Cognition)
+    vendor: Cognition
     category: coding
     approved: false
     added_by: manual
-    domains: [codeium.com, windsurf.com, server.codeium.com, codeiumdata.com]
+    domains: [codeium.com, windsurf.com, server.codeium.com, codeiumdata.com,
+              devin.ai, app.devin.ai, api.devin.ai, cognition.ai]
+    # Also a VS Code fork. server.codeium.com is the completion backend the
+    # editor calls per keystroke and api.devin.ai is the agent API; the rest
+    # are the site, the account portal and the update/licence hosts, which
+    # the editor reaches on launch with the AI untouched. codeiumdata.com is
+    # deliberately NOT here: it looks like telemetry and we have not
+    # confirmed it carries completions, and over-claiming one of these turns
+    # "the app opened" into "someone used AI".
+    form: ide
+    inference_domains: [server.codeium.com, api.devin.ai]
     app_names: ["Windsurf.app", "Windsurf"]
     extension_ids:
       vscode: [codeium.codeium]
     risk_tier: high
-    email_senders: [codeium.com, windsurf.com]
+    email_senders: [codeium.com, windsurf.com, devin.ai, cognition.ai]
     bundle_ids: [com.codeium.windsurf]
     exe_names: [Windsurf.exe]
 

--- a/registry/schema.json
+++ b/registry/schema.json
@@ -231,6 +231,21 @@
               "$ref": "#/$defs/relativePath"
             },
             "description": "MCP config paths that exist only on Windows, relative to the user profile."
+          },
+          "form": {
+            "type": "string",
+            "enum": [
+              "ide"
+            ],
+            "description": "The product is a general-purpose tool that BUNDLES AI rather than being one: an editor people use all day whether or not they ever invoke a model (Cursor, Windsurf/Devin Desktop - both VS Code forks). For these, an inventory finding proves the editor is installed, NOT that anyone sent code to a model, so presence alone is reported as installed rather than in use. Absent means presence does imply use, which is true of every other shape here - a Claude desktop app or an AI browser extension has no non-AI purpose. Only `ide` is defined because it is the only shape whose handling is built; do not invent values."
+          },
+          "inference_domains": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z0-9.-]+$"
+            },
+            "description": "The subset of `domains` a host only reaches when a model is actually invoked - the completion/chat backend. Everything else in `domains` is reached on launch anyway for telemetry, updates and licence checks, so a hit there proves the product exists, not that the AI ran. Only meaningful with `form: ide`, where that difference decides installed vs in use; build.py requires every entry to also appear in `domains`. Leave empty when you cannot tell the two apart - an over-claimed inference domain silently turns telemetry into evidence of use."
           }
         }
       }

--- a/registry/test_build.py
+++ b/registry/test_build.py
@@ -80,10 +80,12 @@ def test_the_vs_code_forks_are_marked_and_their_backends_named():
                          ("codeium", "server.codeium.com")):
         t = _tool(registry, tid)
         assert t.get("form") == "ide", tid
-        assert backend in t.get("inference_domains", []), tid
+        # Set algebra rather than `x in y`: these are host lists, and the
+        # membership form reads to CodeQL as a URL substring check.
+        inference = set(t.get("inference_domains", []))
+        assert {backend} <= inference, tid
         # And the hosts an editor reaches on launch anyway must NOT be there.
-        assert "cursor.com" not in t.get("inference_domains", [])
-        assert "windsurf.com" not in t.get("inference_domains", [])
+        assert inference.isdisjoint({"cursor.com", "windsurf.com"}), tid
 
 
 def test_the_scanner_view_carries_the_distinction():
@@ -105,5 +107,5 @@ def test_the_scanner_view_carries_the_distinction():
         (tmp / "scanner.json").read_text())["services"]}
     ws = services["Windsurf / Devin (Cognition)"]
     assert ws["form"] == "ide"
-    assert "server.codeium.com" in ws["inference_domains"]
+    assert {"server.codeium.com"} <= set(ws["inference_domains"])
     assert services["Claude"]["form"] == ""

--- a/registry/test_build.py
+++ b/registry/test_build.py
@@ -40,3 +40,70 @@ def test_emitted_mcp_entries_have_no_duplicates():
             seen.add(key)
     finally:
         shutil.rmtree(tmpdir)
+def _tool(registry, tid):
+    return next(t for t in registry["tools"] if t["id"] == tid)
+
+
+def test_inference_domains_must_be_real_domains_of_that_tool():
+    """A typo here fails silently in the worst direction: the host matches
+    nothing, so the tool is never credited with being used and quietly reads
+    as installed-only forever. JSON Schema cannot express a subset, so
+    build.py checks it and this checks build.py."""
+    import copy
+
+    registry, schema = build.load()
+    assert build.validate(registry, schema)
+
+    bad = copy.deepcopy(registry)
+    _tool(bad, "codeium")["inference_domains"].append("typo.example")
+    assert not build.validate(bad, schema)
+
+
+def test_inference_domains_without_form_ide_is_refused():
+    """On any other shape the field is inert, and inert configuration reads
+    as working - someone would set it and believe presence had stopped
+    counting as use."""
+    import copy
+
+    registry, schema = build.load()
+    bad = copy.deepcopy(registry)
+    _tool(bad, "tabnine")["inference_domains"] = ["api.tabnine.com"]
+    assert not build.validate(bad, schema)
+
+
+def test_the_vs_code_forks_are_marked_and_their_backends_named():
+    """Cursor and Windsurf/Devin Desktop are the two entries where presence
+    does not imply use. If either loses its form or its inference domains,
+    an editor rollout silently starts reporting as an AI rollout again."""
+    registry, _ = build.load()
+    for tid, backend in (("cursor", "api2.cursor.sh"),
+                         ("codeium", "server.codeium.com")):
+        t = _tool(registry, tid)
+        assert t.get("form") == "ide", tid
+        assert backend in t.get("inference_domains", []), tid
+        # And the hosts an editor reaches on launch anyway must NOT be there.
+        assert "cursor.com" not in t.get("inference_domains", [])
+        assert "windsurf.com" not in t.get("inference_domains", [])
+
+
+def test_the_scanner_view_carries_the_distinction():
+    """The scanner is the only component that sees a DNS hit next to the
+    registry entry, so it is the only one that can classify. If these fields
+    stop being emitted, every fork silently reverts to presence-is-use."""
+    import tempfile
+    from pathlib import Path as _P
+
+    registry, _ = build.load()
+    tmp = _P(tempfile.mkdtemp())
+    orig = build.DIST
+    try:
+        build.DIST = tmp
+        build.emit(registry, write_fallback=False)
+    finally:
+        build.DIST = orig
+    services = {s["name"]: s for s in json.loads(
+        (tmp / "scanner.json").read_text())["services"]}
+    ws = services["Windsurf / Devin (Cognition)"]
+    assert ws["form"] == "ide"
+    assert "server.codeium.com" in ws["inference_domains"]
+    assert services["Claude"]["form"] == ""

--- a/scanner/ai_guard/registry/__init__.py
+++ b/scanner/ai_guard/registry/__init__.py
@@ -64,7 +64,37 @@ class AIService:
     desktop_apps: dict = field(default_factory=dict)
     browser_extensions: dict = field(default_factory=dict)
     mcp_identifiers: list[str] = field(default_factory=list)
+
+    # "ide" marks a product that is an editor first and bundles AI second -
+    # a VS Code fork. Finding it installed proves an editor is installed,
+    # which is not the same claim as someone having used a model. Empty for
+    # every other shape, where presence does imply use.
+    form: str = ""
+    # The subset of `domains` reached only when a model actually runs. The
+    # rest of `domains` is reached on launch anyway (telemetry, updates,
+    # licence), so for an `ide` the two mean different things.
+    inference_domains: list[str] = field(default_factory=list)
     notes: str = ""
+
+    def domain_signal(self, host: str) -> str:
+        """What a DNS or network hit on `host` proves about this tool.
+
+        "active" - a model ran. "ambient" - the product is present, and
+        nothing more. Only an `ide` can produce "ambient" from a domain: for
+        everything else the domain IS the product, so any hit is use.
+
+        An `ide` with no inference_domains recorded returns "ambient" for
+        every host, which is the honest answer - we cannot tell its
+        telemetry from its completions, so we do not claim it is use.
+        """
+        if self.form != "ide":
+            return "active"
+        h = (host or "").lower().strip(".")
+        for d in self.inference_domains:
+            d = d.lower()
+            if h == d or h.endswith("." + d):
+                return "active"
+        return "ambient"
 
     @property
     def label(self) -> str:
@@ -202,6 +232,8 @@ class Registry:
                         if browser in ("chrome", "edge")
                     },
                     "mcp_identifiers": tool.get("mcp_identifiers", []),
+                    "form": tool.get("form", ""),
+                    "inference_domains": tool.get("inference_domains", []),
                     "notes": tool.get("notes", ""),
                 }
             )
@@ -228,6 +260,8 @@ class Registry:
                 desktop_apps=entry.get("desktop_apps", {}),
                 browser_extensions=entry.get("browser_extensions", {}),
                 mcp_identifiers=entry.get("mcp_identifiers", []),
+                form=entry.get("form", ""),
+                inference_domains=entry.get("inference_domains", []),
                 notes=entry.get("notes", ""),
             )
             self.services.append(svc)

--- a/scanner/ai_guard/registry/ai_services.yaml
+++ b/scanner/ai_guard/registry/ai_services.yaml
@@ -33,6 +33,8 @@ services:
   browser_extensions: {}
   mcp_identifiers:
   - anthropic-claude
+  form: ''
+  inference_domains: []
   notes: Claude desktop app supports MCP server connections.
 - name: Claude Code
   vendor: Anthropic
@@ -47,6 +49,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: CLI tool with agentic capabilities.
 - name: ChatGPT
   vendor: OpenAI
@@ -73,6 +77,8 @@ services:
     - ChatGPT.exe
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: Users can sign up with work email + password without any Entra involvement.
 - name: Codex CLI
   vendor: OpenAI
@@ -86,6 +92,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Gemini
   vendor: Google
@@ -103,6 +111,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Gemini CLI
   vendor: Google
@@ -116,6 +126,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: GitHub Copilot
   vendor: GitHub
@@ -133,6 +145,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Cursor
   vendor: Anysphere
@@ -155,6 +169,9 @@ services:
     - Cursor.exe
   browser_extensions: {}
   mcp_identifiers: []
+  form: ide
+  inference_domains:
+  - api2.cursor.sh
   notes: ''
 - name: Cline
   vendor: Cline Bot Inc
@@ -169,6 +186,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Roo Code
   vendor: Roo Veterinary Inc
@@ -182,6 +201,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Continue
   vendor: Continue Dev
@@ -196,9 +217,11 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
-- name: Codeium / Windsurf
-  vendor: Codeium
+- name: Windsurf / Devin (Cognition)
+  vendor: Cognition
   category: coding
   risk_tier: high
   domains:
@@ -206,10 +229,16 @@ services:
   - windsurf.com
   - server.codeium.com
   - codeiumdata.com
+  - devin.ai
+  - app.devin.ai
+  - api.devin.ai
+  - cognition.ai
   entra_app_ids: []
   email_domains:
   - codeium.com
   - windsurf.com
+  - devin.ai
+  - cognition.ai
   desktop_apps:
     macos:
     - com.codeium.windsurf
@@ -219,6 +248,10 @@ services:
     - Windsurf.exe
   browser_extensions: {}
   mcp_identifiers: []
+  form: ide
+  inference_domains:
+  - server.codeium.com
+  - api.devin.ai
   notes: ''
 - name: Tabnine
   vendor: Tabnine
@@ -234,6 +267,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Otter
   vendor: Otter.ai
@@ -256,6 +291,8 @@ services:
     chrome:
     - bnmojkbbkkonlmlfgejehefjldooied
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Grammarly
   vendor: Grammarly
@@ -282,6 +319,8 @@ services:
     edge:
     - kbfnbcaeplbcioakkpcpgfkobkghlhen
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Wispr Flow
   vendor: Wispr
@@ -301,6 +340,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Perplexity
   vendor: Perplexity AI
@@ -323,6 +364,8 @@ services:
     chrome:
     - hlgbcneanomplepojfcnclggenpcoldo
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Ollama
   vendor: Ollama
@@ -345,6 +388,8 @@ services:
     - Ollama.exe
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: Local models; data stays on device but model provenance unknown. Separate risk class.
 - name: LM Studio
   vendor: Element Labs
@@ -361,6 +406,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: DeepSeek
   vendor: DeepSeek
@@ -378,6 +425,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Mistral Le Chat
   vendor: Mistral AI
@@ -395,6 +444,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Grok
   vendor: xAI
@@ -410,6 +461,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Microsoft Copilot (Free)
   vendor: Microsoft
@@ -429,6 +482,8 @@ services:
     edge:
     - Microsoft-Copilot
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Microsoft 365 Copilot
   vendor: Microsoft
@@ -444,6 +499,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Atlassian Rovo
   vendor: Atlassian
@@ -460,6 +517,8 @@ services:
   browser_extensions: {}
   mcp_identifiers:
   - atlassian
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Notion AI
   vendor: Notion Labs
@@ -481,6 +540,8 @@ services:
   browser_extensions: {}
   mcp_identifiers:
   - notion
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Fireflies.ai
   vendor: Fireflies
@@ -497,6 +558,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Midjourney
   vendor: Midjourney
@@ -513,6 +576,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: OpenAI API Platform
   vendor: OpenAI
@@ -528,6 +593,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 - name: Hugging Face
   vendor: Hugging Face
@@ -544,6 +611,8 @@ services:
     windows: []
   browser_extensions: {}
   mcp_identifiers: []
+  form: ''
+  inference_domains: []
   notes: ''
 bridge_targets:
 - name: Atlassian (Jira/Confluence)

--- a/scanner/ai_guard/scanners/base.py
+++ b/scanner/ai_guard/scanners/base.py
@@ -34,6 +34,53 @@ class DetectionSource(str, Enum):
     MCP_SCAN = "mcp_scan"
 
 
+# What a finding proves: that a model actually ran ("active"), or only that
+# the product is present on the machine ("ambient").
+#
+# For almost every tool in the registry the two are the same thing - a Claude
+# desktop app or an Otter extension has no purpose except its AI, so finding
+# it installed IS finding it used. The exception is a product that is an
+# editor first and bundles AI second: Cursor and Windsurf/Devin Desktop are
+# VS Code forks, and someone can run one all day without ever invoking a
+# model. Reporting those the same way is how "23 people use AI" comes to mean
+# "23 people have an editor installed", which is the same mistake as
+# identifying Notion AI by notion.so.
+#
+# Only a tool the registry marks `form: ide` can ever be ambient. Everything
+# else stays active and nothing about it changes.
+SIGNAL_ACTIVE = "active"
+SIGNAL_AMBIENT = "ambient"
+
+# Inventory sources: they enumerate installed software and nothing more. For
+# an IDE fork that is exactly the weak claim - the editor is on the machine.
+_PRESENCE_ONLY = frozenset({
+    "intune_app",
+    "jamf_app",
+})
+
+
+def classify_signal(service, source, host: str = "") -> str:
+    """Whether this finding shows the AI ran, or only that it is installed.
+
+    `service` is an AIService; a BridgeTarget (which has no form) is always
+    active, because a non-browser process holding a token is use by
+    definition.
+
+    Extension findings stay active even on an IDE fork: `extension_ids` names
+    the AI plugin itself, not the editor hosting it, so installing one is a
+    deliberate choice to add AI - the same reason plain VS Code is detected
+    through its extensions rather than being in the registry at all.
+    """
+    if getattr(service, "form", "") != "ide":
+        return SIGNAL_ACTIVE
+    value = getattr(source, "value", source) or ""
+    if value in _PRESENCE_ONLY:
+        return SIGNAL_AMBIENT
+    if host:
+        return service.domain_signal(host)
+    return SIGNAL_ACTIVE
+
+
 # occurrence_count is a different quantity per source: sign-in events for
 # Entra, installed devices for Intune, signup emails for Exchange. The number
 # alone invites comparing things that are not comparable, so anything that
@@ -66,6 +113,10 @@ class Finding:
     # Evidence
     detail: str = ""
     raw_evidence: dict = field(default_factory=dict)
+
+    # active | ambient. See classify_signal above. Defaults to active so a
+    # scanner that never sets it keeps reporting exactly what it did before.
+    signal: str = SIGNAL_ACTIVE
 
     # When
     timestamp: Optional[datetime] = None

--- a/scanner/receiver_reporter.py
+++ b/scanner/receiver_reporter.py
@@ -38,7 +38,8 @@ from typing import Optional
 import httpx
 
 from ai_guard import __version__ as AGENT_VERSION
-from ai_guard.scanners.base import DetectionSource, Finding, occurrence_unit
+from ai_guard.scanners.base import (DetectionSource, Finding,
+                                    classify_signal, occurrence_unit)
 
 logger = logging.getLogger(__name__)
 
@@ -290,6 +291,14 @@ class ReceiverReporter:
         # several dashboard rows: "Otter" and "otter" are not the same key.
         tool = getattr(f.service, "label", None) or slugify(f.service.name)
 
+        # Classified here rather than in each scanner: this is the one place
+        # that already holds the service, the source and the structured
+        # evidence together. The host comes from raw_evidence, not from the
+        # detail string - the same value, but a field rather than a sentence
+        # someone may reword.
+        signal = classify_signal(
+            f.service, f.source, f.raw_evidence.get("dns_request", ""))
+
         return {
             "tool": tool,
             "surface": surface,
@@ -301,6 +310,10 @@ class ReceiverReporter:
             "evidence": f.detail[:500],
             "severity": "warn" if (personal or bridge) else "info",
             "source": f.source.value,
+            # active = a model ran; ambient = the product is merely installed.
+            # Only ever ambient for an `ide` registry entry, so every other
+            # tool's payload is unchanged.
+            "signal": signal,
             "risk_tier": f.risk_tier,
             # Volume, with its unit: the number means sign-ins for Entra,
             # devices for Intune, signup emails for Exchange. Goes in the log

--- a/scanner/tests/test_ide_signal.py
+++ b/scanner/tests/test_ide_signal.py
@@ -1,0 +1,91 @@
+"""Installed versus used, for products that are an editor first.
+
+Cursor and Windsurf/Devin Desktop are VS Code forks. Finding one on a laptop
+proves an editor is installed; it does not prove anyone sent code to a model.
+Every other tool in the registry has no purpose except its AI, so presence is
+use and nothing about it changes - the tests here pin both halves, because
+the risk of this feature is not that it under-reports IDE forks, it is that
+it quietly starts under-reporting everything else.
+"""
+
+from ai_guard.registry import AIService
+from ai_guard.scanners.base import (DetectionSource, Finding, classify_signal)
+
+IDE = AIService(
+    name="Windsurf / Devin (Cognition)", vendor="Cognition", category="coding",
+    risk_tier="high", id="codeium",
+    domains=["windsurf.com", "server.codeium.com", "api.devin.ai"],
+    form="ide", inference_domains=["server.codeium.com", "api.devin.ai"],
+)
+# No form: an assistant whose only reason to exist is the model.
+PLAIN = AIService(
+    name="Claude", vendor="Anthropic", category="assistant", risk_tier="high",
+    id="claude", domains=["claude.ai"],
+)
+
+
+def test_the_completion_backend_is_use_and_the_marketing_host_is_not():
+    """The distinction the whole feature rests on. An editor reaches its
+    update, licence and telemetry hosts on launch with the AI untouched, so
+    a hit there proves the product exists and nothing more."""
+    assert IDE.domain_signal("server.codeium.com") == "active"
+    assert IDE.domain_signal("api.devin.ai") == "active"
+    assert IDE.domain_signal("windsurf.com") == "ambient"
+    assert IDE.domain_signal("codeium.com") == "ambient"
+
+
+def test_a_subdomain_of_an_inference_host_still_counts():
+    assert IDE.domain_signal("eu.api.devin.ai") == "active"
+    # But a lookalike suffix must not: notdevin.ai is not devin.ai.
+    assert IDE.domain_signal("xapi.devin.ai.evil.example") == "ambient"
+
+
+def test_inventory_of_an_editor_is_installed_not_used():
+    for src in (DetectionSource.INTUNE_APP, DetectionSource.JAMF_APP):
+        assert classify_signal(IDE, src) == "ambient", src
+
+
+def test_an_account_or_an_mcp_config_is_use_even_for_an_editor():
+    """These are not "the binary exists" - they are someone having signed in
+    or wired an agent up, which no amount of merely having an editor does."""
+    for src in (DetectionSource.MCP_SCAN, DetectionSource.ENTRA_SIGN_IN,
+                DetectionSource.EXCHANGE_EMAIL):
+        assert classify_signal(IDE, src) == "active", src
+
+
+def test_nothing_changes_for_a_tool_that_is_only_an_ai():
+    """The regression that would matter: a Claude desktop app or an Otter
+    extension has no non-AI use, so every source stays active for it."""
+    for src in (DetectionSource.INTUNE_APP, DetectionSource.JAMF_APP,
+                DetectionSource.SENTINELONE_DNS, DetectionSource.MCP_SCAN):
+        assert classify_signal(PLAIN, src, "claude.ai") == "active", src
+
+
+def test_an_editor_with_no_inference_domains_recorded_never_claims_use():
+    """The honest default. If we cannot tell a fork's telemetry from its
+    completions we do not get to call a DNS hit evidence of use - an
+    over-claimed inference domain turns "the app opened" into "someone used
+    AI", which is the failure this feature exists to remove."""
+    unknown = AIService(name="Some Fork", vendor="x", category="coding",
+                        risk_tier="medium", domains=["fork.example"],
+                        form="ide")
+    assert unknown.domain_signal("fork.example") == "ambient"
+    assert classify_signal(unknown, DetectionSource.SENTINELONE_DNS,
+                           "fork.example") == "ambient"
+
+
+def test_a_bridge_target_has_no_form_and_is_always_use():
+    """Bridge findings carry a BridgeTarget, not an AIService: a non-browser
+    process holding a token is use by definition, and getattr must not turn
+    the missing attribute into a crash."""
+    class BridgeTargetLike:
+        name = "Atlassian"
+
+    assert classify_signal(BridgeTargetLike(),
+                           DetectionSource.SENTINELONE_BRIDGE) == "active"
+
+
+def test_the_finding_default_keeps_an_unconverted_scanner_honest():
+    """A scanner that never sets the field reports what it always reported."""
+    assert Finding(service=PLAIN, source=DetectionSource.MCP_SCAN,
+                   risk_tier="high").signal == "active"


### PR DESCRIPTION
A Windsurf licence now signs in at `app.devin.ai`, and the portal showed neither Windsurf nor Devin - only `codeium`. Chasing that turned up one registry entry that was three releases behind its vendor, one connector entry that was telling operators the wrong plan, and one assumption underneath both that is worth fixing on its own.

## One licence, three names

Codeium renamed itself Windsurf, Cognition then bought it, and `windsurf.com` now redirects to `devin.ai/desktop`. One licence covers all three, so `devin.ai`, `app.devin.ai`, `api.devin.ai` and `cognition.ai` join the domains the entry is detected on rather than becoming a second entry.

They stay one id, and the id stays `codeium`. It is the label on every finding already stored, and splitting the entry would split the counts the receiver's domain map exists to merge. The display name and vendor move to Cognition so the next person to follow that link is not left guessing.

Before this, a lookup of `app.devin.ai` was attributed to nothing at all.

## The member list Cognition actually offers

The `codeium` entry in `MEMBER_APIS` said Enterprise-only. That was true of the old Windsurf analytics API and stopped being true when the product moved onto Devin's platform: Teams has its own API quick start and a Teams org admin can mint a service user. Operators on Teams were being sent to do a CSV import they did not need.

Adds the connector the entry now points at. Two things about it are unlike every other vendor in that module:

**It needs an organisation id in the path**, and Devin publishes nothing that resolves a key to its own org. The stored value carries both as `org-xxxx:cog_xxxx` - they sit on the same Settings > Service Users page, so this asks for two values from one screen rather than inventing a second field. The id is checked against a pattern before it reaches a URL, so the host and path stay as fixed as everywhere else in that module.

**The members endpoint is on a `v3beta1` path** while its neighbours are `v3`. Written down in the code because it will move.

Roles arrive as assignments rather than a field, so a member holding more than one keeps all of them. Service users come back with no address and hold no paid seat, so they are not counted as people.

## Installed is not used

The above makes the licence picture correct and, on its own, makes the usage picture slightly worse - a hit on `devin.ai` and a `Windsurf.exe` in an inventory now land on the same row.

Windsurf and Cursor are VS Code forks. They are an editor first and AI second, and someone can run one all day without ever invoking a model. Counting an inventory hit as usage is how "tools in use" quietly comes to mean "editors installed" - the same mistake as identifying Notion AI by `notion.so`.

`form: ide` marks the two entries where presence does not imply use. `inference_domains` names the subset of hosts only reached when a model actually runs; the rest of a fork's domains are reached on launch anyway for telemetry, updates and licence checks.

`codeiumdata.com` is deliberately **not** listed. It looks like telemetry and has not been confirmed to carry completions, and an over-claimed inference domain turns "the app opened" into "someone used AI" - which is the failure this is here to remove. A fork with none recorded reports ambient for every host, which is the honest answer rather than a convenient one.

Findings gain `active`/`ambient`:

- **The scanner classifies its own.** It is the only component that sees a hostname next to a registry entry, and it reads that host from structured evidence rather than from the detail sentence, which is prose somebody may reword.
- **The receiver fills the gap for `surface: desktop` on a fork.** The three endpoint collectors report a plain desktop finding and know nothing about forms. Without this the split would be defeated on the surface that matters most - a `Windsurf.app` the macOS collector found would arrive unlabelled and read as somebody using AI. Filling it centrally means the rule lands without upgrading a bash script, a PowerShell script and a Linux script first. An explicit signal from a scanner is never overwritten: the scanner saw the hostname, the receiver did not.
- **Extensions stay active even on a fork.** `extension_ids` names the AI plugin, not the editor hosting it - the same reason plain VS Code is not in the registry at all and is detected through its extensions.

The portal gains `usage` and `devices_active`: the Tools table marks a fork `installed only` until something shows a model ran, and shows "3 devices · 1 using" where those differ. Locally, against a stand-in log store: `codeium` 3 devices / 1 using, `cursor` installed only / 0 using, `claude` and `chatgpt` unchanged.

`build.py` enforces the two invariants the schema cannot express - `inference_domains` must be a subset of `domains`, and is refused without `form: ide`, where it would be inert configuration that reads as working.

## Two things worth pushing on in review

**Nothing changes on existing data until agents redeploy.** An absent signal reads as active, deliberately: every finding written before the field, and every scanner not yet upgraded, sends nothing. Reading that as ambient would empty the in-use column across an estate on upgrade day and look exactly like everybody stopping work. There is a named test holding that.

**The Devin connector has never run against a live tenant.** It was written from published documentation and every test is a mock. The endpoint shape, the auth, the org/key split and the cursor pagination are all doc-derived; the first real run is the actual test. A wrong field name or a permission refusal both surface as a rendered error rather than a crash.

## Unrelated, noticed, not touched

`scanner/policy.yaml` blocks by exact service name, and lists `Windsurf` and `Otter.ai` while the registry names are `Windsurf / Devin (Cognition)` and `Otter`. Neither has ever matched - those two entries are silent no-ops. Pre-existing, and it stands alone as a fix.

Suites green: portal 530, receiver and registry 299, scanner 164.
