### PR TITLE
release: 0.21.2, one refresh and one read

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.21.1
+version: 0.21.2
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.21.1"
+appVersion: "0.21.2"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.1
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.2
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.1
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.2
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.1
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.2
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Version bump only. The work is in #226, which did not touch `charts/` and so carried no version with it.

Without this, `appVersion` stays at `0.21.1` and a default `helm install` keeps pulling the image from before the fix while reporting success — the failure the appVersion gate exists to catch, and the reason tagging `v0.21.2` against an unbumped chart would fail CI.

**Patch.** A caching fix: a refresh dropped the shared findings once per view rather than once per click, so each of the four views threw away what the previous one had fetched. Nothing about what the portal reports changes.

The usual five places: `Chart.yaml` version and appVersion, `receiver/deploy/receiver.yaml`, and both image references in `docs/deployment/kubernetes.md`.

Suites green: receiver 277 (the trio test enforces this set), chart lints clean.
