### PR TITLE
release: 0.22.0, what runs without a person

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.21.2
+version: 0.22.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.21.2"
+appVersion: "0.22.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.2
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.22.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.2
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.22.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.21.2
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.22.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Every view in this platform starts from something somebody did. **This release adds the one that starts from the absence of that** — a tool that begins on a timer, holds a credential no human signs into, and reaches whatever it was pointed at while nobody is watching.

Revoking somebody's single sign-on does not stop it. Nothing here showed that.

Six merged changes. One of them corrects a number you already have.

## Agentic AI

A new section, and four optional fields on a finding to carry it. Old senders are unaffected: absent fields and empty values read downstream as unknown.

| | |
|---|---|
| `mode` | `interactive` \| `autonomous` |
| `identity` | `person` \| `machine` \| `none` |
| `trigger` | what starts it, in the scheduler's own words |
| `schedule` | the raw cadence, dialect-prefixed: `cron:0 2 * * *`, `interval:21600`, `atlogin` |

`schedule` is stored raw rather than normalised. Normalising it means doing it again in a second shell collector and a third time in PowerShell — three chances to disagree about what a schedule means. One parser in the portal is one place to be wrong, and the untranslated spec stays readable by whoever has to go and find the thing.

Each row is drawn as a chain — `starts → who authorised it → runs → can reach` — because the interesting part is a missing link, not a value in a column. Where nothing accountable sits behind the credential, that second box is a hole. A scheduled job under a real account gets a filled box and reads *"runs on a timer, but attributed"*: running unattended is not the problem, running unattended under nobody's name is.

The collectors are what make any of this true on a fleet. macOS reads launchd in a user's agents and the machine-wide agent and daemon directories; Linux reads systemd timers plus cron from `crontab -l`, `/etc/crontab` and `/etc/cron.d`; Windows reads Scheduled Tasks, including logon and boot triggers. A job qualifies when what it runs names a binary the registry already lists, so **a new tool is a registry entry rather than an edit to three scripts**.

One signal needed no new field at all. The DNS scan already records which process resolved a domain, and it had been sitting unread in evidence text:

```
DNS lookup for api.anthropic.com (via python3)
```

Something reaching a model that is neither a browser nor a binary the registry knows is a script with a key in it — no config file, no MCP server, nothing to inventory. That row draws with two holes and is the one nothing else in an estate would surface.

## A number that changes retroactively

**The MCP row on the Sources page could never report, whatever your estate had.** It matched findings whose `source` was `mcp_scan`; no routine scan run has ever sent that. MCP findings come from the endpoint collectors, which set their own source (`collector-macos` and friends) and set the surface to `mcp` separately.

So the row did not merely fail to answer. Its help text drew the conclusion for the reader — *"If a collector is reporting and this is quiet, nobody has configured an MCP server yet"* — while the Inventory tab two clicks away listed the servers.

Rows that describe a surface are now judged on one. Every other row stays matched on source exactly as before.

**Expect a number to move on upgrade.** If you have MCP servers configured, that group goes from not reporting to reporting on findings you already had. Nothing new was detected; the question was being asked wrongly.

## Working hours are a setting, not a constant

The Agentic day chart shaded a hardcoded `09:00-18:00`. That is a reasonable guess and therefore a claim this platform had no basis for — **on a fleet that runs nights, every mark would have sat in the "nobody around" stretch and the page would have said so with a straight face.**

It is now under **Settings › Display & alerting**, and an unset one draws no band at all. Absent context beats invented context, which is the rule applied to silence everywhere else here. A shift crossing midnight is accepted and drawn as two stretches of one day: `22:00-06:00` works.

Adding it surfaced the failure mode that settings path exists to prevent: a field on the write model alone is accepted, returns 200, and is silently dropped. It needs three things — the field, an entry in the settings response so anything can read it back, and a handler that stores it. The write path now refuses a shape that would shade nothing rather than accepting it and leaving somebody to wonder why their hours had no effect.

## Smaller

- **A collapsed sidebar names its icons.** Hovering an icon in the collapsed rail shows the item's label, so a narrow window stops being a guessing game. A divider separates the sections, and the wordmark is aligned against the icons below it rather than against its own bounding box.
- **An overview tile for what runs on its own**, off by default and tickable under Settings › Display & alerting. It leads with the ones that have nothing to revoke rather than the total, because a scheduled job under a real account is not the finding.
- **Lane labels no longer clip.** A fixed column was cutting `every 15 min` to `every 15 mi` with no ellipsis to admit it had, so the row read as a rendering fault.
- **Docs**: `docs/agentic.md` covers what this section claims and what it deliberately does not, including why prompts are not read. The deployment docs now lead with the portal rather than the older route, and the demo's own port was missing from its README.

## Upgrading

```bash
helm upgrade ai-guard oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard \
  --version 0.22.0 --reset-values -f your-values.yaml
```

Prefer `--reset-values` with your own values file over `--reuse-values`, which re-sends the old chart's computed defaults as if you had supplied them.

**Unlike the last two releases, this one does not finish at the chart.**

- **The collectors carry the scheduler scan, so the Agentic AI page stays empty until they are redeployed.** Fresh copies are on the portal's own download page, or in `endpoint/` in the repo. Until an updated collector has run, that section is honestly empty rather than wrong — but it is empty because nothing has looked yet, not because nothing is there.
- **The scanner and discovery CronJobs are hand-maintained and sit outside the chart's version guard.** The `(via <process>)` row above comes from the DNS scan, so it needs a current scanner image to appear at all. Worth checking the image tag on those two while you are here.
- The MCP row will change state on the next status read. See above.

Collectors that predate this release keep working unchanged and keep reporting exactly what they did before.

## Images & chart

- `ghcr.io/amansk5/shadow-ai-guard/receiver:0.22.0`
- `ghcr.io/amansk5/shadow-ai-guard/portal:0.22.0`
- `ghcr.io/amansk5/shadow-ai-guard/discovery:0.22.0`
- `ghcr.io/amansk5/shadow-ai-guard/scanner:0.22.0`
- Helm chart `0.22.0` — `oci://ghcr.io/amansk5/shadow-ai-guard/charts/ai-guard`

All four images are `linux/amd64` and `linux/arm64` under one tag.
