### PR TITLE
One refresh, one read of the log store

### DIFF
--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -732,16 +732,31 @@ def _cached(key, hours, builder):
         return value, at
 
 
-def _invalidate_derived(key):
-    """Drop a derived view AND the findings behind it.
+# Every view derived from one findings read. A refresh drops all of them,
+# not just the one being asked for - see _invalidate_all.
+_DERIVED_KEYS = ("graph", "status", "paste_guard", "register")
 
-    Refresh means "go and look again". Dropping only the derived value
-    would rebuild it from a findings list that is still cached, so the
-    button would redraw the same numbers and look like it had worked -
+
+def _invalidate_all():
+    """Everything a refresh must drop: the shared findings, and every view
+    derived from them.
+
+    All of them, on any one of them, because a refresh is one action on one
+    page rather than four independent requests. Dropping only the view being
+    asked for would rebuild it from a findings list that is still cached, so
+    the button would redraw the same numbers and look like it had worked -
     the one outcome a refresh must never produce.
+
+    And all of them AT ONCE, so the front end only has to say `refresh=true`
+    once. Saying it on each of the four - which is what it used to do -
+    meant each request threw away the findings the previous one had just
+    fetched, so one click cost four full reads of identical data. On an
+    estate where a read takes seconds, that is the whole of the delay this
+    was supposed to remove.
     """
-    _cache.pop(key, None)
     _cache.pop("findings", None)
+    for key in _DERIVED_KEYS:
+        _cache.pop(key, None)
 
 
 def _findings_cached(hours, request=None):
@@ -1064,7 +1079,7 @@ def graph(request: Request,
     indistinguishable from a portal that is not working."""
     hours = hours or LOOKBACK_HOURS
     if refresh:
-        _invalidate_derived("graph")
+        _invalidate_all()
     def build():
         findings = _findings_cached(hours, request)
         reg = _registry(request)
@@ -1085,7 +1100,7 @@ def status(request: Request,
            _=Depends(require_auth)):
     hours = hours or LOOKBACK_HOURS
     if refresh:
-        _invalidate_derived("status")
+        _invalidate_all()
     def build():
         return derive.status_from(_findings_cached(hours, request))
 
@@ -1161,7 +1176,7 @@ def paste_guard_events(request: Request,
     """
     hours = hours or LOOKBACK_HOURS
     if refresh:
-        _invalidate_derived("paste_guard")
+        _invalidate_all()
 
     def build():
         findings = _findings_cached(hours, request)
@@ -1201,7 +1216,7 @@ def register(request: Request,
     """
     hours = hours or LOOKBACK_HOURS
     if refresh:
-        _invalidate_derived("register")
+        _invalidate_all()
 
     # Fetched outside the cached build: the unmatched section below needs it
     # on every request, and in managed mode it carries the portal-recorded

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -1383,6 +1383,11 @@ async function load(force) {
   // seconds on a large estate.
   drawNav();
   app.innerHTML = '<p class="lede">Reading findings…</p>';
+  // Only the FIRST read carries it. The server drops every derived view
+  // and the findings behind them on one refresh, so the calls after this
+  // rebuild from that same fresh read rather than each throwing it away
+  // and fetching again - which is what four ?refresh=true in a row used
+  // to do, at one full read of the log store apiece.
   const q = force ? '?refresh=true' : '';
   // Refresh must clear the views that read a second endpoint too, or the
   // button refreshes some of the page and silently not the rest.
@@ -1406,11 +1411,11 @@ async function load(force) {
     const gr = await fetch('/api/graph' + q);
     if (!gr.ok) throw new Error((await gr.json()).detail || gr.statusText);
     G = await gr.json();
-    const sr = await fetch('/api/status' + q);
+    const sr = await fetch('/api/status');
     if (sr.ok) S = await sr.json();
     // Fetched here rather than lazily, because the overview may draw a paste
     // guard widget and a widget that fetches on render would flash empty.
-    const pr = await fetch('/api/paste-guard' + q);
+    const pr = await fetch('/api/paste-guard');
     if (pr.ok) PG = await pr.json();
     // The recorded answers to findings (acknowledged / accepted), managed
     // mode only. Failure leaves PSTAT null and every row simply reads open.
@@ -1442,7 +1447,7 @@ async function load(force) {
     // Same again for the review queue: it draws from the register, and in
     // managed mode from the discovery candidates queue too.
     if ((CFG.overview_widgets || []).some(w => w.kind === 'review_queue')) {
-      const rr = await fetch('/api/register' + q);
+      const rr = await fetch('/api/register');
       if (rr.ok) REG = await rr.json();
       if (CFG.managed && CFG.managed.enabled && AUTH && AUTH.mode === 'login') {
         const cq = await mfetch('/api/candidates');

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -1137,14 +1137,57 @@ def test_two_readers_at_once_produce_one_build():
     assert results == [{"v": "shared"}] * 4
 
 
-def test_refresh_drops_the_findings_behind_the_view():
-    """Refresh means go and look again. Dropping only the derived value
-    would rebuild it from a findings list that is still cached, so the
-    button would redraw identical numbers and look like it had worked."""
+def test_one_refresh_drops_every_view_and_the_findings_behind_them():
+    """Refresh means go and look again, for the whole page.
+
+    Dropping only the view being asked for would rebuild it from a findings
+    list that is still cached, so the button would redraw identical numbers
+    and look like it had worked. Dropping ALL of them means the front end
+    only has to say refresh once - and it has to, because saying it on each
+    of the four made every request throw away the findings the previous one
+    had just fetched, which cost four reads of identical data for one click.
+    """
     from app import main
 
-    main._cache["graph"] = {"value": 1, "at": time.time(), "hours": 168}
-    main._cache["findings"] = {"value": [], "at": time.time(), "hours": 168}
-    main._invalidate_derived("graph")
-    assert "graph" not in main._cache
+    now = time.time()
+    for key in main._DERIVED_KEYS + ("findings",):
+        main._cache[key] = {"value": 1, "at": now, "hours": 168}
+
+    main._invalidate_all()
+
+    assert not [k for k in main._DERIVED_KEYS if k in main._cache]
     assert "findings" not in main._cache
+
+
+def test_a_refresh_burst_reads_the_log_store_once():
+    """The regression this exists to stop.
+
+    One click fetches graph, status, paste-guard and register. Only the
+    first carries refresh; the rest must rebuild from the findings it
+    fetched, not go back to the log store. Once a read costs seconds, the
+    difference between one and four is the difference between a portal
+    people use and one they wait for.
+    """
+    from app import main
+
+    reads = {"n": 0}
+
+    def fake_findings(hours, request=None):
+        reads["n"] += 1
+        return []
+
+    real = main._findings
+    main._findings = fake_findings
+    try:
+        main._invalidate_all()
+        # graph arrives with refresh=true and clears everything.
+        main._invalidate_all()
+        main._findings_cached(168)          # graph
+        main._findings_cached(168)          # status
+        main._findings_cached(168)          # paste-guard
+        main._findings_cached(168)          # register
+    finally:
+        main._findings = real
+        main._invalidate_all()
+
+    assert reads["n"] == 1, "%d reads for one refresh" % reads["n"]


### PR DESCRIPTION
0.21.1 gave the four derived views a shared findings read, and then defeated it.

A page draws four things — the tools graph, the status strip, the paste-guard card and the register. Refresh clears the shared findings, so the button cannot redraw stale numbers off a list fetched before you clicked. But the page sent `?refresh=true` on **all four** calls, so each one threw away the findings the previous one had just fetched.

One click therefore cost four full reads of identical data. On any estate where a read takes seconds, that is most of the wait.

## Why 0.21.1 did not feel faster

The quadratic graph build it fixed was real — `_device_aliases` was 99.4% of a build and would have become the wall as a fleet grew. But reads dominate long before the build does, and this is the half that was missed. Fixing the computation while still reading the store four times a click leaves the number on the stopwatch roughly where it was.

Worth stating plainly rather than quietly correcting: the earlier diagnosis over-attributed the delay to the build. The instrumentation added in 0.21.1 is what made that visible, which is the argument for having added it.

## The change

A refresh now drops every derived view **and** the findings behind them at once, so the page only has to ask once. The first call carries `refresh=true`; the other three rebuild from the read it did rather than going back to the store.

Clearing all of them together is what makes asking once safe — a later view cannot serve a result cached from before the click, because there is nothing left to serve. It also means a view added later is covered without anyone remembering to wire it up, since the invalidation walks the derived keys rather than naming one.

## What is checked

Three properties, because the risk in this direction is trading slow for wrong:

- **A refresh burst reads the store exactly once.** Four calls, one read.
- **A refresh still refreshes.** On a warm cache it goes back to the store rather than becoming a no-op — the failure that would make the button a lie in the other direction.
- **A refresh clears all four views and the findings**, so nothing survives that predates the click.

Verified end to end against a stand-in store, including from a browser rather than only curl: a real Refresh click issues `graph?refresh=true` followed by three plain reads, and produces one read and five builds. A warm load with no refresh reads nothing at all.

The inline-script parse test passes — required after any edit to `index.html`, where a splice anchored on non-unique text has duplicated half the script before.

Suites green: portal 543, receiver and registry 299, scanner 164.

## What is left after this

The remaining wait is the log store answering a seven-day query, and that is now the whole of it. Two things worth doing before writing any parallel-fetch code:

- **Check the log store's own resourcing.** If it is CPU-throttled or reading from cold storage, that is a config change and a better fix than anything here.
- **Re-read the timing lines once this ships.** If a single read is still slow, parallel pagination is worth its risk — the `max_findings` truncation semantics that `findings_truncated` and the evidence manifest depend on are the part that needs care. If the store speeds up once fed, it is not.
