### PR TITLE
The portal is the route now, and the demo's own port was missing

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -13,7 +13,13 @@ before they reach an AI tool.
 ## Run it
 
 Requires Docker with Compose v2 (`docker compose`, not the legacy
-`docker-compose`), and ports 3000, 8080, 3100 and 8090 free.
+`docker-compose`), and these ports free: **8091** (the portal), 8080 (the
+receiver), 3000 (Grafana), 3100 (the log store), 8090 (the paste guard
+page), 8025 (the mailbox) and 8092 (the stand-in identity provider).
+
+The portal was missing from that list for a while, which is the worst one to
+leave out: the address the instructions send you to is the address that
+quietly fails.
 
 From the repository root:
 

--- a/endpoint/linux/README.md
+++ b/endpoint/linux/README.md
@@ -8,7 +8,8 @@ itself, because RMM and cron jobs run as root, whose home is `/root` and
 contains nothing worth scanning.
 
 Which tools to look for is fetched from the receiver's `/registry/collector`
-endpoint at runtime. Adding a new AI tool is a registry merge request, not a
+endpoint at runtime. Adding a new AI tool is a registry entry - defined in the
+portal, or by merge request against registry.yaml - not a
 change to this script.
 
 ## The one requirement

--- a/endpoint/linux/ai-guard-collector.sh
+++ b/endpoint/linux/ai-guard-collector.sh
@@ -10,7 +10,8 @@
 #
 # The identifiers for all four come from the receiver's /registry/collector
 # at runtime. Nothing tool-specific is hardcoded: adding a new AI tool is a
-# registry merge request, not a script edit plus a re-push through the RMM.
+# registry entry - defined in the portal, or by merge request - not a script
+# edit plus a re-push through the RMM.
 #
 # Delivery: any mechanism that can run this as root on a schedule - an RMM
 # (Level, NinjaOne, Action1...), an Ansible cron/systemd-timer role, or plain

--- a/endpoint/macos/README.md
+++ b/endpoint/macos/README.md
@@ -6,8 +6,9 @@ extensions, AI desktop apps, local runtimes and MCP server configurations.
 Runs as root via your MDM; resolves the logged-in console user itself.
 
 Which tools to look for is fetched from the receiver's `/registry/collector`
-endpoint at runtime. Adding a new AI tool is a registry merge request, not a
-change to this script.
+endpoint at runtime. Adding a new AI tool is a registry entry - defined in the
+portal, or by merge request against registry.yaml - not a change to this
+script.
 
 **EDR note:** the collector runs as root, reads files in user home directories,
 and POSTs data to an external URL. EDR tools may flag this as suspicious; add

--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -10,7 +10,8 @@
 #
 # The identifiers for all four come from the receiver's /registry/collector
 # at runtime. Nothing tool-specific is hardcoded in this script: adding a new
-# AI tool is a registry merge request, not a script edit plus an MDM re-paste.
+# AI tool is a registry entry - defined in the portal, or by merge request -
+# not a script edit plus an MDM re-paste.
 #
 # Privacy: the account_domain field is the domain only. The console username
 # is sent in the user field (already known to IT via MDM).

--- a/endpoint/windows/README.md
+++ b/endpoint/windows/README.md
@@ -10,7 +10,8 @@ scanning.
 
 Which tools to look for is fetched from the receiver's
 `/registry/collector` endpoint at runtime. Adding a new AI tool is a
-registry merge request, not a script edit plus an Intune re-paste.
+registry entry - defined in the portal, or by merge request against
+registry.yaml - not a script edit plus an Intune re-paste.
 
 **EDR note:** the collector runs as SYSTEM, reads files in user home
 directories, and POSTs data to an external URL. EDR tools may flag this as

--- a/endpoint/windows/ai-guard-collector.ps1
+++ b/endpoint/windows/ai-guard-collector.ps1
@@ -6,7 +6,8 @@
   reports which account domain each tool is signed into, plus installed IDE
   extensions and MCP server configurations. Which identifiers to look for
   come from the receiver's /registry/collector at runtime, so a new AI tool
-  is a registry merge request rather than a script edit plus an Intune
+  is a registry entry - defined in the portal, or by merge request - rather
+  than a script edit plus an Intune
   re-paste. The Windows sibling of
   endpoint/macos/ai-guard-collector.sh - same finding schema, same receiver,
   same design rules learned there:

--- a/governance/governance.yaml.example
+++ b/governance/governance.yaml.example
@@ -18,9 +18,17 @@
 # approved tool signed into a personal account is still the thing to act on,
 # because the risky part is the account. Approval must never come to mean safe.
 #
-# Edit it, raise a merge request, merge it. That is the audit trail, and it is
-# a better one than most portals build: signed, timestamped, reviewable, with a
-# diff of exactly what changed and who approved the change.
+# Edit it, raise a merge request, merge it. That is one audit trail, and a good
+# one: signed, timestamped, reviewable, with a diff of exactly what changed and
+# who approved the change.
+#
+# It is no longer the only one. In managed mode the register's cards gain an
+# edit control, decisions are recorded in the receiver with who and when, and
+# the same validator runs on that path - an approval with no review date is
+# refused there too. The two coexist per tool: a portal-recorded decision
+# wins, this file fills the gaps, and the register labels which kind it is
+# showing. Exceptions stay file-only on purpose, because they are rarer and
+# worth the review a merge request gives them. See docs/governance.md.
 
 version: 1
 

--- a/portal/collector-scripts/collector-linux.sh
+++ b/portal/collector-scripts/collector-linux.sh
@@ -10,7 +10,8 @@
 #
 # The identifiers for all four come from the receiver's /registry/collector
 # at runtime. Nothing tool-specific is hardcoded: adding a new AI tool is a
-# registry merge request, not a script edit plus a re-push through the RMM.
+# registry entry - defined in the portal, or by merge request - not a script
+# edit plus a re-push through the RMM.
 #
 # Delivery: any mechanism that can run this as root on a schedule - an RMM
 # (Level, NinjaOne, Action1...), an Ansible cron/systemd-timer role, or plain

--- a/portal/collector-scripts/collector-macos.sh
+++ b/portal/collector-scripts/collector-macos.sh
@@ -10,7 +10,8 @@
 #
 # The identifiers for all four come from the receiver's /registry/collector
 # at runtime. Nothing tool-specific is hardcoded in this script: adding a new
-# AI tool is a registry merge request, not a script edit plus an MDM re-paste.
+# AI tool is a registry entry - defined in the portal, or by merge request -
+# not a script edit plus an MDM re-paste.
 #
 # Privacy: the account_domain field is the domain only. The console username
 # is sent in the user field (already known to IT via MDM).

--- a/portal/collector-scripts/collector-windows.ps1
+++ b/portal/collector-scripts/collector-windows.ps1
@@ -6,7 +6,8 @@
   reports which account domain each tool is signed into, plus installed IDE
   extensions and MCP server configurations. Which identifiers to look for
   come from the receiver's /registry/collector at runtime, so a new AI tool
-  is a registry merge request rather than a script edit plus an Intune
+  is a registry entry - defined in the portal, or by merge request - rather
+  than a script edit plus an Intune
   re-paste. The Windows sibling of
   endpoint/macos/ai-guard-collector.sh - same finding schema, same receiver,
   same design rules learned there:

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -791,7 +791,8 @@ def registry(request: Request, authorization: str = Header(default="")):
 def registry_collector(request: Request, authorization: str = Header(default="")):
     """cli/ide/desktop/mcp identifiers for the endpoint collectors.
 
-    Served so a new AI tool is a registry merge request rather than an edit
+    Served so a new AI tool is a registry entry - defined in the portal, or
+    by merge request - rather than an edit
     to every collector script plus an MDM re-paste on each platform.
 
     Deployment config rides in the same response under "config" when the

--- a/registry/registry.yaml
+++ b/registry/registry.yaml
@@ -10,8 +10,13 @@
 # fleet-wide scan would otherwise alert per device per unapproved tool every
 # morning, and every tool here ships unapproved. See receiver_reporter.py.
 #
-# Discovery-job candidates are appended with category: unreviewed and
-# added_by: discovery, then triaged in the MR.
+# Discovery-job candidates are posted to the receiver and wait in the portal's
+# review queue, where a person defines or dismisses each one - a tool defined
+# there reaches the fleet with no rebuild. With GitLab configured the
+# discovery job proposes a merge request against this file instead, which is
+# the original route and still the one to use if your registry review lives
+# in a forge. Either way a human is the gate: nothing is detected until
+# somebody decides.
 
 version: 1
 


### PR DESCRIPTION
An audit of the tree against what the platform actually is, before picking up new work. Four things had stopped being true — all written before managed mode had a write path — and one of them breaks the demo for anyone whose 8091 is busy.

## The demo's port list left out the portal

It named 3000, 8080, 3100 and 8090. The stack also publishes **8091 for the portal itself**, 8025 for the mailbox and 8092 for the stand-in identity provider.

That is the worst one to leave out: the address the instructions send you to is the address that quietly fails, and the failure looks like the demo being broken rather than a port being taken.

## Discovery candidates are triaged in the portal

`registry.yaml` said they are "triaged in the MR". They are posted to the receiver and wait in the portal's review queue, where a person defines or dismisses each one and a tool defined there reaches the fleet with no rebuild. The merge request is what happens *instead* when GitLab is configured — the original route, still right for a registry review that lives in a forge, but no longer the default.

## Governance has two audit trails, not one

`governance.yaml.example` said a merge request "is the audit trail", and better than what most portals build. It was, when it was the only one. Managed mode records decisions in the receiver stamped with who and when, runs the same validator on that path — an approval with no review date is refused there too — and the two coexist per tool with the portal record winning and the file filling gaps.

`docs/governance.md` already explains this properly, including why exceptions stay file-only. The example file was the outlier.

## "Adding a tool is a registry merge request" — half an answer

Three collector READMEs, three collector scripts and one receiver docstring. The point they are making — that it is not a script edit and not an MDM re-paste — still stands. But a registry entry is now defined in the portal *or* by merge request, and naming only one of those is half of it.

The portal's copies of the collector scripts are re-copied, which a test enforces.

## What was checked and found correct

The README leads with the portal being where the platform is operated, with classic mode as the alternative. `architecture.md` has the queue as the default and the MR as a parenthetical. `docs/governance.md` narrates the move from file-only to managed deliberately rather than quietly.

Two things looked stale and are not, so they are recorded here rather than "fixed" by somebody later:

- **The sign-on card's `beta` pill is deliberate.** Its tooltip says "run against one real Entra tenant so far", and the comment beside it explains that exercised-once is a different claim from proven.
- **The receiver does not verify the id_token signature, and should not start.** OpenID Connect Core 3.1.3.7 permits TLS server validation in place of signature checking when the token is fetched by the client directly from the token endpoint, which is this flow. Issuer, audience, nonce, expiry and `auth_time` are all checked anyway. The reasoning, and the condition under which to revisit it, is at `receiver/app/main.py`.

## How it was verified

By running the demo the way somebody cloning the repository would, not by reading it: `docker compose up`, the setup code out of the receiver's log, the first-boot account, the seven-step wizard, the skip confirmation, the guided tour, and every screen against seeded data — Overview, Inventory, Governance, Budget, Health, Fleet and Settings — plus the sign-on wizard and the stand-in provider's OIDC discovery document.

Worth knowing, not a bug: the demo footer reads `vdev` because no `APP_VERSION` is set there, which also makes the wizard's generated CronJobs pin `:latest` in the demo. Both are honest for a build from source.

Suites green: portal 543, receiver and registry 299, scanner 164.
