### PR TITLE
Let the estate ask, instead of guessing on its behalf

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.23.0
+version: 0.24.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.23.0"
+appVersion: "0.24.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/files/collector.json
+++ b/charts/ai-guard/files/collector.json
@@ -294,6 +294,170 @@
       }
     }
   ],
+  "inference": [
+    {
+      "tool": "claude",
+      "domains": [
+        "api.anthropic.com"
+      ]
+    },
+    {
+      "tool": "chatgpt",
+      "domains": [
+        "api.openai.com",
+        "chat.openai.com"
+      ]
+    },
+    {
+      "tool": "github-copilot",
+      "domains": [
+        "api.githubcopilot.com",
+        "copilot-proxy.githubusercontent.com"
+      ]
+    },
+    {
+      "tool": "cursor",
+      "domains": [
+        "api2.cursor.sh"
+      ]
+    },
+    {
+      "tool": "codeium",
+      "domains": [
+        "server.codeium.com",
+        "api.devin.ai"
+      ]
+    },
+    {
+      "tool": "tabnine",
+      "domains": [
+        "api.tabnine.com"
+      ]
+    },
+    {
+      "tool": "otter",
+      "domains": [
+        "api.otter.ai"
+      ]
+    },
+    {
+      "tool": "wispr-flow",
+      "domains": [
+        "api.wisprflow.ai"
+      ]
+    },
+    {
+      "tool": "warp",
+      "domains": [
+        "app.warp.dev"
+      ]
+    },
+    {
+      "tool": "perplexity",
+      "domains": [
+        "api.perplexity.ai"
+      ]
+    },
+    {
+      "tool": "ollama",
+      "domains": [
+        "api.ollama.com"
+      ]
+    },
+    {
+      "tool": "deepseek",
+      "domains": [
+        "api.deepseek.com",
+        "chat.deepseek.com"
+      ]
+    },
+    {
+      "tool": "mistral",
+      "domains": [
+        "api.mistral.ai",
+        "chat.mistral.ai"
+      ]
+    },
+    {
+      "tool": "fireflies",
+      "domains": [
+        "app.fireflies.ai"
+      ]
+    },
+    {
+      "tool": "hugging-face",
+      "domains": [
+        "api-inference.huggingface.co"
+      ]
+    }
+  ],
+  "env": [
+    {
+      "tool": "claude",
+      "env_vars": [
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN"
+      ]
+    },
+    {
+      "tool": "claude-code",
+      "env_vars": [
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN"
+      ]
+    },
+    {
+      "tool": "chatgpt",
+      "env_vars": [
+        "OPENAI_API_KEY"
+      ]
+    },
+    {
+      "tool": "codex-cli",
+      "env_vars": [
+        "OPENAI_API_KEY",
+        "CODEX_API_KEY"
+      ]
+    },
+    {
+      "tool": "gemini-cli",
+      "env_vars": [
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY"
+      ]
+    },
+    {
+      "tool": "cursor",
+      "env_vars": [
+        "CURSOR_API_KEY"
+      ]
+    },
+    {
+      "tool": "perplexity",
+      "env_vars": [
+        "PERPLEXITY_API_KEY"
+      ]
+    },
+    {
+      "tool": "deepseek",
+      "env_vars": [
+        "DEEPSEEK_API_KEY"
+      ]
+    },
+    {
+      "tool": "mistral",
+      "env_vars": [
+        "MISTRAL_API_KEY"
+      ]
+    },
+    {
+      "tool": "hugging-face",
+      "env_vars": [
+        "HUGGINGFACE_API_KEY",
+        "HF_TOKEN"
+      ]
+    }
+  ],
   "mcp": [
     {
       "tool": "claude",

--- a/charts/ai-guard/files/registry.json
+++ b/charts/ai-guard/files/registry.json
@@ -4,6 +4,10 @@
     {
       "id": "claude",
       "name": "Claude",
+      "env_vars": [
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN"
+      ],
       "vendor": "Anthropic",
       "category": "assistant",
       "license_group": "anthropic-claude",
@@ -16,6 +20,9 @@
         "claude.com",
         "claudeusercontent.com",
         "console.anthropic.com"
+      ],
+      "inference_domains": [
+        "api.anthropic.com"
       ],
       "app_names": [
         "Claude.app",
@@ -49,6 +56,10 @@
     {
       "id": "claude-code",
       "name": "Claude Code",
+      "env_vars": [
+        "ANTHROPIC_API_KEY",
+        "CLAUDE_CODE_OAUTH_TOKEN"
+      ],
       "vendor": "Anthropic",
       "category": "coding",
       "license_group": "anthropic-claude",
@@ -86,6 +97,9 @@
     {
       "id": "chatgpt",
       "name": "ChatGPT",
+      "env_vars": [
+        "OPENAI_API_KEY"
+      ],
       "vendor": "OpenAI",
       "category": "assistant",
       "license_group": "openai-chatgpt",
@@ -98,6 +112,10 @@
         "api.openai.com",
         "cdn.oaistatic.com",
         "auth0.openai.com"
+      ],
+      "inference_domains": [
+        "api.openai.com",
+        "chat.openai.com"
       ],
       "app_names": [
         "ChatGPT.app",
@@ -125,6 +143,10 @@
     {
       "id": "codex-cli",
       "name": "Codex CLI",
+      "env_vars": [
+        "OPENAI_API_KEY",
+        "CODEX_API_KEY"
+      ],
       "vendor": "OpenAI",
       "category": "coding",
       "license_group": "openai-chatgpt",
@@ -168,6 +190,10 @@
     {
       "id": "gemini-cli",
       "name": "Gemini CLI",
+      "env_vars": [
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY"
+      ],
       "vendor": "Google",
       "category": "coding",
       "license_group": "google-gemini",
@@ -205,6 +231,10 @@
         "api.githubcopilot.com",
         "copilot.github.com"
       ],
+      "inference_domains": [
+        "api.githubcopilot.com",
+        "copilot-proxy.githubusercontent.com"
+      ],
       "extension_ids": {
         "vscode": [
           "github.copilot",
@@ -222,6 +252,9 @@
     {
       "id": "cursor",
       "name": "Cursor",
+      "env_vars": [
+        "CURSOR_API_KEY"
+      ],
       "vendor": "Anysphere",
       "category": "coding",
       "approved": false,
@@ -364,6 +397,9 @@
         "tabnine.com",
         "api.tabnine.com"
       ],
+      "inference_domains": [
+        "api.tabnine.com"
+      ],
       "extension_ids": {
         "vscode": [
           "tabnine.tabnine-vscode"
@@ -380,6 +416,9 @@
       "added_by": "manual",
       "domains": [
         "otter.ai",
+        "api.otter.ai"
+      ],
+      "inference_domains": [
         "api.otter.ai"
       ],
       "app_names": [
@@ -450,6 +489,9 @@
         "wisprflow.com",
         "api.wisprflow.ai"
       ],
+      "inference_domains": [
+        "api.wisprflow.ai"
+      ],
       "app_names": [
         "Wispr Flow.app",
         "Wispr Flow"
@@ -470,6 +512,9 @@
         "warp.dev",
         "app.warp.dev"
       ],
+      "inference_domains": [
+        "app.warp.dev"
+      ],
       "app_names": [
         "Warp.app",
         "Warp"
@@ -486,6 +531,9 @@
     {
       "id": "perplexity",
       "name": "Perplexity",
+      "env_vars": [
+        "PERPLEXITY_API_KEY"
+      ],
       "vendor": "Perplexity AI",
       "category": "search",
       "approved": false,
@@ -494,6 +542,9 @@
         "perplexity.ai",
         "api.perplexity.ai",
         "www.perplexity.ai"
+      ],
+      "inference_domains": [
+        "api.perplexity.ai"
       ],
       "app_names": [
         "Perplexity.app",
@@ -524,6 +575,9 @@
         "ollama.com",
         "registry.ollama.ai",
         "ollama.ai",
+        "api.ollama.com"
+      ],
+      "inference_domains": [
         "api.ollama.com"
       ],
       "app_names": [
@@ -569,6 +623,9 @@
     {
       "id": "deepseek",
       "name": "DeepSeek",
+      "env_vars": [
+        "DEEPSEEK_API_KEY"
+      ],
       "vendor": "DeepSeek",
       "category": "assistant",
       "approved": false,
@@ -578,6 +635,10 @@
         "deepseek.com",
         "api.deepseek.com"
       ],
+      "inference_domains": [
+        "api.deepseek.com",
+        "chat.deepseek.com"
+      ],
       "email_senders": [
         "deepseek.com"
       ],
@@ -586,6 +647,9 @@
     {
       "id": "mistral",
       "name": "Mistral Le Chat",
+      "env_vars": [
+        "MISTRAL_API_KEY"
+      ],
       "vendor": "Mistral AI",
       "category": "assistant",
       "approved": false,
@@ -594,6 +658,10 @@
         "chat.mistral.ai",
         "mistral.ai",
         "api.mistral.ai"
+      ],
+      "inference_domains": [
+        "api.mistral.ai",
+        "chat.mistral.ai"
       ],
       "email_senders": [
         "mistral.ai"
@@ -706,6 +774,9 @@
         "fireflies.ai",
         "app.fireflies.ai"
       ],
+      "inference_domains": [
+        "app.fireflies.ai"
+      ],
       "risk_tier": "high",
       "email_senders": [
         "fireflies.ai"
@@ -752,12 +823,19 @@
     {
       "id": "hugging-face",
       "name": "Hugging Face",
+      "env_vars": [
+        "HUGGINGFACE_API_KEY",
+        "HF_TOKEN"
+      ],
       "vendor": "Hugging Face",
       "category": "platform",
       "approved": false,
       "added_by": "manual",
       "domains": [
         "huggingface.co",
+        "api-inference.huggingface.co"
+      ],
+      "inference_domains": [
         "api-inference.huggingface.co"
       ],
       "risk_tier": "medium",

--- a/docs/agentic.md
+++ b/docs/agentic.md
@@ -24,18 +24,44 @@ the credential.
 
 None of them require a new source. Three are read by the endpoint collectors
 you already deploy, and one has been arriving for as long as the network
-scanner has been configured.
+scanner has been configured. The first has three ways of matching; the rest
+have one each.
 
 ### A scheduler starts it
 
 The collectors read what schedules things on each platform: launchd on macOS,
 systemd timers and cron on Linux, Scheduled Tasks on Windows. A job qualifies
-when the command it runs names a binary the registry already lists for a
-tool, so covering a new tool is a registry entry rather than a change to
-three scripts.
+three ways, tried in order, and every one of them is registry-driven - so
+covering a new tool is an entry rather than a change to three scripts.
 
-Matching is deliberately word-ish: `claude` must not match
-`claudeless-backup`, and each platform has a fixture asserting it does not.
+**It names a binary the registry lists.** The original signal. Matching is
+deliberately word-ish: `claude` must not match `claudeless-backup`, and each
+platform has a fixture asserting it does not.
+
+**Its command names an inference host.** A job that curls `api.anthropic.com`
+on a timer is reaching a model whatever binary it runs. Only
+`inference_domains` count, never `domains`: a scheduled download from a
+vendor's website is an acquisition and belongs on the register, not on a page
+about what runs unattended.
+
+**Its definition hands a script a model credential.** The case nothing else
+can see - a job that runs `nightly-report.sh` names nothing matchable, but a
+launchd `EnvironmentVariables` or a systemd `Environment=` setting
+`ANTHROPIC_API_KEY` says what the script reaches. Only variables the registry
+names for a tool: a generic `API_KEY` or `TOKEN` would fire on every
+scheduled backup in the estate.
+
+Two limits worth stating rather than discovering. A Windows scheduled task
+declares no environment - an action carries a command and inherits the
+user's - so the credential path does not exist there, and a wrapper script on
+Windows stays invisible. And `EnvironmentFile=` on Linux is not opened:
+it points at a file of secrets, and reading the names would mean reading the
+values.
+
+One job produces one finding. Several tools can name the same variable -
+`ANTHROPIC_API_KEY` belongs to both Claude and Claude Code - and a credential
+cannot say which the script calls, so the first match wins and the evidence
+names the variable so a reader can judge.
 
 ### The credential has nobody behind it
 
@@ -148,6 +174,38 @@ client logs locally.
 
 **Observed runs.** Process telemetry would turn the day from configured into
 observed, and would cover the two lane kinds a spec can never reach.
+
+**The cross-signal join.** Two halves are already collected and never joined.
+The scheduler scan knows what is scheduled on a device. The DNS scan knows
+which process resolved a model host on that device. A process appearing in
+both sets is autonomous AI use established by observation, with no list of
+binaries, domains or variables involved - which is what makes it worth
+building, because every other signal above degrades to "the registry did not
+know this one".
+
+It is written down rather than built because the join is not sound yet, and
+saying why is the useful part:
+
+- *The key is weak.* Both sides identify a process by name. A unit running
+  `/usr/bin/python3` joins against every other `python3` on the machine, and
+  a wrapper script joins against nothing at all. The join would need the
+  resolved executable on both sides, and the DNS side gets whatever the EDR
+  reports, which is frequently a service host.
+- *It needs a new shape of report.* The scheduler scan currently emits a
+  finding per matched job. Emitting every scheduled executable so the portal
+  has something to join against means emitting inventory, not findings - and
+  emitting them as findings would recreate exactly the flood the process
+  matching was tightened to remove.
+- *An ambiguous join has no honest rendering yet.* "Something scheduled on
+  this device reached a model, and it may have been this job" is a sentence
+  this page has no room for. Everything here is a chain with four filled
+  boxes; a maybe belongs somewhere else or nowhere.
+
+The order matters: the three signals above it are registry-driven and cheap,
+and the process candidates queue turns what they miss into a question for a
+human rather than a silent gap. Run those on a real estate first. What they
+fail to catch is the specification for this, and guessing at it beforehand
+would be building for an imagined miss.
 
 ## What it does not answer, and why not yet
 

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.23.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.23.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/endpoint/linux/ai-guard-collector.sh
+++ b/endpoint/linux/ai-guard-collector.sh
@@ -396,6 +396,10 @@ for t in r.get("cli", []):
                         t.get("account_jwt_claim",""),
                         ",".join(t.get("config_paths") or []),
                         ",".join(t.get("binaries") or [])]))
+for t in r.get("inference", []):
+    out.append(U.join(["inf", t["tool"], ",".join(t.get("domains") or [])]))
+for t in r.get("env", []):
+    out.append(U.join(["env", t["tool"], ",".join(t.get("env_vars") or [])]))
 for m in r.get("mcp", []):
     out.append(U.join(["mcp", m["tool"], m["path"], m.get("os","any")]))
 print("\n".join(out))
@@ -673,6 +677,7 @@ cmd_runs_binary() {
 
 scan_systemd_dir() {
   local dir="$1" label="$2" unit base timer oncal exec tool bins
+  local matched envs etool evars v old_ifs itool idoms d
   [ -d "$dir" ] || return 0
   for unit in "$dir"/*.service; do
     [ -f "$unit" ] || continue
@@ -686,16 +691,70 @@ scan_systemd_dir() {
     oncal=$(grep -h '^OnCalendar=' "$timer" 2>/dev/null | head -1)
     oncal="${oncal#OnCalendar=}"
     [ -n "$oncal" ] || continue
+    matched=0
     while IFS="$SEP" read -r _kind tool _ap _keys _jp _jc _cfg bins; do
       [ -n "$bins" ] || continue
       if cmd_runs_binary "$exec" "$bins"; then
         report_once "cli" "$tool" "" "$label/$(basename "$timer")" \
           "autonomous" "" "systemd timer, $oncal" "oncalendar:$oncal"
+        matched=1
         break
       fi
     done <<EOF2
 $(printf '%s\n' "$REG_TSV" | grep "^cli${SEP}")
 EOF2
+
+    # No binary matched - but the command may name the host instead. A unit
+    # that curls a model API on a timer is reaching a model whatever it runs.
+    # Inference hosts only: a scheduled download from a vendor's website is
+    # an acquisition, not a run.
+    [ "$matched" = 1 ] || while IFS="$SEP" read -r _kind itool idoms; do
+      [ "$matched" = 1 ] && continue
+      [ -n "$idoms" ] || continue
+      old_ifs="$IFS"; IFS=','; set -- $idoms; IFS="$old_ifs"
+      for d in "$@"; do
+        [ -n "$d" ] || continue
+        case "$exec" in
+          *"$d"*)
+            report_once "cli" "$itool" "" \
+              "$label/$(basename "$timer") reaches $d" \
+              "autonomous" "" "systemd timer, $oncal" "oncalendar:$oncal"
+            matched=1
+            break ;;
+        esac
+      done
+    done <<EOF4
+$(printf '%s\n' "$REG_TSV" | grep "^inf${SEP}")
+EOF4
+
+    # No binary matched. A unit that runs a wrapper script names nothing the
+    # registry can match - but a unit that hands that script a model
+    # credential says what it reaches, whatever it runs. Environment= only:
+    # EnvironmentFile= points at a file of secrets, and opening it to read
+    # the names would mean reading the values too.
+    [ "$matched" = 1 ] && continue
+    envs=$(grep -h '^Environment=' "$unit" 2>/dev/null | sed 's/^Environment=//')
+    [ -n "$envs" ] || continue
+    while IFS="$SEP" read -r _kind etool evars; do
+      # One unit is one finding: several tools name the same variable, and a
+      # credential cannot say which of them the script calls.
+      [ "$matched" = 1 ] && continue
+      [ -n "$evars" ] || continue
+      old_ifs="$IFS"; IFS=','; set -- $evars; IFS="$old_ifs"
+      for v in "$@"; do
+        [ -n "$v" ] || continue
+        case "$envs" in
+          *"$v="*)
+            report_once "cli" "$etool" "" \
+              "$label/$(basename "$timer") sets $v" \
+              "autonomous" "" "systemd timer, $oncal" "oncalendar:$oncal"
+            matched=1
+            break ;;
+        esac
+      done
+    done <<EOF3
+$(printf '%s\n' "$REG_TSV" | grep "^env${SEP}")
+EOF3
   done
 }
 

--- a/endpoint/macos/ai-guard-collector.sh
+++ b/endpoint/macos/ai-guard-collector.sh
@@ -343,6 +343,12 @@ registry_tsv() {
                     (t.config_paths || []).join(","),
                     (t.binaries || []).join(",")].join(U));
         });
+        (r.inference || []).forEach(function (t) {
+          out.push(["inf", t.tool, (t.domains || []).join(",")].join(U));
+        });
+        (r.env || []).forEach(function (t) {
+          out.push(["env", t.tool, (t.env_vars || []).join(",")].join(U));
+        });
         (r.mcp || []).forEach(function (m) { out.push(["mcp", m.tool, m.path, m.os || "any"].join(U)); });
         return out.join("\n");
       } catch (e) { return ""; }
@@ -665,6 +671,7 @@ launchd_schedule() {
 
 scan_launchd_dir() {
   local dir="$1" label="$2" f j args tool bins b sched trig old
+  local matched envs etool evars v _k itool idoms d
   [ -d "$dir" ] || return 0
   j=$(/usr/bin/mktemp /tmp/ai-guard-plist.XXXXXX) || return 0
   for f in "$dir"/*.plist; do
@@ -676,6 +683,18 @@ scan_launchd_dir() {
     [ -n "$args" ] || continue
     sched=$(launchd_schedule "$j")
     [ -n "$sched" ] || continue          # not scheduled: nothing to say here
+    matched=0
+    case "${sched%%:*}" in
+      interval)
+        if [ "$(( ${sched#interval:} % 3600 ))" -eq 0 ] \
+           && [ "$(( ${sched#interval:} ))" -ge 3600 ]; then
+          trig="launchd, every $(( ${sched#interval:} / 3600 )) hours"
+        else
+          trig="launchd, every $(( ${sched#interval:} / 60 )) min"
+        fi ;;
+      cron)     trig="launchd, at a set time" ;;
+      *)        trig="launchd, at login" ;;
+    esac
     while IFS="$SEP" read -r _kind tool _ap _keys _jp _jc _cfg bins; do
       [ -n "$bins" ] || continue
       old="$IFS"; IFS=','; set -- $bins; IFS="$old"
@@ -687,24 +706,63 @@ scan_launchd_dir() {
           *" $b "*) ;;
           *) continue ;;
         esac
-        case "${sched%%:*}" in
-          interval)
-            # "every 360 min" is arithmetic; "every 6 hours" is the thing
-            # somebody would say out loud, and this line is read by people.
-            if [ "$(( ${sched#interval:} % 3600 ))" -eq 0 ] \
-               && [ "$(( ${sched#interval:} ))" -ge 3600 ]; then
-              trig="launchd, every $(( ${sched#interval:} / 3600 )) hours"
-            else
-              trig="launchd, every $(( ${sched#interval:} / 60 )) min"
-            fi ;;
-          cron)     trig="launchd, at a set time" ;;
-          *)        trig="launchd, at login" ;;
-        esac
         report_once "cli" "$tool" "" "$label/$(/usr/bin/basename "$f")" \
           "autonomous" "" "$trig" "$sched"
+        matched=1
         break
       done
     done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^cli${SEP}")
+
+    # Nothing in the registry named the binary - but the command line may
+    # name the host instead. A job that curls a model API on a timer is
+    # reaching a model whatever binary it runs. Inference hosts only: a
+    # scheduled download from a vendor's website is an acquisition, not a run.
+    [ "$matched" = 1 ] || while IFS="$SEP" read -r _k itool idoms; do
+      [ "$matched" = 1 ] && continue
+      [ -n "$idoms" ] || continue
+      old="$IFS"; IFS=','; set -- $idoms; IFS="$old"
+      for d in "$@"; do
+        [ -n "$d" ] || continue
+        case "$args" in
+          *"$d"*)
+            report_once "cli" "$itool" "" \
+              "$label/$(/usr/bin/basename "$f") reaches $d" \
+              "autonomous" "" "$trig" "$sched"
+            matched=1
+            break ;;
+        esac
+      done
+    done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^inf${SEP}")
+
+    # Nothing in the registry named the binary. A job that runs a wrapper
+    # script names nothing matchable - but if its definition hands that
+    # script a model credential, the job is reaching a model on a timer and
+    # says so itself. This is the only view onto a scheduled job whose
+    # command is opaque, and it needs no list of binaries at all.
+    [ "$matched" = 1 ] && continue
+    envs=$(json_keys "$j" "EnvironmentVariables")
+    [ -n "$envs" ] || continue
+    while IFS="$SEP" read -r _k etool evars; do
+      # One job is one finding. Several tools can name the same variable -
+      # ANTHROPIC_API_KEY belongs to Claude and to Claude Code - and the
+      # credential cannot say which one the script calls. Reporting both
+      # would turn one scheduled job into two things running unattended.
+      [ "$matched" = 1 ] && continue
+      [ -n "$evars" ] || continue
+      old="$IFS"; IFS=','; set -- $evars; IFS="$old"
+      for v in "$@"; do
+        [ -n "$v" ] || continue
+        case ",$envs," in
+          *",$v,"*) ;;
+          *) continue ;;
+        esac
+        report_once "cli" "$etool" "" \
+          "$label/$(/usr/bin/basename "$f") sets $v" \
+          "autonomous" "" "$trig" "$sched"
+        matched=1
+        break
+      done
+    done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^env${SEP}")
   done
   /bin/rm -f "$j"
 }

--- a/endpoint/windows/ai-guard-collector.ps1
+++ b/endpoint/windows/ai-guard-collector.ps1
@@ -766,6 +766,15 @@ function Get-TaskSchedule {
     return $null
 }
 
+# No credential pass here, unlike the macOS and Linux collectors.
+#
+# Those read a job's own environment block - launchd EnvironmentVariables,
+# systemd Environment= - so a scheduled job that runs an opaque wrapper
+# script still says what it reaches by the key it hands over. A Windows
+# scheduled task has no equivalent: an action carries Execute, Arguments and
+# WorkingDirectory, and inherits the user's environment rather than declaring
+# one. There is nothing to read, so a wrapper script on Windows stays
+# invisible to this scan and the portal says so rather than implying parity.
 $tasks = @()
 try {
     $tasks = @(Get-ScheduledTask -ErrorAction Stop)
@@ -782,13 +791,37 @@ foreach ($task in $tasks) {
     if (-not $cmd.Trim()) { continue }
     $sched = Get-TaskSchedule -Task $task
     if (-not $sched) { continue }     # not self-starting: nothing to say
+    $matched = $false
     foreach ($t in $Registry.cli) {
         if (-not $t.binaries) { continue }
         if (Test-RunsBinary -Command $cmd -Binaries $t.binaries) {
             Send-FindingOnce -Surface 'cli' -Tool $t.tool -Account '' `
                 -Evidence "Scheduled Task $($task.TaskPath)$($task.TaskName)" `
                 -Mode 'autonomous' -Trigger $sched.trigger -Schedule $sched.spec
+            $matched = $true
             break
+        }
+    }
+
+    # No binary matched, but the command may name the host instead: a task
+    # that curls a model API on a timer is reaching a model whatever it runs.
+    # Inference hosts only - a scheduled download from a vendor's website is
+    # an acquisition, not a run, and matching any domain would put every
+    # installer fetch on a page about what runs unattended.
+    if (-not $matched) {
+        foreach ($t in $Registry.inference) {
+            if ($matched) { break }
+            foreach ($d in @($t.domains)) {
+                if (-not $d) { continue }
+                if ($cmd.ToLower().Contains($d.ToLower())) {
+                    Send-FindingOnce -Surface 'cli' -Tool $t.tool -Account '' `
+                        -Evidence ("Scheduled Task $($task.TaskPath)$($task.TaskName)" +
+                                   " reaches $d") `
+                        -Mode 'autonomous' -Trigger $sched.trigger -Schedule $sched.spec
+                    $matched = $true
+                    break
+                }
+            }
         }
     }
 }

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -1025,7 +1025,21 @@ _DNS_HOST = re.compile(r"DNS lookup for ([A-Za-z0-9][A-Za-z0-9._-]{0,252})")
 # is the process worth naming. The closing bracket is optional because _VIA
 # is bounded by ")" and truncates "(via Google Chrome Helper (Renderer))" at
 # the inner one, delivering a role that never closes.
-_HELPER_SUFFIX_RE = re.compile(r"\s+helper(\s*\(.*)?$")
+def _strip_helper_suffix(n):
+    """"google chrome helper (renderer)" -> "google chrome".
+
+    String work rather than a pattern. The regex this replaces was
+    `\\s+helper(\\s*\\(.*)?$`, whose two adjacent whitespace quantifiers
+    backtrack polynomially on a name of many spaces - and the name comes off
+    a posted finding, so it is not input this gets to assume anything about.
+    """
+    i = n.rfind(" helper")
+    if i == -1:
+        return n
+    tail = n[i + len(" helper"):].lstrip(" \t")
+    if tail and not tail.startswith("("):
+        return n
+    return n[:i].rstrip(" \t")
 
 # Resolvers and service hosts that query on behalf of everything else on the
 # box. Naming one says "this device resolved it" and nothing about what
@@ -1061,7 +1075,7 @@ def normalise_process(name):
     n = n.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
     if n.endswith(".exe"):
         n = n[:-4]
-    return _HELPER_SUFFIX_RE.sub("", n).strip()
+    return _strip_helper_suffix(n).strip()
 
 
 def process_stems(process_name):

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -1018,6 +1018,9 @@ BROWSER_PROCESSES = {
 # The DNS scan writes the process into its evidence as "(via python3)".
 _VIA = re.compile(r"\(via ([^)]{1,80})\)")
 
+# ...and the host it looked up, ahead of that.
+_DNS_HOST = re.compile(r"DNS lookup for ([A-Za-z0-9][A-Za-z0-9._-]{0,252})")
+
 # A macOS helper subprocess carries its parent's name and a role. The parent
 # is the process worth naming. The closing bracket is optional because _VIA
 # is bounded by ")" and truncates "(via Google Chrome Helper (Renderer))" at
@@ -1123,6 +1126,44 @@ def bespoke_client(f, known_processes=()):
     if any(s in known_processes for s in stems):
         return ""
     return proc[:80]
+
+
+def inference_domains_by_tool(reg):
+    """tool id -> the hosts that tool only reaches when a model actually runs.
+
+    A tool that declares these has drawn a line between being fetched and
+    being used: cursor.com is a website, api2.cursor.sh is a model answering.
+    A tool that declares none has drawn no line, and nothing here invents one.
+    """
+    out = {}
+    for t in (reg or {}).get("tools", []) or []:
+        inf = [str(d).lower() for d in (t.get("inference_domains") or [])]
+        if inf:
+            out[str(t.get("id") or "").lower()] = set(inf)
+    return out
+
+
+def reached_a_model(f, inference=None):
+    """False when this finding is a tool being FETCHED rather than used.
+
+    A scheduled curl pulling an installer from a vendor's download host is a
+    real signal - somebody is acquiring an AI tool nobody approved - but it is
+    an acquisition, and this page is about what runs. The two were arriving in
+    the same row.
+
+    Only a tool that declares inference_domains gets filtered, and only away
+    from the hosts it named. A tool that declares none is left alone: absence
+    of the distinction reads as unknown, never as "this was only a download",
+    which would silently delete findings as the registry gained entries.
+    """
+    inf = (inference or {}).get(_base_tool(f.get("tool") or "").lower())
+    if not inf:
+        return True
+    m = _DNS_HOST.search(f.get("evidence") or "")
+    if not m:
+        return True
+    host = m.group(1).rstrip(".").lower()
+    return any(host == d or host.endswith("." + d) for d in inf)
 
 
 def registry_processes(reg):
@@ -1444,6 +1485,7 @@ def agentic_from(findings, reg=None):
     report, on every estate that has not upgraded its collectors.
     """
     known = registry_processes(reg)
+    inference = inference_domains_by_tool(reg)
 
     # Which MCP servers sit on each machine, so a chain can say what the
     # thing running there could reach.
@@ -1463,7 +1505,7 @@ def agentic_from(findings, reg=None):
         dev = (f.get("device") or "").strip()
         tool = _base_tool(f.get("tool") or "")
         mode = (f.get("mode") or "").strip()
-        proc = bespoke_client(f, known)
+        proc = bespoke_client(f, known) if reached_a_model(f, inference) else ""
 
         if mode != "autonomous" and not proc:
             continue

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2312,6 +2312,7 @@ const WIDGETS = {
       <table>${cands.slice(0, 6).map(c => `<tr>
         <td>${esc(c.name)}
           ${c.kind === 'mcp_server' ? ' <span class="pill p-acc">MCP server</span>' : ''}
+          ${c.kind === 'process' ? ' <span class="pill p-warn">process</span>' : ''}
           <div style="color:var(--mut);font-size:12px">
           ${esc(c.kind === 'mcp_server' ? (c.evidence || '')
                                         : (c.domains || []).join(', '))}</div></td>
@@ -8349,7 +8350,7 @@ async function managedAction(act, el) {
       domains: c.domains || [],
       // What discovery actually saw, shown as its own card. It is the only
       // thing on the next step that is evidence rather than a guess.
-      evidence: {kind: c.kind, what: c.kind === 'mcp_server'
+      evidence: {kind: c.kind, what: (c.kind === 'mcp_server' || c.kind === 'process')
                    ? (c.evidence || c.name) : (c.domains || []).join(', ') || c.name,
                  devices: c.devices || 0, confidence: c.confidence || '',
                  category: c.category || ''},
@@ -9081,12 +9082,15 @@ async function agentic() {
       <li><b>What it was asked to do.</b> The prompt is on the machine and could be read.
         Reading what somebody typed is a heavier intrusion than knowing which tool ran,
         and it is not needed to answer anything on this page.</li>
-      <li><b>A scheduled job that runs a script.</b> The scan reads what a scheduler
-        declares, so it sees a job that names an AI tool. A job that runs
-        <span class="mono">nightly-report.sh</span>, which calls a model from inside,
-        names nothing the registry can match - and reading the contents of somebody's
-        scripts is the same intrusion as reading their prompts. This is a real gap
-        rather than a quiet one: silence here is not evidence of nothing scheduled.</li>
+      <li><b>A scheduled job that runs a script, on Windows.</b> Elsewhere this is
+        now covered: a job that runs <span class="mono">nightly-report.sh</span> names
+        nothing the registry can match, but if its own definition hands that script a
+        model credential the job says what it reaches. macOS and Linux both declare a
+        job's environment and both are read. A Windows scheduled task does not - an
+        action carries a command and inherits the user's environment - so there is
+        nothing to read, and a wrapper script there stays invisible. Reading the
+        contents of the script itself would be the same intrusion as reading a prompt,
+        so it is not done. Silence on Windows is not evidence of nothing scheduled.</li>
             <li><b>Whether it stayed within its brief.</b> Same material, same trade. Worth
         revisiting once the signals above have been run on a real estate and shown to be
         insufficient - which is also when there is a case to put to whoever approves it.</li>

--- a/portal/collector-scripts/collector-linux.sh
+++ b/portal/collector-scripts/collector-linux.sh
@@ -396,6 +396,10 @@ for t in r.get("cli", []):
                         t.get("account_jwt_claim",""),
                         ",".join(t.get("config_paths") or []),
                         ",".join(t.get("binaries") or [])]))
+for t in r.get("inference", []):
+    out.append(U.join(["inf", t["tool"], ",".join(t.get("domains") or [])]))
+for t in r.get("env", []):
+    out.append(U.join(["env", t["tool"], ",".join(t.get("env_vars") or [])]))
 for m in r.get("mcp", []):
     out.append(U.join(["mcp", m["tool"], m["path"], m.get("os","any")]))
 print("\n".join(out))
@@ -673,6 +677,7 @@ cmd_runs_binary() {
 
 scan_systemd_dir() {
   local dir="$1" label="$2" unit base timer oncal exec tool bins
+  local matched envs etool evars v old_ifs itool idoms d
   [ -d "$dir" ] || return 0
   for unit in "$dir"/*.service; do
     [ -f "$unit" ] || continue
@@ -686,16 +691,70 @@ scan_systemd_dir() {
     oncal=$(grep -h '^OnCalendar=' "$timer" 2>/dev/null | head -1)
     oncal="${oncal#OnCalendar=}"
     [ -n "$oncal" ] || continue
+    matched=0
     while IFS="$SEP" read -r _kind tool _ap _keys _jp _jc _cfg bins; do
       [ -n "$bins" ] || continue
       if cmd_runs_binary "$exec" "$bins"; then
         report_once "cli" "$tool" "" "$label/$(basename "$timer")" \
           "autonomous" "" "systemd timer, $oncal" "oncalendar:$oncal"
+        matched=1
         break
       fi
     done <<EOF2
 $(printf '%s\n' "$REG_TSV" | grep "^cli${SEP}")
 EOF2
+
+    # No binary matched - but the command may name the host instead. A unit
+    # that curls a model API on a timer is reaching a model whatever it runs.
+    # Inference hosts only: a scheduled download from a vendor's website is
+    # an acquisition, not a run.
+    [ "$matched" = 1 ] || while IFS="$SEP" read -r _kind itool idoms; do
+      [ "$matched" = 1 ] && continue
+      [ -n "$idoms" ] || continue
+      old_ifs="$IFS"; IFS=','; set -- $idoms; IFS="$old_ifs"
+      for d in "$@"; do
+        [ -n "$d" ] || continue
+        case "$exec" in
+          *"$d"*)
+            report_once "cli" "$itool" "" \
+              "$label/$(basename "$timer") reaches $d" \
+              "autonomous" "" "systemd timer, $oncal" "oncalendar:$oncal"
+            matched=1
+            break ;;
+        esac
+      done
+    done <<EOF4
+$(printf '%s\n' "$REG_TSV" | grep "^inf${SEP}")
+EOF4
+
+    # No binary matched. A unit that runs a wrapper script names nothing the
+    # registry can match - but a unit that hands that script a model
+    # credential says what it reaches, whatever it runs. Environment= only:
+    # EnvironmentFile= points at a file of secrets, and opening it to read
+    # the names would mean reading the values too.
+    [ "$matched" = 1 ] && continue
+    envs=$(grep -h '^Environment=' "$unit" 2>/dev/null | sed 's/^Environment=//')
+    [ -n "$envs" ] || continue
+    while IFS="$SEP" read -r _kind etool evars; do
+      # One unit is one finding: several tools name the same variable, and a
+      # credential cannot say which of them the script calls.
+      [ "$matched" = 1 ] && continue
+      [ -n "$evars" ] || continue
+      old_ifs="$IFS"; IFS=','; set -- $evars; IFS="$old_ifs"
+      for v in "$@"; do
+        [ -n "$v" ] || continue
+        case "$envs" in
+          *"$v="*)
+            report_once "cli" "$etool" "" \
+              "$label/$(basename "$timer") sets $v" \
+              "autonomous" "" "systemd timer, $oncal" "oncalendar:$oncal"
+            matched=1
+            break ;;
+        esac
+      done
+    done <<EOF3
+$(printf '%s\n' "$REG_TSV" | grep "^env${SEP}")
+EOF3
   done
 }
 

--- a/portal/collector-scripts/collector-macos.sh
+++ b/portal/collector-scripts/collector-macos.sh
@@ -343,6 +343,12 @@ registry_tsv() {
                     (t.config_paths || []).join(","),
                     (t.binaries || []).join(",")].join(U));
         });
+        (r.inference || []).forEach(function (t) {
+          out.push(["inf", t.tool, (t.domains || []).join(",")].join(U));
+        });
+        (r.env || []).forEach(function (t) {
+          out.push(["env", t.tool, (t.env_vars || []).join(",")].join(U));
+        });
         (r.mcp || []).forEach(function (m) { out.push(["mcp", m.tool, m.path, m.os || "any"].join(U)); });
         return out.join("\n");
       } catch (e) { return ""; }
@@ -665,6 +671,7 @@ launchd_schedule() {
 
 scan_launchd_dir() {
   local dir="$1" label="$2" f j args tool bins b sched trig old
+  local matched envs etool evars v _k itool idoms d
   [ -d "$dir" ] || return 0
   j=$(/usr/bin/mktemp /tmp/ai-guard-plist.XXXXXX) || return 0
   for f in "$dir"/*.plist; do
@@ -676,6 +683,18 @@ scan_launchd_dir() {
     [ -n "$args" ] || continue
     sched=$(launchd_schedule "$j")
     [ -n "$sched" ] || continue          # not scheduled: nothing to say here
+    matched=0
+    case "${sched%%:*}" in
+      interval)
+        if [ "$(( ${sched#interval:} % 3600 ))" -eq 0 ] \
+           && [ "$(( ${sched#interval:} ))" -ge 3600 ]; then
+          trig="launchd, every $(( ${sched#interval:} / 3600 )) hours"
+        else
+          trig="launchd, every $(( ${sched#interval:} / 60 )) min"
+        fi ;;
+      cron)     trig="launchd, at a set time" ;;
+      *)        trig="launchd, at login" ;;
+    esac
     while IFS="$SEP" read -r _kind tool _ap _keys _jp _jc _cfg bins; do
       [ -n "$bins" ] || continue
       old="$IFS"; IFS=','; set -- $bins; IFS="$old"
@@ -687,24 +706,63 @@ scan_launchd_dir() {
           *" $b "*) ;;
           *) continue ;;
         esac
-        case "${sched%%:*}" in
-          interval)
-            # "every 360 min" is arithmetic; "every 6 hours" is the thing
-            # somebody would say out loud, and this line is read by people.
-            if [ "$(( ${sched#interval:} % 3600 ))" -eq 0 ] \
-               && [ "$(( ${sched#interval:} ))" -ge 3600 ]; then
-              trig="launchd, every $(( ${sched#interval:} / 3600 )) hours"
-            else
-              trig="launchd, every $(( ${sched#interval:} / 60 )) min"
-            fi ;;
-          cron)     trig="launchd, at a set time" ;;
-          *)        trig="launchd, at login" ;;
-        esac
         report_once "cli" "$tool" "" "$label/$(/usr/bin/basename "$f")" \
           "autonomous" "" "$trig" "$sched"
+        matched=1
         break
       done
     done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^cli${SEP}")
+
+    # Nothing in the registry named the binary - but the command line may
+    # name the host instead. A job that curls a model API on a timer is
+    # reaching a model whatever binary it runs. Inference hosts only: a
+    # scheduled download from a vendor's website is an acquisition, not a run.
+    [ "$matched" = 1 ] || while IFS="$SEP" read -r _k itool idoms; do
+      [ "$matched" = 1 ] && continue
+      [ -n "$idoms" ] || continue
+      old="$IFS"; IFS=','; set -- $idoms; IFS="$old"
+      for d in "$@"; do
+        [ -n "$d" ] || continue
+        case "$args" in
+          *"$d"*)
+            report_once "cli" "$itool" "" \
+              "$label/$(/usr/bin/basename "$f") reaches $d" \
+              "autonomous" "" "$trig" "$sched"
+            matched=1
+            break ;;
+        esac
+      done
+    done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^inf${SEP}")
+
+    # Nothing in the registry named the binary. A job that runs a wrapper
+    # script names nothing matchable - but if its definition hands that
+    # script a model credential, the job is reaching a model on a timer and
+    # says so itself. This is the only view onto a scheduled job whose
+    # command is opaque, and it needs no list of binaries at all.
+    [ "$matched" = 1 ] && continue
+    envs=$(json_keys "$j" "EnvironmentVariables")
+    [ -n "$envs" ] || continue
+    while IFS="$SEP" read -r _k etool evars; do
+      # One job is one finding. Several tools can name the same variable -
+      # ANTHROPIC_API_KEY belongs to Claude and to Claude Code - and the
+      # credential cannot say which one the script calls. Reporting both
+      # would turn one scheduled job into two things running unattended.
+      [ "$matched" = 1 ] && continue
+      [ -n "$evars" ] || continue
+      old="$IFS"; IFS=','; set -- $evars; IFS="$old"
+      for v in "$@"; do
+        [ -n "$v" ] || continue
+        case ",$envs," in
+          *",$v,"*) ;;
+          *) continue ;;
+        esac
+        report_once "cli" "$etool" "" \
+          "$label/$(/usr/bin/basename "$f") sets $v" \
+          "autonomous" "" "$trig" "$sched"
+        matched=1
+        break
+      done
+    done < <(printf '%s\n' "$REG_TSV" | /usr/bin/grep "^env${SEP}")
   done
   /bin/rm -f "$j"
 }

--- a/portal/collector-scripts/collector-windows.ps1
+++ b/portal/collector-scripts/collector-windows.ps1
@@ -766,6 +766,15 @@ function Get-TaskSchedule {
     return $null
 }
 
+# No credential pass here, unlike the macOS and Linux collectors.
+#
+# Those read a job's own environment block - launchd EnvironmentVariables,
+# systemd Environment= - so a scheduled job that runs an opaque wrapper
+# script still says what it reaches by the key it hands over. A Windows
+# scheduled task has no equivalent: an action carries Execute, Arguments and
+# WorkingDirectory, and inherits the user's environment rather than declaring
+# one. There is nothing to read, so a wrapper script on Windows stays
+# invisible to this scan and the portal says so rather than implying parity.
 $tasks = @()
 try {
     $tasks = @(Get-ScheduledTask -ErrorAction Stop)
@@ -782,13 +791,37 @@ foreach ($task in $tasks) {
     if (-not $cmd.Trim()) { continue }
     $sched = Get-TaskSchedule -Task $task
     if (-not $sched) { continue }     # not self-starting: nothing to say
+    $matched = $false
     foreach ($t in $Registry.cli) {
         if (-not $t.binaries) { continue }
         if (Test-RunsBinary -Command $cmd -Binaries $t.binaries) {
             Send-FindingOnce -Surface 'cli' -Tool $t.tool -Account '' `
                 -Evidence "Scheduled Task $($task.TaskPath)$($task.TaskName)" `
                 -Mode 'autonomous' -Trigger $sched.trigger -Schedule $sched.spec
+            $matched = $true
             break
+        }
+    }
+
+    # No binary matched, but the command may name the host instead: a task
+    # that curls a model API on a timer is reaching a model whatever it runs.
+    # Inference hosts only - a scheduled download from a vendor's website is
+    # an acquisition, not a run, and matching any domain would put every
+    # installer fetch on a page about what runs unattended.
+    if (-not $matched) {
+        foreach ($t in $Registry.inference) {
+            if ($matched) { break }
+            foreach ($d in @($t.domains)) {
+                if (-not $d) { continue }
+                if ($cmd.ToLower().Contains($d.ToLower())) {
+                    Send-FindingOnce -Surface 'cli' -Tool $t.tool -Account '' `
+                        -Evidence ("Scheduled Task $($task.TaskPath)$($task.TaskName)" +
+                                   " reaches $d") `
+                        -Mode 'autonomous' -Trigger $sched.trigger -Schedule $sched.spec
+                    $matched = $true
+                    break
+                }
+            }
         }
     }
 }

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -1651,3 +1651,42 @@ def test_no_heartbeat_at_all_is_not_reported_as_capable():
     ], REG_BIN)
     c = out["scan_coverage"]
     assert c["devices_reporting"] == 0 and c["capable"] == 0
+
+
+def test_fetching_a_tool_is_not_the_same_as_running_one():
+    """A scheduled curl pulling an installer off a vendor's download host is
+    a real signal - somebody is acquiring an AI tool nobody approved - but it
+    is an acquisition, and this page is about what runs. Both were arriving
+    in the same row, so the page reported a download as something running
+    without being asked."""
+    reg = {"tools": [{"id": "cursor", "domains": ["cursor.com", "api2.cursor.sh"],
+                      "inference_domains": ["api2.cursor.sh"]}]}
+    fetched = finding(tool="cursor", surface="network", device="D1",
+                      evidence="DNS lookup for cursor.com (via curl)")
+    used = finding(tool="cursor", surface="network", device="D2",
+                   evidence="DNS lookup for api2.cursor.sh (via curl)")
+    out = derive.agentic_from([fetched, used], reg)
+    assert [a["device"] for a in out["agents"]] == ["D2"]
+
+
+def test_a_tool_that_draws_no_line_keeps_every_finding():
+    """Only a tool that declares inference_domains gets filtered. One that
+    declares none has drawn no line between fetched and used, and nothing
+    here invents one - absence reads as unknown, never as "only a download",
+    which would silently delete findings as the registry gained entries."""
+    reg = {"tools": [{"id": "claude", "domains": ["api.anthropic.com"]}]}
+    out = derive.agentic_from([
+        finding(tool="claude", surface="network", device="D9",
+                evidence="DNS lookup for api.anthropic.com (via curl)"),
+    ], reg)
+    assert out["agents"][0]["process"] == "curl"
+
+
+def test_a_subdomain_of_an_inference_host_still_counts_as_use():
+    reg = {"tools": [{"id": "codeium", "domains": ["server.codeium.com"],
+                      "inference_domains": ["server.codeium.com"]}]}
+    out = derive.agentic_from([
+        finding(tool="codeium", surface="network", device="D1",
+                evidence="DNS lookup for eu.server.codeium.com (via python3)"),
+    ], reg)
+    assert len(out["agents"]) == 1

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -832,7 +832,21 @@ _UNATTRIBUTABLE = {
     "update", "updater", "squirrel",
 }
 _VIA_RE = re.compile(r"\(via ([^)]{1,80})\)")
-_HELPER_RE = re.compile(r"\s+helper(\s*\(.*)?$")
+def _strip_helper_suffix(n):
+    """"google chrome helper (renderer)" -> "google chrome".
+
+    String work rather than a pattern. The regex this replaces was
+    `\\s+helper(\\s*\\(.*)?$`, whose two adjacent whitespace quantifiers
+    backtrack polynomially on a name of many spaces - and the name comes off
+    a posted finding, so it is not input this gets to assume anything about.
+    """
+    i = n.rfind(" helper")
+    if i == -1:
+        return n
+    tail = n[i + len(" helper"):].lstrip(" \t")
+    if tail and not tail.startswith("("):
+        return n
+    return n[:i].rstrip(" \t")
 
 
 def _norm_process(name: str) -> str:
@@ -843,7 +857,7 @@ def _norm_process(name: str) -> str:
     n = n.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
     if n.endswith(".exe"):
         n = n[:-4]
-    return _HELPER_RE.sub("", n).strip()
+    return _strip_helper_suffix(n).strip()
 
 
 def _process_stems(name: str) -> list[str]:

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -803,11 +803,72 @@ def _refresh_domain_map():
     _IDE_TOOLS = _build_ide_tools(reg)
     _REGISTRY_IDS = {t.get("id") for t in (reg or {}).get("tools", [])
                      if t.get("id")}
+    _REBUILD_KNOWN_PROCESSES(reg)
 
 
 _DOMAIN_TO_TOOL: dict[str, str] = {}
 _REGISTRY_IDS: set[str] = set()
 _IDE_TOOLS: set[str] = set()
+# Every process name the registry can account for: the binaries its CLIs run
+# as, the apps and Windows executables its desktop tools ship under, and the
+# browsers, apps and daemons on allowed_processes. Anything else that reaches
+# a model is a question for a human, which is what the candidates queue is.
+_KNOWN_PROCESSES: set[str] = set()
+
+# The same three sets the portal reads findings through. They live here too
+# because the receiver decides what becomes a candidate at ingest, and the
+# two services share no library - a parity test asserts they do not drift.
+_BROWSERS = {
+    "chrome", "google chrome", "chromium", "firefox", "safari",
+    "com.apple.safari", "msedge", "microsoft edge", "brave", "brave browser",
+    "opera", "vivaldi", "arc",
+}
+_UNATTRIBUTABLE = {
+    "systemd-resolved", "systemd-executor", "systemd", "resolvconf",
+    "mdnsresponder", "discoveryd", "dnsmasq", "unbound", "nscd",
+    "svchost", "dnscache", "networkservice",
+    "backgroundtaskhost", "taskhostw", "taskhost", "taskeng", "rundll32",
+    "dllhost", "wermgr",
+    "update", "updater", "squirrel",
+}
+_VIA_RE = re.compile(r"\(via ([^)]{1,80})\)")
+_HELPER_RE = re.compile(r"\s+helper(\s*\(.*)?$")
+
+
+def _norm_process(name: str) -> str:
+    """Lowercased, path and .exe stripped, a macOS "X Helper (Role)" cut to X."""
+    n = (name or "").strip().lower()
+    if not n:
+        return ""
+    n = n.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
+    if n.endswith(".exe"):
+        n = n[:-4]
+    return _HELPER_RE.sub("", n).strip()
+
+
+def _process_stems(name: str) -> list[str]:
+    """The name and its shorter dotted prefixes, longest first."""
+    n = _norm_process(name)
+    if not n:
+        return []
+    parts = n.split(".")
+    return [".".join(parts[:i]) for i in range(len(parts), 0, -1)]
+
+
+def _REBUILD_KNOWN_PROCESSES(reg):
+    global _KNOWN_PROCESSES
+    out = set()
+    for t in (reg or {}).get("tools", []) or []:
+        for b in ((t.get("cli") or {}).get("binaries") or []):
+            out.add(_norm_process(str(b)))
+        for a in (t.get("app_names") or []):
+            a = str(a)
+            out.add(_norm_process(a[:-4] if a.lower().endswith(".app") else a))
+        for e in (t.get("exe_names") or []):
+            out.add(_norm_process(str(e)))
+    for pn in (reg or {}).get("allowed_processes", []) or []:
+        out.add(_norm_process(str(pn)))
+    _KNOWN_PROCESSES = out - {""}
 _refresh_domain_map()  # also primes the tools gauge at boot
 
 
@@ -2460,7 +2521,7 @@ def put_registry_entries(req: RegistryEntriesUpdate,
 # a scanner credential must not become a way to put arbitrary text in
 # front of an admin who is one click from adding it to the registry.
 
-_CANDIDATE_KINDS = ("domain", "mcp_server")
+_CANDIDATE_KINDS = ("domain", "mcp_server", "process")
 # The same shape discovery enforces on classifier output, enforced again
 # here because the receiver cannot know its caller ran that code.
 _CANDIDATE_TEXT = re.compile(r"^[\w .,'&()/+-]{1,80}$")
@@ -2747,6 +2808,50 @@ def _note_mcp_candidates(f: Finding):
             _notify_webhook(
                 "ai-guard: unknown MCP server %r seen in a %s config - now"
                 " in the review queue" % (name, f.tool))
+
+
+def _note_process_candidates(f: Finding):
+    """A process reached a model and the registry cannot name it. Ask.
+
+    This is the same move the MCP path above makes, on the surface that
+    never got it. An unrecognised process was shown on the Agentic AI view
+    as "no tool we know" and then discarded - so the only way it ever became
+    known was somebody editing the registry by hand, having spotted it on a
+    page. The estate observed it; the estate should be the one asking.
+
+    Deliberately quiet about what it is. The receiver knows a name reached a
+    model host and nothing more, so the candidate carries the evidence and a
+    human decides whether it is a tool to define, a system process to allow,
+    or a script somebody wrote. That is the same contract as a domain
+    candidate: the classifier proposes, the human disposes.
+    """
+    if STATE is None or f.surface not in ("network", "cloud"):
+        return
+    m = _VIA_RE.search(f.evidence or "")
+    if not m:
+        return
+    name = m.group(1).strip()
+    stems = _process_stems(name)
+    if not stems:
+        return
+    # Names the registry already accounts for, resolvers and hosts that
+    # name nothing, and browsers: none of these is a question.
+    if any(x in _KNOWN_PROCESSES for x in stems):
+        return
+    if any(x in _UNATTRIBUTABLE for x in stems):
+        return
+    if name.lower() in _BROWSERS or any(x in _BROWSERS for x in stems):
+        return
+    if not _CANDIDATE_TEXT.match(name):
+        return
+    if STATE.observe_candidate(
+            _candidate_key("process", name), "process", name,
+            (f.evidence or "")[:500], "network",
+            f.device if f.device != "unknown" else ""):
+        _notify_webhook(
+            "ai-guard: %r reached a model host and is not a tool, a browser"
+            " or a system process this knows - now in the review queue"
+            % (name,))
 
 
 @app.get("/admin/candidates")
@@ -3427,6 +3532,8 @@ async def report(f: Finding, request: Request, authorization: str = Header(defau
     # MCP server names ride in as evidence; unknown ones join the
     # candidates queue (managed mode only - the function gates itself).
     _note_mcp_candidates(f)
+    # ...and the same question for a process the registry cannot name.
+    _note_process_candidates(f)
 
     # Loki: every finding, warn and info alike. Stdout always; direct push
     # when a push target is configured - the portal-saved log store when

--- a/receiver/app/registry-schema.json
+++ b/receiver/app/registry-schema.json
@@ -245,7 +245,15 @@
               "type": "string",
               "pattern": "^[a-z0-9.-]+$"
             },
-            "description": "The subset of `domains` a host only reaches when a model is actually invoked - the completion/chat backend. Everything else in `domains` is reached on launch anyway for telemetry, updates and licence checks, so a hit there proves the product exists, not that the AI ran. Only meaningful with `form: ide`, where that difference decides installed vs in use; build.py requires every entry to also appear in `domains`. Leave empty when you cannot tell the two apart - an over-claimed inference domain silently turns telemetry into evidence of use."
+            "description": "The subset of `domains` a host only reaches when a model is actually invoked - the completion/chat backend. Everything else in `domains` is reached on launch anyway for telemetry, updates and licence checks, so a hit there proves the product exists, not that the AI ran. Two readers: the IDE installed-vs-used signal, and the agentic view, which uses it to tell a tool being fetched from one being used so a scheduled installer download stops reading as something running unattended. build.py requires every entry to also appear in `domains`. Leave empty when you cannot tell the two apart - an over-claimed inference domain silently turns telemetry into evidence of use, and an over-claimed set silently hides the hosts it leaves out."
+          },
+          "env_vars": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[A-Z][A-Z0-9_]{2,63}$"
+            },
+            "description": "Environment variables that hold this tool's API credential. Read by the collectors' scheduler scan: a scheduled job whose definition sets one of these is reaching a model on a timer, whatever binary it runs - which is the only way to see a job that runs a wrapper script. Name only the vendor-specific ones. A generic name like API_KEY or TOKEN would fire on every scheduled backup in the estate."
           }
         }
       }

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.23.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/receiver/tests/test_candidates.py
+++ b/receiver/tests/test_candidates.py
@@ -246,8 +246,11 @@ def test_a_process_the_registry_cannot_name_becomes_a_candidate(managed, monkeyp
     got = [c for c in rows if c["kind"] == "process"]
     assert [c["name"] for c in got] == ["nightly-digest"]
     # The evidence travels with it: a human decides what it is, and cannot
-    # do that from a bare name.
-    assert "api.anthropic.com" in got[0]["evidence"]
+    # do that from a bare name. Compared whole rather than by substring -
+    # a substring test on something URL-shaped passes on a value that merely
+    # contains it somewhere.
+    assert got[0]["evidence"] == ("DNS lookup for api.anthropic.com"
+                                  " (via nightly-digest)")
 
 
 @pytest.mark.parametrize("proc,why", [

--- a/receiver/tests/test_candidates.py
+++ b/receiver/tests/test_candidates.py
@@ -222,3 +222,63 @@ def test_a_dismissed_server_keeps_its_record_and_its_decision(managed):
     c = _queue()["mcp_server:figma"]
     assert c["dismissed_at"] is not None
     assert c["devices"] == 2
+
+
+# ---------------------------------------------------------------- processes --
+#
+# The surface that never got a queue. An unrecognised process reaching a model
+# was drawn on the Agentic AI view as "no tool we know" and then discarded, so
+# the only way it ever became known was somebody spotting it on a page and
+# editing the registry by hand. The estate observed it; the estate should ask.
+
+def _dns(process, host="api.anthropic.com", device="D1"):
+    return {"tool": "claude", "surface": "network", "os": "macos",
+            "account_domain": "", "device": device, "user": "",
+            "evidence": "DNS lookup for %s (via %s)" % (host, process),
+            "severity": "info", "reported_at": "2026-09-02T10:00:00Z"}
+
+
+def test_a_process_the_registry_cannot_name_becomes_a_candidate(managed, monkeypatch):
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", {"claude", "google chrome"})
+    r = client.post("/report", json=_dns("nightly-digest"), headers=AUTH)
+    assert r.status_code == 200
+    rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
+    got = [c for c in rows if c["kind"] == "process"]
+    assert [c["name"] for c in got] == ["nightly-digest"]
+    # The evidence travels with it: a human decides what it is, and cannot
+    # do that from a bare name.
+    assert "api.anthropic.com" in got[0]["evidence"]
+
+
+@pytest.mark.parametrize("proc,why", [
+    ("claude", "a binary the registry names is the tool, not a question"),
+    ("Google Chrome Helper", "a browser is the ordinary case"),
+    ("systemd-resolved", "a resolver names nothing to ask about"),
+    ("Update.exe", "Squirrel's updater names the framework, not the app"),
+])
+def test_the_things_that_are_not_questions_are_not_queued(managed, monkeypatch, proc, why):
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", {"claude", "google chrome"})
+    client.post("/report", json=_dns(proc), headers=AUTH)
+    rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
+    assert [c for c in rows if c["kind"] == "process"] == [], why
+
+
+def test_the_same_process_on_many_devices_is_one_question(managed, monkeypatch):
+    """A review queue that asks the same question once per machine is a
+    queue nobody reads."""
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", {"claude"})
+    for d in ("D1", "D2", "D3"):
+        client.post("/report", json=_dns("nightly-digest", device=d), headers=AUTH)
+    rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
+    assert len([c for c in rows if c["kind"] == "process"]) == 1
+
+
+def test_a_process_candidate_survives_the_receivers_own_validation(managed, monkeypatch):
+    """Names that fail the candidate text rule are skipped rather than
+    refused: they are evidence on a valid finding, and a finding must never
+    bounce because a process has an odd name."""
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", {"claude"})
+    r = client.post("/report", json=_dns("weird\x01name"), headers=AUTH)
+    assert r.status_code == 200
+    rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
+    assert [c for c in rows if c["kind"] == "process"] == []

--- a/receiver/tests/test_process_set_parity.py
+++ b/receiver/tests/test_process_set_parity.py
@@ -60,3 +60,38 @@ def test_a_helper_and_an_exe_normalise_the_same_way_everywhere():
              r"C:\Program Files\x\Code.exe"]
     for c in cases:
         assert main._norm_process(c) == scanner_norm(c), c
+
+
+def test_a_hostile_name_returns_promptly():
+    """The helper suffix used to be found with `\\s+helper(\\s*\\(.*)?$`, whose
+    adjacent whitespace quantifiers backtrack polynomially: many viable start
+    positions, each failing late. Measured on the old pattern it was cleanly
+    quadratic - n doubles, time quadruples - reaching a second per call at
+    16k characters:
+
+        n= 2000   near-miss    5ms   tail-fail    19ms
+        n= 4000   near-miss   18ms   tail-fail    65ms
+        n= 8000   near-miss   64ms   tail-fail   257ms
+        n=16000   near-miss  257ms   tail-fail  1029ms
+
+    In practice the caller capped the name at 80 characters, so the exposure
+    was small - but the cap lives in the regex that extracts the name, not in
+    this function, and this function is now called from three services. The
+    property is asserted here rather than left to a caller none of them share.
+    """
+    import time
+
+    hostile = []
+    for n in (8000, 16000):
+        hostile.append(" " * n + "helpe")               # fails at the last char
+        hostile.append(" " * n + "helper" + " " * n + "x")   # fails after the literal
+    start = time.monotonic()
+    for h in hostile:
+        main._norm_process(h)
+    assert time.monotonic() - start < 1.0
+
+    # And the shapes that have to keep working.
+    assert main._norm_process("Google Chrome Helper (Renderer)") == "google chrome"
+    assert main._norm_process("Claude Helper") == "claude"
+    assert main._norm_process("my helper app") == "my helper app"
+    assert main._norm_process(" " * 5000) == ""

--- a/receiver/tests/test_process_set_parity.py
+++ b/receiver/tests/test_process_set_parity.py
@@ -1,0 +1,62 @@
+"""The three services must agree on what a process name means.
+
+The receiver decides at ingest whether a process becomes a candidate; the
+portal decides at render whether it becomes an agentic row; the scanner
+decides at collection whether to write "(via ...)" at all. They share no
+library, so the sets are written out three times - and three copies of a set
+that must agree is a drift risk, which is the shape of bug this whole area
+has already produced once.
+
+Checked here rather than assumed. A name treated as a resolver by one service
+and a mystery by another produces a candidate for something the portal will
+never show, or a row for something the receiver already dismissed.
+"""
+
+import os
+import pathlib
+import sys
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+from app import main  # noqa: E402
+
+
+def _load(path, names):
+    """Read a module's module-level sets without importing its package."""
+    src = (_ROOT / path).read_text()
+    ns = {}
+    exec(compile(src.split("\ndef ", 1)[0], str(path), "exec"), ns)  # noqa: S102
+    return {n: ns[n] for n in names if n in ns}
+
+
+def test_the_receiver_and_the_portal_agree_on_what_names_nothing():
+    portal = (_ROOT / "portal/app/derive.py").read_text()
+    start = portal.index("UNATTRIBUTABLE_PROCESSES = {")
+    block = portal[start:portal.index("}", start) + 1]
+    ns = {}
+    exec(compile(block, "derive", "exec"), ns)  # noqa: S102
+    assert ns["UNATTRIBUTABLE_PROCESSES"] == main._UNATTRIBUTABLE
+
+
+def test_the_receiver_and_the_scanner_agree_too():
+    scanner = (_ROOT / "scanner/ai_guard/scanners/sentinelone.py").read_text()
+    start = scanner.index("_UNATTRIBUTABLE_PROCESSES = {")
+    block = scanner[start:scanner.index("}", start) + 1]
+    ns = {}
+    exec(compile(block, "sentinelone", "exec"), ns)  # noqa: S102
+    assert ns["_UNATTRIBUTABLE_PROCESSES"] == main._UNATTRIBUTABLE
+
+
+def test_a_helper_and_an_exe_normalise_the_same_way_everywhere():
+    """Normalisation is written three times too. If the receiver strips a
+    suffix the portal keeps, one queues a candidate the other will not show."""
+    sys.path.insert(0, str(_ROOT / "scanner"))
+    from ai_guard.registry import normalise_process as scanner_norm
+
+    cases = ["OneDrive.Sync.Service.exe", "Google Chrome Helper (Renderer)",
+             "chrome.exe", "Claude Helper", "curl", "stable",
+             r"C:\Program Files\x\Code.exe"]
+    for c in cases:
+        assert main._norm_process(c) == scanner_norm(c), c

--- a/registry/build.py
+++ b/registry/build.py
@@ -88,13 +88,16 @@ def validate(registry, schema):
                 print(f"{t['id']}: inference_domains entry {d} is not in "
                       f"domains", file=sys.stderr)
                 ok = False
-        # The reverse pairing: inference_domains only changes how a finding
-        # reads for a tool whose presence does not imply use. On anything
-        # else it is inert, and inert configuration reads as working.
-        if t.get("inference_domains") and t.get("form") != "ide":
-            print(f"{t['id']}: inference_domains needs form: ide - it has no "
-                  f"effect on any other shape", file=sys.stderr)
-            ok = False
+        # This used to require form: ide, because the installed-vs-used signal
+        # was the only thing reading inference_domains and the field was inert
+        # anywhere else - and inert configuration reads as working.
+        #
+        # It has a second reader now, on every shape: the agentic view uses it
+        # to tell a tool being FETCHED from a tool being USED, so that a
+        # scheduled curl pulling an installer off a vendor's download host
+        # stops being reported as something running unattended. That applies
+        # to any tool with a download host and an API host, which is most of
+        # them, so the pairing no longer holds and the rule is gone.
     return ok
 
 
@@ -187,6 +190,28 @@ def emit(registry, write_fallback=True):
         # finding "<tool>-mcp:<servers>" and cannot do that from a bare path.
         # os says which collector should look for it; Claude Desktop's config
         # lives under Library on macOS and AppData on Windows.
+        # The hosts a tool only reaches when a model actually answers. Its
+        # own row kind so the scheduler scan can read a command line: a job
+        # that curls api.anthropic.com on a timer is reaching a model
+        # whatever binary it names. Deliberately inference_domains rather
+        # than domains - matching any domain would make a scheduled
+        # installer download read as something running unattended, which is
+        # the noise this same field exists to remove elsewhere.
+        "inference": [
+            {"tool": t["id"], "domains": t["inference_domains"]}
+            for t in tools
+            if t.get("inference_domains")
+        ],
+        # Environment variables that hold a tool's credential. Its own row
+        # kind because a tool can have one without having a cli block:
+        # a scheduled job that sets ANTHROPIC_API_KEY is reaching a model on
+        # a timer whatever binary it runs, which is the only way to see a job
+        # that runs a wrapper script.
+        "env": [
+            {"tool": t["id"], "env_vars": t["env_vars"]}
+            for t in tools
+            if t.get("env_vars")
+        ],
         "mcp": [
             {"tool": t["id"], "path": p, "os": os_}
             for t in tools

--- a/registry/registry.yaml
+++ b/registry/registry.yaml
@@ -23,12 +23,14 @@ version: 1
 tools:
   - id: claude
     name: Claude
+    env_vars: [ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN]
     vendor: Anthropic
     category: assistant
     license_group: anthropic-claude
     approved: false
     added_by: manual
     domains: [claude.ai, anthropic.com, api.anthropic.com, claude.com, claudeusercontent.com, console.anthropic.com]
+    inference_domains: [api.anthropic.com]
     app_names: ["Claude.app", "Claude"]
     bundle_ids: [com.anthropic.claudefordesktop]
     mcp_config_paths_macos:
@@ -45,6 +47,7 @@ tools:
 
   - id: claude-code
     name: Claude Code
+    env_vars: [ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN]
     vendor: Anthropic
     category: coding
     license_group: anthropic-claude
@@ -65,12 +68,14 @@ tools:
 
   - id: chatgpt
     name: ChatGPT
+    env_vars: [OPENAI_API_KEY]
     vendor: OpenAI
     category: assistant
     license_group: openai-chatgpt
     approved: false
     added_by: manual
     domains: [chat.openai.com, chatgpt.com, openai.com, api.openai.com, cdn.oaistatic.com, auth0.openai.com]
+    inference_domains: [api.openai.com, chat.openai.com]
     app_names: ["ChatGPT.app", "ChatGPT"]
     bundle_ids: [com.openai.chat]
     extension_ids:
@@ -82,6 +87,7 @@ tools:
 
   - id: codex-cli
     name: Codex CLI
+    env_vars: [OPENAI_API_KEY, CODEX_API_KEY]
     vendor: OpenAI
     category: coding
     license_group: openai-chatgpt
@@ -110,6 +116,7 @@ tools:
 
   - id: gemini-cli
     name: Gemini CLI
+    env_vars: [GEMINI_API_KEY, GOOGLE_API_KEY]
     vendor: Google
     category: coding
     license_group: google-gemini
@@ -132,6 +139,7 @@ tools:
     approved: false
     added_by: manual
     domains: [copilot-proxy.githubusercontent.com, api.githubcopilot.com, copilot.github.com]
+    inference_domains: [api.githubcopilot.com, copilot-proxy.githubusercontent.com]
     extension_ids:
       vscode: [github.copilot, github.copilot-chat]
       jetbrains: [github-copilot]
@@ -140,6 +148,7 @@ tools:
 
   - id: cursor
     name: Cursor
+    env_vars: [CURSOR_API_KEY]
     vendor: Anysphere
     category: coding
     approved: false
@@ -228,6 +237,7 @@ tools:
     approved: false
     added_by: manual
     domains: [tabnine.com, api.tabnine.com]
+    inference_domains: [api.tabnine.com]
     extension_ids:
       vscode: [tabnine.tabnine-vscode]
     risk_tier: medium
@@ -239,6 +249,7 @@ tools:
     approved: false
     added_by: manual
     domains: [otter.ai, api.otter.ai]
+    inference_domains: [api.otter.ai]
     app_names: ["Otter.app", "Otter"]
     email_senders: [otter.ai]
     risk_tier: high
@@ -270,6 +281,7 @@ tools:
     approved: false
     added_by: manual
     domains: [wisprflow.ai, wisprflow.com, api.wisprflow.ai]
+    inference_domains: [api.wisprflow.ai]
     app_names: ["Wispr Flow.app", "Wispr Flow"]
     risk_tier: high
     email_senders: [wisprflow.ai]
@@ -281,6 +293,7 @@ tools:
     approved: false
     added_by: manual
     domains: [warp.dev, app.warp.dev]
+    inference_domains: [app.warp.dev]
     app_names: ["Warp.app", "Warp"]
     # Warp's binary is named after its release channel, not the product:
     # Warp.app/Contents/MacOS/stable. Nothing derives "Warp" from that, which
@@ -290,11 +303,13 @@ tools:
     bundle_ids: [dev.warp.Warp-Stable]
   - id: perplexity
     name: Perplexity
+    env_vars: [PERPLEXITY_API_KEY]
     vendor: Perplexity AI
     category: search
     approved: false
     added_by: manual
     domains: [perplexity.ai, api.perplexity.ai, www.perplexity.ai]
+    inference_domains: [api.perplexity.ai]
     app_names: ["Perplexity.app", "Perplexity"]
     email_senders: [perplexity.ai]
     risk_tier: medium
@@ -310,6 +325,7 @@ tools:
     added_by: manual
     notes: Local models; data stays on device but model provenance unknown. Separate risk class.
     domains: [ollama.com, registry.ollama.ai, ollama.ai, api.ollama.com]
+    inference_domains: [api.ollama.com]
     app_names: ["Ollama.app", "Ollama", ollama]
     cli:
       config_paths: [".ollama/models"]
@@ -331,21 +347,25 @@ tools:
 
   - id: deepseek
     name: DeepSeek
+    env_vars: [DEEPSEEK_API_KEY]
     vendor: DeepSeek
     category: assistant
     approved: false
     added_by: manual
     domains: [chat.deepseek.com, deepseek.com, api.deepseek.com]
+    inference_domains: [api.deepseek.com, chat.deepseek.com]
     email_senders: [deepseek.com]
     risk_tier: high
 
   - id: mistral
     name: Mistral Le Chat
+    env_vars: [MISTRAL_API_KEY]
     vendor: Mistral AI
     category: assistant
     approved: false
     added_by: manual
     domains: [chat.mistral.ai, mistral.ai, api.mistral.ai]
+    inference_domains: [api.mistral.ai, chat.mistral.ai]
     email_senders: [mistral.ai]
     risk_tier: medium
   - id: grok
@@ -405,6 +425,7 @@ tools:
     approved: false
     added_by: manual
     domains: [fireflies.ai, app.fireflies.ai]
+    inference_domains: [app.fireflies.ai]
     risk_tier: high
     email_senders: [fireflies.ai]
     app_names: ["Fireflies.app", "Fireflies"]
@@ -430,11 +451,13 @@ tools:
     email_senders: [openai.com]
   - id: hugging-face
     name: Hugging Face
+    env_vars: [HUGGINGFACE_API_KEY, HF_TOKEN]
     vendor: Hugging Face
     category: platform
     approved: false
     added_by: manual
     domains: [huggingface.co, api-inference.huggingface.co]
+    inference_domains: [api-inference.huggingface.co]
     risk_tier: medium
     email_senders: [huggingface.co]
 bridge_targets:

--- a/registry/schema.json
+++ b/registry/schema.json
@@ -245,7 +245,15 @@
               "type": "string",
               "pattern": "^[a-z0-9.-]+$"
             },
-            "description": "The subset of `domains` a host only reaches when a model is actually invoked - the completion/chat backend. Everything else in `domains` is reached on launch anyway for telemetry, updates and licence checks, so a hit there proves the product exists, not that the AI ran. Only meaningful with `form: ide`, where that difference decides installed vs in use; build.py requires every entry to also appear in `domains`. Leave empty when you cannot tell the two apart - an over-claimed inference domain silently turns telemetry into evidence of use."
+            "description": "The subset of `domains` a host only reaches when a model is actually invoked - the completion/chat backend. Everything else in `domains` is reached on launch anyway for telemetry, updates and licence checks, so a hit there proves the product exists, not that the AI ran. Two readers: the IDE installed-vs-used signal, and the agentic view, which uses it to tell a tool being fetched from one being used so a scheduled installer download stops reading as something running unattended. build.py requires every entry to also appear in `domains`. Leave empty when you cannot tell the two apart - an over-claimed inference domain silently turns telemetry into evidence of use, and an over-claimed set silently hides the hosts it leaves out."
+          },
+          "env_vars": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "pattern": "^[A-Z][A-Z0-9_]{2,63}$"
+            },
+            "description": "Environment variables that hold this tool's API credential. Read by the collectors' scheduler scan: a scheduled job whose definition sets one of these is reaching a model on a timer, whatever binary it runs - which is the only way to see a job that runs a wrapper script. Name only the vendor-specific ones. A generic name like API_KEY or TOKEN would fire on every scheduled backup in the estate."
           }
         }
       }

--- a/registry/test_build.py
+++ b/registry/test_build.py
@@ -59,15 +59,33 @@ def test_inference_domains_must_be_real_domains_of_that_tool():
     assert not build.validate(bad, schema)
 
 
-def test_inference_domains_without_form_ide_is_refused():
-    """On any other shape the field is inert, and inert configuration reads
-    as working - someone would set it and believe presence had stopped
-    counting as use."""
+def test_inference_domains_is_accepted_on_any_shape():
+    """This once required form: ide, because the installed-vs-used signal was
+    the only reader and the field was inert anywhere else.
+
+    It has a second reader now, on every shape: the agentic view uses it to
+    tell a tool being fetched from a tool being used, so a scheduled curl
+    pulling an installer off a download host stops reading as something
+    running unattended. tabnine has no form at all and the field is no longer
+    inert on it."""
+    import copy
+
+    registry, schema = build.load()
+    fine = copy.deepcopy(registry)
+    assert _tool(fine, "tabnine").get("form") is None
+    _tool(fine, "tabnine")["inference_domains"] = ["api.tabnine.com"]
+    assert build.validate(fine, schema)
+
+
+def test_an_inference_domain_outside_domains_is_still_refused():
+    """Relaxing the shape rule does not relax the subset rule. A host the
+    tool is not detected on matches nothing, and would fail silently: the
+    tool would simply never be credited with being used."""
     import copy
 
     registry, schema = build.load()
     bad = copy.deepcopy(registry)
-    _tool(bad, "tabnine")["inference_domains"] = ["api.tabnine.com"]
+    _tool(bad, "tabnine")["inference_domains"] = ["typo.tabnine.example"]
     assert not build.validate(bad, schema)
 
 

--- a/scanner/ai_guard/registry/__init__.py
+++ b/scanner/ai_guard/registry/__init__.py
@@ -421,6 +421,21 @@ class Registry:
                 return target
         return None
 
+    # The browsers among allowed_processes. A person using a model in a
+    # browser is the ordinary case every other view already covers, and it is
+    # the one thing that must stay visible on a backend domain where every
+    # other process is background noise.
+    BROWSER_NAMES = frozenset({
+        "chrome", "google chrome", "chromium", "firefox", "safari",
+        "com.apple.safari", "msedge", "microsoft edge", "brave",
+        "brave browser", "opera", "vivaldi", "arc",
+    })
+
+    def is_browser_process(self, process_name: str) -> bool:
+        """True when this name is a browser, in any shape a platform reports."""
+        return any(stem in self.BROWSER_NAMES
+                   for stem in process_stems(process_name))
+
     def is_allowed_process(self, process_name: str) -> bool:
         """Check if a process is a known browser, native app, or system process.
 

--- a/scanner/ai_guard/registry/__init__.py
+++ b/scanner/ai_guard/registry/__init__.py
@@ -42,7 +42,21 @@ _DOMAIN_RE = re.compile(r"^(\*\.)?[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$")
 # "Google Chrome Helper", "Google Chrome Helper (Renderer)", "Claude Helper".
 # The parent is the process worth naming, so the suffix is dropped. The
 # closing bracket is optional: a role can reach us already truncated.
-_HELPER_SUFFIX_RE = re.compile(r"\s+helper(\s*\(.*)?$")
+def _strip_helper_suffix(n):
+    """"google chrome helper (renderer)" -> "google chrome".
+
+    String work rather than a pattern. The regex this replaces was
+    `\\s+helper(\\s*\\(.*)?$`, whose two adjacent whitespace quantifiers
+    backtrack polynomially on a name of many spaces - and the name comes off
+    a posted finding, so it is not input this gets to assume anything about.
+    """
+    i = n.rfind(" helper")
+    if i == -1:
+        return n
+    tail = n[i + len(" helper"):].lstrip(" \t")
+    if tail and not tail.startswith("("):
+        return n
+    return n[:i].rstrip(" \t")
 
 
 def normalise_process(process_name: str) -> str:
@@ -62,7 +76,7 @@ def normalise_process(process_name: str) -> str:
     n = n.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
     if n.endswith(".exe"):
         n = n[:-4]
-    return _HELPER_SUFFIX_RE.sub("", n).strip()
+    return _strip_helper_suffix(n).strip()
 
 
 def process_stems(process_name):

--- a/scanner/ai_guard/registry/ai_services.yaml
+++ b/scanner/ai_guard/registry/ai_services.yaml
@@ -34,7 +34,8 @@ services:
   mcp_identifiers:
   - anthropic-claude
   form: ''
-  inference_domains: []
+  inference_domains:
+  - api.anthropic.com
   notes: Claude desktop app supports MCP server connections.
 - name: Claude Code
   vendor: Anthropic
@@ -78,7 +79,9 @@ services:
   browser_extensions: {}
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - api.openai.com
+  - chat.openai.com
   notes: Users can sign up with work email + password without any Entra involvement.
 - name: Codex CLI
   vendor: OpenAI
@@ -146,7 +149,9 @@ services:
   browser_extensions: {}
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - api.githubcopilot.com
+  - copilot-proxy.githubusercontent.com
   notes: ''
 - name: Cursor
   vendor: Anysphere
@@ -268,7 +273,8 @@ services:
   browser_extensions: {}
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - api.tabnine.com
   notes: ''
 - name: Otter
   vendor: Otter.ai
@@ -292,7 +298,8 @@ services:
     - bnmojkbbkkonlmlfgejehefjldooied
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - api.otter.ai
   notes: ''
 - name: Grammarly
   vendor: Grammarly
@@ -341,7 +348,8 @@ services:
   browser_extensions: {}
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - api.wisprflow.ai
   notes: ''
 - name: Warp
   vendor: Warp
@@ -363,7 +371,8 @@ services:
   browser_extensions: {}
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - app.warp.dev
   notes: ''
 - name: Perplexity
   vendor: Perplexity AI
@@ -387,7 +396,8 @@ services:
     - hlgbcneanomplepojfcnclggenpcoldo
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - api.perplexity.ai
   notes: ''
 - name: Ollama
   vendor: Ollama
@@ -411,7 +421,8 @@ services:
   browser_extensions: {}
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - api.ollama.com
   notes: Local models; data stays on device but model provenance unknown. Separate risk class.
 - name: LM Studio
   vendor: Element Labs
@@ -448,7 +459,9 @@ services:
   browser_extensions: {}
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - api.deepseek.com
+  - chat.deepseek.com
   notes: ''
 - name: Mistral Le Chat
   vendor: Mistral AI
@@ -467,7 +480,9 @@ services:
   browser_extensions: {}
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - api.mistral.ai
+  - chat.mistral.ai
   notes: ''
 - name: Grok
   vendor: xAI
@@ -584,7 +599,8 @@ services:
   browser_extensions: {}
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - app.fireflies.ai
   notes: ''
 - name: Midjourney
   vendor: Midjourney
@@ -637,7 +653,8 @@ services:
   browser_extensions: {}
   mcp_identifiers: []
   form: ''
-  inference_domains: []
+  inference_domains:
+  - api-inference.huggingface.co
   notes: ''
 bridge_targets:
 - name: Atlassian (Jira/Confluence)

--- a/scanner/ai_guard/scanners/sentinelone.py
+++ b/scanner/ai_guard/scanners/sentinelone.py
@@ -70,6 +70,18 @@ _MICROSOFT_SYSTEM_DOMAINS = {
     "substrate.office.com",
 }
 
+# A pure M365 backend: no human reaches it as an AI tool, so ANY non-browser
+# hitting it is background activity regardless of which process it was.
+#
+# Narrower than the set above on purpose. The copilot hosts are user-facing -
+# a script reaching copilot.microsoft.com is worth a second look - and only
+# substrate is a backend nobody visits. Keying on the domain instead of the
+# process is what lets the shell-process names stop being maintained by hand:
+# Microsoft can ship a new one and it stays quiet without an entry.
+_MICROSOFT_BACKEND_DOMAINS = {
+    "substrate.office.com",
+}
+
 # Maximum time to spend polling a single DV query before giving up.
 DV_QUERY_TIMEOUT_SECONDS = 60
 
@@ -292,6 +304,17 @@ class SentinelOneScanner(BaseScanner):
                     process_name
                     and self.registry.is_allowed_process(process_name)
                     and any(dns_request.endswith(d) for d in _MICROSOFT_SYSTEM_DOMAINS)
+                ):
+                    continue
+
+                # A backend nobody visits: the process does not matter, only
+                # that it is not somebody in a browser. This is the rule that
+                # replaces maintaining a list of Windows shell process names.
+                if (
+                    process_name
+                    and not self.registry.is_browser_process(process_name)
+                    and any(dns_request.endswith(d)
+                            for d in _MICROSOFT_BACKEND_DOMAINS)
                 ):
                     continue
 

--- a/scanner/tests/test_process_attribution.py
+++ b/scanner/tests/test_process_attribution.py
@@ -42,6 +42,8 @@ class _Reg:
 
     def __init__(self, entries):
         self.allowed_processes = {normalise_process(p) for p in entries} - {""}
+        from ai_guard.registry import Registry
+        self.BROWSER_NAMES = Registry.BROWSER_NAMES
 
     is_allowed_process = None
 
@@ -128,3 +130,18 @@ def test_a_squirrel_updater_names_the_framework_not_the_app(proc):
     it, so the name says an application updated itself and not which one.
     An allowlist entry would wrongly read as "this program is fine"."""
     assert is_unattributable(proc) is True
+
+
+# ---- the rule that replaces a maintained list of shell process names -------
+
+def test_a_browser_is_recognised_in_every_shape():
+    """The one process that must stay visible on a backend domain: somebody
+    using a model in a browser is the ordinary case, and it is the only
+    non-background thing that reaches these hosts."""
+    from ai_guard.registry import Registry
+    r = _Reg([])
+    for n in ["chrome.exe", "Google Chrome Helper (Renderer)", "msedge.exe",
+              "firefox", r"C:\Program Files\Google\Chrome\chrome.exe"]:
+        assert Registry.is_browser_process(r, n) is True, n
+    for n in ["SearchHost.exe", "curl", "OneDrive.Sync.Service.exe", ""]:
+        assert Registry.is_browser_process(r, n) is False, n


### PR DESCRIPTION
Every list in 0.23.0 was one I wrote by hand after reading process names off a screen. That is the wrong direction — the estate had already observed all of them, and this platform already has the machinery to ask about what it does not recognise. It just was never wired to this surface.

Discovery does it for **domains**: unknown host, classify, queue, a human decides. The receiver does it for **MCP servers**, automatically on ingest. `CandidateIn` has carried a `kind` field the whole time.

```
_CANDIDATE_KINDS = ("domain", "mcp_server")        before
_CANDIDATE_KINDS = ("domain", "mcp_server", "process")   now
```

## Processes become questions

The receiver derives every process name the registry can account for — CLI binaries, desktop `app_names`, Windows `exe_names`, `allowed_processes` — and anything else reaching a model host becomes a candidate carrying its evidence, **deduped by name** so one script on forty machines is one question rather than forty.

`SearchHost.exe`, `Fireflies.exe` and `stable` should have arrived that way rather than as a commit.

Those sets now live in three services that share no library, so there is a **parity test** asserting they do not drift — verified failing on a one-word divergence before it passes. Same class of bug as the collector dedupe key: a property that must hold in three places, checked in one.

## inference_domains needed unpicking before it could help

`build.py` refused the field on anything but `form: ide`, and that rule was **correct** — the IDE signal was its only reader, and inert configuration reads as working. So the second reader came first: the agentic view now uses it to tell a tool being *fetched* from one being *used*. Only then is relaxing the rule honest rather than convenient.

Then the backfill, **2 tools → 15**. Safe polarity throughout: a tool that declares nothing is never filtered, so a growing registry can never silently delete findings.

```
cursor  cursor.com       -> dropped (a fetch, not a run)
cursor  api2.cursor.sh   -> kept   (a model answered)
claude  anthropic.com    -> dropped
claude  api.anthropic.com-> kept
```

## A scheduled job is now recognised three ways

Tried in order, all registry-driven:

1. **It names a binary the registry lists.** The original signal.
2. **Its command names an inference host.** A job curling `api.anthropic.com` on a timer is reaching a model whatever binary it runs. `inference_domains` only, never `domains` — a scheduled installer download is an acquisition, and matching any domain would put every one of them on a page about what runs unattended.
3. **Its definition hands a script a model credential.** This closes the blind spot 0.23.0 could only *state*. A job running `nightly-report.sh` names nothing matchable, but a launchd `EnvironmentVariables` or systemd `Environment=` setting `ANTHROPIC_API_KEY` says what it reaches.

Only variables the registry names for a tool. A generic `API_KEY` would have fired on every scheduled backup in the estate — a worse false positive than the one this whole sequence started with.

**Two limits, stated rather than left to be discovered.** A Windows scheduled task declares no environment — an action carries a command and inherits the user's — so the credential path cannot exist there, and a wrapper script on Windows stays invisible; the page says so. And `EnvironmentFile=` is not opened: it points at a file of secrets, and reading the names would mean reading the values.

## substrate.office.com suppresses on the domain

For any non-browser, regardless of process. This **deletes** a maintained list rather than growing one: Microsoft can ship another shell process and it stays quiet without an entry.

## The cross-signal join is written down, not built

`docs/agentic.md` now carries the three reasons it is not sound yet: the join key is a process name (`python3` joins against every other `python3`), it needs inventory rather than findings or it recreates the flood this sequence removed, and an ambiguous join has no honest rendering on a page made of four filled boxes. What the cheap signals miss on a real estate is the specification for it.

## Checked

Verified on a real machine and in a container, five job shapes:

```
runs claude                          -> reported (binary)
curls api.anthropic.com              -> reported (inference host)
runs nightly.sh + ANTHROPIC_API_KEY  -> reported (credential)
curls cursor.com/install.sh          -> silent
runs backup.sh + AWS_SECRET_ACCESS_KEY -> silent
```

One job produces one finding: several tools name `ANTHROPIC_API_KEY`, so the first match wins and the evidence names the variable rather than guessing louder. I caught that as a duplicate during testing, before it shipped.

Suites: registry 23, portal 615, scanner 210, receiver 290. Plus collector parity, `build.py --check`, both byte-identical invariants, shellcheck, PSScriptAnalyzer, and the containerised Linux collector harness (14/14).

`docs/agentic.md` updated so the documented signals match the code.
