### PR TITLE
release: 0.21.1, a refresh that answers

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.21.0
+version: 0.21.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.21.0"
+appVersion: "0.21.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.1
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.1
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.1
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Version bump only. The work is in #224, which did not touch `charts/` and so did not carry a version with it.

Without this, `appVersion` stays at `0.21.0` and a default `helm install` keeps pulling the image from before the fix while reporting success — the exact failure the appVersion gate exists to catch, and the reason tagging `v0.21.1` against an unbumped chart would fail CI.

**Patch rather than minor.** The change is performance only: `_device_aliases` was 99.4% of every graph build and quadratic in device count, and the entire derived graph compares equal to what the old code produced. Nothing the portal reports is different — only how long you wait for it.

The five places, as usual: `Chart.yaml` version and appVersion, `receiver/deploy/receiver.yaml`, and both image references in `docs/deployment/kubernetes.md`.

Suites green: receiver 277 (the trio test enforces this set), chart lints clean.
