### PR TITLE
The version it was reading was not the collector's

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.24.0
+version: 0.24.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.24.0"
+appVersion: "0.24.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.1
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.1
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -1451,23 +1451,29 @@ def _version_tuple(v):
     return tuple(int(p) for p in parts[:3]) + (0,) * (3 - len(parts[:3]))
 
 
-def scheduler_coverage(findings):
+def scheduler_coverage(devices):
     """How many devices report a collector that can be trusted to have looked.
 
-    Absence of a scheduled job is only meaningful from a device that reads
-    schedulers. Without this the page could not tell "nothing here runs on a
-    timer" from "nothing here has been asked" - the same failure the Sources
-    view exists to prevent for detection sources, one level down.
+    Reads the collector version the receiver stores when a device enrols or
+    reports - the same field the Fleet view shows. The first version of this
+    read `heartbeat version=` out of finding evidence instead, which is the
+    BROWSER EXTENSION's paste-guard heartbeat: no collector emits one. So it
+    compared a paste-guard version against a collector threshold, found
+    nothing at or above it, and told an operator nothing had looked on an
+    estate whose Fleet view was showing 2.1.0 at the time.
+
+    `devices` is None when the source is unavailable at all - classic mode
+    has no receiver to ask. That is unknown, and unknown is not zero: the
+    caller renders nothing rather than claiming an absence it cannot see.
     """
+    if devices is None:
+        return None
     seen = {}
-    for f in findings:
-        dev = (f.get("device") or "").strip()
-        ev = f.get("evidence") or ""
-        if not dev or not ev.startswith("heartbeat version="):
-            continue
-        v = _version_tuple(ev.split("version=", 1)[1].split()[0])
-        if v and v > seen.get(dev, (0, 0, 0)):
-            seen[dev] = v
+    for d in devices or []:
+        did = (d.get("id") or d.get("device") or "").strip()
+        v = _version_tuple((d.get("agent_version") or "").strip())
+        if did and v and v > seen.get(did, (0, 0, 0)):
+            seen[did] = v
     capable = sum(1 for v in seen.values() if v >= SCHEDULER_SCAN_VERSION)
     return {
         "devices_reporting": len(seen),
@@ -1609,8 +1615,9 @@ def agentic_from(findings, reg=None):
         },
         "servers": mcp_from(findings),
         "coverage": mcp_coverage(reg),
-        # Whether an empty page is an answer or an absence.
-        "scan_coverage": scheduler_coverage(findings),
+        # Whether an empty page is an answer or an absence. Filled by the
+        # caller, which is the layer that can ask the receiver for it.
+        "scan_coverage": None,
     }
 
 

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1171,6 +1171,30 @@ def evidence_snapshot(request: Request,
     return JSONResponse(doc)
 
 
+def _fleet_devices(request):
+    """The receiver's enrolled-device rows, or None when there is no receiver
+    to ask.
+
+    Never [] on failure: an empty list reads as "no devices reported", and
+    the difference between that and "could not look" is the whole point of
+    the field this feeds. Classic mode has no receiver; an operator without
+    a session has no token to forward; either way the answer is unknown.
+    """
+    if not RECEIVER_URL:
+        return None
+    token = request.cookies.get(SESSION_COOKIE, "")
+    if not token:
+        return None
+    try:
+        out = managed.receiver_request(RECEIVER_URL, "GET", "/admin/devices",
+                                       token)
+    except Exception:
+        return None
+    if isinstance(out, dict):
+        return out.get("devices") or []
+    return out if isinstance(out, list) else None
+
+
 @app.get("/api/agentic")
 def agentic(request: Request,
             hours: float = Query(default=None, gt=0, le=24 * 90),
@@ -1194,6 +1218,12 @@ def agentic(request: Request,
     def build():
         out = derive.agentic_from(_findings_cached(hours, request),
                                   _registry(request))
+        # Whether an empty page is an answer or an absence. The collector
+        # version lives on the receiver's device rows, not in any finding -
+        # the same field Fleet shows. None means the question could not be
+        # asked at all (classic mode has no receiver), and the page then
+        # says nothing rather than claiming an absence it cannot see.
+        out["scan_coverage"] = derive.scheduler_coverage(_fleet_devices(request))
         # Nothing here can know when an organisation works, so the shaded
         # stretch is a setting and an unset one draws nothing at all.
         out["working_hours"] = derive.working_hours_band(

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -8912,8 +8912,12 @@ async function agentic() {
   // "Nothing reported it" is only an answer from devices that looked. A
   // collector too old to read a scheduler produces the same silence as an
   // estate that schedules nothing, and the difference is the whole question.
-  const sc = AGENTIC.scan_coverage || {};
-  const scanNote = !nAuto && sc.devices_reporting ? `<p class="lede" style="margin:-2px 0 14px;max-width:56ch">${
+  // null when the question could not be asked - classic mode has no receiver
+  // to ask. Unknown renders nothing: an empty page with no way to check the
+  // collectors is still an empty page, and saying "nothing has looked" from
+  // no data is the same overclaim this view keeps being fixed for.
+  const sc = AGENTIC.scan_coverage;
+  const scanNote = (!nAuto && sc && sc.devices_reporting) ? `<p class="lede" style="margin:-2px 0 14px">${
       sc.capable
         ? `<b>${sc.capable}</b> of ${sc.devices_reporting} device${
             sc.devices_reporting === 1 ? '' : 's'} run a collector that reads schedulers,
@@ -8924,7 +8928,7 @@ async function agentic() {
            <b>nothing here has looked yet</b>. This is an absence, not a finding -
            update the collectors before reading the zero.`}</p>` : '';
   const weak = nUnrec
-    ? `<p class="lede" style="margin:-2px 0 14px;max-width:52ch">${nUnrec === 1
+    ? `<p class="lede" style="margin:-2px 0 14px">${nUnrec === 1
         ? 'One more process' : nUnrec + ' more processes'} reached a model
        without being a browser or a tool the registry knows. Whether a person
        was driving ${nUnrec === 1 ? 'it' : 'them'} is not established${

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -1628,29 +1628,49 @@ def test_reach_says_it_belongs_to_the_machine():
 
 def test_an_empty_page_says_whether_anything_looked():
     """Absence of a scheduled job means nothing from a collector that cannot
-    read a scheduler. The scan shipped without the version moving, so 2.0.0
-    is genuinely ambiguous and is counted as unknown rather than clean."""
-    def beat(dev, v):
-        return finding(device=dev, surface="endpoint", tool="ai-guard-collector",
-                       evidence="heartbeat version=%s" % v)
-    out = derive.agentic_from([beat("D1", "2.1.0"), beat("D2", "2.0.0"),
-                               beat("D3", "2.1.3")], REG_BIN)
-    c = out["scan_coverage"]
+    read a scheduler. The version comes off the receiver's device rows - the
+    field Fleet shows - because no collector emits it as a finding."""
+    devs = [{"id": "D1", "agent_version": "2.1.0"},
+            {"id": "D2", "agent_version": "2.0.0"},
+            {"id": "D3", "agent_version": "2.1.3"}]
+    c = derive.scheduler_coverage(devs)
     assert c["devices_reporting"] == 3
     assert c["capable"] == 2          # 2.1.0 and 2.1.3
     assert c["unknown"] == 1          # 2.0.0 may never have looked
     assert c["min_version"] == "2.1.0"
 
 
-def test_no_heartbeat_at_all_is_not_reported_as_capable():
-    """The estate that has never run a collector must not read as one that
-    looked and found nothing."""
-    out = derive.agentic_from([
-        finding(tool="claude", surface="network", device="D9",
-                evidence="DNS lookup for api.anthropic.com (via curl)"),
-    ], REG_BIN)
-    c = out["scan_coverage"]
-    assert c["devices_reporting"] == 0 and c["capable"] == 0
+def test_it_does_not_read_the_paste_guards_heartbeat():
+    """The first version of this parsed `heartbeat version=` out of finding
+    evidence. That is the BROWSER EXTENSION's paste-guard heartbeat - no
+    collector emits one - so it compared a paste-guard version against a
+    collector threshold and told an operator nothing had looked while the
+    Fleet view beside it was showing 2.1.0."""
+    findings = [finding(device="D1", surface="browser", tool="paste-guard",
+                        evidence="heartbeat version=1.3.0 mode=warn reason=installed")]
+    out = derive.agentic_from(findings, REG_BIN)
+    # The derivation no longer decides this at all: the caller supplies it,
+    # because only the caller can ask the receiver.
+    assert out["scan_coverage"] is None
+
+
+def test_no_source_at_all_is_unknown_not_zero():
+    """Classic mode has no receiver to ask. An empty list would read as "no
+    devices reported"; the difference between that and "could not look" is
+    the whole point of the field."""
+    assert derive.scheduler_coverage(None) is None
+    empty = derive.scheduler_coverage([])
+    assert empty["devices_reporting"] == 0 and empty["capable"] == 0
+
+
+def test_a_device_with_no_version_is_not_counted_as_reporting():
+    """A row that has never carried a version says nothing about whether its
+    collector can read a scheduler."""
+    c = derive.scheduler_coverage([{"id": "D1", "agent_version": ""},
+                                   {"id": "D2"},
+                                   {"id": "D3", "agent_version": "2.1.0"}])
+    assert c["devices_reporting"] == 1 and c["capable"] == 1
+
 
 
 def test_fetching_a_tool_is_not_the_same_as_running_one():

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.1
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
The page said **"no device reports a collector at 2.1.0 or newer, so nothing here has looked yet"** while the Fleet view beside it showed 2.1.0 on real machines. Two views of one estate disagreeing, and the one making the stronger claim was the wrong one.

## What it was actually reading

`scheduler_coverage` parsed `heartbeat version=` out of finding evidence. That is the **browser extension's paste-guard heartbeat** — no collector emits one. Grepping for who writes it returns `portal/extension-src/background.js` and the paste guard's own docs, and nothing else.

So it read a paste-guard version (`1.3.0`), compared it against a *collector* threshold (`2.1.0`), found nothing at or above it, and reported an absence. Worse than reading nothing: it read something real and confidently wrong.

The collector's version arrives as `agent_version` on the enrol and report path, is stored on the device row, and is what Fleet shows. It reads that now — which means the portal has to ask the receiver, because a derivation over findings cannot. Pretending otherwise is exactly what produced a plausible number from the wrong field.

```
devices: 2.1.0, 2.1.0, 2.0.0, ""
  -> devices_reporting 3, capable 2, unknown 1

"12 of 31 devices run a collector that reads schedulers, so for those this
 is an answer rather than a gap. The other 19 report a version older than
 2.1.0, which may never have looked."
```

## Unavailable is now distinct from zero

Classic mode has no receiver to ask, so `scheduler_coverage(None)` returns `None` and the page renders **nothing** — an empty page with no way to check the collectors is still an empty page, and asserting an absence from no data is the same overclaim this view keeps being fixed for. An empty *device list* still reads as zero, because that is a real answer.

## The wrapping

Two paragraphs I added carried `max-width` in `ch`, so they broke into short lines beside a lede running the full width. The measure on the headline is deliberate and stays; the ones under it are gone.

## Checked

Verified rendered, not just at the data layer: the coverage sentence, the full-width wrap, and `scan_coverage: null` in classic mode producing no sentence at all.

One test was **removed rather than adapted** — it asserted the paste-guard heartbeat path, which was the bug, so adapting it would have preserved the mistake in a new shape. Three replace it: the real source, the absent source, and a device row that has never carried a version.

Suites: registry 23, portal 617, scanner 210, receiver 291. Plus collector parity, `build.py --check`, chart copies and the identifier guard.
