### PR TITLE
What runs without a person

### DIFF
--- a/demo/seed.sh
+++ b/demo/seed.sh
@@ -41,6 +41,22 @@ post "{\"tool\":\"codex-cli\",\"surface\":\"cloud\",\"os\":\"unknown\",\"account
 post "{\"tool\":\"cursor\",\"surface\":\"desktop\",\"os\":\"macos\",\"account_domain\":\"\",\"device\":\"C02GENGAR\",\"user\":\"gengar\",\"evidence\":\"~/.cursor\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"collector-macos\"}"
 post "{\"tool\":\"ollama\",\"surface\":\"desktop\",\"os\":\"linux\",\"account_domain\":\"\",\"device\":\"NIX-DITTO\",\"user\":\"ditto\",\"evidence\":\"ollama binary\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"collector-linux\"}"
 
+# --- what runs without a person ---
+# The Agentic AI view. Four shapes, because the page is only worth having if
+# it can tell them apart: a timer under a key nobody owns, a machine with no
+# owner on record, a scheduled job that IS properly attributed, and the one
+# with nothing installed to find - a process that is not a browser and not a
+# tool the registry knows, reaching a model API.
+post "{\"tool\":\"claude-code\",\"surface\":\"cli\",\"os\":\"linux\",\"account_domain\":\"\",\"device\":\"NIX-BULBA\",\"user\":\"bulbasaur\",\"evidence\":\"/etc/systemd/system/nightly-triage.service\",\"severity\":\"warn\",\"reported_at\":\"$(now)\",\"source\":\"collector-linux\",\"mode\":\"autonomous\",\"identity\":\"machine\",\"trigger\":\"systemd timer, every 15 min\"}"
+post "{\"tool\":\"claude-code\",\"surface\":\"cli\",\"os\":\"macos\",\"account_domain\":\"\",\"device\":\"C02EEVEE\",\"user\":\"\",\"evidence\":\"~/Library/LaunchAgents/ai.helper.plist\",\"severity\":\"warn\",\"reported_at\":\"$(now)\",\"source\":\"collector-macos\",\"mode\":\"autonomous\",\"identity\":\"machine\",\"trigger\":\"launchd, at login\"}"
+post "{\"tool\":\"claude-code\",\"surface\":\"cli\",\"os\":\"macos\",\"account_domain\":\"example.com\",\"device\":\"C02PIKACHU\",\"user\":\"pikachu\",\"evidence\":\"~/Library/LaunchAgents/daily-notes.plist\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"collector-macos\",\"mode\":\"autonomous\",\"identity\":\"person\",\"trigger\":\"launchd, every 6 hours\"}"
+# No config file, no known binary, no MCP. Only the network saw it.
+post "{\"tool\":\"claude\",\"surface\":\"network\",\"os\":\"linux\",\"account_domain\":\"\",\"device\":\"NIX-GENGAR\",\"user\":\"\",\"evidence\":\"DNS lookup for api.anthropic.com (via python3)\",\"severity\":\"warn\",\"reported_at\":\"$(now)\",\"source\":\"sentinelone_dns\"}"
+# A browser reaching the same place is the ordinary case and must NOT appear.
+post "{\"tool\":\"claude\",\"surface\":\"network\",\"os\":\"macos\",\"account_domain\":\"\",\"device\":\"C02MEW\",\"user\":\"mew\",\"evidence\":\"DNS lookup for claude.ai (via Google Chrome)\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"sentinelone_dns\"}"
+# Reach for the unattended linux box, so its chain has something in the last box.
+post "{\"tool\":\"claude-code-mcp\",\"surface\":\"mcp\",\"os\":\"linux\",\"account_domain\":\"\",\"device\":\"NIX-BULBA\",\"user\":\"bulbasaur\",\"evidence\":\".claude.json mcpServers: github,postgres-prod\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"collector-linux\"}"
+
 # --- mcp + network ---
 post "{\"tool\":\"claude-code-mcp:atlassian,figma\",\"surface\":\"mcp\",\"os\":\"macos\",\"account_domain\":\"\",\"device\":\"C02PIKACHU\",\"user\":\"pikachu\",\"evidence\":\".claude.json mcpServers\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"collector-macos\"}"
 post "{\"tool\":\"deepseek\",\"surface\":\"network\",\"os\":\"unknown\",\"account_domain\":\"\",\"device\":\"NIX-BULBA\",\"device_name\":\"BULBASAUR-NIX\",\"user\":\"bulbasaur\",\"evidence\":\"dns:deepseek.com\",\"severity\":\"info\",\"reported_at\":\"$(now)\",\"source\":\"sentinelone_bridge\"}"

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -1000,6 +1000,192 @@ def personal_accounts_from(findings, domain_map=None, corp_domains=None,
     return out
 
 
+# Processes that reaching a model API says nothing new about: a browser is
+# how a person uses one. Everything else resolving api.anthropic.com is a
+# process holding a key, and that is the thing worth naming.
+#
+# Deliberately a small list of browsers rather than a large list of runtimes.
+# python, node and pwsh are exactly what a bespoke agent runs as, so an
+# allowlist of "not interesting" is the only shape that does not quietly
+# exclude the case this exists to find.
+BROWSER_PROCESSES = {
+    "chrome", "google chrome", "chrome.exe", "chromium", "chromium.exe",
+    "firefox", "firefox.exe", "safari", "com.apple.safari",
+    "msedge", "msedge.exe", "microsoft edge", "brave", "brave.exe",
+    "brave browser", "opera", "opera.exe", "vivaldi", "vivaldi.exe", "arc",
+}
+
+# The DNS scan writes the process into its evidence as "(via python3)".
+_VIA = re.compile(r"\(via ([^)]{1,80})\)")
+
+
+def bespoke_client(f, known_binaries=()):
+    """The process name when a finding shows something OTHER than a browser
+    or a known AI tool reaching a model, else "".
+
+    This is the case with nothing to inventory. No config file, no registry
+    binary, no MCP server - a script with a key in it, which is what an agent
+    somebody wrote themselves looks like from the outside. The signal was
+    already being collected and never read: the DNS scan records which
+    process resolved the domain, and that has been sitting in evidence text.
+
+    A browser is excluded because a person using a model in a browser is the
+    ordinary case and every other page here already covers it. A known
+    binary is excluded because the tool is then the finding - `claude`
+    reaching Anthropic is claude-code, not a mystery.
+    """
+    if (f.get("surface") or "") not in ("network", "cloud"):
+        return ""
+    m = _VIA.search(f.get("evidence") or "")
+    if not m:
+        return ""
+    proc = m.group(1).strip()
+    low = proc.lower()
+    if low in BROWSER_PROCESSES:
+        return ""
+    stem = low.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    if stem in BROWSER_PROCESSES:
+        return ""
+    for b in known_binaries:
+        b = (b or "").lower()
+        if b and (stem == b or stem == b + ".exe"):
+            return ""
+    return proc[:80]
+
+
+def registry_binaries(reg):
+    """Every binary the registry knows an AI tool runs as."""
+    out = set()
+    for t in (reg or {}).get("tools", []) or []:
+        for b in ((t.get("cli") or {}).get("binaries") or []):
+            out.add(str(b).lower())
+    return out
+
+
+def agentic_from(findings, reg=None):
+    """What runs without a person, and how far it can reach.
+
+    Every other view here starts from something somebody did. This one
+    starts from the absence of that: a finding that says it ran unattended,
+    or a process reaching a model that is neither a browser nor a tool the
+    registry knows.
+
+    Two things are deliberately NOT inferred.
+
+    A finding that says nothing about mode is not autonomous. Absence reads
+    as unknown, because "this ran with nobody watching" is an accusation and
+    silence is not evidence for it - the same rule the rest of the platform
+    follows in the other direction for coverage.
+
+    A blank account domain is not a machine identity. Before `identity`
+    existed, "authenticated by a key" and "installed and never signed in"
+    both arrived blank and could not be told apart. Reading blank as a
+    machine identity would manufacture the finding this page exists to
+    report, on every estate that has not upgraded its collectors.
+    """
+    binaries = registry_binaries(reg)
+
+    # Which MCP servers sit on each machine, so a chain can say what the
+    # thing running there could reach.
+    reach = defaultdict(set)
+    for f in findings:
+        if (f.get("surface") or "") != "mcp":
+            continue
+        dev = (f.get("device") or "").strip()
+        if not dev:
+            continue
+        servers, _ = mcp_servers_in(f)
+        for srv in servers:
+            reach[dev].add(srv)
+
+    agents, seen = [], set()
+    for f in findings:
+        dev = (f.get("device") or "").strip()
+        tool = _base_tool(f.get("tool") or "")
+        mode = (f.get("mode") or "").strip()
+        proc = bespoke_client(f, binaries)
+
+        if mode != "autonomous" and not proc:
+            continue
+
+        key = (dev, tool, proc)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        acct = (f.get("account_domain") or "").strip().lower()
+        identity = (f.get("identity") or "").strip()
+        if not identity and acct:
+            # An account domain is a person by construction. The reverse
+            # does not hold, which is why nothing is inferred from a blank.
+            identity = "person"
+
+        agents.append({
+            "device": dev,
+            "device_name": (f.get("device_name") or "").strip(),
+            "os": f.get("os") or "unknown",
+            "user": (f.get("user") or "").strip(),
+            "tool": tool,
+            "trigger": (f.get("trigger") or "").strip(),
+            "identity": identity,
+            "account": acct,
+            "mode": mode or "unknown",
+            "process": proc,
+            "reach": sorted(reach.get(dev, ())),
+            "evidence": (f.get("evidence") or "")[:300],
+            "last_seen": f.get("reported_at") or "",
+            # The two states worth counting separately. Accountable means
+            # there is something to revoke; the rest is the point of the page.
+            "accountable": identity == "person",
+        })
+
+    agents.sort(key=lambda a: (a["accountable"], a["device"], a["tool"]))
+    return {
+        "agents": agents,
+        "counts": {
+            "agents": len(agents),
+            "unaccountable": sum(1 for a in agents if not a["accountable"]),
+            "machine_identities": sum(1 for a in agents
+                                      if a["identity"] == "machine"),
+            "bespoke": sum(1 for a in agents if a["process"]),
+            "devices": len({a["device"] for a in agents if a["device"]}),
+        },
+        "servers": mcp_from(findings),
+    }
+
+
+def mcp_servers_in(f):
+    """(servers, base tool) for one finding on the mcp surface.
+
+    Two evidence formats are read, because a log store holds both for as long
+    as the lookback window. The current collectors emit
+
+        .claude.json mcpServers: figma,context7
+
+    and older ones folded the list into the tool name instead
+
+        claude-code-mcp:figma,context7
+
+    which is why the second exists at all: every distinct combination of
+    servers became a separate tool, so a machine with two servers and a
+    machine with one looked like two unrelated tools rather than one server
+    in common.
+
+    Split out because more than one view needs it now, and the archaeology
+    above is exactly the kind of thing that rots when it is copied.
+    """
+    tool = f.get("tool") or ""
+    servers, base_tool = [], tool
+    ev = f.get("evidence") or ""
+    if "mcpServers:" in ev:
+        servers = [x.strip() for x in ev.split("mcpServers:", 1)[1].split(",")]
+    elif "-mcp:" in tool:
+        base_tool, listed = tool.split("-mcp:", 1)
+        base_tool += "-mcp"
+        servers = [x.strip() for x in listed.split(",")]
+    return [x for x in servers if x], base_tool
+
+
 def mcp_from(findings):
     """One row per MCP server, with the tools that configured it and the
     devices it was found on.
@@ -1030,15 +1216,7 @@ def mcp_from(findings):
         if not tool:
             continue
 
-        servers, base_tool = [], tool
-        ev = f.get("evidence") or ""
-        if "mcpServers:" in ev:
-            servers = [x.strip() for x in ev.split("mcpServers:", 1)[1].split(",")]
-        elif "-mcp:" in tool:
-            base_tool, listed = tool.split("-mcp:", 1)
-            base_tool += "-mcp"
-            servers = [x.strip() for x in listed.split(",")]
-        servers = [x for x in servers if x]
+        servers, base_tool = mcp_servers_in(f)
         if not servers:
             # A tool on the mcp surface with no server list is still worth
             # recording: something configured MCP and the detail did not

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -734,7 +734,7 @@ def _cached(key, hours, builder):
 
 # Every view derived from one findings read. A refresh drops all of them,
 # not just the one being asked for - see _invalidate_all.
-_DERIVED_KEYS = ("graph", "status", "paste_guard", "register")
+_DERIVED_KEYS = ("graph", "status", "paste_guard", "register", "agentic")
 
 
 def _invalidate_all():
@@ -1155,6 +1155,34 @@ def evidence_snapshot(request: Request,
             headers={"Content-Disposition": 'attachment; filename="%s"' % name},
         )
     return JSONResponse(doc)
+
+
+@app.get("/api/agentic")
+def agentic(request: Request,
+            hours: float = Query(default=None, gt=0, le=24 * 90),
+            refresh: bool = Query(default=False),
+            _=Depends(require_auth)):
+    """What runs without a person, and how far it can reach.
+
+    Built from the same findings as everything else - nothing here needs a
+    source the deployment does not already have. What it adds is a reading:
+    a finding that says it ran unattended, or a process reaching a model
+    that is neither a browser nor a tool the registry knows.
+
+    It reports that something ran and what it could touch. It does not
+    report what it was asked to do, and nothing on this path carries a
+    prompt: the same line the paste guard holds, for the same reason.
+    """
+    hours = hours or LOOKBACK_HOURS
+    if refresh:
+        _invalidate_all()
+
+    def build():
+        return derive.agentic_from(_findings_cached(hours, request),
+                                   _registry(request))
+
+    value, at = _cached("agentic", hours, build)
+    return JSONResponse(dict(value, derived_at=at, hours=hours))
 
 
 @app.get("/api/paste-guard")

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -849,6 +849,40 @@ a.libtn:hover{border-color:var(--pri)}
 @media (prefers-reduced-motion: reduce) {
   .meterrow .fill, .ctip { transition: none; }
 }
+
+/* ---- Agentic AI ------------------------------------------------------
+   Prefixed, because this view draws a shape nothing else here draws and
+   unprefixed names like .node or .chain would collide with the cascade
+   the rest of the page already depends on. */
+.ag-verdict{margin:0 0 6px;font-size:26px;line-height:1.22;letter-spacing:-.02em;
+  font-weight:600;text-wrap:balance;max-width:26ch}
+.ag-verdict em{font-style:normal;color:var(--dstr)}
+.ag-chain{background:var(--sf);border:1px solid var(--bd);border-radius:12px;
+  box-shadow:var(--shadow);padding:14px 16px 16px;margin-bottom:11px}
+.ag-head{display:flex;justify-content:space-between;align-items:baseline;gap:12px;
+  flex-wrap:wrap;margin-bottom:12px}
+.ag-who{font-size:14.5px;font-weight:600}
+.ag-who span{color:var(--mut);font-weight:400;font-size:12.5px}
+.ag-link{display:flex;align-items:stretch;flex-wrap:wrap}
+.ag-node{flex:1 1 148px;min-width:136px;border:1px solid var(--bd);background:var(--sf2);
+  border-radius:9px;padding:8px 11px}
+.ag-node b{font-size:9.5px;letter-spacing:.11em;text-transform:uppercase;color:var(--mut);
+  font-weight:650;display:block;margin-bottom:3px}
+.ag-node i{font-style:normal;font-size:13px;line-height:1.35;word-break:break-word;display:block}
+.ag-node s{text-decoration:none;display:block;color:var(--mut);font-size:11.5px;margin-top:2px}
+.ag-rail{flex:0 0 20px;display:flex;align-items:center}
+.ag-rail:before{content:"";height:2px;width:100%;background:var(--bd)}
+.ag-gap{border:2px dashed var(--dstr);background:transparent;display:flex;
+  flex-direction:column;justify-content:center}
+.ag-gap i{color:var(--dstr);font-weight:600}
+.ag-held{border-color:var(--acc);background:var(--acc-soft)}
+.ag-note{margin:10px 0 0;font-size:12.5px;color:var(--mut)}
+.ag-limit{background:var(--sf);border:1px solid var(--bd);border-left:3px solid var(--warn);
+  border-radius:12px;padding:15px 17px;margin-top:18px}
+.ag-limit ul{margin:9px 0 0;padding-left:18px;color:var(--mut);font-size:13px}
+.ag-limit li{margin-bottom:7px}
+.ag-limit li:last-child{margin-bottom:0}
+.ag-limit li b{color:var(--fg);font-weight:600}
 </style>
 <div class="overlay" id="overlay"></div>
 <div class="drawer" id="drawer"></div>
@@ -1391,7 +1425,7 @@ async function load(force) {
   const q = force ? '?refresh=true' : '';
   // Refresh must clear the views that read a second endpoint too, or the
   // button refreshes some of the page and silently not the rest.
-  if (force) { DIAG = null; REG = null; EV = null; PG = null; FLEET = null; TOKENS = null; SETTINGS = null; REGTOOLS = null; GOVDECS = null; RENTRIES = null; CAND = null; PSTAT = null; AUDITLOG = null; USERS = null; BUDGET = null; BFX = null; }
+  if (force) { AGENTIC = null; DIAG = null; REG = null; EV = null; PG = null; FLEET = null; TOKENS = null; SETTINGS = null; REGTOOLS = null; GOVDECS = null; RENTRIES = null; CAND = null; PSTAT = null; AUDITLOG = null; USERS = null; BUDGET = null; BFX = null; }
   try {
     const cr = await fetch('/api/config');
     if (cr.status === 401 && AUTH && AUTH.mode === 'login') { sessionLost(); return; }
@@ -1670,6 +1704,7 @@ const NAV = [
   {id:'governance',lbl:'Governance', items:[['register','AI register'],['registry','Tool registry'],
                                             ['paste','Paste guard'],['iso','ISO 42001 evidence']]},
   {id:'spend',     lbl:'Budget',     items:[['budget','Budget']]},
+  {id:'agentic',   lbl:'Agentic AI', items:[['agentic','What runs on its own']]},
   {id:'health',    lbl:'Health',     items:[['setup','Sources'],['coverage','Uncovered devices']]},
   {id:'managed',   lbl:'Fleet',      items:[['fleet','Devices'],['tokens','Enrollment tokens']]},
   {id:'system',    lbl:'Settings',   items:[['settings','Settings']]},
@@ -1679,6 +1714,7 @@ const NAVICONS = {
   inventory:'<rect x="3" y="4" width="18" height="6" rx="1.5"/><rect x="3" y="14" width="18" height="6" rx="1.5"/>',
   governance:'<path d="M12 3l8 3v5.5c0 4.7-3.2 8.2-8 10-4.8-1.8-8-5.3-8-10V6l8-3z"/>',
   spend:'<rect x="3" y="6" width="18" height="12" rx="2"/><path d="M3 10h18"/><path d="M7 15h4"/>',
+  agentic:'<circle cx="12" cy="12" r="3.2"/><path d="M12 2v3.4M12 18.6V22M2 12h3.4M18.6 12H22"/><path d="M5.6 5.6l2.4 2.4m8 8l2.4 2.4m0-12.8l-2.4 2.4m-8 8l-2.4 2.4"/>',
   health:'<path d="M3 12h4l3-7 4 14 3-7h4"/>',
   managed:'<rect x="3" y="5" width="18" height="12" rx="1.5"/><path d="M8 21h8"/>',
   system:'<circle cx="12" cy="12" r="3"/><path d="M12 2v3m0 14v3M2 12h3m14 0h3M4.9 4.9l2.1 2.1m10 10l2.1 2.1M19.1 4.9l-2.1 2.1m-10 10l-2.1 2.1"/>',
@@ -8703,6 +8739,106 @@ function loadBanner() {
   </div>`;
 }
 
+// What runs without a person. Every other view starts from something
+// somebody did; this one starts from the absence of that, which is why it
+// reads differently - a chain per thing, with the missing link drawn as a
+// hole rather than described in a cell.
+let AGENTIC = null;
+async function agentic() {
+  if (!AGENTIC) {
+    const r = await fetch('/api/agentic');
+    if (!r.ok) return `<h2>Agentic AI</h2><p class="lede">${
+      esc((await r.json().catch(() => ({}))).detail || r.statusText)}</p>`;
+    AGENTIC = await r.json();
+  }
+  const A = AGENTIC.agents || [], c = AGENTIC.counts || {};
+  const srv = AGENTIC.servers || [];
+
+  const head = c.agents
+    ? `<h1 class="ag-verdict">${c.agents} thing${c.agents === 1 ? '' : 's'} run${
+        c.agents === 1 ? 's' : ''} without being asked.${
+        c.unaccountable ? ` <em>${c.unaccountable} answer${
+          c.unaccountable === 1 ? 's' : ''} to nobody.</em>` : ''}</h1>`
+    : `<h1 class="ag-verdict">Nothing here is running on its own.</h1>`;
+
+  const nodes = a => {
+    // Starts / who authorised it / runs / can reach. The second is the
+    // point of the page: an empty box is a credential with nobody behind
+    // it, and there is nothing to revoke when somebody leaves.
+    const who = a.accountable
+      ? `<div class="ag-node ag-held"><b>Who authorised it</b><i>${esc(a.account || a.user)}</i>
+         <s>${esc(a.identity || 'account seen')}</s></div>`
+      : `<div class="ag-node ag-gap"><b>Who authorised it</b><i>${
+          a.identity === 'machine' ? '— a key, not a person'
+          : a.identity === 'none' ? '— nothing signed in'
+          : '— not established'}</i></div>`;
+    const runs = a.process
+      ? `<div class="ag-node ag-gap"><b>Runs</b><i>— no tool we know</i>
+         <s>${esc(a.process)}</s></div>`
+      : `<div class="ag-node"><b>Runs</b><i>${esc(a.tool)}</i>${
+          a.mode === 'autonomous' ? '<s>unattended</s>' : ''}</div>`;
+    const reach = a.reach.length
+      ? a.reach.map(x => `<span class="pill p-amb">${esc(x)}</span>`).join('')
+      : (a.process ? `<span class="pill p-mut">a model API direct</span>`
+                   : `<span class="pill p-mut">nothing configured</span>`);
+    return `<div class="ag-link">
+      <div class="ag-node"><b>Starts</b><i>${esc(a.trigger || 'not established')}</i>
+        <s>${esc(a.os || '')}</s></div>
+      <div class="ag-rail"></div>${who}<div class="ag-rail"></div>${runs}
+      <div class="ag-rail"></div>
+      <div class="ag-node"><b>Can reach</b><i>${reach}</i></div></div>`;
+  };
+
+  const chains = A.map(a => `<div class="ag-chain">
+    <div class="ag-head">
+      <span class="ag-who">${esc(label(a.device, G.devices[a.device] || {}))}
+        <span>${esc(a.user || 'no owner on record')}</span></span>
+      ${a.accountable
+        ? '<span class="pill p-acc">runs on a timer, but attributed</span>'
+        : a.process
+          ? '<span class="pill p-warn">nothing installed to find</span>'
+          : '<span class="pill p-warn">no accountable identity</span>'}
+    </div>${nodes(a)}
+    ${a.process ? `<p class="ag-note">No config file, no known binary, no MCP server.
+      Only the network saw it: a process that is not a browser reaching a model.
+      Evidence: <span class="mono">${esc(a.evidence)}</span></p>` : ''}
+  </div>`).join('');
+
+  const servers = srv.length ? `<div class="tcard">
+    <div class="cardhead"><h3>What they can reach</h3></div>
+    <p class="lede">Configuring an MCP server hands a model a capability. These are the
+    servers the fleet reported; the risk assessment is not applied to them yet.</p>
+    <table><tr><th>server</th><th>configured in</th><th>devices</th></tr>
+    ${srv.map(m => `<tr><td class="mono">${esc(m.server)}</td>
+      <td>${(m.tools || []).map(t => `<span class="pill p-mut">${esc(t)}</span>`).join('')}</td>
+      <td>${(m.devices || []).length}</td></tr>`).join('')}</table></div>` : '';
+
+  return `${head}
+  <p class="lede">Something started these without being asked - a timer, a scheduler, a
+  pipeline step - or reached a model from a process that is neither a browser nor a tool
+  the registry knows. The second box in each chain is the one to read: an empty box means
+  there is nothing to revoke when somebody leaves.</p>
+  ${A.length ? chains : `<div class="tcard"><p class="lede" style="margin:12px 0">
+    Nothing on this estate reported running unattended. That is either true, or the
+    collectors have not been updated to look - Health says which sources are reporting.
+    </p></div>`}
+  ${servers}
+  <div class="ag-limit">
+    <p class="label" style="margin:0">What this does not answer, and why not yet</p>
+    <ul>
+      <li><b>What it was asked to do.</b> The prompt is on the machine and could be read.
+        Reading what somebody typed is a heavier intrusion than knowing which tool ran,
+        and it is not needed to answer anything on this page.</li>
+      <li><b>Whether it stayed within its brief.</b> Same material, same trade. Worth
+        revisiting once the signals above have been run on a real estate and shown to be
+        insufficient - which is also when there is a case to put to whoever approves it.</li>
+      <li><b>What it actually did.</b> Counting tool calls is an outcome with no prompt in
+        it, the same shape the paste guard already reports. Whether it is reachable depends
+        on what each client logs locally.</li>
+    </ul>
+  </div>`;
+}
+
 async function renderView() {
   const sec = sectionOf(view);
   if (sec) SECTAB[sec.id] = view;
@@ -8714,6 +8850,7 @@ async function renderView() {
   if (view === 'settings') { app.innerHTML = tb + await settings(); return; }
   if (view === 'register') { app.innerHTML = tb + await register(); return; }
   if (view === 'paste') { app.innerHTML = tb + await paste(); return; }
+  if (view === 'agentic') { app.innerHTML = tb + await agentic(); return; }
   if (view === 'iso') { app.innerHTML = tb + await iso(); return; }
   if (view === 'fleet') { app.innerHTML = tb + await fleet(); return; }
   if (view === 'tokens') { app.innerHTML = tb + await tokens(); return; }
@@ -9156,11 +9293,19 @@ const TOURS = {
          + 'decided about each tool: owner, status, review date. A tool '
          + 'missing from the registry is flagged rather than hidden. What '
          + 'it all costs is next - open Budget.'},
-    {view: 'budget', sel: '[data-s="health"]', click: true,
+    {view: 'budget', sel: '[data-s="agentic"]', click: true,
      title: 'What it costs',
      body: 'Subscriptions set against what the estate is observed doing: '
          + 'seats nobody uses, people on a tool no seat covers, personal '
-         + 'accounts running beside paid ones. All of it rests on '
+         + 'accounts running beside paid ones. Every page so far assumed a '
+         + 'person did something - open Agentic AI for the ones where '
+         + 'nobody did.'},
+    {view: 'agentic', sel: '[data-s="health"]', click: true,
+     title: 'The ones nobody is driving',
+     body: 'Things that start on a timer or a trigger, and what they can '
+         + 'reach once running. Read the second box in each chain: an empty '
+         + 'one is a credential with no person behind it, so revoking '
+         + 'somebody\'s sign-on does not stop it. All of it rests on '
          + 'something still reporting - open Health.'},
     {view: 'setup', sel: '[data-s="managed"]', click: true,
      title: 'Is anything actually reporting?',
@@ -9230,12 +9375,20 @@ const TOURS = {
          + 'the registry is flagged rather than hidden. Reading it is the '
          + 'half this account does. What it all costs is next - open '
          + 'Budget.'},
-    {view: 'budget', sel: '[data-s="health"]', click: true,
+    {view: 'budget', sel: '[data-s="agentic"]', click: true,
      title: 'What it costs',
      body: 'Unused seats, people on a tool no seat covers, and personal '
          + 'accounts running beside paid ones - figures worth quoting. '
-         + 'Every one of them rests on something still reporting, which '
-         + 'is the next page - open Health.'},
+         + 'Every figure so far counts something a person did - open '
+         + 'Agentic AI for what runs when nobody is there.'},
+    {view: 'agentic', sel: '[data-s="health"]', click: true,
+     title: 'What runs when nobody is there',
+     body: 'Tools that start on a schedule rather than because somebody '
+         + 'opened them, and what each can reach. The question an auditor '
+         + 'asks is who authorised it: where that box is empty there is no '
+         + 'person to name and nothing to revoke. All of it rests on '
+         + 'something still reporting, which is the next page - open '
+         + 'Health.'},
     {view: 'setup', sel: '[data-s="managed"]', click: true,
      title: 'Is anything actually reporting?',
      body: 'Which detection sources are reporting, which are silent, and '

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -1250,3 +1250,108 @@ def test_judging_one_row_on_surface_leaves_the_scanner_rows_alone():
     assert by["sentinelone_dns"]["reporting"] is False
     # And a surface value must never be mistaken for a source.
     assert "mcp" not in by
+
+
+# ------------------------------------------------------------- agentic AI --
+
+REG_BIN = {"tools": [{"id": "claude-code", "cli": {"binaries": ["claude"]}}]}
+
+
+def test_a_finding_that_says_nothing_is_not_called_autonomous():
+    """The rule this whole view rests on.
+
+    "Ran with nobody watching" is an accusation, and silence is not evidence
+    for it. Every finding written before `mode` existed, and every collector
+    not yet upgraded, says nothing - so absence has to read as unknown. The
+    platform already refuses the mirror image of this for coverage: a silent
+    source is not a clean estate."""
+    out = derive.agentic_from([
+        finding(tool="claude-code", surface="cli", device="D1"),
+        finding(tool="chatgpt", surface="browser", device="D2",
+                account_domain="gmail.com"),
+    ], REG_BIN)
+
+    assert out["agents"] == []
+    assert out["counts"]["agents"] == 0
+
+
+def test_a_blank_account_is_not_read_as_a_machine_identity():
+    """The other thing that must not be inferred.
+
+    Before `identity` existed, "authenticated by a key" and "installed and
+    never signed in" both arrived as a blank account domain and could not be
+    told apart. Reading blank as a machine identity would manufacture the
+    exact finding this page exists to report, on every estate that has not
+    upgraded its collectors yet."""
+    out = derive.agentic_from([
+        finding(tool="claude-code", surface="cli", device="D1",
+                account_domain="", mode="autonomous"),
+    ], REG_BIN)
+
+    a = out["agents"][0]
+    assert a["identity"] == ""            # not "machine"
+    assert a["accountable"] is False      # but still not accountable
+    assert out["counts"]["machine_identities"] == 0
+
+
+def test_an_unattended_run_under_a_real_account_is_not_the_same_finding():
+    """Running on a timer is not the problem. Running on a timer under
+    nobody's name is. A scheduled job with a person behind it has something
+    to revoke, and the page has to say so rather than colouring everything
+    unattended red."""
+    out = derive.agentic_from([
+        finding(tool="claude-code", surface="cli", device="D1",
+                account_domain="corp.example", mode="autonomous",
+                identity="person", trigger="launchd, every 6 hours"),
+    ], REG_BIN)
+
+    a = out["agents"][0]
+    assert a["accountable"] is True
+    assert a["trigger"] == "launchd, every 6 hours"
+    assert out["counts"]["unaccountable"] == 0
+
+
+def test_a_process_that_is_not_a_browser_or_a_known_tool_is_found():
+    """The case with nothing to inventory: no config file, no registry
+    binary, no MCP server - a script with a key in it. The signal was
+    already being collected and never read, sitting in the DNS scan's
+    evidence text."""
+    out = derive.agentic_from([
+        finding(tool="claude", surface="network", device="D9",
+                evidence="DNS lookup for api.anthropic.com (via python3)"),
+    ], REG_BIN)
+
+    a = out["agents"][0]
+    assert a["process"] == "python3"
+    assert a["accountable"] is False
+    assert out["counts"]["bespoke"] == 1
+
+
+@pytest.mark.parametrize("proc,why", [
+    ("Google Chrome", "a person using a model in a browser is the ordinary case"),
+    ("firefox", "same"),
+    ("msedge.exe", "same, named the way Windows names it"),
+    ("claude", "a known binary IS the tool; that finding is claude-code, not a mystery"),
+    ("claude.exe", "same binary, Windows spelling"),
+])
+def test_browsers_and_known_binaries_are_not_mysteries(proc, why):
+    out = derive.agentic_from([
+        finding(tool="claude", surface="network", device="D9",
+                evidence="DNS lookup for api.anthropic.com (via %s)" % proc),
+    ], REG_BIN)
+    assert out["agents"] == [], why
+
+
+def test_reach_is_joined_from_the_mcp_servers_on_the_same_machine():
+    """What a thing can reach is the fourth link in the chain, and it comes
+    from findings the fleet already reports rather than anything new."""
+    out = derive.agentic_from([
+        finding(tool="claude-code", surface="cli", device="D1",
+                mode="autonomous", identity="machine"),
+        finding(tool="claude-code-mcp", surface="mcp", device="D1",
+                evidence=".claude.json mcpServers: github,postgres-prod"),
+        finding(tool="claude-code-mcp", surface="mcp", device="D2",
+                evidence=".claude.json mcpServers: elsewhere"),
+    ], REG_BIN)
+
+    assert out["agents"][0]["reach"] == ["github", "postgres-prod"]

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -338,6 +338,24 @@ VALID_SURFACES = {"browser", "network", "cli", "ide", "desktop", "mcp", "cloud"}
 # before 0.21 carry neither, and "" is read as active downstream - the
 # meaning they were reported with.
 VALID_SIGNALS = {"active", "ambient"}
+# Whether a person was at the keyboard. "autonomous" means something started
+# this without being asked - a timer, a scheduler, a pipeline step - and
+# nobody was present while it ran. Absent reads as "unknown", never as
+# autonomous: claiming a tool ran unattended when nothing established that is
+# the accusation this must not make by default.
+VALID_MODES = {"interactive", "autonomous"}
+# Who the credential belongs to, which is a different question from which
+# account domain was seen. Three states a collector can genuinely tell apart:
+#   person   an account with a human behind it
+#   machine  a credential that authenticates, with no human behind it - an
+#            API key in a unit file, a service token. This is the one that
+#            survives offboarding, because revoking somebody's sign-on does
+#            not touch it.
+#   none     nothing authenticated at all; installed and never signed in
+# Empty means the sender did not say. Before this existed, "machine" and
+# "none" both arrived as a blank account domain and were indistinguishable,
+# which is why the blank alone could never carry this meaning.
+VALID_IDENTITIES = {"person", "machine", "none"}
 VALID_SEVERITIES = {"info", "warn"}
 # Bounded set: safe as a Loki stream label and a Prometheus metric label.
 # Sources that pre-date the field (older browser extensions) report "unknown".
@@ -492,6 +510,16 @@ class Finding(BaseModel):
     # every other tool's presence is use. Empty from senders that pre-date
     # the field, which reads as active - what they always meant.
     signal: str = Field(default="", max_length=16)
+    # interactive | autonomous. See VALID_MODES.
+    mode: str = Field(default="", max_length=16)
+    # person | machine | none. See VALID_IDENTITIES.
+    identity: str = Field(default="", max_length=16)
+    # What starts it, in the words of whatever schedules it: "systemd timer",
+    # "launchd, at login", "Scheduled Task, hourly". Free text because every
+    # scheduler describes itself differently and flattening them into an
+    # enum would lose the part an operator needs to go and find the thing.
+    # Bounded like every other field that arrives from outside.
+    trigger: str = Field(default="", max_length=200)
     device_name: str = Field(default="", max_length=256)
     risk_tier: str = Field(default="", max_length=32)
     # How many, and of what. The unit differs per source (sign-ins for Entra,
@@ -3338,6 +3366,10 @@ async def report(f: Finding, request: Request, authorization: str = Header(defau
         f.os = "unknown"
     if f.signal and f.signal not in VALID_SIGNALS:
         f.signal = ""
+    if f.mode and f.mode not in VALID_MODES:
+        f.mode = ""
+    if f.identity and f.identity not in VALID_IDENTITIES:
+        f.identity = ""
     if not f.reported_at:
         f.reported_at = datetime.now(timezone.utc).isoformat()
 

--- a/receiver/tests/test_custom_registry.py
+++ b/receiver/tests/test_custom_registry.py
@@ -281,3 +281,48 @@ def test_a_scanner_that_classified_itself_is_not_second_guessed(managed):
                 device="MAC-2")
     # The ingest rule only fills a blank.
     assert f.signal == "active"
+
+
+def test_the_new_finding_fields_are_bounded_like_every_other_label(managed):
+    """mode and identity are label sets, so a sender cannot invent values.
+    An unrecognised one is dropped to empty rather than refused: a finding
+    with one odd field is still evidence, and losing the whole thing because
+    a collector sent a typo would be the worse trade."""
+    with _capture() as records:
+        assert client.post("/report", headers=AUTH, json={
+            "tool": "claude-code", "surface": "cli", "device": "MAC-9",
+            "mode": "autonomous", "identity": "machine",
+            "trigger": "systemd timer, every 15 min"}).status_code == 200
+        assert client.post("/report", headers=AUTH, json={
+            "tool": "claude-code", "surface": "cli", "device": "MAC-9",
+            "mode": "sentient", "identity": "moon"}).status_code == 200
+
+    good, bad = records[0], records[1]
+    assert good["mode"] == "autonomous"
+    assert good["identity"] == "machine"
+    assert good["trigger"] == "systemd timer, every 15 min"
+    assert bad["mode"] == "" and bad["identity"] == ""
+
+
+def test_an_over_long_label_is_refused_rather_than_truncated(managed):
+    """The two guards are different on purpose, and it is worth pinning
+    which is which. An unrecognised VALUE is dropped to empty, because a
+    finding with one odd field is still evidence. An over-LONG one is
+    refused outright, because these become log-store labels and a sender
+    that can grow one without bound can grow the label set with it."""
+    r = client.post("/report", headers=AUTH, json={
+        "tool": "claude-code", "surface": "cli", "device": "MAC-7",
+        "mode": "a" * 40})
+    assert r.status_code == 422
+
+
+def test_a_sender_that_knows_nothing_of_these_fields_still_reports(managed):
+    """Every collector in the field predates them. Their findings must land
+    unchanged, carrying empty values that downstream reads as unknown."""
+    with _capture() as records:
+        assert client.post("/report", headers=AUTH, json={
+            "tool": "claude-code", "surface": "cli", "device": "MAC-8",
+            "evidence": "~/.claude.json"}).status_code == 200
+
+    f = records[0]
+    assert f["mode"] == "" and f["identity"] == "" and f["trigger"] == ""


### PR DESCRIPTION
Every view in this portal starts from something somebody did. This one starts from the absence of that: a tool that begins on a timer, holds a credential no human signs into, and reaches whatever it was pointed at while nobody is watching.

Revoking somebody's single sign-on does not stop it. That is the thing worth showing, and nothing here showed it.

## The contract

Three optional fields on a finding, bounded like every other label:

| | |
|---|---|
| `mode` | `interactive` \| `autonomous` |
| `identity` | `person` \| `machine` \| `none` |
| `trigger` | free text — what starts it, in the scheduler's own words |

`identity` exists because a blank account domain could not carry this meaning. *Authenticated by a key* and *installed and never signed in* both arrived blank and were indistinguishable — so the collector already knew which it had seen and had no way to say so.

Old senders are unaffected: absent fields, empty values, read downstream as unknown.

## Why it is drawn as a chain rather than a table

Each thing is `starts → who authorised it → runs → can reach`, because the interesting part is a **missing link**, not a value in a column. Where nothing accountable sits behind the credential, that second box is drawn as a hole reading *"— a key, not a person"*.

It also makes the good case legible. A scheduled job under a real account gets a filled box and reads *"runs on a timer, but attributed"*. Running unattended is not the problem; running unattended under nobody's name is.

## A fourth signal that needed no new field

The DNS scan already records which process resolved a domain, and it has been sitting unread in evidence text:

```
DNS lookup for api.anthropic.com (via python3)
```

Something reaching a model that is neither a browser nor a binary the registry knows is a script with a key in it — the case with no config file, no MCP server and nothing to inventory. Browsers are excluded because a person using a model in a browser is the ordinary case every other page already covers; known binaries because the tool is then the finding rather than a mystery.

That row renders with **two** holes, and it is the one nothing else in an estate would surface.

## Two things deliberately not inferred

Each has a test whose name says so, because both are the kind of shortcut that looks like a feature:

- **A finding that says nothing about mode is not autonomous.** Absence reads as unknown. "Ran with nobody watching" is an accusation, and silence is not evidence for it — the same rule the platform already applies in the other direction, where a silent source is not a clean estate.
- **A blank account domain is not a machine identity.** Reading it that way would manufacture the exact finding this page exists to report, on every estate that has not upgraded its collectors.

## The tour

Both walkthroughs gain a step, worded for who is reading it. The admin one points at what cannot be revoked; the viewer one at who there is to name. A test already required every nav section to be reachable from the tour, and it caught the omission before I did — which is the test doing its job.

## Seeing it

The demo seeds all four shapes, so the page can be looked at rather than imagined: a timer under a key nobody owns, a machine with no owner on record, a properly attributed scheduled job, and the bespoke script. It also seeds a browser reaching the same host, to prove that one is left out.

## What is not built, and the page says so

- **Nothing populates these fields on a real fleet yet.** The collectors do not read launchd, systemd, cron or Scheduled Tasks at all — that is the next piece, and it is an addition to the collector you already deploy rather than a new agent.
- **The MCP servers are listed without the risk assessment applied.** `ai-guard mcp-scan` scores a server against the OWASP Agentic Top 10 and is a command nobody runs on a schedule.
- **What it was asked to do is not answered**, and the page explains that as a choice with conditions rather than a limitation: the prompt is on the machine and could be read, it is a heavier intrusion than knowing which tool ran, and it is not needed for anything on this page. Worth revisiting once these signals have been run on a real estate and shown to be insufficient — which is also when there is a case to put to whoever approves it.

Suites green: portal 556, receiver and registry 302, scanner 164.
