### PR TITLE
Nothing here knows when you work, so it stops pretending to

### DIFF
--- a/docs/agentic.md
+++ b/docs/agentic.md
@@ -94,6 +94,17 @@ of lane, because four different things are true and only one of them is
 job was loaded. The gaps between runs are true; the clock positions are not,
 and the lane says so rather than implying four tidy times.
 
+### Working hours
+
+The shaded stretch is a setting, under **Settings > Display & alerting**, and
+nothing is shaded until it is set. Nothing here can know when an organisation
+works, and a shaded stretch nobody chose is a claim the platform has no basis
+for - on a fleet that runs nights, every mark would sit in the "nobody around"
+stretch and the page would say so with a straight face.
+
+A shift crossing midnight is two stretches of one day and is handled as such:
+`22:00-06:00` works.
+
 **A spec is what something is set to do, not what it was seen doing.** The
 panel is titled "as configured" for that reason. Watching runs actually
 happen needs process telemetry, which is a different source and a different
@@ -197,3 +208,10 @@ Check, in order:
    in itself.
 3. **Is the network scanner configured?** The bespoke-script signal comes from
    it, and it is the one that catches what has no config file to find.
+
+## On the overview
+
+An optional widget, off by default, under **Settings > Display & alerting**.
+It shows the count and the ones with nothing to revoke - a scheduled job
+under a real account is not the finding, so it is not what the tile leads
+with.

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -1153,6 +1153,45 @@ def _cron_field(spec, lo, hi):
     return sorted(out) or None
 
 
+def working_hours_band(spec):
+    """(start %, width %) for the shaded stretch, or None.
+
+    Nothing here can know when an organisation works. The first version of
+    this panel shaded 09:00-18:00 because that is a reasonable guess, which
+    made it a claim the platform had no basis for - on a fleet that runs
+    nights, every mark would have sat in the "nobody around" stretch and the
+    page would have said so with a straight face.
+
+    So it is a setting, and an unset one draws no band. Absent context is
+    better than invented context, which is the same rule the rest of this
+    codebase follows about silence.
+    """
+    spec = (spec or "").strip()
+    if not spec:
+        return None
+    try:
+        a, _, b = spec.partition("-")
+        ah, _, am = a.strip().partition(":")
+        bh, _, bm = b.strip().partition(":")
+        start = int(ah) * 60 + int(am or 0)
+        end = int(bh) * 60 + int(bm or 0)
+    except (ValueError, TypeError):
+        return None
+    if not (0 <= start <= 24 * 60 and 0 <= end <= 24 * 60) or start == end:
+        return None
+    # A shift that crosses midnight is two stretches of one day, not an
+    # invalid range. Refusing it would have been particularly poor here,
+    # since a fleet that works nights is the case that makes this a setting
+    # rather than a constant in the first place.
+    if end > start:
+        spans = [(start, end)]
+    else:
+        spans = [(0, end), (start, 24 * 60)]
+    return {"spans": [{"left": a2 / 14.4, "width": (b2 - a2) / 14.4}
+                      for a2, b2 in spans if b2 > a2],
+            "label": "%s-%s" % (a.strip(), b.strip())}
+
+
 def schedule_lane(spec):
     """How to draw one thing's day, from the raw spec its scheduler holds.
 

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -668,6 +668,19 @@ def _corp_domains(request) -> list:
     return []
 
 
+def _working_hours(request) -> str:
+    """When this organisation works, as an operator set it, or "".
+
+    Empty on anything unreadable, and empty is the honest default: nothing
+    here can know an organisation's hours, so an unset value draws no shaded
+    stretch rather than a guessed one.
+    """
+    entry = (_remote_settings(request) or {}).get("working_hours")
+    if isinstance(entry, dict):
+        return str(entry.get("value") or "")
+    return ""
+
+
 def _registry(request) -> dict:
     """The registry every portal view should reason over: the shipped file
     plus the portal-defined entries, merged exactly as the receiver serves
@@ -938,6 +951,7 @@ KNOWN_WIDGETS = {
     "review_queue": "Observed tools awaiting a governance decision",
     "budget_spend": "Tracked AI spend against observed use (managed mode)",
     "activity_trend": "Personal accounts and devices per day across the window",
+    "agentic": "What runs with no person behind it",
 }
 
 DEFAULT_WIDGETS = ["stat_row", "review_queue", "budget_spend", "top_tools",
@@ -1178,8 +1192,13 @@ def agentic(request: Request,
         _invalidate_all()
 
     def build():
-        return derive.agentic_from(_findings_cached(hours, request),
-                                   _registry(request))
+        out = derive.agentic_from(_findings_cached(hours, request),
+                                  _registry(request))
+        # Nothing here can know when an organisation works, so the shaded
+        # stretch is a setting and an unset one draws nothing at all.
+        out["working_hours"] = derive.working_hours_band(
+            _working_hours(request))
+        return out
 
     value, at = _cached("agentic", hours, build)
     return JSONResponse(dict(value, derived_at=at, hours=hours))
@@ -1832,6 +1851,7 @@ class SettingsWrite(BaseModel):
     invite_body: str | None = Field(default=None, max_length=4000)
     portal_public_url: str | None = Field(default=None, max_length=500)
     paste_guard_mode: str | None = Field(default=None, max_length=8)
+    working_hours: str | None = Field(default=None, max_length=11)
     firefox_extension_id: str | None = Field(default=None, max_length=128)
     classification_markings: list[str] | None = Field(default=None,
                                                       max_length=50)

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -863,12 +863,21 @@ a.libtn:hover{border-color:var(--pri)}
 .ag-day{background:var(--sf);border:1px solid var(--bd);border-radius:12px;
   box-shadow:var(--shadow);padding:15px 17px 12px;margin-bottom:26px;overflow-x:auto}
 .ag-grid{min-width:600px}
-.ag-lane{display:grid;grid-template-columns:174px 1fr;align-items:center;gap:13px;padding:4px 0}
-.ag-lname{font-size:12.5px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.ag-lname s{display:block;text-decoration:none;font-size:11px;color:var(--mut)}
+.ag-lane{display:grid;grid-template-columns:210px 1fr;align-items:center;gap:13px;padding:5px 0}
+.ag-lname{font-size:12.5px;min-width:0}
+/* The device name is one line and truncates with an ellipsis that shows.
+   The cadence underneath wraps instead: it is the row's actual content -
+   "every 15 min", "start unknown" - and cutting it mid-word taught the
+   reader nothing while looking like a rendering fault, which is what it
+   was. */
+.ag-lname b{display:block;font-weight:600;white-space:nowrap;overflow:hidden;
+  text-overflow:ellipsis}
+.ag-lname s{display:block;text-decoration:none;font-size:11px;color:var(--mut);
+  line-height:1.3;white-space:normal;overflow-wrap:anywhere}
+.ag-ticks{padding-left:223px}
 .ag-track{position:relative;height:18px;border-radius:5px;background:var(--sf2);overflow:hidden}
 /* 09:00-18:00, the stretch somebody is likely to be at a desk. */
-.ag-work{position:absolute;top:0;bottom:0;left:37.5%;width:37.5%;
+.ag-work{position:absolute;top:0;bottom:0;
   background:color-mix(in srgb, var(--fg) 6%, transparent)}
 .ag-run{position:absolute;top:4px;height:10px;border-radius:3px;background:var(--dstr)}
 .ag-run.ok{background:var(--acc)}
@@ -877,7 +886,7 @@ a.libtn:hover{border-color:var(--pri)}
 .ag-cont.ok{background:repeating-linear-gradient(90deg,var(--acc) 0 7px,transparent 7px 14px)}
 .ag-nolane{font-size:11.5px;color:var(--mut);padding-left:2px}
 .ag-ticks{display:flex;justify-content:space-between;font-size:10.5px;color:var(--mut);
-  margin-top:5px;padding-left:187px}
+  margin-top:5px}
 .ag-key{display:flex;gap:15px;flex-wrap:wrap;margin-top:11px;font-size:12px;color:var(--mut)}
 .ag-sw{width:15px;height:9px;border-radius:3px;display:inline-block;vertical-align:-1px;margin-right:5px}
 .ag-chain{background:var(--sf);border:1px solid var(--bd);border-radius:12px;
@@ -1509,6 +1518,13 @@ async function load(force) {
         await bFetchFx();
       } catch (e) { /* the tile simply stays absent */ }
     }
+    // The agentic tile needs its own read, and only when it is on the page.
+    if ((CFG.overview_widgets || []).some(w => w.kind === 'agentic') && !AGENTIC) {
+      try {
+        const ar = await fetch('/api/agentic');
+        if (ar.ok) AGENTIC = await ar.json();
+      } catch (e) { /* the tile says it has not been read */ }
+    }
     // Same again for the review queue: it draws from the register, and in
     // managed mode from the discovery candidates queue too.
     if ((CFG.overview_widgets || []).some(w => w.kind === 'review_queue')) {
@@ -2021,6 +2037,33 @@ function trendChart(days, a, b, aLabel, bLabel) {
 }
 
 const WIDGETS = {
+
+  // What runs with no person behind it, small enough to sit on an overview.
+  // The count is the headline; the rows are the ones with nothing to revoke,
+  // because a scheduled job under a real account is not the finding.
+  agentic: () => {
+    if (!AGENTIC) return `<div class="wcard w6"><h3>Running on its own</h3>
+      <p class="lede">Not read yet - open Agentic AI.</p></div>`;
+    const c = AGENTIC.counts || {};
+    const loose = (AGENTIC.agents || []).filter(a => !a.accountable);
+    return `<div class="wcard w6"><h3>Running on its own
+      <span class="count">${c.agents || 0}</span></h3>
+      ${!c.agents ? `<p class="lede">Nothing reported starting itself. That is either
+        true or the collectors have not been updated to look - Health says which.</p>`
+      : `<p class="lede">${c.unaccountable
+          ? `<b>${c.unaccountable}</b> of them answer to nobody: a credential with no
+             person behind it, so revoking a sign-on does not stop them.`
+          : 'All of them run under an identity somebody can be asked about.'}</p>
+        ${loose.length ? `<table>${loose.slice(0, 5).map(a => `<tr>
+          <td>${esc(label(a.device, G.devices[a.device] || {}))}
+            <div style="color:var(--mut);font-size:12px">${esc(a.trigger || a.evidence || '')}</div></td>
+          <td style="color:var(--mut)">${a.process
+            ? '<span class="pill p-warn">no tool we know</span>'
+            : '<span class="pill p-warn">' + esc(a.identity || 'unattributed') + '</span>'}</td>
+          </tr>`).join('')}</table>` : ''}
+        <p class="src-note" style="margin-top:8px"><a href="#agentic">Open Agentic AI</a></p>`}
+    </div>`;
+  },
 
   stat_row: () => {
     const devs = ents(G.devices), pa = G.personal_accounts || [];
@@ -5137,6 +5180,9 @@ function alertingSettings() {
     ${settingRow('budget_currency', 'Preferred currency',
       'GBP',
       'The Budget headline converts into it at the ECB daily reference rate, naming the rate date inline; newly linked tools default to it.', true)}
+    ${settingRow('working_hours', 'Working hours',
+      '09:00-18:00',
+      'Shades that stretch on the Agentic AI day, so a job firing when nobody is around reads as one. Nothing here can know your hours, so nothing is shaded until you set them. A shift crossing midnight works: 22:00-06:00.', true)}
     ${widgetPickerRow()}
   </dl></div>`;
 }
@@ -8834,21 +8880,24 @@ async function agentic() {
     return a.lane.marks.map(m =>
       `<span class="ag-run${cls}" style="left:${pct(m)}%;width:1.1%"></span>`).join('');
   };
+  const wh = AGENTIC.working_hours;
+  const band = wh ? wh.spans.map(sp =>
+    `<span class="ag-work" style="left:${sp.left}%;width:${sp.width}%"></span>`).join('') : '';
   const scheduled = A.filter(a => a.lane.kind !== 'none');
   const unscheduled = A.filter(a => a.lane.kind === 'none');
   const day = scheduled.length ? `<div class="ag-day"><div class="ag-grid">
     ${scheduled.map(a => `<div class="ag-lane">
-      <div class="ag-lname">${esc(label(a.device, G.devices[a.device] || {}))}
+      <div class="ag-lname"><b>${esc(label(a.device, G.devices[a.device] || {}))}</b>
         <s class="mono">${esc(a.trigger || a.schedule)}${
           a.lane.kind === 'unphased' ? ' · start unknown' : ''}</s></div>
-      <div class="ag-track"><span class="ag-work"></span>${laneOf(a)}</div>
+      <div class="ag-track">${band}${laneOf(a)}</div>
     </div>`).join('')}
     </div>
     <div class="ag-ticks mono"><span>00</span><span>06</span><span>12</span><span>18</span><span>24</span></div>
     <div class="ag-key">
       <span><span class="ag-sw" style="background:var(--dstr)"></span>nobody accountable</span>
       <span><span class="ag-sw" style="background:var(--acc)"></span>runs under a known identity</span>
-      <span><span class="ag-sw" style="background:color-mix(in srgb,var(--fg) 6%,transparent)"></span>working hours</span>
+      ${wh ? `<span><span class="ag-sw" style="background:color-mix(in srgb,var(--fg) 6%,transparent)"></span>working hours, ${esc(wh.label)}</span>` : ''}
     </div>
     ${unscheduled.length ? `<p class="ag-nolane" style="margin:9px 0 0">Not drawn:
       ${unscheduled.map(a => esc(label(a.device, G.devices[a.device] || {}))).join(', ')}
@@ -8885,9 +8934,14 @@ async function agentic() {
   pipeline step - or reached a model from a process that is neither a browser nor a tool
   the registry knows. The second box in each chain is the one to read: an empty box means
   there is nothing to revoke when somebody leaves.</p>
-  ${scheduled.length ? `<p class="label" style="margin:0 0 9px">The day, as configured</p>
-    <p class="lede" style="margin:0 0 10px">What each is set to do, not what it was seen
-    doing - nothing here watches a run happen. The shaded stretch is working hours.</p>` : ''}
+  ${scheduled.length ? `<p class="label" style="margin:0 0 9px">The day each is set to run</p>
+    <p class="lede" style="margin:0 0 10px">Read from the schedule each job declares -
+    a cron line, a systemd timer, a launchd interval. It is what each is <em>set</em> to
+    do, not what it was seen doing: nothing here watches a run happen.
+    ${wh ? `The shaded stretch is your working hours, ${esc(wh.label)}, from Settings.`
+         : `Set your working hours under <b>Settings &rsaquo; Display &amp; alerting</b>
+            to shade the stretch people are around - nothing here can know them, so
+            nothing is shaded until you say.`}</p>` : ''}
   ${day}
   ${A.length ? chains : `<div class="tcard"><p class="lede" style="margin:12px 0">
     Nothing on this estate reported running unattended. That is either true, or the

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -1438,3 +1438,25 @@ def test_the_day_is_what_is_configured_not_what_was_seen():
     lane = derive.schedule_lane("interval:21600")
     assert lane["kind"] == "unphased"
     assert lane["kind"] != "marks", "must not claim to know the hour"
+
+
+@pytest.mark.parametrize("spec,spans,why", [
+    ("09:00-18:00", 1, "an ordinary day"),
+    ("8-16", 1, "hours without minutes"),
+    ("22:00-06:00", 2, "a night shift is two stretches of one day, not invalid"),
+    ("", 0, "unset draws nothing"),
+    ("nonsense", 0, "unreadable draws nothing"),
+    ("09:00-09:00", 0, "zero width is not a range"),
+    ("25:00-26:00", 0, "outside a day"),
+])
+def test_working_hours_are_read_or_not_drawn(spec, spans, why):
+    """The first version of the day shaded 09:00-18:00 as a constant, which
+    made it a claim the platform had no basis for: on a fleet that runs
+    nights every mark would have sat in the "nobody around" stretch and the
+    page would have said so with a straight face.
+
+    So it is a setting, and an unset or unreadable one draws no band at all.
+    Absent context beats invented context - the same rule this codebase
+    applies to silence everywhere else."""
+    band = derive.working_hours_band(spec)
+    assert (len(band["spans"]) if band else 0) == spans, why

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -356,6 +356,11 @@ VALID_MODES = {"interactive", "autonomous"}
 # "none" both arrived as a blank account domain and were indistinguishable,
 # which is why the blank alone could never carry this meaning.
 VALID_IDENTITIES = {"person", "machine", "none"}
+# H:MM-H:MM, hours 0-23 and minutes optional. Only the shape: whether the
+# range makes sense is the reader's business, and a value that saves and
+# then shades nothing is worse than one refused at the point of typing.
+_WORKING_HOURS_RE = re.compile(
+    r"^([01]?\d|2[0-3])(:[0-5]\d)?-([01]?\d|2[0-3])(:[0-5]\d)?$")
 VALID_SEVERITIES = {"info", "warn"}
 # Bounded set: safe as a Loki stream label and a Prometheus metric label.
 # Sources that pre-date the field (older browser extensions) report "unknown".
@@ -1958,6 +1963,11 @@ class SettingsUpdate(BaseModel):
     portal_public_url: str | None = Field(default=None, max_length=500)
     budget_currency: str | None = Field(default=None, max_length=8)
     paste_guard_mode: str | None = Field(default=None, max_length=8)
+    # "09:00-18:00", or empty. Empty is the honest default: nothing here can
+    # know when an organisation works, and a shaded stretch nobody set is a
+    # claim the platform has no basis for. Unset, the day is drawn with no
+    # band at all rather than with an invented one.
+    working_hours: str | None = Field(default=None, max_length=11)
     firefox_extension_id: str | None = Field(default=None, max_length=128)
     classification_markings: list[str] | None = Field(default=None,
                                                       max_length=50)
@@ -2021,6 +2031,7 @@ def get_settings(authorization: str = Header(default="")):
         "extension_crx_url": plain("extension_crx_url"),
         "extension_xpi_url": plain("extension_xpi_url"),
         "paste_guard_mode": plain("paste_guard_mode"),
+        "working_hours": plain("working_hours"),
         "budget_currency": plain("budget_currency"),
         "firefox_extension_id": plain("firefox_extension_id"),
         # An incoming webhook URL is itself a bearer capability - whoever
@@ -2163,6 +2174,17 @@ def put_settings(req: SettingsUpdate, authorization: str = Header(default="")):
                                 % ", ".join(_PASTE_GUARD_MODES))
         else:
             STATE.set_setting("paste_guard_mode", mode, by)
+
+    if "working_hours" in req.model_fields_set:
+        wh = (req.working_hours or "").strip()
+        if not wh:
+            STATE.set_setting("working_hours", None, by)
+        elif not _WORKING_HOURS_RE.match(wh):
+            raise HTTPException(
+                422, "working_hours must look like 09:00-18:00. A shift "
+                     "crossing midnight is fine: 22:00-06:00.")
+        else:
+            STATE.set_setting("working_hours", wh, by)
 
     if "firefox_extension_id" in req.model_fields_set:
         fid = (req.firefox_extension_id or "").strip()


### PR DESCRIPTION
Three things from reading the page rather than the diff, and the middle one is a flaw I put there.

## The lane labels were clipped

A single nowrap line in a fixed column cut `every 15 min` to `every 15 mi` and `start unknown` to `st`, **with no ellipsis to admit it had** — so the row read as a rendering fault, which is exactly what it was.

The device name keeps one line and truncates properly. The cadence underneath wraps instead: it is the row's actual content, and cutting it mid-word taught the reader nothing.

## The shaded stretch was a guess presented as a fact

It was hardcoded `09:00-18:00`. That is a reasonable guess and therefore a claim this platform had no basis for. **On a fleet that runs nights, every mark would have sat in the "nobody around" stretch and the page would have said so with a straight face.**

It is now a setting under **Settings › Display & alerting**, and an unset one **draws no band at all**. Absent context beats invented context — the same rule applied to silence everywhere else here, where a silent source is never read as a clean estate.

A shift crossing midnight is two stretches of one day and is drawn as such: `22:00-06:00` works. Refusing it would have been a poor joke given a night-shift fleet is the case that makes this a setting rather than a constant.

### And adding it found the bug that settings path exists to prevent

**A field on the write model alone is accepted, returns 200, and is silently dropped.** It needs three things, not one:

1. the field on `SettingsUpdate` *and* the portal's mirror
2. an entry in the settings response, or nothing can ever read it back
3. a handler that actually stores it

With only the first, the portal reported a successful save and nothing changed — which is precisely the failure mode the `extra=forbid` on both models exists to stop, arriving through a different door. The write path now also refuses a shape that would silently shade nothing, rather than accepting it and leaving somebody to wonder why their hours had no effect.

The existing model-drift test checks the two *models* agree. It cannot catch this, because both models were correct.

## "The day, as configured" answered a question nobody asked

It left the real one open: configured from what? The heading is now **"The day each is set to run"**, and the caption says where it comes from — the schedule each job declares, a cron line, a systemd timer, a launchd interval.

## An overview tile

Off by default, tickable under **Settings › Display & alerting**, as suggested.

It leads with **the ones that have nothing to revoke** rather than the total, because a scheduled job under a real account is not the finding and a tile that counts both equally would say the opposite of what the page says.

The test asserting the widget lists in Python and JavaScript agree caught it missing from one of them, which is the test doing its job.

## Checked

Working hours round-tripped through the running stack: `09:00-18:00` gives one span, `22:00-06:00` gives two, `nonsense` and `25:00-26:00` are **refused with 422** and leave the previous value alone, and clearing it removes the band.

Docs updated for the setting and the tile. Suites green: portal 589, receiver and registry 302, scanner 164.
