### PR TITLE
The scheduler finding that never arrived

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,12 @@ jobs:
             "apt-get update -qq && apt-get install -yqq curl >/dev/null && \
              endpoint/tests/test_linux_collector.sh"
 
+      # Static, because Linux is the only collector CI can run - and it was the
+      # only one of the three that had the dedupe key right. A property that
+      # must hold for all three is checked against all three.
+      - name: collector parity
+        run: endpoint/tests/test_collector_parity.sh
+
   psscriptanalyzer:
     runs-on: ubuntu-latest
     steps:

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.22.1
+version: 0.23.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.22.1"
+appVersion: "0.23.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/files/collector.json
+++ b/charts/ai-guard/files/collector.json
@@ -136,6 +136,16 @@
       "bundle_ids": []
     },
     {
+      "tool": "warp",
+      "app_names": [
+        "Warp.app",
+        "Warp"
+      ],
+      "bundle_ids": [
+        "dev.warp.Warp-Stable"
+      ]
+    },
+    {
       "tool": "perplexity",
       "app_names": [
         "Perplexity.app",
@@ -159,6 +169,14 @@
       "app_names": [
         "LM Studio.app",
         "LM Studio"
+      ],
+      "bundle_ids": []
+    },
+    {
+      "tool": "fireflies",
+      "app_names": [
+        "Fireflies.app",
+        "Fireflies"
       ],
       "bundle_ids": []
     }

--- a/charts/ai-guard/files/registry.json
+++ b/charts/ai-guard/files/registry.json
@@ -460,6 +460,30 @@
       ]
     },
     {
+      "id": "warp",
+      "name": "Warp",
+      "vendor": "Warp",
+      "category": "coding",
+      "approved": false,
+      "added_by": "manual",
+      "domains": [
+        "warp.dev",
+        "app.warp.dev"
+      ],
+      "app_names": [
+        "Warp.app",
+        "Warp"
+      ],
+      "exe_names": [
+        "warp.exe",
+        "stable"
+      ],
+      "risk_tier": "medium",
+      "bundle_ids": [
+        "dev.warp.Warp-Stable"
+      ]
+    },
+    {
       "id": "perplexity",
       "name": "Perplexity",
       "vendor": "Perplexity AI",
@@ -685,6 +709,13 @@
       "risk_tier": "high",
       "email_senders": [
         "fireflies.ai"
+      ],
+      "app_names": [
+        "Fireflies.app",
+        "Fireflies"
+      ],
+      "exe_names": [
+        "Fireflies.exe"
       ]
     },
     {
@@ -822,7 +853,22 @@
     "systemd-resolved",
     "mDNSResponder",
     "trustd",
-    "nsurlsessiond"
+    "nsurlsessiond",
+    "SearchHost",
+    "StartMenuExperienceHost",
+    "ShellExperienceHost",
+    "SearchApp",
+    "Microsoft.Notes",
+    "OneDriveStandaloneUpdater",
+    "msedgewebview2",
+    "Code",
+    "Code - Insiders",
+    "idea",
+    "pycharm",
+    "webstorm",
+    "goland",
+    "rider",
+    "clion"
   ],
   "discover_exclude_domains": [
     "jetbrains.com",

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.22.1
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.23.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.22.1
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.23.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/endpoint/linux/ai-guard-collector.sh
+++ b/endpoint/linux/ai-guard-collector.sh
@@ -73,7 +73,7 @@ STATE_FILE="$STATE_DIR/reported.state"
 CRED_FILE="$STATE_DIR/device.cred"
 # Reported at enrollment and on every report, so the receiver's inventory can
 # answer "which script version does the fleet actually run".
-COLLECTOR_VERSION="2.0.0"
+COLLECTOR_VERSION="2.1.0"
 SUMMARY_DIR="$STATE_DIR"
 SUMMARY_FILE="$SUMMARY_DIR/last_scan.txt"
 INFO_INTERVAL=$((24 * 3600))

--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -64,7 +64,7 @@ SUMMARY_FILE="$SUMMARY_DIR/last_scan.txt"
 CRED_FILE="$SUMMARY_DIR/device.cred"
 # Reported at enrollment and on every report, so the receiver's inventory can
 # answer "which script version does the fleet actually run".
-COLLECTOR_VERSION="2.0.0"
+COLLECTOR_VERSION="2.1.0"
 
 # Report throttling. The policy runs at every recurring check-in (~20 min).
 # Unchanged inventory (info) findings only need reporting once a day; warn
@@ -468,7 +468,14 @@ HOME_LABEL='~'
 
 SEEN=""
 report_once() {
-  local key="$1|$2"
+  # The trigger joins the key for the same reason it joins the throttle key
+  # in report(): two scheduled jobs on one machine are two findings, and a
+  # scheduled job is a different finding from the same tool being installed.
+  # Without it the scheduler scan was discarded on every machine where the
+  # tool was also signed in - which is every machine anybody would schedule
+  # it on. Linux and Windows have keyed on the trigger since the scan
+  # shipped; this is macOS catching up.
+  local key="$1|$2|${7:-}"
   case "$SEEN" in *"[$key]"*) return 0 ;; esac
   SEEN="${SEEN}[$key]"
   report "$@"

--- a/endpoint/tests/test_collector_parity.sh
+++ b/endpoint/tests/test_collector_parity.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Cross-collector invariants, asserted statically.
+#
+# Why static rather than end-to-end: the Linux collector is the only one CI can
+# actually run, and it was the only one of the three that had this right. The
+# macOS collector deduped on "surface|tool" while Linux and Windows deduped on
+# "surface|tool|trigger", so on macOS every scheduled-job finding was discarded
+# whenever the tool was also installed - which is every machine anybody would
+# schedule it on. The scheduler scan therefore reported nothing on macOS from
+# the day it shipped, and no test could have noticed because no test runs the
+# macOS collector.
+#
+# These assertions cost nothing and hold on any runner. A property that must be
+# true of all three collectors is checked against all three.
+set -u
+fail=0
+ok()   { printf '  ok   %s\n' "$1"; }
+bad()  { printf '  FAIL %s\n' "$1"; fail=1; }
+
+MAC=endpoint/macos/ai-guard-collector.sh
+LIN=endpoint/linux/ai-guard-collector.sh
+WIN=endpoint/windows/ai-guard-collector.ps1
+
+echo "the dedupe key includes the trigger, in all three"
+# A scheduled job and an installed tool are different findings about the same
+# tool. Two scheduled jobs on one machine are two findings. Both require the
+# trigger in the key; without it the second is silently dropped.
+# sed the function body rather than a fixed -A window: a comment added above
+# the line would otherwise slide it out of view and pass the test by accident.
+key_line() { sed -n "/^$2()/,/^}/p" "$1" | grep -E 'local (key|k)='; }
+key_line "$MAC" report_once | grep -q '"\$1|\$2|\${7:-}"' \
+  && ok "macos"   || bad "macos: report_once drops the trigger from its key"
+key_line "$LIN" report_once | grep -q '"\$1|\$2|\${7:-}"' \
+  && ok "linux"   || bad "linux: report_once drops the trigger from its key"
+grep -q '\$key = "\$Surface|\$Tool|\$Trigger"' "$WIN" \
+  && ok "windows" || bad "windows: Send-FindingOnce drops the trigger from its key"
+
+echo "the collector version moves when the collectors do"
+# The scheduler scan shipped without this moving, so a collector that could
+# read schedulers and one that could not both reported 2.0.0 - and an empty
+# Agentic AI page could not be told from an undeployed one.
+mv=$(grep -m1 '^COLLECTOR_VERSION=' "$MAC" | cut -d'"' -f2)
+lv=$(grep -m1 '^COLLECTOR_VERSION=' "$LIN" | cut -d'"' -f2)
+wv=$(grep -m1 'CollectorVersion = ' "$WIN" | cut -d"'" -f2)
+if [ "$mv" = "$lv" ] && [ "$lv" = "$wv" ]; then
+  ok "all three report $mv"
+else
+  bad "versions disagree: macos=$mv linux=$lv windows=$wv"
+fi
+
+echo "the scripts the portal serves match the ones in endpoint/"
+# The portal hands these to an operator to deploy. A fix that lands in one
+# copy and not the other ships the bug to the fleet while the repo looks fixed.
+for pair in "$MAC portal/collector-scripts/collector-macos.sh" \
+            "$LIN portal/collector-scripts/collector-linux.sh" \
+            "$WIN portal/collector-scripts/collector-windows.ps1"; do
+  set -- $pair
+  if diff -q "$1" "$2" >/dev/null 2>&1; then
+    ok "$(basename "$2")"
+  else
+    bad "$(basename "$2") differs from $1"
+  fi
+done
+
+[ "$fail" -eq 0 ] && echo "collector parity: all invariants hold" \
+                  || echo "collector parity: FAILED"
+exit "$fail"

--- a/endpoint/windows/ai-guard-collector.ps1
+++ b/endpoint/windows/ai-guard-collector.ps1
@@ -60,7 +60,7 @@ $Breadcrumb = Join-Path $StateDir 'last_scan.txt'
 $CredFile = Join-Path $StateDir 'device.cred'
 # Reported at enrollment and on every report, so the receiver's inventory can
 # answer "which script version does the fleet actually run".
-$CollectorVersion = '2.0.0'
+$CollectorVersion = '2.1.0'
 $InfoReportIntervalHours = 24
 $WarnReportIntervalHours = 1
 

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -1034,6 +1034,13 @@ UNATTRIBUTABLE_PROCESSES = {
     "systemd-resolved", "systemd-executor", "systemd", "resolvconf",
     "mdnsresponder", "discoveryd", "dnsmasq", "unbound", "nscd",
     "svchost", "dnscache", "networkservice",
+    # Generic hosts: Windows runs scheduled and background work inside these,
+    # so the name is whatever they were told to run.
+    "backgroundtaskhost", "taskhostw", "taskhost", "taskeng", "rundll32",
+    "dllhost", "wermgr",
+    # Squirrel ships its updater as "Update.exe" inside every app that uses
+    # it, so the name says an application updated itself, not which one.
+    "update", "updater", "squirrel",
 }
 
 
@@ -1052,6 +1059,27 @@ def normalise_process(name):
     if n.endswith(".exe"):
         n = n[:-4]
     return _HELPER_SUFFIX_RE.sub("", n).strip()
+
+
+def process_stems(process_name):
+    """Every form of a name worth matching, longest first.
+
+    A Windows service often names itself in dotted components -
+    "OneDrive.Sync.Service.exe" - and only the leading one is the product.
+    Yielding the progressively shorter prefixes lets an allowlist hold
+    "OneDrive" and still match, without the entry itself having to guess
+    which suffixes Microsoft will ship.
+
+    Longest first so a specific entry always beats a shorter prefix, and
+    the bare first component is yielded last: "Microsoft.Notes" is matched
+    as itself before anything gets the chance to match "Microsoft" and
+    allowlist every product they make.
+    """
+    n = normalise_process(process_name)
+    if not n:
+        return []
+    parts = n.split(".")
+    return [".".join(parts[:i]) for i in range(len(parts), 0, -1)]
 
 
 def bespoke_client(f, known_processes=()):
@@ -1082,15 +1110,17 @@ def bespoke_client(f, known_processes=()):
     if not m:
         return ""
     proc = m.group(1).strip()
-    stem = normalise_process(proc)
-    if not stem:
+    stems = process_stems(proc)
+    if not stems:
         return ""
     # Says a device resolved it, not what wanted the name.
-    if stem in UNATTRIBUTABLE_PROCESSES:
+    if any(s in UNATTRIBUTABLE_PROCESSES for s in stems):
         return ""
-    if proc.lower() in BROWSER_PROCESSES or stem in BROWSER_PROCESSES:
+    if proc.lower() in BROWSER_PROCESSES:
         return ""
-    if stem in known_processes:
+    if any(s in BROWSER_PROCESSES for s in stems):
+        return ""
+    if any(s in known_processes for s in stems):
         return ""
     return proc[:80]
 
@@ -1098,18 +1128,32 @@ def bespoke_client(f, known_processes=()):
 def registry_processes(reg):
     """Every process name the registry can account for, normalised.
 
-    Two sources, because "a tool the registry knows" is both: the binaries
-    its AI CLIs run as, and allowed_processes - the browsers, desktop apps
-    and system daemons the scanner already refuses to raise findings about.
-    Only the first was read here, so an estate's whole Office install
-    arrived on the agentic page as processes nobody could account for.
+    Four sources, because "a tool the registry knows" is all of them: the
+    binaries its AI CLIs run as, the app names and Windows executables its
+    desktop tools ship under, and allowed_processes - the browsers, apps and system daemons the scanner
+    already refuses to raise findings about.
+
+    Only the binaries were read here, and only four tools have any, so an
+    estate's whole Office install arrived on the agentic page as processes
+    nobody could account for - and so did the desktop tools whose own vendor
+    domain the same finding had just resolved.
     """
     out = set()
     for t in (reg or {}).get("tools", []) or []:
         for b in ((t.get("cli") or {}).get("binaries") or []):
             out.add(normalise_process(b))
-    for p in (reg or {}).get("allowed_processes", []) or []:
-        out.add(normalise_process(p))
+        # A desktop app reaching its own vendor's API is that tool, not a
+        # mystery. ".app" is stripped so the macOS bundle name and the bare
+        # process name are one entry.
+        for a in (t.get("app_names") or []):
+            a = str(a)
+            out.add(normalise_process(a[:-4] if a.lower().endswith(".app") else a))
+        # Windows executable names, already in the registry for nine tools
+        # and read by nothing until now.
+        for e in (t.get("exe_names") or []):
+            out.add(normalise_process(e))
+    for pn in (reg or {}).get("allowed_processes", []) or []:
+        out.add(normalise_process(pn))
     return out - {""}
 
 
@@ -1336,6 +1380,48 @@ def _oncalendar(rest):
     return {"kind": "none", "marks": []}
 
 
+# The collector version from which a scheduled job is both read and
+# reported. The scheduler scan shipped before this without the version
+# moving, and on macOS its findings were then dropped by a dedupe key that
+# ignored the trigger - so a device on 2.0.0 may or may not have looked, and
+# saying which is not possible. It is counted as unknown, never as clean.
+SCHEDULER_SCAN_VERSION = (2, 1, 0)
+
+
+def _version_tuple(v):
+    """A dotted version as comparable integers, or None if it is not one."""
+    parts = (v or "").strip().split(".")
+    if not parts or not all(p.isdigit() for p in parts):
+        return None
+    return tuple(int(p) for p in parts[:3]) + (0,) * (3 - len(parts[:3]))
+
+
+def scheduler_coverage(findings):
+    """How many devices report a collector that can be trusted to have looked.
+
+    Absence of a scheduled job is only meaningful from a device that reads
+    schedulers. Without this the page could not tell "nothing here runs on a
+    timer" from "nothing here has been asked" - the same failure the Sources
+    view exists to prevent for detection sources, one level down.
+    """
+    seen = {}
+    for f in findings:
+        dev = (f.get("device") or "").strip()
+        ev = f.get("evidence") or ""
+        if not dev or not ev.startswith("heartbeat version="):
+            continue
+        v = _version_tuple(ev.split("version=", 1)[1].split()[0])
+        if v and v > seen.get(dev, (0, 0, 0)):
+            seen[dev] = v
+    capable = sum(1 for v in seen.values() if v >= SCHEDULER_SCAN_VERSION)
+    return {
+        "devices_reporting": len(seen),
+        "capable": capable,
+        "unknown": len(seen) - capable,
+        "min_version": ".".join(str(n) for n in SCHEDULER_SCAN_VERSION),
+    }
+
+
 def agentic_from(findings, reg=None):
     """What runs without a person, and how far it can reach.
 
@@ -1409,7 +1495,13 @@ def agentic_from(findings, reg=None):
             "account": acct,
             "mode": mode or "unknown",
             "process": proc,
+            # Device-level, and labelled as such. An MCP server is configured
+            # in a client on a machine; nothing here establishes that THIS
+            # process can drive it. Rendering the machine's servers as this
+            # row's capability told an operator a curl downloading an
+            # installer could reach their issue tracker.
             "reach": sorted(reach.get(dev, ())),
+            "reach_is_device": True,
             "evidence": (f.get("evidence") or "")[:300],
             "last_seen": f.get("reported_at") or "",
             # The two states worth counting separately. Accountable means
@@ -1461,6 +1553,8 @@ def agentic_from(findings, reg=None):
         },
         "servers": mcp_from(findings),
         "coverage": mcp_coverage(reg),
+        # Whether an empty page is an answer or an absence.
+        "scan_coverage": scheduler_coverage(findings),
     }
 
 

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -880,6 +880,13 @@ a.libtn:hover{border-color:var(--pri)}
    to nobody." on the same line, which reads as one clause and buries the
    number that matters. */
 .ag-verdict em{font-style:normal;color:var(--dstr);display:block}
+/* A cadence with no claim of autonomy behind it: drawn, but hollow, so a
+   scheduled-and-unattended job never reads the same as a process we merely
+   could not name. */
+.ag-run.weak,.ag-cont.weak{background:transparent;
+  box-shadow:inset 0 0 0 1.5px color-mix(in srgb,var(--dstr) 70%,transparent)}
+.ag-run.weak.ok,.ag-cont.weak.ok{
+  box-shadow:inset 0 0 0 1.5px color-mix(in srgb,var(--acc) 70%,transparent)}
 .ag-day{background:var(--sf);border:1px solid var(--bd);border-radius:12px;
   box-shadow:var(--shadow);padding:15px 17px 12px;margin-bottom:26px;overflow-x:auto}
 .ag-grid{min-width:600px}
@@ -8901,6 +8908,20 @@ async function agentic() {
         c.unaccountable ? ` <em>${c.unaccountable} answer${
           c.unaccountable === 1 ? 's' : ''} to nobody.</em>` : ''}</h1>`
     : `<h1 class="ag-verdict">Nothing here reports running on its own.</h1>`;
+  // "Nothing reported it" is only an answer from devices that looked. A
+  // collector too old to read a scheduler produces the same silence as an
+  // estate that schedules nothing, and the difference is the whole question.
+  const sc = AGENTIC.scan_coverage || {};
+  const scanNote = !nAuto && sc.devices_reporting ? `<p class="lede" style="margin:-2px 0 14px;max-width:56ch">${
+      sc.capable
+        ? `<b>${sc.capable}</b> of ${sc.devices_reporting} device${
+            sc.devices_reporting === 1 ? '' : 's'} run a collector that reads schedulers,
+           so for ${sc.capable === 1 ? 'that one' : 'those'} this is an answer rather than
+           a gap.${sc.unknown ? ` The other ${sc.unknown} report a version older than
+           ${esc(sc.min_version)}, which may never have looked.` : ''}`
+        : `No device reports a collector at ${esc(sc.min_version)} or newer, so
+           <b>nothing here has looked yet</b>. This is an absence, not a finding -
+           update the collectors before reading the zero.`}</p>` : '';
   const weak = nUnrec
     ? `<p class="lede" style="margin:-2px 0 14px;max-width:52ch">${nUnrec === 1
         ? 'One more process' : nUnrec + ' more processes'} reached a model
@@ -8909,7 +8930,7 @@ async function agentic() {
        c.unattributed ? `, and ${c.unattributed} of the rows below name no
        identity at all` : ''}.</p>`
     : '';
-  const head = strong + weak;
+  const head = strong + scanNote + weak;
 
   const nodes = a => {
     // Starts / who authorised it / runs / can reach. The second is the
@@ -8927,8 +8948,13 @@ async function agentic() {
          <s>${esc(a.process)}</s></div>`
       : `<div class="ag-node"><b>Runs</b><i>${esc(a.tool)}</i>${
           a.mode === 'autonomous' ? '<s>unattended</s>' : ''}</div>`;
+    // What the MACHINE has configured, which is not the same as what this
+    // process can drive - and the box has to say which it means. A curl
+    // downloading an installer was being shown its machine's MCP servers as
+    // though they were its own capability.
     const reach = a.reach.length
       ? a.reach.map(x => `<span class="pill p-amb">${esc(x)}</span>`).join('')
+        + `<s>configured on this machine</s>`
       : (a.process ? `<span class="pill p-mut">a model API direct</span>`
                    : `<span class="pill p-mut">nothing configured</span>`);
     return `<div class="ag-link">
@@ -8936,7 +8962,7 @@ async function agentic() {
         <s>${esc(a.os || '')}</s></div>
       <div class="ag-rail"></div>${who}<div class="ag-rail"></div>${runs}
       <div class="ag-rail"></div>
-      <div class="ag-node"><b>Can reach</b><i>${reach}</i></div></div>`;
+      <div class="ag-node"><b>The machine can reach</b><i>${reach}</i></div></div>`;
   };
 
   // The day. Configured cadence, not observed runs - a spec says what a
@@ -8945,7 +8971,11 @@ async function agentic() {
   // drawn with an invented one.
   const pct = m => (m / 1440 * 100).toFixed(2);
   const laneOf = a => {
-    const k = a.lane.kind, cls = a.accountable ? ' ok' : '';
+    // Unrecognised rows are drawn hollow: they have a cadence, but nothing
+    // said they ran unattended, and a solid mark beside a genuinely
+    // autonomous job re-merges the two claims the headline separates.
+    const k = a.lane.kind;
+    const cls = (a.accountable ? ' ok' : '') + (a.autonomous ? '' : ' weak');
     if (k === 'continuous')
       return `<span class="ag-cont${cls}" title="No cadence: runs while somebody is logged in"></span>`;
     if (k === 'band')
@@ -8958,7 +8988,20 @@ async function agentic() {
     `<span class="ag-work" style="left:${sp.left}%;width:${sp.width}%"></span>`).join('') : '';
   const scheduled = A.filter(a => a.lane.kind !== 'none');
   const unscheduled = A.filter(a => a.lane.kind === 'none');
-  const day = scheduled.length ? `<div class="ag-day"><div class="ag-grid">
+  const nolane = unscheduled.length ? `<p class="ag-nolane" style="margin:9px 0 0">Not drawn:
+      ${unscheduled.map(a => esc(label(a.device, G.devices[a.device] || {}))).join(', ')}
+      - triggered by an event, or a spec this cannot read. Guessing at a time would be
+      worse than leaving the row out.</p>` : '';
+  // A panel that vanishes says the same thing as a panel that was never
+  // built. With rows on the page and none of them drawable, the reason has
+  // to be on screen - the estate cannot otherwise tell "nothing declares a
+  // cadence" from "this was never deployed".
+  const day = !A.length ? '' : !scheduled.length ? `<div class="ag-day">
+    <p class="lede" style="margin:0">Nothing here declares a cadence this can read.
+    Every row came from the network rather than a scheduler, so there is no day to
+    draw - which is not the same as nothing running on a timer. A device only reports
+    a schedule once its collector is new enough to read one; Health says which are.</p>
+    ${nolane}</div>` : `<div class="ag-day"><div class="ag-grid">
     ${scheduled.map(a => `<div class="ag-lane">
       <div class="ag-lname"><b>${esc(label(a.device, G.devices[a.device] || {}))}</b>
         <s class="mono">${esc(a.trigger || a.schedule)}${
@@ -8970,13 +9013,11 @@ async function agentic() {
     <div class="ag-key">
       <span><span class="ag-sw" style="background:var(--dstr)"></span>nobody accountable</span>
       <span><span class="ag-sw" style="background:var(--acc)"></span>runs under a known identity</span>
+      <span><span class="ag-sw" style="background:transparent;box-shadow:inset 0 0 0 1.5px var(--dstr)"></span>has a cadence, but nothing said it runs unattended</span>
       ${wh ? `<span><span class="ag-sw" style="background:color-mix(in srgb,var(--fg) 6%,transparent)"></span>working hours, ${esc(wh.label)}</span>` : ''}
     </div>
-    ${unscheduled.length ? `<p class="ag-nolane" style="margin:9px 0 0">Not drawn:
-      ${unscheduled.map(a => esc(label(a.device, G.devices[a.device] || {}))).join(', ')}
-      - triggered by an event, or a spec this cannot read. Guessing at a time would be
-      worse than leaving the row out.</p>` : ''}
-  </div>` : '';
+    ${nolane}
+  </div>`;
 
   const chains = A.map(a => `<div class="ag-chain">
     <div class="ag-head">
@@ -9040,7 +9081,13 @@ async function agentic() {
       <li><b>What it was asked to do.</b> The prompt is on the machine and could be read.
         Reading what somebody typed is a heavier intrusion than knowing which tool ran,
         and it is not needed to answer anything on this page.</li>
-      <li><b>Whether it stayed within its brief.</b> Same material, same trade. Worth
+      <li><b>A scheduled job that runs a script.</b> The scan reads what a scheduler
+        declares, so it sees a job that names an AI tool. A job that runs
+        <span class="mono">nightly-report.sh</span>, which calls a model from inside,
+        names nothing the registry can match - and reading the contents of somebody's
+        scripts is the same intrusion as reading their prompts. This is a real gap
+        rather than a quiet one: silence here is not evidence of nothing scheduled.</li>
+            <li><b>Whether it stayed within its brief.</b> Same material, same trade. Worth
         revisiting once the signals above have been run on a real estate and shown to be
         insufficient - which is also when there is a case to put to whoever approves it.</li>
       <li><b>What it actually did.</b> Counting tool calls is an outcome with no prompt in

--- a/portal/collector-scripts/collector-linux.sh
+++ b/portal/collector-scripts/collector-linux.sh
@@ -73,7 +73,7 @@ STATE_FILE="$STATE_DIR/reported.state"
 CRED_FILE="$STATE_DIR/device.cred"
 # Reported at enrollment and on every report, so the receiver's inventory can
 # answer "which script version does the fleet actually run".
-COLLECTOR_VERSION="2.0.0"
+COLLECTOR_VERSION="2.1.0"
 SUMMARY_DIR="$STATE_DIR"
 SUMMARY_FILE="$SUMMARY_DIR/last_scan.txt"
 INFO_INTERVAL=$((24 * 3600))

--- a/portal/collector-scripts/collector-macos.sh
+++ b/portal/collector-scripts/collector-macos.sh
@@ -64,7 +64,7 @@ SUMMARY_FILE="$SUMMARY_DIR/last_scan.txt"
 CRED_FILE="$SUMMARY_DIR/device.cred"
 # Reported at enrollment and on every report, so the receiver's inventory can
 # answer "which script version does the fleet actually run".
-COLLECTOR_VERSION="2.0.0"
+COLLECTOR_VERSION="2.1.0"
 
 # Report throttling. The policy runs at every recurring check-in (~20 min).
 # Unchanged inventory (info) findings only need reporting once a day; warn
@@ -468,7 +468,14 @@ HOME_LABEL='~'
 
 SEEN=""
 report_once() {
-  local key="$1|$2"
+  # The trigger joins the key for the same reason it joins the throttle key
+  # in report(): two scheduled jobs on one machine are two findings, and a
+  # scheduled job is a different finding from the same tool being installed.
+  # Without it the scheduler scan was discarded on every machine where the
+  # tool was also signed in - which is every machine anybody would schedule
+  # it on. Linux and Windows have keyed on the trigger since the scan
+  # shipped; this is macOS catching up.
+  local key="$1|$2|${7:-}"
   case "$SEEN" in *"[$key]"*) return 0 ;; esac
   SEEN="${SEEN}[$key]"
   report "$@"

--- a/portal/collector-scripts/collector-windows.ps1
+++ b/portal/collector-scripts/collector-windows.ps1
@@ -60,7 +60,7 @@ $Breadcrumb = Join-Path $StateDir 'last_scan.txt'
 $CredFile = Join-Path $StateDir 'device.cred'
 # Reported at enrollment and on every report, so the receiver's inventory can
 # answer "which script version does the fleet actually run".
-$CollectorVersion = '2.0.0'
+$CollectorVersion = '2.1.0'
 $InfoReportIntervalHours = 24
 $WarnReportIntervalHours = 1
 

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -1569,3 +1569,85 @@ def test_a_script_is_still_a_mystery_when_the_registry_is_widened():
     ], reg)
     assert out["agents"][0]["process"] == "curl"
     assert out["counts"]["unrecognised"] == 1
+
+
+@pytest.mark.parametrize("proc,why", [
+    ("Fireflies.exe", "a desktop app reaching its own vendor's gateway is that tool"),
+    ("Fireflies", "same app, macOS spelling"),
+    ("stable", "Warp's binary is named for its release channel, not the product"),
+    ("Warp", "and its app name"),
+    ("Claude.exe", "exe_names has carried this for nine tools, unread until now"),
+])
+def test_a_desktop_app_is_named_by_the_registry_not_called_a_mystery(proc, why):
+    """The page said "no tool we know" about tools it did know. Matching read
+    cli.binaries only - four tools have any - while app_names and exe_names sat
+    in the same registry, populated and unread. The finding's own tool had
+    already been resolved from the domain."""
+    reg = {"tools": [
+        {"id": "fireflies", "app_names": ["Fireflies.app", "Fireflies"],
+         "exe_names": ["Fireflies.exe"]},
+        {"id": "warp", "app_names": ["Warp.app", "Warp"],
+         "exe_names": ["warp.exe", "stable"]},
+        {"id": "claude", "exe_names": ["claude.exe"]},
+    ]}
+    out = derive.agentic_from([
+        finding(tool="fireflies", surface="network", device="D9",
+                evidence="DNS lookup for gateway.fireflies.ai (via %s)" % proc),
+    ], reg)
+    assert out["agents"] == [], why
+
+
+def test_a_dotted_service_name_matches_the_product_on_the_allowlist():
+    """OneDrive.Sync.Service.exe reduced to onedrive.sync.service and never
+    matched the OneDrive already listed - a gap in the normaliser that
+    shipped with the first pass at this."""
+    reg = {"tools": [], "allowed_processes": ["OneDrive", "Microsoft.Notes"]}
+    findings = [
+        finding(tool="microsoft-365-copilot", surface="network", device="D%d" % i,
+                evidence="DNS lookup for substrate.office.com (via %s)" % p)
+        for i, p in enumerate(["OneDrive.Sync.Service.exe", "Microsoft.Notes.exe"])
+    ]
+    assert derive.agentic_from(findings, reg)["agents"] == []
+
+
+def test_reach_says_it_belongs_to_the_machine():
+    """An MCP server is configured in a client on a machine; nothing here
+    establishes that a given process can drive it. Rendering the machine's
+    servers as the row's own capability told an operator that a curl
+    downloading an installer could reach their issue tracker."""
+    out = derive.agentic_from([
+        finding(tool="claude", surface="network", device="D1",
+                evidence="DNS lookup for api.anthropic.com (via curl)"),
+        finding(tool="claude-code-mcp", surface="mcp", device="D1",
+                evidence=".claude.json mcpServers: atlassian"),
+    ], REG_BIN)
+    a = out["agents"][0]
+    assert a["reach"] == ["atlassian"]
+    assert a["reach_is_device"] is True
+
+
+def test_an_empty_page_says_whether_anything_looked():
+    """Absence of a scheduled job means nothing from a collector that cannot
+    read a scheduler. The scan shipped without the version moving, so 2.0.0
+    is genuinely ambiguous and is counted as unknown rather than clean."""
+    def beat(dev, v):
+        return finding(device=dev, surface="endpoint", tool="ai-guard-collector",
+                       evidence="heartbeat version=%s" % v)
+    out = derive.agentic_from([beat("D1", "2.1.0"), beat("D2", "2.0.0"),
+                               beat("D3", "2.1.3")], REG_BIN)
+    c = out["scan_coverage"]
+    assert c["devices_reporting"] == 3
+    assert c["capable"] == 2          # 2.1.0 and 2.1.3
+    assert c["unknown"] == 1          # 2.0.0 may never have looked
+    assert c["min_version"] == "2.1.0"
+
+
+def test_no_heartbeat_at_all_is_not_reported_as_capable():
+    """The estate that has never run a collector must not read as one that
+    looked and found nothing."""
+    out = derive.agentic_from([
+        finding(tool="claude", surface="network", device="D9",
+                evidence="DNS lookup for api.anthropic.com (via curl)"),
+    ], REG_BIN)
+    c = out["scan_coverage"]
+    assert c["devices_reporting"] == 0 and c["capable"] == 0

--- a/receiver/app/budget.py
+++ b/receiver/app/budget.py
@@ -269,6 +269,12 @@ MEMBER_APIS = {
         "plan": "Enterprise, SaaS console or self-hosted.",
         "how": "Admin APIs for teams and users, plus SCIM IdP sync.",
     },
+    "warp": {
+        "api": "unknown", "plan": "",
+        "how": "Warp Teams and Enterprise manage members in the Warp "
+               "dashboard; no public members endpoint is documented. "
+               "Unknown rather than none - nobody has looked properly.",
+    },
     "cline": {
         "api": "unknown",
         "plan": "Enterprise.",

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.22.1
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.23.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/registry/registry.yaml
+++ b/registry/registry.yaml
@@ -274,6 +274,20 @@ tools:
     risk_tier: high
     email_senders: [wisprflow.ai]
 
+  - id: warp
+    name: Warp
+    vendor: Warp
+    category: coding
+    approved: false
+    added_by: manual
+    domains: [warp.dev, app.warp.dev]
+    app_names: ["Warp.app", "Warp"]
+    # Warp's binary is named after its release channel, not the product:
+    # Warp.app/Contents/MacOS/stable. Nothing derives "Warp" from that, which
+    # is why it arrived as an unaccountable process reaching a model.
+    exe_names: ["warp.exe", "stable"]
+    risk_tier: medium
+    bundle_ids: [dev.warp.Warp-Stable]
   - id: perplexity
     name: Perplexity
     vendor: Perplexity AI
@@ -393,6 +407,9 @@ tools:
     domains: [fireflies.ai, app.fireflies.ai]
     risk_tier: high
     email_senders: [fireflies.ai]
+    app_names: ["Fireflies.app", "Fireflies"]
+    exe_names: ["Fireflies.exe"]
+
   - id: midjourney
     name: Midjourney
     vendor: Midjourney
@@ -448,5 +465,14 @@ allowed_processes: [chrome, "Google Chrome", chromium, firefox, safari, msedge, 
   # Office resolves the Copilot endpoints as background M365 activity.
   Excel, PowerPnt, PowerPoint, WinWord, OneNote, MsAccess, MSPub, lync,
   Figma, Notion, svchost.exe, explorer.exe, git, gh, systemd-resolved, mDNSResponder,
-  trustd, nsurlsessiond]
+  trustd, nsurlsessiond,
+  # Windows shell and search. These reach substrate.office.com as background
+  # M365 activity - the Start menu and Search box have model-backed features
+  # nobody opened on purpose.
+  SearchHost, StartMenuExperienceHost, ShellExperienceHost, SearchApp,
+  Microsoft.Notes, OneDriveStandaloneUpdater, msedgewebview2,
+  # Editors. An IDE reaching a model is a person using an AI extension in
+  # their editor - the ordinary case the register and the IDE surface both
+  # already cover, and the same reason browsers are here.
+  Code, "Code - Insiders", idea, pycharm, webstorm, goland, rider, clion]
 discover_exclude_domains: [jetbrains.com, fastly.net, ably.net, ably-realtime.com, shopifysvc.com, shopifycloud.com, vsassets.io, vscode-cdn.net, vercel.app, thehubevents.com, ai.engineer, www.ai.engineer]

--- a/scanner/ai_guard/registry/__init__.py
+++ b/scanner/ai_guard/registry/__init__.py
@@ -65,6 +65,27 @@ def normalise_process(process_name: str) -> str:
     return _HELPER_SUFFIX_RE.sub("", n).strip()
 
 
+def process_stems(process_name):
+    """Every form of a name worth matching, longest first.
+
+    A Windows service often names itself in dotted components -
+    "OneDrive.Sync.Service.exe" - and only the leading one is the product.
+    Yielding the progressively shorter prefixes lets an allowlist hold
+    "OneDrive" and still match, without the entry itself having to guess
+    which suffixes Microsoft will ship.
+
+    Longest first so a specific entry always beats a shorter prefix, and
+    the bare first component is yielded last: "Microsoft.Notes" is matched
+    as itself before anything gets the chance to match "Microsoft" and
+    allowlist every product they make.
+    """
+    n = normalise_process(process_name)
+    if not n:
+        return []
+    parts = n.split(".")
+    return [".".join(parts[:i]) for i in range(len(parts), 0, -1)]
+
+
 @dataclass
 class AIService:
     """A single AI service from the registry."""
@@ -406,8 +427,8 @@ class Registry:
         Both sides are normalised, so one entry covers a name in every
         shape the platforms report it in.
         """
-        n = normalise_process(process_name)
-        return bool(n) and n in self.allowed_processes
+        return any(stem in self.allowed_processes
+                   for stem in process_stems(process_name))
 
     @property
     def all_domains(self) -> set[str]:

--- a/scanner/ai_guard/registry/ai_services.yaml
+++ b/scanner/ai_guard/registry/ai_services.yaml
@@ -343,6 +343,28 @@ services:
   form: ''
   inference_domains: []
   notes: ''
+- name: Warp
+  vendor: Warp
+  category: coding
+  risk_tier: medium
+  domains:
+  - warp.dev
+  - app.warp.dev
+  entra_app_ids: []
+  email_domains: []
+  desktop_apps:
+    macos:
+    - dev.warp.Warp-Stable
+    - Warp.app
+    - Warp
+    windows:
+    - warp.exe
+    - stable
+  browser_extensions: {}
+  mcp_identifiers: []
+  form: ''
+  inference_domains: []
+  notes: ''
 - name: Perplexity
   vendor: Perplexity AI
   category: search
@@ -554,8 +576,11 @@ services:
   email_domains:
   - fireflies.ai
   desktop_apps:
-    macos: []
-    windows: []
+    macos:
+    - Fireflies.app
+    - Fireflies
+    windows:
+    - Fireflies.exe
   browser_extensions: {}
   mcp_identifiers: []
   form: ''
@@ -683,6 +708,21 @@ allowed_processes:
 - mDNSResponder
 - trustd
 - nsurlsessiond
+- SearchHost
+- StartMenuExperienceHost
+- ShellExperienceHost
+- SearchApp
+- Microsoft.Notes
+- OneDriveStandaloneUpdater
+- msedgewebview2
+- Code
+- Code - Insiders
+- idea
+- pycharm
+- webstorm
+- goland
+- rider
+- clion
 discover_exclude_domains:
 - jetbrains.com
 - fastly.net

--- a/scanner/ai_guard/scanners/sentinelone.py
+++ b/scanner/ai_guard/scanners/sentinelone.py
@@ -92,6 +92,17 @@ _UNATTRIBUTABLE_PROCESSES = {
     "systemd-resolved", "systemd-executor", "systemd", "resolvconf",
     "mdnsresponder", "discoveryd", "dnsmasq", "unbound", "nscd",
     "svchost", "dnscache", "networkservice",
+    # Generic task hosts. Windows runs scheduled and background work inside
+    # these, so the name is whatever they were told to run - the same
+    # non-answer as svchost, and an allowlist entry would be the wrong shape:
+    # "this is fine" rather than "this names nothing".
+    "backgroundtaskhost", "taskhostw", "taskhost", "taskeng", "rundll32",
+    "dllhost", "wermgr",
+    # Squirrel ships its updater as "Update.exe" inside every app that uses
+    # it, so the name says an application updated itself and not which one.
+    # Generic by construction, the same as the hosts above - and an allowlist
+    # entry would wrongly read as "this particular program is fine".
+    "update", "updater", "squirrel",
 }
 
 

--- a/scanner/tests/test_process_attribution.py
+++ b/scanner/tests/test_process_attribution.py
@@ -87,3 +87,44 @@ def test_the_cases_it_already_refused_are_still_refused(proc):
 def test_a_real_client_is_still_attributable(proc):
     """The signal this all exists to keep: a script with a key in it."""
     assert is_unattributable(proc) is False
+
+
+@pytest.mark.parametrize("reported,expected", [
+    ("OneDrive.Sync.Service.exe", ["onedrive.sync.service", "onedrive.sync", "onedrive"]),
+    ("Microsoft.Notes.exe", ["microsoft.notes", "microsoft"]),
+    ("SearchHost.exe", ["searchhost"]),
+])
+def test_a_dotted_name_offers_its_shorter_prefixes(reported, expected):
+    """A Windows service names itself in dotted components and only the
+    leading one is the product, so "OneDrive.Sync.Service.exe" never matched
+    the "OneDrive" already on the allowlist."""
+    from ai_guard.registry import process_stems
+    assert process_stems(reported) == expected
+
+
+def test_a_prefix_does_not_allowlist_everything_a_vendor_ships():
+    """The shorter prefixes are offered longest-first so a specific entry
+    always wins, and the bare vendor component only matches if somebody
+    actually put a bare vendor name on the list. Nobody should."""
+    entries = ["Microsoft.Notes", "OneDrive"]
+    assert _allowed(entries, "Microsoft.Notes.exe") is True
+    assert _allowed(entries, "OneDrive.Sync.Service.exe") is True
+    # Same vendor, different product, not listed: must not inherit.
+    assert _allowed(entries, "Microsoft.Telemetry.exe") is False
+
+
+@pytest.mark.parametrize("proc", [
+    "backgroundTaskHost.exe", "taskhostw.exe", "rundll32.exe", "dllhost.exe",
+])
+def test_a_generic_task_host_names_nothing(proc):
+    """Windows runs scheduled and background work inside these, so the name
+    is whatever they were told to run - the same non-answer as svchost."""
+    assert is_unattributable(proc) is True
+
+
+@pytest.mark.parametrize("proc", ["Update.exe", "Updater.exe", "Squirrel.exe"])
+def test_a_squirrel_updater_names_the_framework_not_the_app(proc):
+    """Squirrel ships its updater as Update.exe inside every app that uses
+    it, so the name says an application updated itself and not which one.
+    An allowlist entry would wrongly read as "this program is fine"."""
+    assert is_unattributable(proc) is True


### PR DESCRIPTION
The Agentic AI view reported nothing running on its own, on an estate that had just deployed the collectors built to find exactly that. It was not an empty estate and it was not a stale rollout. **The finding was being made and then thrown away.**

## report_once dropped it on the floor

`report_once` on macOS deduped on `surface|tool`:

```
macos   :  local key="$1|$2"              ← the bug
linux   :  local k="$1|$2|${7:-}"
windows :  $key = "$Surface|$Tool|$Trigger"
```

A scheduled job and an installed tool are the same `surface|tool` pair. So the moment the account scan reported `cli|claude-code`, every scheduled-job finding for that tool on that machine was silently discarded — and a machine with a scheduled Claude Code is, necessarily, a machine with Claude Code installed.

The scan has therefore reported nothing on macOS since the day it shipped.

Traced on a real machine, with a decoy launchd job:

```
+ report_once cli claude-code '' '~/Library/LaunchAgents/zz.probe.plist' \
              autonomous '' 'launchd, every 6 hours' interval:21600
+ local 'key=cli|claude-code'
+ case "$SEEN" in
+ return 0                                  ← dropped here
```

The control: the same probe for a tool *not* otherwise present reported perfectly. `claude` suppressed, `gemini` reported, the only difference being whether the tool had already been seen.

Linux and Windows have keyed on the trigger since the first day. Only macOS was missed — and macOS is the one collector CI cannot run. There is now a **static parity check across all three**, which I verified fails on the old key before it passes on the new one.

## The version never moved either

The scan shipped without touching `COLLECTOR_VERSION`, so a collector that reads schedulers and one that cannot both reported `2.0.0`. An empty page could not be told from an undeployed one — the only question worth asking about a zero.

It is `2.1.0` everywhere now, and the page states how many devices report a collector new enough to have looked, with `2.0.0` counted as **unknown rather than clean**, because it genuinely is:

> No device reports a collector at 2.1.0 or newer, so **nothing here has looked yet**. This is an absence, not a finding — update the collectors before reading the zero.

## Two overclaims, same family as the last release

**Reach was joined per device and drawn per row**, so a `curl` fetching an installer was shown its machine's MCP servers as its own capability — it read as "this curl can reach your Atlassian." The box now says whose they are.

**The day panel drew unrecognised rows solid** beside genuinely unattended ones, re-merging the two claims the headline was split to separate. Those lanes are hollow now, with a legend entry that says why.

## Two silences

**The panel rendered nothing at all** when no row had a readable schedule, because the "Not drawn" note was nested inside the `scheduled.length ?` ternary. Twenty-five undrawable rows produced no timeline and no reason — "no cadence" and "never deployed" looked identical. It now explains itself.

**A scheduled job that runs a wrapper script** cannot be seen by any endpoint-only approach, and reading the contents of somebody's scripts is the same intrusion the page already refuses for prompts. That limit is now stated beside the other things it does not answer. An unstated limit is the same failure as an unstated source.

## The registry, finally read whole

Matching used `cli.binaries` — four tools have any — while `app_names` and `exe_names` sat populated and unread for nineteen more. A desktop app reaching its own vendor's gateway was a process nobody could account for, on a finding whose tool had just been resolved from the domain.

- **Warp added.** Its binary is named for the release channel (`Warp.app/Contents/MacOS/stable`), so nothing derives the product from `stable`. This was the unexplained process name.
- **Fireflies** gains the desktop names it always shipped under.
- **Windows shell and search** join the allowlist; they reach `substrate.office.com` as background M365 activity.
- **Generic task hosts and Squirrel's `Update.exe`** join the *unattributable* set instead — naming one says an application did something, not which. An allowlist entry would wrongly read as "this program is fine".
- **Dotted service names** now offer their shorter prefixes, longest first, so `OneDrive.Sync.Service.exe` matches the `OneDrive` already listed — without `Microsoft.Notes.exe` quietly allowlisting everything Microsoft ships. That last one is asserted in a test.

## Checked

Ten process names taken from a real estate, replayed through the built registry: **one survives, and it is the `curl` that should.**

Both new page states confirmed rendering, not just the data layer — the coverage note and the empty-day-panel explanation. The `claude` probe verified reporting `mode=autonomous` on a real machine after the fix, having been silently dropped before it.

Suites green: portal 612, scanner 209, receiver 280, registry 22. Plus collector parity, `build.py --check`, both chart copies, and shellcheck.

## Not in this release

Deliberately, and they need a decision rather than a guess: the API-key-in-job-definition heuristic and the cross-signal join of scheduled executables against DNS-observed processes — both are new detection and belong together with thought about what they would falsely catch. Widening the scheduler matcher to domains is held with them for the same reason: matching a domain in a scheduled command line is real coverage, and it is also a fresh false-positive class one release after cutting one to remove one.
