### PR TITLE
Docs for what runs without a person

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ leaves your infrastructure.
   <a href="#install-it">Install it</a> ·
   <a href="#what-it-sees">What it sees</a> ·
   <a href="#everything-runs-from-the-portal">The portal</a> ·
+  <a href="#what-runs-without-a-person">Agentic AI</a> ·
   <a href="#try-it-in-five-minutes">Try it</a> ·
   <a href="#how-it-works">How it works</a>
   <br>
@@ -190,6 +191,14 @@ is operated:
   and that arrangement is yours, not the deployment's. Both are available
   again at any time under Settings > Getting started.
 
+- **What runs without a person.** <a id="what-runs-without-a-person"></a>Every
+  page above assumes somebody did something. This one is the exception: tools
+  that start on a timer or a trigger, the credential each holds, and what it
+  can reach once running. A key in a unit file belongs to no leaver, so
+  revoking somebody's sign-on does not stop it. It will not call something
+  autonomous on silence, and it says what it deliberately does not answer -
+  see [Agentic AI](docs/agentic.md).
+
 Grafana is optional and complementary: better at graphs and history, and the
 portal can embed its panels. The portal is better at relationships, current
 state, and doing something about what it shows.
@@ -306,6 +315,7 @@ not a fork; if you are not sure which you want, start with managed. The
 | Configure the receiver | [Receiver](receiver/README.md) |
 | Record approvals, owners and review dates | [Governance decisions](docs/governance.md) |
 | Track paid seats against observed use | [Budget](docs/budget.md) |
+| See what runs with no person behind it | [Agentic AI](docs/agentic.md) |
 | Produce evidence for an AI management system | [Evidence](docs/evidence.md) |
 | Deploy macOS collection | [macOS collector](endpoint/macos/README.md) |
 | Deploy Windows collection | [Windows collector](endpoint/windows/README.md) |
@@ -351,6 +361,22 @@ with everything downstream.
   "source": "collector-macos"
 }
 ```
+
+Five optional fields carry what a source knows beyond presence. A sender that
+omits them is unaffected, and every one of them reads as unknown when absent
+rather than as its more interesting value.
+
+| Field | Values | Means |
+|---|---|---|
+| `signal` | `active`, `ambient` | whether a model ran, or the product is merely installed. Only ever `ambient` for an editor that bundles AI, where finding it installed proves an editor is installed |
+| `mode` | `interactive`, `autonomous` | whether a person was at the keyboard |
+| `identity` | `person`, `machine`, `none` | who the credential belongs to. `machine` is a key that authenticates with nobody behind it, which is the one that survives offboarding |
+| `trigger` | free text | what starts it, in the scheduler's own words |
+| `schedule` | dialect-prefixed spec | the raw cadence: `cron:0 2 * * *`, `interval:21600`, `atlogin` |
+
+`mode` and `identity` are the two that must never be inferred: absence is not
+autonomy, and a blank account domain is not a machine identity. See
+[Agentic AI](docs/agentic.md).
 
 `severity` is `warn` when the account domain is not one of your corporate
 domains, and `info` otherwise.

--- a/docs/agentic.md
+++ b/docs/agentic.md
@@ -1,0 +1,199 @@
+# What runs without a person
+
+Every other view in this portal starts from something somebody did. Somebody
+signed in, somebody installed a tool, somebody pasted into a chat box. This
+one starts from the absence of that.
+
+A tool that begins on a timer, holds a credential no human signs into, and
+reaches whatever it was pointed at while nobody is watching is a different
+governance problem from a person using an assistant. Revoking somebody's
+single sign-on stops the second and does nothing at all to the first.
+
+The page answers two questions, and refuses several others.
+
+## The two questions
+
+**What is acting without a person.** Something on the machine starts an AI
+tool on a schedule or a trigger, and nobody is present while it runs.
+
+**What it can reach once it is running.** Configuring an MCP server hands a
+model a capability. That capability is the blast radius of anything holding
+the credential.
+
+## The four signals
+
+None of them require a new source. Three are read by the endpoint collectors
+you already deploy, and one has been arriving for as long as the network
+scanner has been configured.
+
+### A scheduler starts it
+
+The collectors read what schedules things on each platform: launchd on macOS,
+systemd timers and cron on Linux, Scheduled Tasks on Windows. A job qualifies
+when the command it runs names a binary the registry already lists for a
+tool, so covering a new tool is a registry entry rather than a change to
+three scripts.
+
+Matching is deliberately word-ish: `claude` must not match
+`claudeless-backup`, and each platform has a fixture asserting it does not.
+
+### The credential has nobody behind it
+
+Three states a collector can tell apart, where two of them used to arrive as
+the same blank:
+
+| What was found | Means |
+|---|---|
+| An account file with an account in it | a person |
+| An account file with **no** account in it | a key that authenticates, with nobody behind it |
+| A config directory and no account file | installed, never signed into |
+
+The middle row is the one that matters. An API key in a unit file belongs to
+no joiner and no leaver, so offboarding does not touch it. The collector
+always knew which of the three it had seen; until recently it had no way to
+say.
+
+### Something reaches a model that is not a browser or a known tool
+
+The network scan already records which process resolved a domain, and that
+has been sitting in evidence text unread:
+
+```
+DNS lookup for api.anthropic.com (via python3)
+```
+
+A process reaching a model that is neither a browser nor a binary the
+registry knows is a script with a key in it. There is no config file to
+find, no MCP server, nothing installed to inventory - so this is the case
+nothing else in an estate would surface, and it needs no collector change at
+all.
+
+Browsers are excluded because a person using a model in a browser is the
+ordinary case every other page already covers. Known binaries are excluded
+because the tool is then the finding rather than a mystery.
+
+### An MCP server is configured
+
+Read from the client config files the collectors already parse. What each
+server can *do* is not yet assessed - see [what is not built](#what-is-not-built-yet).
+
+## The day, as configured
+
+Where a scheduler gives a cadence, the page draws it across a day. Four kinds
+of lane, because four different things are true and only one of them is
+"marks at these times":
+
+| Lane | Means |
+|---|---|
+| marks | discrete runs at known times |
+| band | often enough that individual ticks stop meaning anything |
+| unphased | a known interval with no known start |
+| continuous | no cadence at all; runs while somebody is logged in |
+
+`unphased` exists because launchd's `StartInterval` counts from whenever the
+job was loaded. The gaps between runs are true; the clock positions are not,
+and the lane says so rather than implying four tidy times.
+
+**A spec is what something is set to do, not what it was seen doing.** The
+panel is titled "as configured" for that reason. Watching runs actually
+happen needs process telemetry, which is a different source and a different
+claim.
+
+A cadence the parser cannot read draws **nothing**, and the row is listed
+underneath as not drawn. A timeline with an invented time on it is worse than
+a row left out.
+
+## Two things this will not infer
+
+Both are the kind of shortcut that looks like a feature and is not. Each has
+a test named after the reason.
+
+**A finding that says nothing about mode is not autonomous.** Absence reads
+as unknown. "Ran with nobody watching" is an accusation, and silence is not
+evidence for it - the same rule this platform applies in the other direction,
+where a silent source is never read as a clean estate.
+
+**A blank account domain is not a machine identity.** Inferring it would
+manufacture the exact finding this page exists to report, on every estate
+whose collectors have not been upgraded yet.
+
+Both mean the page is empty on a deployment running older collectors, and it
+says so rather than showing zero as though zero were the answer.
+
+## What is not built yet
+
+**The risk assessment on MCP servers.** Servers are listed without a verdict.
+`ai-guard mcp-scan` scores a server against the OWASP Agentic AI Top 10, but
+it assesses a *manifest* - a server's declared tools and auth scopes - and
+neither the fleet report nor the client config contains that, because an MCP
+server declares its tools at runtime rather than in the config that launches
+it. Closing that needs a catalogue of known servers keyed on the package
+rather than the display name.
+
+**What it actually did.** Counting tool calls - "reached this server forty
+times overnight" - is an outcome with no prompt in it, the same shape the
+paste guard already reports. Whether it is reachable depends on what each
+client logs locally.
+
+**Observed runs.** Process telemetry would turn the day from configured into
+observed, and would cover the two lane kinds a spec can never reach.
+
+## What it does not answer, and why not yet
+
+**What an agent was asked to do**, and whether it stayed within that brief.
+
+This is a choice rather than a limitation, and it is worth being straight
+about which. The prompt is on the machine and could be read. Endpoint tooling
+reads plenty already - command lines, file writes, mail bodies - so this is a
+question of proportion, not of capability.
+
+The reasoning that survives contact with that:
+
+- Reading what somebody typed is a heavier intrusion than knowing which tool
+  they ran, and it answers no question on this page. Collecting it anyway is
+  capability in search of a justification, which is the shape that gets
+  monitoring programmes challenged.
+- This is free software that arrives with `helm install`, often into an
+  organisation that has done no assessment. A capability that ships exists on
+  every deployment, and somebody will enable it without the conversation.
+
+So the position is not *never*. It is **not by default, opt-in, and only once
+the signals above have been run on a real estate and shown to be
+insufficient** - which is also the evidence anyone would need to justify it.
+This project already has the pattern for a capability like that: federated
+sign-in refuses to point at anything but Microsoft unless told to in so many
+words, and says so in its log on every boot when it has been.
+
+## Where the fields come from
+
+Four optional fields on a finding, bounded like every other label. A sender
+that knows nothing of them is unaffected.
+
+| Field | Values |
+|---|---|
+| `mode` | `interactive`, `autonomous` |
+| `identity` | `person`, `machine`, `none` |
+| `trigger` | free text: what starts it, in the scheduler's own words |
+| `schedule` | the raw cadence, dialect-prefixed |
+
+`schedule` carries the spec untranslated - `cron:0 2 * * *`,
+`oncalendar:*:0/15`, `interval:21600`, `atlogin`, `event` - and is read once
+in the portal. Normalising it in the collectors would mean doing it in a bash
+script, a second bash script and a PowerShell script: three chances to
+disagree about what a schedule means, where one parser is one place to be
+wrong. It also keeps the spec readable by whoever has to go and find the
+thing.
+
+## If the page is empty
+
+That is either true or a coverage gap, and the two look identical from here.
+Check, in order:
+
+1. **Are the collectors current?** The scheduler scan is script code. Machines
+   need the collector that has it before anything populates these fields.
+   Health shows which sources are reporting.
+2. **Is anything actually scheduled?** A fleet where nobody has wired an AI
+   tool into a timer is a fleet with nothing to show, and that is a finding
+   in itself.
+3. **Is the network scanner configured?** The bespoke-script signal comes from
+   it, and it is the one that catches what has no config file to find.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -209,6 +209,16 @@ report which account each tool is signed into. This is the data no
 API-level product has, because the account identity lives in a local file,
 not in any cloud log.
 
+They also read what schedules things on that platform - launchd, systemd
+timers and cron, Scheduled Tasks - to find AI tools that start with nobody
+asking. A job qualifies when the command it runs names a binary the registry
+already lists, so covering a new tool is a registry entry rather than a
+change to three scripts. Those findings carry the cadence untranslated, in
+the scheduler's own dialect, and one parser in the portal reads all of them:
+normalising in the collectors would mean doing it three times, in two shell
+scripts and a PowerShell one, which is three chances to disagree about what
+a schedule means. See [Agentic AI](agentic.md).
+
 **scanners**, cloud and network detection: Entra sign-ins, Exchange signup
 evidence, Intune and Jamf software inventory, SentinelOne DNS telemetry.
 Each is an independent module; a deployer runs the ones their estate

--- a/endpoint/linux/README.md
+++ b/endpoint/linux/README.md
@@ -89,6 +89,25 @@ exactly what the collector reports about you.
 Account findings carry the domain in `account_domain` and the console
 username in `user`.
 
+
+### What starts a tool on its own
+
+Beyond presence, the collector reads systemd timers, `crontab -l`, `/etc/crontab` and `/etc/cron.d` to find AI tools that start without
+being asked. A job qualifies when the command it runs names a binary the
+registry already lists, so covering a new tool is a registry entry rather
+than a change to this script - and the match is word-ish, so `claude` does
+not match `claudeless-backup`.
+
+Those findings carry `mode: autonomous`, the trigger in the scheduler's own
+words, and the raw cadence in `schedule` for the portal to read. See
+[Agentic AI](../../docs/agentic.md).
+
+The account scan also now says which of three states it found rather than
+leaving two of them as the same blank: an account file with an account in it
+is a `person`, an account file with none is a `machine` credential - a key
+that authenticates with nobody behind it, and the one that survives somebody
+being offboarded - and a config directory with no account file is `none`.
+
 ## Reporting behaviour
 
 Identical to the other collectors: warn findings post at most once per hour, info findings 

--- a/endpoint/macos/README.md
+++ b/endpoint/macos/README.md
@@ -23,10 +23,30 @@ an allowlist entry for the script path and the receiver URL if needed.
 | browser | AI extensions in Chrome, Brave, Edge | no, presence only |
 | desktop | AI apps in /Applications, local runtimes like Ollama | no, presence only |
 | mcp     | MCP servers wired into AI tool configs | no, lists server names |
+| cli     | launchd jobs that start an AI tool on their own | no, reports the cadence |
 
 Account findings carry the domain in `account_domain` and the console
 username in `user`. An account on a domain outside your corporate list
 reports as `warn`; everything else is `info`.
+
+
+### What starts a tool on its own
+
+Beyond presence, the collector reads launchd agents and daemons to find AI tools that start without
+being asked. A job qualifies when the command it runs names a binary the
+registry already lists, so covering a new tool is a registry entry rather
+than a change to this script - and the match is word-ish, so `claude` does
+not match `claudeless-backup`.
+
+Those findings carry `mode: autonomous`, the trigger in the scheduler's own
+words, and the raw cadence in `schedule` for the portal to read. See
+[Agentic AI](../../docs/agentic.md).
+
+The account scan also now says which of three states it found rather than
+leaving two of them as the same blank: an account file with an account in it
+is a `person`, an account file with none is a `machine` credential - a key
+that authenticates with nobody behind it, and the one that survives somebody
+being offboarded - and a config directory with no account file is `none`.
 
 ## Reporting behaviour
 

--- a/endpoint/windows/README.md
+++ b/endpoint/windows/README.md
@@ -109,6 +109,25 @@ after a sync, check:
   attention on your image; that is the failure mode to catch on one
   machine instead of fifty)
 
+## What starts a tool on its own
+
+Beyond presence, the collector reads Scheduled Tasks to find AI tools that
+start without being asked - logon and boot triggers, repetition intervals,
+and start boundaries. A task qualifies when what it executes names a binary
+the registry already lists, so covering a new tool is a registry entry rather
+than a change to this script, and the match is word-ish so `claude` does not
+match `claudeless-backup`.
+
+Those findings carry `mode: autonomous`, the trigger in the scheduler's own
+words, and the raw cadence in `schedule` for the portal to read. See
+[Agentic AI](../../docs/agentic.md).
+
+The account scan also now says which of three states it found rather than
+leaving two of them as the same blank: an account file with an account in it
+is a `person`, an account file with none is a `machine` credential - a key
+that authenticates with nobody behind it, and the one that survives somebody
+being offboarded - and a config directory with no account file is `none`.
+
 ## Reporting behaviour
 
 Identical to macOS: warn findings post at most once per hour, info findings

--- a/portal/README.md
+++ b/portal/README.md
@@ -450,7 +450,7 @@ effect within `CACHE_TTL_SECONDS` (default 30) without a restart.
 
 ## Sections
 
-The sidebar is seven sections; each holds its pages as tabs. Details open in
+The sidebar is eight sections; each holds its pages as tabs. Details open in
 an inspector beside the list rather than a separate page, and the theme
 toggle (light or dark) is remembered per browser.
 
@@ -460,6 +460,7 @@ toggle (light or dark) is remembered per browser.
 | Inventory | Tools, People, Devices, Personal accounts, MCP servers | what is in use, by whom, on what, signed into which account |
 | Governance | AI register, Tool registry, Paste guard, ISO 42001 evidence | what each tool is, what was decided, what the guard stopped |
 | Budget | Budget | what each AI tool costs, and whether the seats paid for match the people observed using them |
+| Agentic AI | What runs on its own | what starts without being asked, under whose credential, and how far it can reach |
 | Health | Sources, Uncovered devices | which detection sources are reporting, which are silent, and which machines nothing covers |
 | Fleet | Devices, Enrollment tokens | who is enrolled with their own credential, and the invitations that enroll them |
 | Settings | Settings tabs, Diagnostics | central settings, accounts, the audit trail, and what the portal verified about itself |
@@ -582,6 +583,34 @@ Admins link, edit and import; viewers read - including the report, which is
 what an auditor or a finance owner usually needs. Vendor API keys are held
 by the receiver, spent server-side and never returned to any page.
 [Budget](../docs/budget.md) covers the whole feature.
+
+## Agentic AI
+
+What runs with no person behind it. Every other page here starts from
+something somebody did; this one starts from the absence of that.
+
+Each thing is drawn as a chain - what starts it, who authorised it, what it
+runs, what it can reach - because the interesting part is a missing link
+rather than a value in a column. Where nothing accountable sits behind the
+credential, that second box is drawn as a hole. A scheduled job under a real
+account gets a filled one: running unattended is not the problem, running
+unattended under nobody's name is.
+
+Where a scheduler gives a cadence, a day is drawn across the top. It is
+titled "as configured" because a spec is what something is set to do, not
+what it was seen doing - a cadence the parser cannot read draws nothing and
+the row is listed as not drawn, since a timeline with an invented time on it
+is worse than a row left out.
+
+Two things it will not infer, each for the same reason: a finding that says
+nothing about mode is not autonomous, and a blank account domain is not a
+machine identity. Both would manufacture findings on estates whose
+collectors have not been upgraded.
+
+The page is empty until collectors report the fields, and says which of the
+three reasons that might be. Full reasoning, including what it deliberately
+does not answer and the conditions under which that would change, is in
+[Agentic AI](../docs/agentic.md).
 
 ## Personal accounts
 


### PR DESCRIPTION
The feature shipped without any of these. Nothing in the tree mentioned the section at all, and checking turned up that the gap went back further than this release.

## What was wrong

- **No mention of Agentic AI anywhere in the docs.** The only `agentic` in the tree was the pre-existing OWASP MCP scanner.
- **`portal/README.md` said "the sidebar is seven sections".** It is eight, and the table listing them had no row for the new one.
- **The finding schema in the root README was two releases behind, not one.** `signal` shipped with installed-versus-used and never made it in either, so the field that decides whether an editor reads as *used* or merely *installed* has been undocumented since it went out.
- **The three collector READMEs described scans that no longer match what the scripts do** — they read schedulers now.

## `docs/agentic.md`

The substantial piece, and most of it is reasoning rather than feature description:

- what the page answers, and the two questions it refuses
- the four signals, and which of them needed no new source — the bespoke-script one has been arriving in DNS evidence text unread for as long as the network scanner has been configured
- why a spec drawn across a day is titled **"as configured"** and never "as observed", and why `unphased` is its own lane kind
- the two things that must never be inferred, with the reason each would be wrong: **absence is not autonomy**, and **a blank account domain is not a machine identity**. Both would manufacture findings on estates whose collectors have not been upgraded
- what is not built, including why the MCP verdict is not simply a wiring job: `_assess` wants a manifest, and an MCP server declares its tools at runtime rather than in the config that launches it

It also carries **the position on reading prompts**, which until now lived only in a commit message, a pull request body and one panel in the interface. Those are the wrong three places for the argument somebody will need when they ask why this does not do what a DLP product does.

It is stated as what it is: a question of proportion rather than a technical wall, not by default, and with the condition under which it would be revisited written down. The project already has the pattern — federated sign-in refuses to point anywhere but Microsoft unless told to in so many words, and says so in its log on every boot when it has been.

## Everything else

- **Root README** — the documentation link, a contents entry, a portal bullet with an anchor, and the five optional finding fields with what each means and which two are never inferred
- **`portal/README.md`** — eight sections, a row in the table, and a section describing the view
- **`docs/architecture.md`** — the collectors read schedulers, and why the cadence travels untranslated rather than being normalised three times across two shell scripts and a PowerShell one
- **`endpoint/*/README.md`** — what each platform's scan covers, and that the account scan now distinguishes a person from a key from nothing at all

## No wizard step

The wizard's business is what a deployment cannot work without: the receiver URL, corporate domains, a log store. This needs no configuration at all — it lights up when collectors report, and says which of three reasons it is empty when they have not. A step for a view that requires no setup would make the wizard longer without making a deployment more correct, and Health already answers "why is this blank".

Happy to be overruled on that.

## Checked

Every relative link in every markdown file resolves. Suites green: portal 582, receiver and registry 302, scanner 164.
