### PR TITLE
A refresh that answers in under a second, not forty

### DIFF
--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -793,24 +793,52 @@ def _device_aliases(devices):
     ambiguous bare key - one that is the tail of two different prefixed
     keys - is left alone: merging the wrong pair of machines is worse
     than showing two cards.
+
+    Read by index rather than by comparing every pair. The relation being
+    computed is "does some key end with <separator><bare>", and that
+    question is invertible: instead of testing each key against every
+    other, take each key's own post-separator tails and look those up
+    among the bare keys. A key has a handful of separators in it, so the
+    cost tracks the number of devices rather than its square.
+
+    That is not a micro-optimisation. The pairwise form was the whole
+    cost of a graph build on any real estate - 99% of it, quadratic in
+    device count, which is 1.2s at four thousand devices and 33s at
+    twenty thousand. A portal that takes half a minute to answer is one
+    people stop opening.
+
+    The relation is unchanged, and the tests either side of this say so:
+    the minimum length, the ambiguity refusal and the chain refusal all
+    mean exactly what they meant before.
     """
     keys = [k for k in devices if k]
     lowered = {k: k.lower() for k in keys}
+    # Lowered bare form -> the keys spelling it. A list, because two keys
+    # can differ only in case and both are still candidates.
+    by_low = {}
+    for k in keys:
+        low = lowered[k]
+        if len(low) >= _MIN_ALIAS_KEY:
+            by_low.setdefault(low, []).append(k)
+
     out, ambiguous = {}, set()
-    for bare in keys:
-        low = lowered[bare]
-        if len(low) < _MIN_ALIAS_KEY:
-            continue
-        for other in keys:
-            if other == bare:
-                continue
-            o = lowered[other]
-            if len(o) <= len(low):
-                continue
-            if any(o.endswith(sep + low) for sep in _ALIAS_SEPARATORS):
+    for other in keys:
+        o = lowered[other]
+        # Every tail of `other` that follows a separator. A set because
+        # each (bare, other) pair must be weighed once, exactly as the
+        # pairwise form weighed it once.
+        tails = set()
+        for i, ch in enumerate(o):
+            if ch in _ALIAS_SEPARATORS and len(o) - i - 1 >= _MIN_ALIAS_KEY:
+                tails.add(o[i + 1:])
+        for tail in tails:
+            for bare in by_low.get(tail, ()):
+                if bare == other:
+                    continue
                 if bare in out:
                     ambiguous.add(bare)
                 out[bare] = other
+
     for k in ambiguous:
         out.pop(k, None)
     # A key cannot be both a bare form and a canonical one: A -> B while

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -80,6 +80,7 @@ import logging
 import os
 import re
 import secrets
+import threading
 import time
 import urllib.parse
 import urllib.request
@@ -94,6 +95,19 @@ from pydantic import BaseModel, Field
 
 from app import derive, evidence, governance, managed, paste_guard
 
+# The portal never configured logging, so every log.info in it went
+# nowhere - including the one whose comment promises the log-store fallback
+# is "not silent", and the one that says the weekly digest was sent. Only
+# warnings and errors were ever visible, through Python's last-resort
+# handler. Configured here the way the receiver does it, to stdout, which is
+# where a container's logs are read from.
+# Level only, and deliberately not the stream: warnings already reached
+# stderr through the last-resort handler, and a test pins them there.
+# Redirecting them to stdout to match the receiver would have moved output
+# an operator may already be grepping, which is not a trade worth making to
+# turn on some info lines.
+logging.basicConfig(level=logging.INFO,
+                    format="%(levelname)s:     %(message)s")
 log = logging.getLogger("portal")
 
 
@@ -668,14 +682,87 @@ def _registry(request) -> dict:
     return reg
 
 
+# One lock per cache key. Two people refreshing at once used to mean two
+# full reads of the same window, because these endpoints are sync defs and
+# FastAPI runs those in a threadpool - they genuinely overlap. The second
+# arrival now waits for the first build and takes its answer, which is also
+# why the check is made again after the lock: by then the value it wanted
+# usually exists.
+_cache_locks: dict = {}
+_cache_locks_guard = threading.Lock()
+
+
+def _lock_for(key):
+    with _cache_locks_guard:
+        lock = _cache_locks.get(key)
+        if lock is None:
+            lock = _cache_locks[key] = threading.Lock()
+        return lock
+
+
+def _fresh(hit, hours, now):
+    return bool(hit) and hit["hours"] == hours and now - hit["at"] < CACHE_TTL
+
+
 def _cached(key, hours, builder):
-    now = time.time()
+    """A derived value, rebuilt at most once per TTL and at most once at a
+    time.
+
+    The timestamp is taken AFTER the builder returns, not before. Stamping
+    the start meant an entry was born as old as the build that made it - so
+    on any deployment where a build took longer than CACHE_TTL the entry was
+    expired the moment it was written, the cache never returned anything,
+    and every page load paid the full cost forever. The symptom is a portal
+    that is uniformly slow rather than slow once.
+    """
     hit = _cache.get(key)
-    if hit and hit["hours"] == hours and now - hit["at"] < CACHE_TTL:
+    if _fresh(hit, hours, time.time()):
         return hit["value"], hit["at"]
-    value = builder()
-    _cache[key] = {"value": value, "at": now, "hours": hours}
-    return value, now
+    with _lock_for(key):
+        # Re-check: another thread may have built it while this one waited,
+        # and rebuilding it again would defeat the point of the lock.
+        hit = _cache.get(key)
+        if _fresh(hit, hours, time.time()):
+            return hit["value"], hit["at"]
+        started = time.time()
+        value = builder()
+        at = time.time()
+        log.info("built %r in %.2fs", key, at - started)
+        _cache[key] = {"value": value, "at": at, "hours": hours}
+        return value, at
+
+
+def _invalidate_derived(key):
+    """Drop a derived view AND the findings behind it.
+
+    Refresh means "go and look again". Dropping only the derived value
+    would rebuild it from a findings list that is still cached, so the
+    button would redraw the same numbers and look like it had worked -
+    the one outcome a refresh must never produce.
+    """
+    _cache.pop(key, None)
+    _cache.pop("findings", None)
+
+
+def _findings_cached(hours, request=None):
+    """The findings every derived view is built from, read once.
+
+    `graph`, `status`, `paste_guard` and `register` all want the same list
+    for the same window, and each used to fetch it separately - so opening
+    the portal paginated the whole window three times over, in series,
+    before anything rendered.
+
+    Sharing one read also makes a page load internally consistent. Three
+    separate reads happen at three different instants, so the overview and
+    the paste-guard card could legitimately disagree about the same
+    minute. One snapshot cannot.
+
+    Cached under its own key, so `refresh=true` clearing a derived view
+    does not silently re-read Loki when the findings behind it are still
+    fresh; the refresh path clears this key too.
+    """
+    value, _ = _cached("findings", hours, lambda: _findings(hours, request))
+    return value
 
 
 def _findings(hours, request=None):
@@ -689,6 +776,7 @@ def _findings(hours, request=None):
         )
     global _last_loki_ok, _last_loki_error, _last_read_truncated
     global _last_loki_error_at
+    started = time.time()
     try:
         out = derive.fetch_from_loki(
             # The bearer token is env configuration and belongs to the env
@@ -697,6 +785,18 @@ def _findings(hours, request=None):
             username=username or None, password=password or None,
             max_findings=LOKI_MAX_FINDINGS)
         _last_loki_ok = time.time()
+        # Where the time went, on the one line that can say. Working out
+        # that a slow portal was a quadratic graph build rather than a slow
+        # log store took a profiler; it should take a log line. Cheap, and
+        # it is the difference between answering the next performance
+        # question in a minute and guessing at pod sizes.
+        # getattr, like the line below it: a stubbed read returns a plain
+        # list, and instrumentation must never be the thing that breaks a
+        # read it was only meant to describe.
+        log.info("read %d findings over %.0fh in %.2fs%s", len(out), hours,
+                 _last_loki_ok - started,
+                 " (TRUNCATED at the cap)"
+                 if getattr(out, "truncated", False) else "")
         _last_loki_error = ""
         _last_read_truncated = getattr(out, "truncated", False)
         return out
@@ -964,9 +1064,9 @@ def graph(request: Request,
     indistinguishable from a portal that is not working."""
     hours = hours or LOOKBACK_HOURS
     if refresh:
-        _cache.pop("graph", None)
+        _invalidate_derived("graph")
     def build():
-        findings = _findings(hours, request)
+        findings = _findings_cached(hours, request)
         reg = _registry(request)
         domain_map = derive.load_domain_map_from(reg)
         return derive.graph_from(findings, domain_map,
@@ -985,9 +1085,9 @@ def status(request: Request,
            _=Depends(require_auth)):
     hours = hours or LOOKBACK_HOURS
     if refresh:
-        _cache.pop("status", None)
+        _invalidate_derived("status")
     def build():
-        return derive.status_from(_findings(hours, request))
+        return derive.status_from(_findings_cached(hours, request))
 
     value, at = _cached("status", hours, build)
     return JSONResponse(dict(value, derived_at=at, hours=hours,
@@ -1061,10 +1161,10 @@ def paste_guard_events(request: Request,
     """
     hours = hours or LOOKBACK_HOURS
     if refresh:
-        _cache.pop("paste_guard", None)
+        _invalidate_derived("paste_guard")
 
     def build():
-        findings = _findings(hours, request)
+        findings = _findings_cached(hours, request)
         reg = _registry(request)
         return paste_guard.paste_guard_from(
             findings, derive.load_domain_map_from(reg))
@@ -1101,7 +1201,7 @@ def register(request: Request,
     """
     hours = hours or LOOKBACK_HOURS
     if refresh:
-        _cache.pop("register", None)
+        _invalidate_derived("register")
 
     # Fetched outside the cached build: the unmatched section below needs it
     # on every request, and in managed mode it carries the portal-recorded
@@ -1109,7 +1209,7 @@ def register(request: Request,
     gov, exceptions, portal_decisions = _merged_governance(request)
 
     def build():
-        findings = _findings(hours, request)
+        findings = _findings_cached(hours, request)
         reg = _registry(request)
         return derive.register_from(findings, reg,
                                     derive.load_domain_map_from(reg), gov,

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -11,10 +11,13 @@ during the build, or to a property the design depends on.
 """
 
 import os
+import time
 
 # PORTAL_AUTH must be set before the app module is imported: main.py refuses to
 # start without authentication, and that refusal happens at module level.
 os.environ.setdefault("PORTAL_AUTH", "none")
+
+import pytest
 
 from app import derive
 
@@ -951,3 +954,197 @@ def test_a_finding_with_no_signal_still_counts_as_use():
 
     assert g["tools"]["claude"]["usage"] == "in-use"
     assert g["tools"]["claude"]["devices_active"] == ["A"]
+
+
+# ------------------------------------------------- device alias matching --
+#
+# `_device_aliases` used to compare every device key against every other,
+# which was 99% of a graph build and quadratic in device count: 1.2s at four
+# thousand devices, 33s at twenty thousand, 113s at forty. It is now an
+# indexed lookup. These tests exist so that stays true AND stays identical -
+# a faster function that merges a different set of machines would be worse
+# than the slow one.
+
+
+def _aliases_by_definition(devices):
+    """The relation `_device_aliases` computes, written the obvious way.
+
+    This IS the specification: a bare key merges into another key that is
+    the same string with a prefix and a separator in front. Deliberately
+    the slow pairwise form, so it can be read and believed. The shipped
+    implementation has to agree with it on every input.
+    """
+    keys = [k for k in devices if k]
+    lowered = {k: k.lower() for k in keys}
+    out, ambiguous = {}, set()
+    for bare in keys:
+        low = lowered[bare]
+        if len(low) < derive._MIN_ALIAS_KEY:
+            continue
+        for other in keys:
+            if other == bare:
+                continue
+            o = lowered[other]
+            if len(o) <= len(low):
+                continue
+            if any(o.endswith(sep + low) for sep in derive._ALIAS_SEPARATORS):
+                if bare in out:
+                    ambiguous.add(bare)
+                out[bare] = other
+    for k in ambiguous:
+        out.pop(k, None)
+    return {b: c for b, c in out.items() if c not in out}
+
+
+@pytest.mark.parametrize("keys,why", [
+    (["SERIAL1234", "LAP-SERIAL1234", "MAC-SERIAL1234"],
+     "ambiguous: the tail of two prefixed keys, so neither merge is safe"),
+    (["ABCDEF", "LAP-ABCDEF", "SITE-LAP-ABCDEF"],
+     "a chain: merging A into B while B merges into C would strand A"),
+    (["abcdef", "LAP-ABCDEF"], "case differs between sources"),
+    (["SHORT", "LAP-SHORT"], "under the minimum: too short to be an identifier"),
+    (["-ABCDEF", "ABCDEF"], "a separator with nothing in front of it"),
+    (["", "LAP-ABCDEF", "ABCDEF"], "an empty key among real ones"),
+    (["ASSET.ABC123", "ABC123", "WS_ABC123X"], "mixed separators"),
+])
+def test_the_alias_matcher_agrees_with_its_definition_on_hard_cases(keys, why):
+    devices = {k: {} for k in keys}
+    assert derive._device_aliases(devices) == _aliases_by_definition(devices), why
+
+
+def test_the_alias_matcher_agrees_with_its_definition_on_random_estates():
+    """Property test rather than examples. The rewrite is only worth having
+    if it is indistinguishable from the definition, and the way to believe
+    that is to try inputs nobody thought about."""
+    import random
+    import string
+
+    rng = random.Random(20260901)
+    seps = derive._ALIAS_SEPARATORS
+    for _ in range(300):
+        keys = set()
+        for _ in range(rng.randint(4, 90)):
+            core = "".join(rng.choice(string.ascii_uppercase + string.digits)
+                           for _ in range(rng.randint(3, 9)))
+            roll = rng.random()
+            if roll < 0.45:
+                keys.add(rng.choice(["LAP", "MAC", "WS", "ASSET", "IT"])
+                         + rng.choice(seps) + core)
+            elif roll < 0.6:
+                keys.add(core.lower())
+            else:
+                keys.add(core)
+        devices = {k: {} for k in keys}
+        assert derive._device_aliases(devices) == _aliases_by_definition(devices), (
+            "diverged on %r" % sorted(keys))
+
+
+def test_a_large_estate_does_not_take_quadratic_time():
+    """The guard against the regression that caused this.
+
+    Twenty thousand device keys took the pairwise form roughly thirty
+    seconds; indexed it is milliseconds. The bound is deliberately loose -
+    this is here to catch a return to quadratic, which would miss it by two
+    orders of magnitude, not to police a percentage drift on a shared CI
+    runner.
+    """
+    import time
+
+    devices = {}
+    for i in range(20_000):
+        devices["SERIAL%06d" % i] = {}
+        if i % 3 == 0:
+            devices["LAP-SERIAL%06d" % i] = {}
+
+    started = time.perf_counter()
+    out = derive._device_aliases(devices)
+    elapsed = time.perf_counter() - started
+
+    # Every third key is a bare form with exactly one prefixed partner.
+    assert len(out) == len(range(0, 20_000, 3))
+    assert elapsed < 5.0, "took %.1fs: the pairwise scan is back" % elapsed
+
+
+# --------------------------------------------------------- the graph cache --
+
+
+def test_a_slow_build_is_still_cached_afterwards():
+    """The cache used to stamp an entry with the time the build STARTED, so
+    an entry was born as old as the build that made it. On any deployment
+    where a build took longer than CACHE_TTL that made it expired on
+    arrival: the cache returned nothing, ever, and every page load paid full
+    cost. The symptom is a portal that is uniformly slow rather than slow
+    once, which reads like a sizing problem and is not one."""
+    from app import main
+
+    clock = {"t": 1000.0}
+    real_time = main.time.time
+    main.time.time = lambda: clock["t"]
+    builds = {"n": 0}
+
+    def slow_build():
+        builds["n"] += 1
+        clock["t"] += 40.0          # a build longer than the 30s TTL
+        return {"v": builds["n"]}
+
+    try:
+        main._cache.pop("graph", None)
+        main._cached("graph", 168, slow_build)
+        clock["t"] += 1             # a second later, somebody loads the page
+        value, _ = main._cached("graph", 168, slow_build)
+    finally:
+        main.time.time = real_time
+        main._cache.pop("graph", None)
+
+    assert builds["n"] == 1, "rebuilt a value it had just finished building"
+    assert value == {"v": 1}
+
+
+def test_two_readers_at_once_produce_one_build():
+    """These endpoints are sync defs, so FastAPI runs them in a threadpool
+    and two people refreshing genuinely overlap. Without single-flight that
+    is two full reads of the same window for one answer - which is the shape
+    that turns a busy morning into a slow portal."""
+    import threading
+
+    from app import main
+
+    builds = {"n": 0}
+    started = threading.Event()
+
+    def slow_build():
+        builds["n"] += 1
+        started.set()
+        time.sleep(0.3)             # long enough for the others to arrive
+        return {"v": "shared"}
+
+    main._cache.pop("graph", None)
+    results = []
+    threads = [threading.Thread(
+        target=lambda: results.append(main._cached("graph", 168, slow_build)[0]))
+        for _ in range(4)]
+    try:
+        threads[0].start()
+        started.wait(timeout=5)     # make sure the first is inside the builder
+        for t in threads[1:]:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+    finally:
+        main._cache.pop("graph", None)
+
+    assert builds["n"] == 1, "%d builds for four concurrent readers" % builds["n"]
+    assert results == [{"v": "shared"}] * 4
+
+
+def test_refresh_drops_the_findings_behind_the_view():
+    """Refresh means go and look again. Dropping only the derived value
+    would rebuild it from a findings list that is still cached, so the
+    button would redraw identical numbers and look like it had worked."""
+    from app import main
+
+    main._cache["graph"] = {"value": 1, "at": time.time(), "hours": 168}
+    main._cache["findings"] = {"value": [], "at": time.time(), "hours": 168}
+    main._invalidate_derived("graph")
+    assert "graph" not in main._cache
+    assert "findings" not in main._cache


### PR DESCRIPTION
A refresh on a real estate sat on "Reading findings…" for around forty seconds. The obvious readings were a slow log store or an undersized pod. It was neither.

## What it actually was

Profiling one graph build: **`_device_aliases` was 86.8 of 87.4 seconds — 99.4% of the whole thing.** It compared every device key against every other one, so cost was quadratic in device count, not in findings:

| findings | devices | `graph_from` |
|---|---|---|
| 100,000 | 4,000 | 1.2s |
| 100,000 | 20,000 | 33.4s |
| 200,000 | 40,000 | 113.4s |

294 million generator calls and 235 million `str.endswith` calls to draw one page. No amount of CPU fixes that — it is single-threaded and quadratic, so a bigger pod buys nothing for a single request.

Worth recording how nearly this was misdiagnosed: the first benchmark used four thousand devices, showed 1.2s, and pointed squarely at Loki. The blowup only appears at real cardinality. **When benchmarking this code, raise the device count — findings count is not the driver.**

## The fix

The relation being computed is "does some key end with `<separator><bare>`", and that question is invertible. Rather than testing every pair, take each key's own post-separator tails and look those up among the bare keys. A key holds a handful of separators, so cost tracks the number of devices instead of its square.

End to end, on identical findings:

| devices | before | after |
|---|---|---|
| 5,000 | 8.04s | 0.18s |
| 15,000 | 17.16s | 0.35s |
| 30,000 | 74.81s | 0.91s |

## Why you can believe nothing merges differently

A faster function that merges a different set of machines would be worse than the slow one, so this is the part that got the attention rather than the speed.

The slow pairwise form is now written out in the tests as `_aliases_by_definition`. It **is** the specification — deliberately the obvious, readable, quadratic version — and the shipped implementation is required to agree with it on every input: seven adversarial cases (ambiguity, A→B→C chains, case differing between sources, keys under the minimum length, a separator with nothing in front of it, empty keys, mixed separators) plus three hundred randomised estates.

On the same inputs **the entire derived graph compares equal**, not merely the alias map. The existing behavioural tests are untouched — they are the contract, and this is an implementation swap beneath them.

## Three more, because they survive the build being fast

**The cache stamped entries with the time the build started.** An entry was born as old as the build that made it, so on any deployment where a build outran `CACHE_TTL` it was expired on arrival: the cache returned nothing, ever, and every page load paid full cost. Effective TTL was `CACHE_TTL - build_duration`, which goes negative exactly when caching matters. The symptom is a portal that is uniformly slow rather than slow once — which reads like a sizing problem and is not one.

**One findings read per page, not three.** Graph, status, paste-guard and register each read the findings separately with identical arguments, so opening the portal paginated the whole window three times, in series, because the page awaits them one after another. They now share one read. That is also more correct than what it replaces: three reads happen at three instants and can legitimately disagree about the same minute, and one snapshot cannot. Refresh drops the shared findings along with the derived view, or the button would redraw the same numbers off a still-cached list and look like it had worked.

**Builds are single-flight.** These endpoints are sync defs, so FastAPI runs them in a threadpool and two people refreshing genuinely overlap. Without a lock that was two full reads of the same window for one answer.

## An aside that fell out of it

The portal never called `logging.basicConfig`, so every `log.info` in it went nowhere — including the one whose comment promises the log-store fallback is "not silent", and the one that says the weekly digest was sent. Only warnings and errors were ever visible, through Python's last-resort handler.

Turned on at level only, and deliberately not redirecting the stream. Matching the receiver's `stream=sys.stdout` moved warnings off stderr, where a test pins them, and moving output an operator may already be grepping is not worth it to enable some info lines.

With it on, a page load says where its time went:

```
INFO:     read 7 findings over 168h in 0.01s
INFO:     built 'findings' in 0.01s
INFO:     built 'graph' in 0.03s
INFO:     built 'status' in 0.00s
INFO:     built 'paste_guard' in 0.01s
```

One read, three builds. Working out that a slow portal was a quadratic graph build took a profiler; it should take a log line.

## Deliberately not done

**Parallelising the Loki pagination.** It is strictly sequential — each page's end comes from the previous page's oldest entry — and slicing the window into concurrent sub-queries would complicate the `max_findings` truncation semantics that `findings_truncated` and the evidence manifest depend on (#104). With the build now sub-second the read should no longer dominate. Better to come back to it with numbers than add concurrency to a correctness-sensitive path on spec.

**Raising `CACHE_TTL_SECONDS` or lowering `LOOKBACK_HOURS`.** Both buy speed with freshness or with the size of the window. They stay available as operator levers; the defaults should not need them.

## Checking it

The three new guards were each verified to fail against the old code before being trusted — old cache produced 2 builds where the test asserts 1, no lock produced 4 builds for 4 concurrent readers, and the old matcher took 48.6s against a 5s bound. A guard that passes on the broken code is not a guard.

The scale test builds twenty thousand device keys and asserts the work finishes well inside a loose bound. Loose on purpose: it is there to catch a return to quadratic, which would miss by two orders of magnitude, not to police a percentage drift on a shared runner.

Also run against a stand-in log store end to end, with the views compared before and after: same tools, same counts, same installed-versus-used split.

Suites green: portal 542, receiver and registry 299, scanner 164.
