### PR TITLE
The MCP row could never report, whatever the estate had

### DIFF
--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -1219,22 +1219,25 @@ def status_from(findings):
     and "the Entra scanner has never reported, here is the doc". Absence is
     ambiguous on its own, so each row says which of the two it is where it
     can, and says nothing more where it cannot."""
-    by_source = defaultdict(lambda: {"findings": 0, "last_seen": "", "devices": set()})
-    for f in findings:
-        src = f.get("source") or "(none)"
-        e = by_source[src]
+    def _tally(index, key, f):
+        e = index[key]
         e["findings"] += 1
-        ts = f.get("reported_at") or ""
-        e["last_seen"] = max(e["last_seen"], ts)
+        e["last_seen"] = max(e["last_seen"], f.get("reported_at") or "")
         dev = (f.get("device") or "").strip()
         if dev:
             e["devices"].add(dev)
 
-    # The authoritative list. Scanner values are DetectionSource in
-    # scanner/ai_guard/scanners/base.py; collectors and the extension set
-    # theirs directly. Guessing at these produces a setup page that reports
-    # "not reporting" for something that is reporting, which is the exact
-    # false signal this view exists to remove.
+    _blank = lambda: {"findings": 0, "last_seen": "", "devices": set()}
+    by_source = defaultdict(_blank)
+    # A second index, because not every row in the list below is a scanner.
+    # See _JUDGED_ON_SURFACE.
+    by_surface = defaultdict(_blank)
+    for f in findings:
+        _tally(by_source, f.get("source") or "(none)", f)
+        surface = (f.get("surface") or "").strip()
+        if surface:
+            _tally(by_surface, surface, f)
+
     # The authoritative list. Scanner values are DetectionSource in
     # scanner/ai_guard/scanners/base.py; collectors and the extension set
     # theirs directly. Guessing at these produces a setup page that reports
@@ -1244,6 +1247,27 @@ def status_from(findings):
     # Each carries what it needs to start reporting, because a status page
     # that says "not reporting" and nothing else leaves the reader exactly
     # where they were.
+    # Rows judged on the SURFACE a finding carries rather than on its source.
+    #
+    # MCP is the case that forced this. Its findings come from the endpoint
+    # collectors, which stamp their own source on everything they send
+    # ("collector-macos" and friends) and set the surface to "mcp"
+    # separately. Nothing in a routine scan run has ever emitted a source of
+    # "mcp_scan": the module that would is the one `ai-guard mcp-scan`
+    # points at a config file by hand.
+    #
+    # So this row matched on a value that never arrives, and reported "not
+    # reporting" on an estate whose Inventory was listing MCP servers from
+    # the very same findings. Its help text then invited the reader to
+    # conclude nobody had configured one - which is exactly the false signal
+    # the note above says this view exists to remove, and the reason a row
+    # that describes a surface has to be judged on one.
+    #
+    # Not fixed by having collectors send source "mcp_scan" instead: source
+    # is how a device is known to have a collector on it at all
+    # (COLLECTOR_SOURCES), and which collector found it is worth keeping.
+    _JUDGED_ON_SURFACE = {"mcp_scan": "mcp"}
+
     expected = [
         ("endpoint", "collector-macos", "macOS collector", "endpoint/macos/README.md",
          "Download the pre-configured script below and run it as a Jamf "
@@ -1335,7 +1359,8 @@ def status_from(findings):
 
     rows = []
     for group, src, label, doc, needs in expected:
-        e = by_source.get(src)
+        surface = _JUDGED_ON_SURFACE.get(src)
+        e = by_surface.get(surface) if surface else by_source.get(src)
         rows.append({
             "group": group,
             "source": src,

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -1191,3 +1191,62 @@ def test_a_refresh_burst_reads_the_log_store_once():
         main._invalidate_all()
 
     assert reads["n"] == 1, "%d reads for one refresh" % reads["n"]
+
+
+# ------------------------------------------------- the sources status page --
+
+
+def test_the_mcp_row_reports_from_the_findings_that_actually_carry_it():
+    """The row said "not reporting" on estates whose Inventory was listing
+    MCP servers from the very same findings.
+
+    MCP findings come from the endpoint collectors, which stamp their own
+    source on everything they send and set the surface to "mcp" separately.
+    Nothing in a routine scan run has ever emitted a source of "mcp_scan" -
+    the module that would is the one `ai-guard mcp-scan` points at a config
+    file by hand. So the row matched a value that never arrives.
+
+    That is the exact false signal this page exists to remove, and it was
+    worse than a wrong pill: the row's help text invited the reader to
+    conclude nobody had configured an MCP server."""
+    st = derive.status_from([
+        finding(tool="claude-code-mcp", surface="mcp", source="collector-macos",
+                device="MAC-1", evidence="~/.claude.json mcpServers: github"),
+        finding(tool="claude-code-mcp", surface="mcp", source="collector-linux",
+                device="NIX-1", evidence="~/.claude.json mcpServers: filesystem"),
+    ])
+
+    row = [r for r in st["sources"] if r["source"] == "mcp_scan"][0]
+    assert row["reporting"] is True
+    assert row["findings"] == 2
+    assert row["devices"] == 2
+    assert [g for g in st["groups"] if g["group"] == "mcp"][0]["reporting"] == 1
+
+
+def test_the_mcp_row_stays_silent_when_nobody_has_configured_one():
+    """The other half. Judging on surface must not turn the row into
+    something that is always green - a status page that cannot say "no" is
+    as useless as one that cannot say "yes"."""
+    st = derive.status_from([
+        finding(tool="claude-code", surface="cli", source="collector-macos"),
+    ])
+
+    row = [r for r in st["sources"] if r["source"] == "mcp_scan"][0]
+    assert row["reporting"] is False
+    assert row["findings"] == 0
+
+
+def test_judging_one_row_on_surface_leaves_the_scanner_rows_alone():
+    """Every other row is a scanner and stays matched on source. If this
+    slips, a page whose whole job is telling set-up apart from silent starts
+    guessing."""
+    st = derive.status_from([
+        finding(tool="claude-code-mcp", surface="mcp", source="collector-macos"),
+    ])
+    by = {r["source"]: r for r in st["sources"]}
+
+    assert by["collector-macos"]["reporting"] is True   # it did send this
+    assert by["entra_sign_in"]["reporting"] is False
+    assert by["sentinelone_dns"]["reporting"] is False
+    # And a surface value must never be mistaken for a source.
+    assert "mcp" not in by


### PR DESCRIPTION
Found by noticing that the Sources page said MCP was **not reporting** while Inventory, on the same findings, was listing MCP servers across several devices and naming the tools that had configured them. Both numbers were right about their own data. Only one of them was asking the right question.

## Why it could never report

`status_from` indexes findings by their `source` field, and the MCP row matched the value `mcp_scan`. Nothing in a routine scan run has ever sent that.

MCP findings come from the endpoint collectors, which hardcode their own source on everything they send — `collector-macos` and friends — and set the surface to `mcp` separately:

```
"source":"collector-macos"          # endpoint/macos/ai-guard-collector.sh
report_once "mcp" "${tool}-mcp" ... # surface set here, source already fixed
```

The module that *would* send `mcp_scan` is the one `ai-guard mcp-scan` points at a config file by hand — not part of a scan run, not on a schedule.

So the row matched a value that never arrives, and could only ever say "not reporting".

## Why this one is worse than a wrong pill

The note directly above that list says:

> Guessing at these produces a setup page that reports "not reporting" for something that is reporting, **which is the exact false signal this view exists to remove.**

And the row's help text does not stop at silence — it draws the conclusion for the reader: *"If a collector is reporting and this is quiet, nobody has configured an MCP server yet."*

So the page did not merely fail to answer. It answered wrongly and gave a reason. Anyone deciding whether MCP was in use would have concluded it was not, while the Inventory tab two clicks away listed the servers.

## The fix

A row that describes a surface is judged on one. There is a second index alongside the source index, and a single map naming which rows use it:

```python
_JUDGED_ON_SURFACE = {"mcp_scan": "mcp"}
```

Every other row stays matched on source exactly as before. A page whose whole job is telling set-up apart from silent must not start guessing at the rest of them either.

**Not** fixed by having the collectors send `mcp_scan` instead. Source is how a device is known to have a collector on it at all (`COLLECTOR_SOURCES`), and which collector found a thing is worth keeping.

## Checked

Three tests, and the first two are the two halves that matter:

- collector-sourced MCP findings make the row report, with the right finding and device counts
- **no MCP findings still means not reporting** — judging on surface must not turn the row into something that is always green; a status page that cannot say "no" is as useless as one that cannot say "yes"
- the scanner rows are untouched, and a surface value is never mistaken for a source

The first was verified to fail against the previous matching before being trusted.

Also confirmed end to end in the local demo, which reproduced the bug: the MCP group went from 0/1 to 1/1 and no other group moved.

One more thing while in there: the comment above that list was duplicated word for word. One copy remains.

Suites green: portal 546, receiver and registry 299.
