### PR TITLE
Budget by plan, and the answer the review queue could not give

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.24.1
+version: 0.25.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.24.1"
+appVersion: "0.25.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/charts/ai-guard/files/registry.json
+++ b/charts/ai-guard/files/registry.json
@@ -520,8 +520,7 @@
         "Warp"
       ],
       "exe_names": [
-        "warp.exe",
-        "stable"
+        "warp.exe"
       ],
       "risk_tier": "medium",
       "bundle_ids": [

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.1
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.1
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -1058,6 +1058,16 @@ UNATTRIBUTABLE_PROCESSES = {
     # Squirrel ships its updater as "Update.exe" inside every app that uses
     # it, so the name says an application updated itself, not which one.
     "update", "updater", "squirrel",
+    # VPN and zero-trust clients. A tunnel daemon resolves DNS for
+    # everything behind the tunnel, so naming one says "something on this
+    # device, through the VPN" - the same non-answer as a stub resolver.
+    # The queue found firezone-client-tunnel; these are the rest of the
+    # category rather than waiting to be asked about one at a time.
+    "firezone-client-tunnel", "firezone-gui-client", "tailscaled",
+    "openvpn", "wireguard", "wg-quick", "nordvpn", "expressvpn",
+    "warp-svc", "cloudflared", "vpnagentd", "acwebsecagent", "pangps",
+    "pangpa", "zsatunnel", "zscaler", "stagent", "netskope", "nsdiag",
+    "globalprotect", "ivanti", "pulsesecure", "forticlient", "sonicwall",
 }
 
 
@@ -1099,7 +1109,7 @@ def process_stems(process_name):
     return [".".join(parts[:i]) for i in range(len(parts), 0, -1)]
 
 
-def bespoke_client(f, known_processes=()):
+def bespoke_client(f, known_processes=(), ruled_out=()):
     """The process name when a finding shows something OTHER than a browser
     or an application the registry knows reaching a model, else "".
 
@@ -1130,8 +1140,12 @@ def bespoke_client(f, known_processes=()):
     stems = process_stems(proc)
     if not stems:
         return ""
-    # Says a device resolved it, not what wanted the name.
+    # Says a device resolved it, not what wanted the name. The shipped set,
+    # and whatever a human has since told the review queue is the same shape
+    # of thing - a name is only ever asked about once.
     if any(s in UNATTRIBUTABLE_PROCESSES for s in stems):
+        return ""
+    if any(s in ruled_out for s in stems):
         return ""
     if proc.lower() in BROWSER_PROCESSES:
         return ""
@@ -1483,7 +1497,7 @@ def scheduler_coverage(devices):
     }
 
 
-def agentic_from(findings, reg=None):
+def agentic_from(findings, reg=None, not_attributable=()):
     """What runs without a person, and how far it can reach.
 
     Every other view here starts from something somebody did. This one
@@ -1506,6 +1520,11 @@ def agentic_from(findings, reg=None):
     """
     known = registry_processes(reg)
     inference = inference_domains_by_tool(reg)
+    # Names a human has ruled out from the review queue: a resolver, a
+    # service host, a VPN tunnel. Without this the queue asked a question
+    # whose answer went nowhere - dismissing the row cleared the card and
+    # left the process on this page for ever.
+    ruled_out = {normalise_process(n) for n in (not_attributable or ())} - {""}
 
     # Which MCP servers sit on each machine, so a chain can say what the
     # thing running there could reach.
@@ -1525,7 +1544,8 @@ def agentic_from(findings, reg=None):
         dev = (f.get("device") or "").strip()
         tool = _base_tool(f.get("tool") or "")
         mode = (f.get("mode") or "").strip()
-        proc = bespoke_client(f, known) if reached_a_model(f, inference) else ""
+        proc = bespoke_client(f, known, ruled_out) if reached_a_model(
+            f, inference) else ""
 
         if mode != "autonomous" and not proc:
             continue

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1171,6 +1171,26 @@ def evidence_snapshot(request: Request,
     return JSONResponse(doc)
 
 
+def _not_attributable(request):
+    """Process names an operator has ruled out from the review queue.
+
+    Empty when there is no receiver to ask, which is right: the shipped set
+    still applies, and a missing answer must not silently un-rule-out a name
+    somebody already decided about.
+    """
+    if not RECEIVER_URL:
+        return ()
+    token = request.cookies.get(SESSION_COOKIE, "")
+    if not token:
+        return ()
+    try:
+        out = managed.receiver_request(
+            RECEIVER_URL, "GET", "/admin/candidates/not-attributable", token)
+    except Exception:
+        return ()
+    return (out or {}).get("names") or ()
+
+
 def _fleet_devices(request):
     """The receiver's enrolled-device rows, or None when there is no receiver
     to ask.
@@ -1217,7 +1237,8 @@ def agentic(request: Request,
 
     def build():
         out = derive.agentic_from(_findings_cached(hours, request),
-                                  _registry(request))
+                                  _registry(request),
+                                  _not_attributable(request))
         # Whether an empty page is an answer or an absence. The collector
         # version lives on the receiver's device rows, not in any finding -
         # the same field Fleet shows. None means the question could not be
@@ -2678,6 +2699,14 @@ def api_candidates(_=Depends(require_auth), token: str = Depends(_admin_forward)
     return _receiver("GET", "/admin/candidates", token)
 
 
+@app.post("/api/candidates/not-attributable")
+def api_candidate_not_attributable(req: CandidateDismiss, _=Depends(require_auth),
+                                   token: str = Depends(_admin_forward)):
+    return _receiver(
+        "POST", "/admin/candidates/%s/not-attributable"
+        % urllib.parse.quote(req.key, safe=""), token)
+
+
 @app.post("/api/candidates/dismiss")
 def api_candidate_dismiss(req: CandidateDismiss, _=Depends(require_auth),
                           token: str = Depends(_admin_forward)):
@@ -2706,6 +2735,10 @@ class BudgetSeatTier(BaseModel):
 class BudgetSubscriptionWrite(BaseModel):
     model_config = {"extra": "forbid"}
     tool_id: str = Field(min_length=1, max_length=100)
+    # Names which subscription on the tool is being written. Sent when
+    # editing so a renamed plan updates its row instead of creating a
+    # second one beside it; empty when creating.
+    plan_key: str = Field(default="", max_length=64, pattern=r"^[a-z0-9-]*$")
     vendor: str = Field(default="", max_length=200)
     plan: str = Field(default="", max_length=100)
     currency: str = Field(default="", max_length=8)
@@ -2728,6 +2761,10 @@ class BudgetMemberWrite(BaseModel):
 class BudgetMembersWrite(BaseModel):
     model_config = {"extra": "forbid"}
     tool_id: str = Field(min_length=1, max_length=100)
+    # Which subscription on that tool. The portal only carries it; the
+    # receiver decides what an empty one means.
+    plan_key: str = Field(default="", max_length=64,
+                          pattern=r"^[a-z0-9-]*$")
     source: str = Field(min_length=1, max_length=16)
     members: list[BudgetMemberWrite] = Field(default_factory=list,
                                              max_length=5000)
@@ -2736,6 +2773,10 @@ class BudgetMembersWrite(BaseModel):
 class BudgetConnectionWrite(BaseModel):
     model_config = {"extra": "forbid"}
     tool_id: str = Field(min_length=1, max_length=100)
+    # Which subscription on that tool. The portal only carries it; the
+    # receiver decides what an empty one means.
+    plan_key: str = Field(default="", max_length=64,
+                          pattern=r"^[a-z0-9-]*$")
     provider: str = Field(min_length=1, max_length=32)
     api_key: str = Field(min_length=8, max_length=512)
 
@@ -2743,6 +2784,10 @@ class BudgetConnectionWrite(BaseModel):
 class BudgetToolRef(BaseModel):
     model_config = {"extra": "forbid"}
     tool_id: str = Field(min_length=1, max_length=100)
+    # Which subscription on that tool. The portal only carries it; the
+    # receiver decides what an empty one means.
+    plan_key: str = Field(default="", max_length=64,
+                          pattern=r"^[a-z0-9-]*$")
 
 
 @app.get("/api/budget")

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -7793,6 +7793,27 @@ async function _refusal(r) {
   return typeof d === 'string' ? d : 'check the values';
 }
 
+// Re-read what a write just invalidated.
+//
+// Nulling a cached view and calling render() works for everything render()
+// fetches on demand - the register re-reads itself when REG is null. It does
+// NOT work for the candidates queue, which is only ever fetched by load(),
+// behind a check for whether the review-queue widget is on the overview. So
+// "add to registry" cleared the queue, drew an empty one, and left the
+// remaining candidates invisible until the operator reloaded the page by
+// hand. Three handlers had the same shape; this is the one place that knows
+// the queue needs asking for again.
+async function reloadDerived() {
+  REG = null; REGTOOLS = null; EV = null; CAND = null;
+  if (CFG.managed && CFG.managed.enabled && AUTH && AUTH.mode === 'login'
+      && (CFG.overview_widgets || []).some(w => w.kind === 'review_queue')) {
+    try {
+      const cq = await mfetch('/api/candidates');
+      if (cq.ok) CAND = (await cq.json()).candidates || [];
+    } catch (e) { /* the queue simply stays unread until the next load */ }
+  }
+}
+
 async function managedAction(act, el) {
   if (act.startsWith('b-')) return budgetAction(act, el);
   if (act === 'id-download') {
@@ -8383,7 +8404,7 @@ async function managedAction(act, el) {
       REDIT = null; RPRE = null; RERR = ''; RADV = false;
       // The registry feeds everything derived; those views are stale now,
       // the candidates queue included - a saved entry may have resolved one.
-      REG = null; REGTOOLS = null; EV = null; CAND = null;
+      await reloadDerived();
     } else {
       if (r.status === 401) { sessionLost(); return; }
       let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
@@ -8403,7 +8424,7 @@ async function managedAction(act, el) {
       let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
       alert('Could not delete: ' + d);
     } else { RENTRIES = (await r.json()).entries || []; }
-    REG = null; REGTOOLS = null; EV = null; CAND = null;
+    await reloadDerived();
     render(); return;
   }
   if (act === 'gov-edit') {

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2319,7 +2319,8 @@ const WIDGETS = {
         <td style="color:var(--mut)">${c.devices || 0} device${c.devices === 1 ? '' : 's'}
           ${c.confidence ? ' · ' + esc(c.confidence) : ''}</td>
         <td style="white-space:nowrap">
-          <button class="btn" data-act="cand-add" data-key="${esc(c.key)}">Add to registry</button>
+          ${c.kind === 'process' ? `<button class="mini" data-act="cand-noattr"
+            data-key="${esc(c.key)}" title="This name identifies no program - a resolver, a service host, a VPN tunnel that resolves for everything behind it. Recorded once and honoured everywhere a process name is read.">Names nothing</button> ` : ''}<button class="btn" data-act="cand-add" data-key="${esc(c.key)}">Add to registry</button>
           <button class="btn" data-act="cand-dismiss" data-key="${esc(c.key)}">Dismiss</button>
         </td></tr>`).join('')}</table>
       ${cands.length > 6 ? `<p class="src-note">And ${cands.length - 6} more in the queue.</p>` : ''}`;
@@ -6777,7 +6778,15 @@ function bwRail() {
 function bwBodyTool() {
   const w = BWIZ;
   const tools = (REGTOOLS || []).slice().sort((a, b) => a.name.localeCompare(b.name));
-  const linked = new Set((BUDGET.subscriptions || []).map(s => s.tool_id));
+  // Which PLANS are already recorded per tool, not which tools are taken.
+  // An organisation does not have "a Claude subscription" - it has a Teams
+  // contract and a handful of Max seats - so a tool is only exhausted when
+  // there is nothing left to add, which there never is: the plan is free
+  // text. What a second link must not do is repeat a plan already there.
+  const plansOn = {};
+  (BUDGET.subscriptions || []).forEach(s => {
+    (plansOn[s.tool_id] = plansOn[s.tool_id] || []).push(s.plan || s.plan_key);
+  });
   const picker = w.editing ? `<span class="mono">${esc(w.tool_id)}</span>` : (() => {
     // Observed tools first: the one being linked is almost always one the
     // estate already uses, and the whole registry in one flat list buries it.
@@ -6787,11 +6796,16 @@ function bwBodyTool() {
       bCovers(o).forEach(t => { coveredBy[t] = o.tool_id; });
     });
     const opt = t => {
-      const taken = t.id !== w.tool_id && (linked.has(t.id) || coveredBy[t.id]);
-      const label = !taken ? '' : linked.has(t.id) ? ' (linked)'
-        : ` (covered by ${coveredBy[t.id]})`;
+      // Only a licence billed twice is refused. A tool that already has a
+      // plan stays selectable and says which plans it has, so adding Max 20
+      // beside Team is an ordinary link rather than a wall.
+      const covered = t.id !== w.tool_id && coveredBy[t.id]
+        && coveredBy[t.id] !== t.id;
+      const have = plansOn[t.id] || [];
+      const label = covered ? ` (covered by ${coveredBy[t.id]})`
+        : have.length ? ` — ${have.join(', ')} linked` : '';
       return `<option value="${esc(t.id)}"${t.id === w.tool_id ? ' selected' : ''}
-        ${taken ? 'disabled' : ''}>${esc(t.name)}${esc(label)}</option>`;
+        ${covered ? 'disabled' : ''}>${esc(t.name)}${esc(label)}</option>`;
     };
     const obs = tools.filter(t => seen.has(t.id));
     const rest = tools.filter(t => !seen.has(t.id));
@@ -7141,9 +7155,30 @@ function bProvenance(sub, conn) {
   return bits.join(' · ');
 }
 
+// A subscription is a tool AND a plan. Every card button used to carry the
+// tool alone, and every handler looked it up with find(s => s.tool_id === k)
+// - which returns whichever plan happens to be first. Editing the Max seats
+// would have opened the Teams contract, and importing users into one would
+// have replaced the other's list.
+const bKey = s => s.tool_id + '|' + (s.plan_key || 'default');
+const bSplit = k => {
+  const i = String(k || '').indexOf('|');
+  return i < 0 ? {tool_id: k, plan_key: ''}
+               : {tool_id: k.slice(0, i), plan_key: k.slice(i + 1)};
+};
+const bFind = k => {
+  const {tool_id, plan_key} = bSplit(k);
+  return (BUDGET.subscriptions || []).find(
+    s => s.tool_id === tool_id
+      && (!plan_key || (s.plan_key || 'default') === plan_key)) || null;
+};
+const bConn = sub => ((BUDGET.connections || []).find(
+  c => c.tool_id === sub.tool_id
+    && (c.plan_key || 'default') === (sub.plan_key || 'default'))) || null;
+
 function budgetCard(sub) {
   const ro = AUTH && AUTH.role === 'viewer';
-  const conn = ((BUDGET.connections || []).find(c => c.tool_id === sub.tool_id)) || null;
+  const conn = bConn(sub);
   const tiers = sub.seat_tiers || [];
   const monthly = tiers.reduce((a, t) => a + (t.seats || 0) * (t.unit_price_monthly || 0), 0);
   const seats = tiers.reduce((a, t) => a + (t.seats || 0), 0);
@@ -7187,7 +7222,7 @@ function budgetCard(sub) {
     <td>${esc(m.role || '—')}</td><td>${esc(m.seat_tier || '—')}</td>
     <td>${esc(usageBits(m)) || '<span class="src-note">—</span>'}</td>
     <td>${m.source === 'manual' && !ro
-      ? `<button class="mini" data-act="b-mdel" data-tool="${esc(sub.tool_id)}" data-key="${esc(m.email)}">Remove</button>`
+      ? `<button class="mini" data-act="b-mdel" data-tool="${esc(bKey(sub))}" data-key="${esc(m.email)}">Remove</button>`
       : `<span class="pill p-mut">${esc(m.source)}</span>`}</td></tr>`;
   // The same licence linked twice, from before covers existed: name the
   // fold-together steps on the card rather than leave the double count
@@ -7290,15 +7325,15 @@ function budgetCard(sub) {
     with no person attached - not counted anywhere
     above. An identity map (Sources view) links them.</p>` : ''}
   ${ro ? '' : `<div style="margin-top:10px;display:flex;gap:6px;flex-wrap:wrap">
-    ${conn ? `<button class="mini" data-act="b-sync" data-key="${esc(sub.tool_id)}">Sync users now</button>` : ''}
-    <button class="mini" data-act="b-edit" data-key="${esc(sub.tool_id)}">Edit</button>
-    <button class="mini" data-act="b-import" data-key="${esc(sub.tool_id)}">Import users</button>
-    <button class="mini" data-act="b-unlink" data-key="${esc(sub.tool_id)}">Unlink</button>
+    ${conn ? `<button class="mini" data-act="b-sync" data-key="${esc(bKey(sub))}">Sync users now</button>` : ''}
+    <button class="mini" data-act="b-edit" data-key="${esc(bKey(sub))}">Edit</button>
+    <button class="mini" data-act="b-import" data-key="${esc(bKey(sub))}">Import users</button>
+    <button class="mini" data-act="b-unlink" data-key="${esc(bKey(sub))}">Unlink</button>
   </div>
   <div style="margin-top:8px;display:flex;gap:6px;flex-wrap:wrap;align-items:center">
-    <input id="bm-email-${esc(sub.tool_id)}" class="mfield" placeholder="add member: email" autocomplete="off">
-    <input id="bm-tier-${esc(sub.tool_id)}" class="mfield" style="min-width:110px" placeholder="seat tier">
-    <button class="mini" data-act="b-madd" data-key="${esc(sub.tool_id)}">Add</button>
+    <input id="bm-email-${esc(bKey(sub))}" class="mfield" placeholder="add member: email" autocomplete="off">
+    <input id="bm-tier-${esc(bKey(sub))}" class="mfield" style="min-width:110px" placeholder="seat tier">
+    <button class="mini" data-act="b-madd" data-key="${esc(bKey(sub))}">Add</button>
   </div>`}
   </div>`;
 }
@@ -7429,8 +7464,7 @@ function budgetReport() {
       ${bMoney(monthly, sub.currency)} per month
       ${sub.renewal_date ? ` · renews ${esc(sub.renewal_date)}` : ''}
       ${sub.owner ? ` · owner ${esc(sub.owner)}` : ''}
-      · ${bProvenance(sub, (BUDGET.connections || [])
-          .find(c => c.tool_id === sub.tool_id) || null) || 'manual entries'}</p>
+      · ${bProvenance(sub, bConn(sub)) || 'manual entries'}</p>
     <table class="plain"><tr><th>on the licence</th><th>observed using it</th>
       <th>never observed</th><th>using it without a seat</th><th>personal accounts</th></tr>
       <tr><td class="num">${(sub.members || []).length}</td>
@@ -7597,10 +7631,13 @@ async function budgetAction(act, el) {
     // one - and pressing through to the end overwrote the subscription that
     // existed, with nothing on screen saying so. The review step made it
     // visible; the fix belongs here.
+    // Only what a licence already COVERS is taken. A tool that has one plan
+    // recorded is not used up - a Teams contract and a handful of Max seats
+    // are two subscriptions for the same product - so it stays offerable and
+    // the picker says which plans it already has.
     const taken = new Set();
     (BUDGET.subscriptions || []).forEach(o => {
-      taken.add(o.tool_id);
-      bCovers(o).forEach(t => taken.add(t));
+      bCovers(o).filter(t => t !== o.tool_id).forEach(t => taken.add(t));
     });
     const free = (REGTOOLS || []).slice()
       .sort((a, b) => a.name.localeCompare(b.name))
@@ -7612,10 +7649,12 @@ async function budgetAction(act, el) {
     render(); return;
   }
   if (act === 'b-edit') {
-    const sub = (BUDGET.subscriptions || []).find(s => s.tool_id === key);
-    const conn = (BUDGET.connections || []).find(c => c.tool_id === key);
+    const sub = bFind(key);
+    if (!sub) return;
+    const conn = bConn(sub);
     BMSG = '';
-    BWIZ = {step: 1, editing: true, tool_id: key, vendor: sub.vendor,
+    BWIZ = {step: 1, editing: true, tool_id: sub.tool_id,
+            plan_key: sub.plan_key || 'default', vendor: sub.vendor,
             plan: sub.plan, source: conn ? 'api' : 'csv',
             provider: conn ? conn.provider : 'anthropic', api_key: '',
             key_set: !!conn, tiers: sub.seat_tiers || [],
@@ -7665,7 +7704,8 @@ async function budgetAction(act, el) {
     const w = BWIZ;
     if (!w.tool_id) { BMSG = 'Pick a tool first.'; render(); return; }
     let r = await post('/api/budget/subscription', {
-      tool_id: w.tool_id, vendor: w.vendor || '', plan: w.plan || '',
+      tool_id: w.tool_id, plan_key: w.plan_key || '',
+      vendor: w.vendor || '', plan: w.plan || '',
       currency: (w.currency || '').toUpperCase(), renewal_date: w.renewal || '',
       owner: w.owner || '', covers: w.covers || [],
       seat_tiers: w.tiers || []});
@@ -7673,25 +7713,28 @@ async function budgetAction(act, el) {
     if (!r.ok) { BMSG = 'Not saved: ' + await _refusal(r); render(); return; }
     if (w.source === 'api' && w.api_key) {
       r = await post('/api/budget/connection', {
-        tool_id: w.tool_id, provider: w.provider, api_key: w.api_key});
+        tool_id: w.tool_id, plan_key: w.plan_key || '',
+        provider: w.provider, api_key: w.api_key});
       if (!r) return;
       if (!r.ok) { BMSG = 'Subscription saved, but the connection was refused: '
         + await _refusal(r); BUDGET = null; BWIZ = null; render(); return; }
-      const s = await post('/api/budget/sync', {tool_id: w.tool_id});
+      const s = await post('/api/budget/sync',
+                           {tool_id: w.tool_id, plan_key: w.plan_key || ''});
       if (!s) return;
       const out = s.ok ? await s.json() : {ok: false, detail: await _refusal(s)};
       BMSG = out.ok ? `Linked. Synced ${out.count} members from the vendor.`
         : 'Linked, but the first sync failed: ' + out.detail;
     } else if (w.source === 'csv' && !w.editing) {
       BWIZ = null; BUDGET = null;
-      BCSV = {tool_id: w.tool_id, text: '', parsed: null};
+      BCSV = {tool_id: w.tool_id, plan_key: w.plan_key || '',
+              text: '', parsed: null};
       BMSG = '';
       render(); return;
     } else BMSG = w.editing ? 'Saved.' : 'Linked. Add users from the card.';
     BWIZ = null; BUDGET = null; render(); return;
   }
   if (act === 'b-sync') {
-    const r = await post('/api/budget/sync', {tool_id: key});
+    const r = await post('/api/budget/sync', bSplit(key));
     if (!r) return;
     const out = r.ok ? await r.json() : {ok: false, detail: await _refusal(r)};
     BMSG = out.ok ? `Synced ${out.count} members for ${key}.`
@@ -7699,14 +7742,14 @@ async function budgetAction(act, el) {
     BUDGET = null; render(); return;
   }
   if (act === 'b-unlink') {
-    const r = await post('/api/budget/subscription-delete', {tool_id: key});
+    const r = await post('/api/budget/subscription-delete', bSplit(key));
     if (!r) return;
     BMSG = r.ok ? `Unlinked ${key}. Its users and any stored key went with it.`
       : 'Not unlinked: ' + await _refusal(r);
     BUDGET = null; render(); return;
   }
   if (act === 'b-import') {
-    BMSG = ''; BCSV = {tool_id: key, text: '', parsed: null};
+    BMSG = ''; BCSV = Object.assign(bSplit(key), {text: '', parsed: null});
     render(); return;
   }
   if (act === 'b-csv-parse') {
@@ -7717,7 +7760,8 @@ async function budgetAction(act, el) {
   if (act === 'b-csv-cancel') { BCSV = null; BMSG = ''; render(); return; }
   if (act === 'b-csv-save') {
     const r = await post('/api/budget/members', {
-      tool_id: BCSV.tool_id, source: 'csv', members: BCSV.parsed.members});
+      tool_id: BCSV.tool_id, plan_key: BCSV.plan_key || '',
+      source: 'csv', members: BCSV.parsed.members});
     if (!r) return;
     BMSG = r.ok ? `Imported ${BCSV.parsed.members.length} members for ${BCSV.tool_id}.`
       : 'Not imported: ' + await _refusal(r);
@@ -7727,27 +7771,30 @@ async function budgetAction(act, el) {
   if (act === 'b-madd') {
     const email = _val('bm-email-' + key), tier = _val('bm-tier-' + key);
     if (!email) return;
-    const sub = (BUDGET.subscriptions || []).find(s => s.tool_id === key);
+    const sub = bFind(key);
+    if (!sub) return;
     const manual = (sub.members || []).filter(m => m.source === 'manual')
       .map(m => ({email: m.email, name: m.name, role: m.role,
                   seat_tier: m.seat_tier}));
     manual.push({email, seat_tier: tier});
     const r = await post('/api/budget/members',
-                         {tool_id: key, source: 'manual', members: manual});
+                         Object.assign(bSplit(key),
+                                       {source: 'manual', members: manual}));
     if (!r) return;
     BMSG = r.ok ? '' : 'Not added: ' + await _refusal(r);
     if (r.ok) BUDGET = null;
     render(); return;
   }
   if (act === 'b-mdel') {
-    const tool = el.getAttribute('data-tool');
-    const sub = (BUDGET.subscriptions || []).find(s => s.tool_id === tool);
+    const sub = bFind(el.getAttribute('data-tool'));
+    if (!sub) return;
     const manual = (sub.members || [])
       .filter(m => m.source === 'manual' && m.email !== key)
       .map(m => ({email: m.email, name: m.name, role: m.role,
                   seat_tier: m.seat_tier}));
     const r = await post('/api/budget/members',
-                         {tool_id: tool, source: 'manual', members: manual});
+                         Object.assign(bSplit(el.getAttribute('data-tool')),
+                                       {source: 'manual', members: manual}));
     if (!r) return;
     if (r.ok) BUDGET = null;
     render(); return;
@@ -8379,6 +8426,24 @@ async function managedAction(act, el) {
     view = 'registry'; detail = null;
     history.replaceState(null, '', '#registry');
     drawNav(); render(); return;
+  }
+  if (act === 'cand-noattr') {
+    // Not a dismissal. Dismissing says "not a tool" and closes the card;
+    // this says the name identifies no program, which the agentic view has
+    // to know too - otherwise the answer goes nowhere and the process stays
+    // on that page for ever.
+    const key = el.getAttribute('data-key');
+    const r = await mfetch('/api/candidates/not-attributable',
+      {method: 'POST', body: JSON.stringify({key})});
+    if (!r.ok) {
+      if (r.status === 401) { sessionLost(); return; }
+      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+      alert('Could not record that: ' + d);
+    } else {
+      CAND = (CAND || []).filter(x => x.key !== key);
+      AGENTIC = null;   // that page shows this process today
+    }
+    render(); return;
   }
   if (act === 'cand-dismiss') {
     const key = el.getAttribute('data-key');

--- a/portal/tests/test_budget.py
+++ b/portal/tests/test_budget.py
@@ -86,7 +86,11 @@ def test_the_body_reaches_the_receiver_intact(receiver_spy):
         tool_id="fireflies", provider="fireflies",
         api_key="ff-key-123"), token=token)
     body = receiver_spy[-1]["body"]
-    assert body == {"tool_id": "fireflies", "provider": "fireflies",
+    # plan_key rides along empty: the portal only carries it, and the
+    # receiver decides what an empty one means (the tool's only
+    # subscription, or a refusal when there are several).
+    assert body == {"tool_id": "fireflies", "plan_key": "",
+                    "provider": "fireflies",
                     "api_key": "ff-key-123"}
 
 

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -1710,3 +1710,50 @@ def test_a_subdomain_of_an_inference_host_still_counts_as_use():
                 evidence="DNS lookup for eu.server.codeium.com (via python3)"),
     ], reg)
     assert len(out["agents"]) == 1
+
+
+@pytest.mark.parametrize("proc", [
+    "firezone-client-tunnel", "tailscaled", "openvpn", "warp-svc",
+    "vpnagentd", "PanGPS", "forticlient",
+])
+def test_a_vpn_tunnel_resolves_for_everything_behind_it(proc):
+    """The review queue found firezone-client-tunnel on a real estate. A
+    tunnel daemon resolves DNS for everything behind the tunnel, so naming
+    one says "something on this device, through the VPN" - the same
+    non-answer as a stub resolver, and a whole category rather than one
+    name."""
+    out = derive.agentic_from([
+        finding(tool="claude", surface="network", device="D1",
+                evidence="DNS lookup for api.anthropic.com (via %s)" % proc),
+    ], REG_BIN)
+    assert out["agents"] == []
+
+
+def test_a_name_a_human_ruled_out_stops_appearing():
+    """The queue asked, somebody answered, and the answer has to reach this
+    page. Before this, dismissing a process candidate cleared the card and
+    left the process here for ever - a question whose answer went nowhere."""
+    f = finding(tool="claude", surface="network", device="D1",
+                evidence="DNS lookup for api.anthropic.com (via corp-proxy-agent)")
+    assert derive.agentic_from([f], REG_BIN)["agents"][0]["process"] \
+        == "corp-proxy-agent"
+    out = derive.agentic_from([f], REG_BIN, not_attributable=["corp-proxy-agent"])
+    assert out["agents"] == []
+
+
+def test_ruling_out_a_name_matches_it_in_every_shape():
+    """The decision is about the name, so it has to survive the same
+    normalisation everything else does."""
+    f = finding(tool="claude", surface="network", device="D1",
+                evidence="DNS lookup for api.anthropic.com (via Corp Proxy Helper.exe)")
+    out = derive.agentic_from([f], REG_BIN, not_attributable=["corp proxy"])
+    assert out["agents"] == []
+
+
+def test_a_real_bespoke_client_is_untouched_by_other_rulings():
+    """Ruling out one name must not quietly excuse the rest."""
+    out = derive.agentic_from([
+        finding(tool="claude", surface="network", device="D1",
+                evidence="DNS lookup for api.anthropic.com (via curl)"),
+    ], REG_BIN, not_attributable=["firezone-client-tunnel"])
+    assert out["agents"][0]["process"] == "curl"

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -830,6 +830,16 @@ _UNATTRIBUTABLE = {
     "backgroundtaskhost", "taskhostw", "taskhost", "taskeng", "rundll32",
     "dllhost", "wermgr",
     "update", "updater", "squirrel",
+    # VPN and zero-trust clients. A tunnel daemon resolves DNS for
+    # everything behind the tunnel, so naming one says "something on this
+    # device, through the VPN" - the same non-answer as a stub resolver.
+    # The queue found firezone-client-tunnel; these are the rest of the
+    # category rather than waiting to be asked about one at a time.
+    "firezone-client-tunnel", "firezone-gui-client", "tailscaled",
+    "openvpn", "wireguard", "wg-quick", "nordvpn", "expressvpn",
+    "warp-svc", "cloudflared", "vpnagentd", "acwebsecagent", "pangps",
+    "pangpa", "zsatunnel", "zscaler", "stagent", "netskope", "nsdiag",
+    "globalprotect", "ivanti", "pulsesecure", "forticlient", "sonicwall",
 }
 _VIA_RE = re.compile(r"\(via ([^)]{1,80})\)")
 def _strip_helper_suffix(n):
@@ -2856,6 +2866,10 @@ def _note_process_candidates(f: Finding):
         return
     if name.lower() in _BROWSERS or any(x in _BROWSERS for x in stems):
         return
+    # Already answered. Asking again is how a review queue becomes something
+    # nobody reads.
+    if name.strip().lower() in set(STATE.dispositioned_names("not_attributable")):
+        return
     if not _CANDIDATE_TEXT.match(name):
         return
     if STATE.observe_candidate(
@@ -2901,6 +2915,37 @@ def dismiss_candidate(key: str, authorization: str = Header(default="")):
     if not STATE.dismiss_candidate(key, _admin_actor(authorization)):
         raise HTTPException(404, "no undismissed candidate with that key")
     return {"dismissed": key}
+
+
+@app.post("/admin/candidates/{key}/not-attributable")
+def mark_candidate_not_attributable(key: str,
+                                    authorization: str = Header(default="")):
+    """This name identifies no program: a resolver, a service host, a VPN
+    tunnel that resolves for everything behind it.
+
+    Distinct from a dismissal, which says "not a tool" and stops there. A
+    dismissed curl is still a real process worth showing on the agentic view;
+    a dismissed VPN tunnel is not, and saying so has to reach the views that
+    read process names rather than just closing a card. Only processes: the
+    claim is about a name, and a domain or an MCP server is not one.
+    """
+    _admin_auth(authorization, write=True)
+    if not re.fullmatch(r"[a-z0-9_:-]{1,100}", key):
+        raise HTTPException(422, "malformed candidate key")
+    if not key.startswith("process:"):
+        raise HTTPException(
+            422, "only a process candidate can be marked not attributable")
+    if not STATE.set_candidate_disposition(
+            key, "not_attributable", _admin_actor(authorization)):
+        raise HTTPException(404, "no candidate with that key")
+    return {"not_attributable": key}
+
+
+@app.get("/admin/candidates/not-attributable")
+def get_not_attributable(authorization: str = Header(default="")):
+    """The names a human has ruled out, for the views that read them."""
+    _admin_auth(authorization)
+    return {"names": STATE.dispositioned_names("not_attributable")}
 
 
 class FindingStatusWrite(BaseModel):
@@ -3084,9 +3129,42 @@ class SeatTierWrite(BaseModel):
     covers: list[str] = Field(default_factory=list, max_length=10)
 
 
+def _resolve_plan_key(tool_id: str, given: str) -> str:
+    """Which subscription on this tool a write means.
+
+    Given explicitly, that. Otherwise the tool's only subscription, because
+    a request that predates plans - or a UI that has not asked yet - means
+    the one that exists. Ambiguous only when there really are several, and
+    then it refuses rather than guessing: writing a member list into the
+    wrong plan silently moves seats between contracts, and the money answer
+    would still look plausible.
+
+    Defaulting to "default" instead would be worse than either: it writes
+    into a subscription nobody has, and the rows simply stop appearing.
+    """
+    keys = [x.get("plan_key") or "default"
+            for x in STATE.list_budget()["subscriptions"]
+            if x["tool_id"] == tool_id]
+    if given:
+        return given
+    if len(keys) == 1:
+        return keys[0]
+    if not keys:
+        return "default"
+    raise HTTPException(
+        422, "%s has %d subscriptions (%s) - say which plan this is for"
+             % (tool_id, len(keys), ", ".join(sorted(keys))))
+
+
 class BudgetSubscriptionWrite(BaseModel):
     model_config = {"extra": "forbid"}
     tool_id: str = Field(min_length=1, max_length=100)
+    # Which subscription on that tool. Empty means "the one this plan names",
+    # so creating the second plan on a tool is an ordinary save. Sent
+    # explicitly when editing, which is what lets a plan be RENAMED - without
+    # it, changing "Team" to "Teams" would quietly create a second
+    # subscription beside the first rather than updating it.
+    plan_key: str = Field(default="", max_length=64, pattern=r"^[a-z0-9-]*$")
     vendor: str = Field(default="", max_length=200)
     plan: str = Field(default="", max_length=100)
     currency: str = Field(default="", max_length=8)
@@ -3112,6 +3190,11 @@ class BudgetMemberWrite(BaseModel):
 class BudgetMembersWrite(BaseModel):
     model_config = {"extra": "forbid"}
     tool_id: str = Field(min_length=1, max_length=100)
+    # Which subscription on that tool. Empty means the one whose plan
+    # this write names, which is what makes creating the second plan
+    # on a tool an ordinary save rather than a special case.
+    plan_key: str = Field(default="", max_length=64,
+                          pattern=r"^[a-z0-9-]*$")
     # csv and manual only: "api" rows are written by sync alone, and a
     # request that could claim to be a sync would let a CSV wear an
     # API-synced provenance label in the portal.
@@ -3123,6 +3206,11 @@ class BudgetMembersWrite(BaseModel):
 class BudgetConnectionWrite(BaseModel):
     model_config = {"extra": "forbid"}
     tool_id: str = Field(min_length=1, max_length=100)
+    # Which subscription on that tool. Empty means the one whose plan
+    # this write names, which is what makes creating the second plan
+    # on a tool an ordinary save rather than a special case.
+    plan_key: str = Field(default="", max_length=64,
+                          pattern=r"^[a-z0-9-]*$")
     provider: str = Field(min_length=1, max_length=32)
     api_key: str = Field(min_length=8, max_length=512)
 
@@ -3130,6 +3218,11 @@ class BudgetConnectionWrite(BaseModel):
 class BudgetToolRef(BaseModel):
     model_config = {"extra": "forbid"}
     tool_id: str = Field(min_length=1, max_length=100)
+    # Which subscription on that tool. Empty means the one whose plan
+    # this write names, which is what makes creating the second plan
+    # on a tool an ordinary save rather than a special case.
+    plan_key: str = Field(default="", max_length=64,
+                          pattern=r"^[a-z0-9-]*$")
 
 
 @app.get("/admin/budget")
@@ -3176,16 +3269,27 @@ def put_budget_subscription(req: BudgetSubscriptionWrite,
                                 % c[:60])
         if c not in covers:
             covers.append(c)
+    pk = req.plan_key or _state.plan_key(req.plan)
     for other in STATE.list_budget()["subscriptions"]:
-        if other["tool_id"] == req.tool_id:
-            continue
+        same_tool = other["tool_id"] == req.tool_id
+        if same_tool and other.get("plan_key") == pk:
+            continue                      # this subscription, being edited
+        mine = set(covers)
         theirs = set(other.get("covers") or []) | {other["tool_id"]}
-        clash = sorted(set(covers) & theirs)
+        if same_tool:
+            # Two plans on one tool BOTH cover that tool, and that is the
+            # whole point: a Teams contract and a handful of Max seats are
+            # two subscriptions for the same product. The double-billing
+            # rule still holds for everything else they claim to cover.
+            mine.discard(req.tool_id)
+            theirs.discard(req.tool_id)
+        clash = sorted(mine & theirs)
         if clash:
             raise HTTPException(
-                422, "%s is already covered by the %s subscription - one "
+                422, "%s is already covered by the %s %s subscription - one "
                      "licence, one subscription; fold them together "
-                     "instead" % (", ".join(clash), other["tool_id"]))
+                     "instead" % (", ".join(clash), other["tool_id"],
+                                  other.get("plan") or other.get("plan_key")))
     for t in req.seat_tiers:
         for c in t.covers:
             if c.strip() not in covers:
@@ -3205,7 +3309,7 @@ def put_budget_subscription(req: BudgetSubscriptionWrite,
                          "unit_price_monthly": t.unit_price_monthly,
                          "covers": [c.strip() for c in t.covers]}
                         for n, t in zip(names, req.seat_tiers)]},
-        _admin_actor(authorization))
+        _admin_actor(authorization), key=req.plan_key)
     return get_budget(authorization)
 
 
@@ -3213,9 +3317,10 @@ def put_budget_subscription(req: BudgetSubscriptionWrite,
 def delete_budget_subscription(req: BudgetToolRef,
                                authorization: str = Header(default="")):
     _admin_auth(authorization, write=True)
-    if not STATE.delete_budget_subscription(req.tool_id,
-                                            _admin_actor(authorization)):
-        raise HTTPException(404, "no subscription for that tool")
+    if not STATE.delete_budget_subscription(
+            req.tool_id, _admin_actor(authorization),
+            key=_resolve_plan_key(req.tool_id, req.plan_key)):
+        raise HTTPException(404, "no subscription for that tool and plan")
     return get_budget(authorization)
 
 
@@ -3241,8 +3346,9 @@ def put_budget_members(req: BudgetMembersWrite,
         members.append({"email": email, "name": m.name.strip(),
                         "role": m.role.strip(),
                         "seat_tier": m.seat_tier.strip()})
-    count = STATE.replace_budget_members(req.tool_id, members, req.source,
-                                         _admin_actor(authorization))
+    count = STATE.replace_budget_members(
+        req.tool_id, members, req.source, _admin_actor(authorization),
+        key=_resolve_plan_key(req.tool_id, req.plan_key))
     return {"ok": True, "count": count}
 
 
@@ -3260,7 +3366,9 @@ def put_budget_connection(req: BudgetConnectionWrite,
         raise HTTPException(422, "the API key contains whitespace or "
                                  "control characters - check the paste")
     STATE.set_budget_connection(req.tool_id, req.provider, key,
-                                _admin_actor(authorization))
+                                _admin_actor(authorization),
+                                key=_resolve_plan_key(req.tool_id,
+                                                      req.plan_key))
     return {"ok": True}
 
 
@@ -3268,9 +3376,10 @@ def put_budget_connection(req: BudgetConnectionWrite,
 def delete_budget_connection(req: BudgetToolRef,
                              authorization: str = Header(default="")):
     _admin_auth(authorization, write=True)
-    if not STATE.delete_budget_connection(req.tool_id,
-                                          _admin_actor(authorization)):
-        raise HTTPException(404, "no connection for that tool")
+    if not STATE.delete_budget_connection(
+            req.tool_id, _admin_actor(authorization),
+            key=_resolve_plan_key(req.tool_id, req.plan_key)):
+        raise HTTPException(404, "no connection for that tool and plan")
     return {"ok": True}
 
 
@@ -3302,7 +3411,8 @@ async def budget_sync(req: BudgetToolRef,
     the result is recorded either way so the card can show it later."""
     _admin_auth(authorization, write=True)
     by = _admin_actor(authorization)
-    conn = STATE.sync_connection_key(req.tool_id)
+    pk = _resolve_plan_key(req.tool_id, req.plan_key)
+    conn = STATE.sync_connection_key(req.tool_id, pk)
     if conn is None:
         raise HTTPException(404, "no connection for that tool: save one "
                                  "first")
@@ -3313,10 +3423,10 @@ async def budget_sync(req: BudgetToolRef,
         # e.detail, not str(e): the field is assigned only from budget.py's
         # own message templates, so the response provably cannot carry a
         # stack trace however the sync failed.
-        STATE.record_budget_sync(req.tool_id, False, e.detail, 0, by)
+        STATE.record_budget_sync(req.tool_id, False, e.detail, 0, by, key=pk)
         return {"ok": False, "detail": e.detail}
-    STATE.replace_budget_members(req.tool_id, members, "api", by)
-    STATE.record_budget_sync(req.tool_id, True, "", len(members), by)
+    STATE.replace_budget_members(req.tool_id, members, "api", by, key=pk)
+    STATE.record_budget_sync(req.tool_id, True, "", len(members), by, key=pk)
     return {"ok": True, "count": len(members)}
 
 

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -152,7 +152,12 @@ CREATE TABLE IF NOT EXISTS candidates (
   first_seen   TEXT NOT NULL,
   last_seen    TEXT NOT NULL,
   dismissed_at TEXT,
-  dismissed_by TEXT NOT NULL DEFAULT ''
+  dismissed_by TEXT NOT NULL DEFAULT '',
+  -- "" | "not_attributable". Dismissing says "not a tool"; this says the
+  -- name identifies no program at all - a resolver, a service host, a VPN
+  -- tunnel that resolves for everything behind it. Different claim, and
+  -- unlike a dismissal it has to reach the views that read process names.
+  disposition  TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS finding_status (
   key    TEXT PRIMARY KEY,
@@ -167,8 +172,18 @@ CREATE TABLE IF NOT EXISTS identity_map (
   updated_at TEXT NOT NULL,
   updated_by TEXT NOT NULL DEFAULT ''
 );
+-- One row per SUBSCRIPTION, not per tool. An organisation does not have "a
+-- Claude subscription": it has a Teams contract and a handful of Max seats,
+-- on different plans, different renewal dates, often different owners. Keying
+-- on tool_id alone meant tracking one and being blind to the other, and the
+-- spend total was wrong either way without saying so.
+--
+-- plan_key is the normalised plan - lowercased, punctuation folded to
+-- hyphens, empty becoming "default" so a subscription recorded before plans
+-- mattered keeps working untouched.
 CREATE TABLE IF NOT EXISTS budget_subscriptions (
-  tool_id      TEXT PRIMARY KEY,
+  tool_id      TEXT NOT NULL,
+  plan_key     TEXT NOT NULL DEFAULT 'default',
   vendor       TEXT NOT NULL DEFAULT '',
   plan         TEXT NOT NULL DEFAULT '',
   currency     TEXT NOT NULL DEFAULT '',
@@ -179,10 +194,12 @@ CREATE TABLE IF NOT EXISTS budget_subscriptions (
   covers       TEXT NOT NULL DEFAULT '[]',
   created_at   TEXT NOT NULL,
   updated_at   TEXT NOT NULL,
-  updated_by   TEXT NOT NULL DEFAULT ''
+  updated_by   TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (tool_id, plan_key)
 );
 CREATE TABLE IF NOT EXISTS budget_members (
   tool_id    TEXT NOT NULL,
+  plan_key   TEXT NOT NULL DEFAULT 'default',
   email      TEXT NOT NULL,
   name       TEXT NOT NULL DEFAULT '',
   role       TEXT NOT NULL DEFAULT '',
@@ -190,10 +207,13 @@ CREATE TABLE IF NOT EXISTS budget_members (
   source     TEXT NOT NULL DEFAULT 'manual',
   usage      TEXT NOT NULL DEFAULT '{}',
   updated_at TEXT NOT NULL,
-  PRIMARY KEY (tool_id, email)
+  PRIMARY KEY (tool_id, plan_key, email)
 );
+-- Per subscription too: a Teams contract has an admin API, a handful of
+-- individual Max seats does not, and one key cannot stand for both.
 CREATE TABLE IF NOT EXISTS budget_connections (
-  tool_id          TEXT PRIMARY KEY,
+  tool_id          TEXT NOT NULL,
+  plan_key         TEXT NOT NULL DEFAULT 'default',
   provider         TEXT NOT NULL,
   api_key          TEXT NOT NULL,
   last_sync_at     TEXT,
@@ -201,7 +221,8 @@ CREATE TABLE IF NOT EXISTS budget_connections (
   last_sync_detail TEXT NOT NULL DEFAULT '',
   members_synced   INTEGER NOT NULL DEFAULT 0,
   created_at       TEXT NOT NULL,
-  updated_by       TEXT NOT NULL DEFAULT ''
+  updated_by       TEXT NOT NULL DEFAULT '',
+  PRIMARY KEY (tool_id, plan_key)
 );
 -- How one person wants the portal to look, and what it has already shown
 -- them. Display state, not governance: nothing here changes what a page
@@ -270,6 +291,25 @@ _ADMIN_COLUMNS_ADDED = (
 _BUDGET_SUB_COLUMNS_ADDED = (
     ("covers", "TEXT NOT NULL DEFAULT '[]'"),
 )
+
+_CANDIDATE_COLUMNS_ADDED = (
+    # A decision about the NAME rather than the thing: this identifies no
+    # program, so no view should present it as one.
+    ("disposition", "TEXT NOT NULL DEFAULT ''"),
+)
+
+
+def plan_key(plan: str) -> str:
+    """A plan name reduced to a key: lowercased, runs of anything that is
+    not a letter or digit folded to one hyphen.
+
+    Empty becomes "default" so a subscription recorded before plans were part
+    of the identity keeps its row and its members without anyone re-entering
+    it. "Max 20" and "max-20" are the same subscription; "Team" and
+    "Enterprise" are not.
+    """
+    out = re.sub(r"[^a-z0-9]+", "-", (plan or "").strip().lower()).strip("-")
+    return out or "default"
 
 
 def _now() -> str:
@@ -446,6 +486,13 @@ class State:
                 "CREATE UNIQUE INDEX IF NOT EXISTS admin_users_sso"
                 " ON admin_users (sso_tenant, sso_subject)"
                 " WHERE sso_subject IS NOT NULL")
+            self._migrate_budget_to_plan_keys()
+            have = {r["name"] for r in self._db.execute(
+                "PRAGMA table_info(candidates)")}
+            for name, decl in _CANDIDATE_COLUMNS_ADDED:
+                if name not in have:
+                    self._db.execute(
+                        f"ALTER TABLE candidates ADD COLUMN {name} {decl}")
             have = {r["name"] for r in self._db.execute(
                 "PRAGMA table_info(budget_subscriptions)")}
             for name, decl in _BUDGET_SUB_COLUMNS_ADDED:
@@ -1438,29 +1485,92 @@ class State:
     # fleet credentials, which are hashes. It is never echoed by any list
     # or GET; sync_connection_key below is its only reader.
 
+    def _migrate_budget_to_plan_keys(self):
+        """Rekey the budget tables from tool_id to (tool_id, plan_key).
+
+        SQLite cannot alter a primary key, so each table is rebuilt and its
+        rows copied with a plan_key derived from the plan already recorded.
+        Runs inside the caller's transaction and only when the old shape is
+        found, so a restart on a migrated database does nothing.
+
+        Nothing is dropped: every existing subscription keeps its row, its
+        members and its connection, and lands under the plan it already
+        named (or "default" if it named none). A deployment that never
+        touched the budget has three empty tables and notices nothing.
+        """
+        cols = {r["name"] for r in
+                self._db.execute("PRAGMA table_info(budget_subscriptions)")}
+        if not cols or "plan_key" in cols:
+            return
+        subs = self._db.execute("SELECT * FROM budget_subscriptions").fetchall()
+        members = self._db.execute("SELECT * FROM budget_members").fetchall()
+        conns = self._db.execute("SELECT * FROM budget_connections").fetchall()
+        keyed = {r["tool_id"]: plan_key(r["plan"]) for r in subs}
+
+        for t in ("budget_subscriptions", "budget_members",
+                  "budget_connections"):
+            self._db.execute(f"ALTER TABLE {t} RENAME TO {t}_old")
+        self._db.executescript(_SCHEMA)
+
+        for r in subs:
+            d = dict(r)
+            d["plan_key"] = keyed[d["tool_id"]]
+            names = ", ".join(d)
+            self._db.execute(
+                f"INSERT INTO budget_subscriptions ({names})"
+                f" VALUES ({', '.join('?' * len(d))})", tuple(d.values()))
+        for r in members:
+            d = dict(r)
+            # A member whose subscription has since gone keeps the default
+            # key rather than being dropped on the floor.
+            d["plan_key"] = keyed.get(d["tool_id"], "default")
+            names = ", ".join(d)
+            self._db.execute(
+                f"INSERT OR REPLACE INTO budget_members ({names})"
+                f" VALUES ({', '.join('?' * len(d))})", tuple(d.values()))
+        for r in conns:
+            d = dict(r)
+            d["plan_key"] = keyed.get(d["tool_id"], "default")
+            names = ", ".join(d)
+            self._db.execute(
+                f"INSERT OR REPLACE INTO budget_connections ({names})"
+                f" VALUES ({', '.join('?' * len(d))})", tuple(d.values()))
+
+        for t in ("budget_subscriptions", "budget_members",
+                  "budget_connections"):
+            self._db.execute(f"DROP TABLE {t}_old")
+        self._event("budget_rekeyed_by_plan",
+                    {"subscriptions": len(subs), "members": len(members),
+                     "connections": len(conns)})
+
     def list_budget(self) -> dict:
         """Everything the budget view shows: subscriptions with their
         members, and each connection's metadata - provider, sync history,
         whether a key is stored - never the key itself."""
         with self._lock:
             subs = self._db.execute(
-                "SELECT tool_id, vendor, plan, currency, renewal_date,"
-                " owner, notes, seat_tiers, covers, created_at, updated_at,"
-                " updated_by FROM budget_subscriptions ORDER BY tool_id"
+                "SELECT tool_id, plan_key, vendor, plan, currency,"
+                " renewal_date, owner, notes, seat_tiers, covers, created_at,"
+                " updated_at, updated_by FROM budget_subscriptions"
+                " ORDER BY tool_id, plan_key"
             ).fetchall()
             members = self._db.execute(
-                "SELECT tool_id, email, name, role, seat_tier, source,"
-                " usage, updated_at FROM budget_members"
-                " ORDER BY tool_id, email"
+                "SELECT tool_id, plan_key, email, name, role, seat_tier,"
+                " source, usage, updated_at FROM budget_members"
+                " ORDER BY tool_id, plan_key, email"
             ).fetchall()
             conns = self._db.execute(
-                "SELECT tool_id, provider, last_sync_at, last_sync_ok,"
-                " last_sync_detail, members_synced, created_at, updated_by"
-                " FROM budget_connections ORDER BY tool_id"
+                "SELECT tool_id, plan_key, provider, last_sync_at,"
+                " last_sync_ok, last_sync_detail, members_synced, created_at,"
+                " updated_by FROM budget_connections"
+                " ORDER BY tool_id, plan_key"
             ).fetchall()
-        by_tool: dict[str, list] = {}
+        # Keyed on the subscription, not the tool: two plans on one tool have
+        # different members, and folding them together is how a seat gets
+        # counted twice.
+        by_sub: dict[tuple, list] = {}
         for m in members:
-            by_tool.setdefault(m["tool_id"], []).append({
+            by_sub.setdefault((m["tool_id"], m["plan_key"]), []).append({
                 "email": m["email"], "name": m["name"], "role": m["role"],
                 "seat_tier": m["seat_tier"], "source": m["source"],
                 "usage": json.loads(m["usage"] or "{}"),
@@ -1470,9 +1580,11 @@ class State:
             "subscriptions": [dict(
                 r, seat_tiers=json.loads(r["seat_tiers"] or "[]"),
                 covers=json.loads(r["covers"] or "[]"),
-                members=by_tool.get(r["tool_id"], [])) for r in subs],
+                members=by_sub.get((r["tool_id"], r["plan_key"]), []))
+                for r in subs],
             "connections": [{
-                "tool_id": c["tool_id"], "provider": c["provider"],
+                "tool_id": c["tool_id"], "plan_key": c["plan_key"],
+                "provider": c["provider"],
                 "key_set": True, "last_sync_at": c["last_sync_at"],
                 "last_sync_ok": bool(c["last_sync_ok"]),
                 "last_sync_detail": c["last_sync_detail"],
@@ -1482,15 +1594,23 @@ class State:
         }
 
     def upsert_budget_subscription(self, tool_id: str, fields: dict,
-                                   by: str = ""):
+                                   by: str = "", key: str = ""):
+        """One subscription, identified by tool AND plan.
+
+        `key` names an existing subscription to edit; without it the plan in
+        `fields` decides. That distinction is what lets a plan be renamed -
+        editing "Team" to "Teams" updates the row rather than silently
+        creating a second subscription beside it.
+        """
         now = _now()
+        pk = key or plan_key(fields.get("plan", ""))
         with self._lock:
             self._db.execute(
-                "INSERT INTO budget_subscriptions (tool_id, vendor, plan,"
-                " currency, renewal_date, owner, notes, seat_tiers, covers,"
-                " created_at, updated_at, updated_by)"
-                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
-                " ON CONFLICT(tool_id) DO UPDATE SET"
+                "INSERT INTO budget_subscriptions (tool_id, plan_key, vendor,"
+                " plan, currency, renewal_date, owner, notes, seat_tiers,"
+                " covers, created_at, updated_at, updated_by)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                " ON CONFLICT(tool_id, plan_key) DO UPDATE SET"
                 " vendor = excluded.vendor, plan = excluded.plan,"
                 " currency = excluded.currency,"
                 " renewal_date = excluded.renewal_date,"
@@ -1499,36 +1619,63 @@ class State:
                 " covers = excluded.covers,"
                 " updated_at = excluded.updated_at,"
                 " updated_by = excluded.updated_by",
-                (tool_id, fields.get("vendor", ""), fields.get("plan", ""),
+                (tool_id, pk, fields.get("vendor", ""),
+                 fields.get("plan", ""),
                  fields.get("currency", ""), fields.get("renewal_date", ""),
                  fields.get("owner", ""), fields.get("notes", ""),
                  json.dumps(fields.get("seat_tiers") or []),
                  json.dumps(fields.get("covers") or []), now, now, by),
             )
+            # Members and a connection can exist before the subscription
+            # does: you can store a vendor key and sync a member list, then
+            # write down what the licence is. Those rows landed under
+            # "default" because no plan had been named yet. If this is the
+            # tool's only subscription, they belong to it - adopt them
+            # rather than stranding them under a key nothing references.
+            if pk != "default":
+                others = self._db.execute(
+                    "SELECT COUNT(*) c FROM budget_subscriptions"
+                    " WHERE tool_id = ? AND plan_key != ?",
+                    (tool_id, pk)).fetchone()["c"]
+                if not others:
+                    for t in ("budget_members", "budget_connections"):
+                        self._db.execute(
+                            f"UPDATE OR REPLACE {t} SET plan_key = ?"
+                            " WHERE tool_id = ? AND plan_key = 'default'",
+                            (pk, tool_id))
             self._event("budget_subscription_saved",
-                        {"tool": tool_id, "by": by})
+                        {"tool": tool_id, "plan": pk, "by": by})
             self._db.commit()
 
-    def delete_budget_subscription(self, tool_id: str, by: str = "") -> bool:
-        """The subscription and everything hanging off it: a member list or a
+    def delete_budget_subscription(self, tool_id: str, by: str = "",
+                                   key: str = "default") -> bool:
+        """One subscription and everything hanging off it: a member list or a
         stored vendor key with no subscription is orphaned data nobody can
-        see or manage, which is the worst kind to keep."""
+        see or manage, which is the worst kind to keep.
+
+        Scoped to the plan. Deleting the Teams contract must not take the
+        individual Max seats with it - they are a different subscription that
+        happens to be for the same tool.
+        """
         with self._lock:
             cur = self._db.execute(
-                "DELETE FROM budget_subscriptions WHERE tool_id = ?",
-                (tool_id,))
+                "DELETE FROM budget_subscriptions"
+                " WHERE tool_id = ? AND plan_key = ?", (tool_id, key))
             self._db.execute(
-                "DELETE FROM budget_members WHERE tool_id = ?", (tool_id,))
+                "DELETE FROM budget_members WHERE tool_id = ? AND plan_key = ?",
+                (tool_id, key))
             self._db.execute(
-                "DELETE FROM budget_connections WHERE tool_id = ?", (tool_id,))
+                "DELETE FROM budget_connections"
+                " WHERE tool_id = ? AND plan_key = ?", (tool_id, key))
             if cur.rowcount:
                 self._event("budget_subscription_deleted",
-                            {"tool": tool_id, "by": by})
+                            {"tool": tool_id, "plan": key, "by": by})
             self._db.commit()
         return bool(cur.rowcount)
 
     def replace_budget_members(self, tool_id: str, members: list[dict],
-                               source: str, by: str = "") -> int:
+                               source: str, by: str = "",
+                               key: str = "default") -> int:
         """Replace the member rows this source owns; other sources' rows
         stay. A CSV re-import replaces the previous import, an API sync
         replaces the previous sync, and neither clobbers a manual entry.
@@ -1547,80 +1694,88 @@ class State:
                 " budget_members.{c} ELSE excluded.{c} END")
         with self._lock:
             self._db.execute(
-                "DELETE FROM budget_members WHERE tool_id = ? AND source = ?",
-                (tool_id, source))
+                "DELETE FROM budget_members"
+                " WHERE tool_id = ? AND plan_key = ? AND source = ?",
+                (tool_id, key, source))
             for m in members:
                 self._db.execute(
-                    "INSERT INTO budget_members (tool_id, email, name, role,"
-                    " seat_tier, source, usage, updated_at)"
-                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
-                    " ON CONFLICT(tool_id, email) DO UPDATE SET"
+                    "INSERT INTO budget_members (tool_id, plan_key, email,"
+                    " name, role, seat_tier, source, usage, updated_at)"
+                    " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"
+                    " ON CONFLICT(tool_id, plan_key, email) DO UPDATE SET"
                     " name = " + keep.format(c="name", empty="") + ","
                     " role = " + keep.format(c="role", empty="") + ","
                     " seat_tier = " + keep.format(c="seat_tier", empty="") + ","
                     " usage = " + keep.format(c="usage", empty="{}") + ","
                     " source = excluded.source,"
                     " updated_at = excluded.updated_at",
-                    (tool_id, m["email"], m.get("name", ""),
+                    (tool_id, key, m["email"], m.get("name", ""),
                      m.get("role", ""), m.get("seat_tier", ""), source,
                      json.dumps(m.get("usage") or {}), now),
                 )
             self._event("budget_members_replaced",
-                        {"tool": tool_id, "source": source,
+                        {"tool": tool_id, "plan": key, "source": source,
                          "count": len(members), "by": by})
             self._db.commit()
         return len(members)
 
     def set_budget_connection(self, tool_id: str, provider: str,
-                              api_key: str, by: str = ""):
+                              api_key: str, by: str = "",
+                              key: str = "default"):
         """Store or replace the vendor connection. A replaced key resets
         the sync history: what the old key last did says nothing about
         what the new one can do."""
         with self._lock:
             self._db.execute(
-                "INSERT INTO budget_connections (tool_id, provider, api_key,"
-                " last_sync_at, last_sync_ok, last_sync_detail,"
-                " members_synced, created_at, updated_by)"
-                " VALUES (?, ?, ?, NULL, 0, '', 0, ?, ?)"
-                " ON CONFLICT(tool_id) DO UPDATE SET"
+                "INSERT INTO budget_connections (tool_id, plan_key,"
+                " provider, api_key, last_sync_at, last_sync_ok,"
+                " last_sync_detail, members_synced, created_at, updated_by)"
+                " VALUES (?, ?, ?, ?, NULL, 0, '', 0, ?, ?)"
+                " ON CONFLICT(tool_id, plan_key) DO UPDATE SET"
                 " provider = excluded.provider, api_key = excluded.api_key,"
                 " last_sync_at = NULL, last_sync_ok = 0,"
                 " last_sync_detail = '', members_synced = 0,"
                 " updated_by = excluded.updated_by",
-                (tool_id, provider, api_key, _now(), by),
+                (tool_id, key, provider, api_key, _now(), by),
             )
             self._event("budget_connection_saved",
-                        {"tool": tool_id, "provider": provider, "by": by})
+                        {"tool": tool_id, "plan": key,
+                         "provider": provider, "by": by})
             self._db.commit()
 
-    def delete_budget_connection(self, tool_id: str, by: str = "") -> bool:
+    def delete_budget_connection(self, tool_id: str, by: str = "",
+                                 key: str = "default") -> bool:
         with self._lock:
             cur = self._db.execute(
-                "DELETE FROM budget_connections WHERE tool_id = ?", (tool_id,))
+                "DELETE FROM budget_connections"
+                " WHERE tool_id = ? AND plan_key = ?", (tool_id, key))
             if cur.rowcount:
                 self._event("budget_connection_deleted",
-                            {"tool": tool_id, "by": by})
+                            {"tool": tool_id, "plan": key, "by": by})
             self._db.commit()
         return bool(cur.rowcount)
 
-    def sync_connection_key(self, tool_id: str) -> tuple[str, str] | None:
+    def sync_connection_key(self, tool_id: str,
+                            key: str = "default") -> tuple[str, str] | None:
         """(provider, api_key) for the sync call, or None. The only reader
         of the key's plaintext; every other query masks it."""
         with self._lock:
             row = self._db.execute(
                 "SELECT provider, api_key FROM budget_connections"
-                " WHERE tool_id = ?", (tool_id,)).fetchone()
+                " WHERE tool_id = ? AND plan_key = ?",
+                (tool_id, key)).fetchone()
         return (row["provider"], row["api_key"]) if row else None
 
     def record_budget_sync(self, tool_id: str, ok: bool, detail: str,
-                           count: int, by: str = ""):
+                           count: int, by: str = "", key: str = "default"):
         with self._lock:
             self._db.execute(
                 "UPDATE budget_connections SET last_sync_at = ?,"
                 " last_sync_ok = ?, last_sync_detail = ?, members_synced = ?"
-                " WHERE tool_id = ?",
-                (_now(), int(ok), detail, count, tool_id))
-            self._event("budget_sync", {"tool": tool_id, "ok": ok,
+                " WHERE tool_id = ? AND plan_key = ?",
+                (_now(), int(ok), detail, count, tool_id, key))
+            self._event("budget_sync", {"tool": tool_id, "plan": key,
+                                        "ok": ok,
                                         "count": count, "by": by})
             self._db.commit()
 
@@ -1689,7 +1844,7 @@ class State:
             rows = self._db.execute(
                 "SELECT key, kind, name, vendor, category, confidence,"
                 " domains, devices, evidence, source, first_seen, last_seen,"
-                " dismissed_at, dismissed_by FROM candidates"
+                " dismissed_at, dismissed_by, disposition FROM candidates"
                 " ORDER BY last_seen DESC"
             ).fetchall()
         out = []
@@ -1835,6 +1990,31 @@ class State:
                 d["detail"] = {}
             out.append(d)
         return out
+
+    def set_candidate_disposition(self, key: str, disposition: str,
+                                  by: str = "") -> bool:
+        """Record what a name IS, as distinct from dismissing the row.
+
+        Dismissing says "not a tool" and stops the queue asking. This says
+        the name identifies no program, which every view reading a process
+        name needs to know - so it is stored where they can all read it
+        rather than being spent closing one card.
+        """
+        with self._lock:
+            cur = self._db.execute(
+                "UPDATE candidates SET disposition = ?, dismissed_at = ?,"
+                " dismissed_by = ? WHERE key = ?",
+                (disposition, _now(), by, key))
+            self._db.commit()
+            return cur.rowcount > 0
+
+    def dispositioned_names(self, disposition: str) -> list:
+        """Every candidate name carrying this disposition, lowercased."""
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT name FROM candidates WHERE disposition = ?",
+                (disposition,)).fetchall()
+        return sorted({(r["name"] or "").strip().lower() for r in rows} - {""})
 
     def dismiss_candidate(self, key: str, by: str = "") -> bool:
         with self._lock:

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.24.1
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/receiver/tests/test_budget.py
+++ b/receiver/tests/test_budget.py
@@ -731,3 +731,98 @@ def test_sync_devin_refuses_a_key_without_a_usable_org_id(managed, monkeypatch,
     # The failure is the operator's answer, so it has to name the shape the
     # key should have taken rather than just refusing.
     assert "org-xxxx" in body["detail"]
+
+
+# ------------------------------------------- two plans on the same tool --
+#
+# An organisation does not have "a Claude subscription": it has a Teams
+# contract and a handful of individual Max seats, on different plans with
+# different renewal dates. Keying on tool_id alone meant tracking one and
+# being blind to the other, and the spend total was wrong either way without
+# saying so.
+
+def _sub(tool, plan, seats, price, **kw):
+    return dict({"tool_id": tool, "plan": plan, "vendor": "Anthropic",
+                 "currency": "GBP",
+                 "seat_tiers": [{"name": "seat", "seats": seats,
+                                 "unit_price_monthly": price}]}, **kw)
+
+
+def test_one_tool_can_carry_several_plans(managed):
+    for s in (_sub("claude", "Team", 40, 25),
+              _sub("claude", "Max 20", 3, 90),
+              _sub("claude", "Max 5", 6, 18)):
+        r = client.put("/admin/budget/subscription", headers=ADMIN, json=s)
+        assert r.status_code == 200, r.text
+    subs = client.get("/admin/budget", headers=ADMIN).json()["subscriptions"]
+    claude = [x for x in subs if x["tool_id"] == "claude"]
+    assert sorted(x["plan_key"] for x in claude) == ["max-20", "max-5", "team"]
+    assert sorted(x["plan"] for x in claude) == ["Max 20", "Max 5", "Team"]
+
+
+def test_renaming_a_plan_updates_rather_than_duplicates(managed):
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=_sub("claude", "Team", 40, 25))
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=_sub("claude", "Teams", 40, 25, plan_key="team"))
+    subs = client.get("/admin/budget", headers=ADMIN).json()["subscriptions"]
+    claude = [x for x in subs if x["tool_id"] == "claude"]
+    assert len(claude) == 1 and claude[0]["plan"] == "Teams"
+
+
+def test_deleting_one_plan_leaves_the_others(managed):
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=_sub("claude", "Team", 40, 25))
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=_sub("claude", "Max 20", 3, 90))
+    client.post("/admin/budget/subscription/delete", headers=ADMIN,
+                json={"tool_id": "claude", "plan_key": "team"})
+    subs = client.get("/admin/budget", headers=ADMIN).json()["subscriptions"]
+    assert [x["plan_key"] for x in subs if x["tool_id"] == "claude"] == ["max-20"]
+
+
+def test_members_belong_to_a_plan_not_a_tool(managed):
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=_sub("claude", "Team", 40, 25))
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=_sub("claude", "Max 20", 3, 90))
+    client.put("/admin/budget/members", headers=ADMIN, json={
+        "tool_id": "claude", "plan_key": "team", "source": "csv",
+        "members": [{"email": "a@corp.example"}, {"email": "b@corp.example"}]})
+    client.put("/admin/budget/members", headers=ADMIN, json={
+        "tool_id": "claude", "plan_key": "max-20", "source": "csv",
+        "members": [{"email": "c@corp.example"}]})
+    subs = {x["plan_key"]: x for x in
+            client.get("/admin/budget", headers=ADMIN).json()["subscriptions"]
+            if x["tool_id"] == "claude"}
+    assert [m["email"] for m in subs["team"]["members"]] == \
+        ["a@corp.example", "b@corp.example"]
+    assert [m["email"] for m in subs["max-20"]["members"]] == ["c@corp.example"]
+
+
+def test_a_write_that_does_not_say_which_plan_is_refused_when_ambiguous(managed):
+    """Guessing would silently move seats between contracts, and the money
+    answer would still look plausible."""
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=_sub("claude", "Team", 40, 25))
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=_sub("claude", "Max 20", 3, 90))
+    r = client.put("/admin/budget/members", headers=ADMIN, json={
+        "tool_id": "claude", "source": "csv",
+        "members": [{"email": "a@corp.example"}]})
+    assert r.status_code == 422
+    assert "say which plan" in r.json()["detail"]
+
+
+def test_two_plans_on_one_tool_are_not_a_double_billed_licence(managed):
+    """The covers rule still refuses one licence billed twice - but two
+    plans for the same product are two licences, not one billed twice."""
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=_sub("claude", "Team", 40, 25, covers=["claude-code"]))
+    # Same tool, different plan: allowed.
+    assert client.put("/admin/budget/subscription", headers=ADMIN,
+                      json=_sub("claude", "Max 20", 3, 90)).status_code == 200
+    # A different tool claiming a tool the Team licence already covers: not.
+    r = client.put("/admin/budget/subscription", headers=ADMIN,
+                   json=_sub("cursor", "Pro", 5, 20, covers=["claude-code"]))
+    assert r.status_code == 422 and "already covered" in r.json()["detail"]

--- a/receiver/tests/test_candidates.py
+++ b/receiver/tests/test_candidates.py
@@ -285,3 +285,45 @@ def test_a_process_candidate_survives_the_receivers_own_validation(managed, monk
     assert r.status_code == 200
     rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
     assert [c for c in rows if c["kind"] == "process"] == []
+
+
+def test_a_name_that_identifies_no_program_is_recorded_as_such(managed, monkeypatch):
+    """Distinct from a dismissal. Dismissing curl says "not a tool" and curl
+    is still a real process worth showing; saying firezone-client-tunnel
+    names nothing is a fact about the NAME, and every view that reads a
+    process name needs it."""
+    # A name NOT on the shipped floor - firezone-client-tunnel is on it now,
+    # so it never becomes a candidate and could not exercise this path. The
+    # long tail is what this disposition is for.
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", {"claude"})
+    client.post("/report", json=_dns("acme-zt-tunnel"), headers=AUTH)
+    key = "process:acme-zt-tunnel"
+    r = client.post("/admin/candidates/%s/not-attributable" % key, headers=ADMIN)
+    assert r.status_code == 200
+    got = client.get("/admin/candidates/not-attributable", headers=ADMIN).json()
+    assert got["names"] == ["acme-zt-tunnel"]
+
+
+def test_a_ruled_out_name_is_not_asked_about_again(managed, monkeypatch):
+    """A review queue that re-asks a settled question is one nobody reads."""
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", {"claude"})
+    client.post("/report", json=_dns("corp-tunnel"), headers=AUTH)
+    client.post("/admin/candidates/process:corp-tunnel/not-attributable",
+                headers=ADMIN)
+    # Same process, seen again on another device.
+    client.post("/report", json=_dns("corp-tunnel", device="D2"), headers=AUTH)
+    rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
+    open_rows = [c for c in rows
+                 if c["kind"] == "process" and not c.get("dismissed_at")]
+    assert open_rows == []
+
+
+def test_only_a_process_can_be_called_unattributable(managed):
+    """The claim is about a name identifying no program. A domain is not a
+    name in that sense, and neither is an MCP server."""
+    client.post("/candidates", headers=AUTH,
+                json={"candidates": [dict(CANDIDATE)]})
+    rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
+    key = rows[0]["key"]
+    r = client.post("/admin/candidates/%s/not-attributable" % key, headers=ADMIN)
+    assert r.status_code == 422

--- a/registry/registry.yaml
+++ b/registry/registry.yaml
@@ -298,7 +298,11 @@ tools:
     # Warp's binary is named after its release channel, not the product:
     # Warp.app/Contents/MacOS/stable. Nothing derives "Warp" from that, which
     # is why it arrived as an unaccountable process reaching a model.
-    exe_names: ["warp.exe", "stable"]
+    # Warp's macOS binary is literally the release channel name. It is far
+    # too generic to match on: any process called "stable" would be read as
+    # Warp and quietly excused. Left out on purpose - the review queue asks
+    # about it instead, which is the right place for a name this ambiguous.
+    exe_names: ["warp.exe"]
     risk_tier: medium
     bundle_ids: [dev.warp.Warp-Stable]
   - id: perplexity

--- a/scanner/ai_guard/registry/ai_services.yaml
+++ b/scanner/ai_guard/registry/ai_services.yaml
@@ -367,7 +367,6 @@ services:
     - Warp
     windows:
     - warp.exe
-    - stable
   browser_extensions: {}
   mcp_identifiers: []
   form: ''

--- a/scanner/ai_guard/scanners/sentinelone.py
+++ b/scanner/ai_guard/scanners/sentinelone.py
@@ -115,6 +115,16 @@ _UNATTRIBUTABLE_PROCESSES = {
     # Generic by construction, the same as the hosts above - and an allowlist
     # entry would wrongly read as "this particular program is fine".
     "update", "updater", "squirrel",
+    # VPN and zero-trust clients. A tunnel daemon resolves DNS for
+    # everything behind the tunnel, so naming one says "something on this
+    # device, through the VPN" - the same non-answer as a stub resolver.
+    # The queue found firezone-client-tunnel; these are the rest of the
+    # category rather than waiting to be asked about one at a time.
+    "firezone-client-tunnel", "firezone-gui-client", "tailscaled",
+    "openvpn", "wireguard", "wg-quick", "nordvpn", "expressvpn",
+    "warp-svc", "cloudflared", "vpnagentd", "acwebsecagent", "pangps",
+    "pangpa", "zsatunnel", "zscaler", "stagent", "netskope", "nsdiag",
+    "globalprotect", "ivanti", "pulsesecure", "forticlient", "sonicwall",
 }
 
 


### PR DESCRIPTION
Five things, batched as agreed so one release carries them.

## 1. An organisation does not have *one* Claude subscription

It has a Teams contract and a handful of individual Max seats, on different plans, different renewal dates, often different owners. `budget_subscriptions` keyed on `tool_id` alone:

```sql
CREATE TABLE budget_subscriptions (
  tool_id TEXT PRIMARY KEY,   -- ← why Claude greyed out the second time
  plan    TEXT NOT NULL DEFAULT '',
```

So the choice was track the contract and be blind to the seats, or the reverse. **Both totals were wrong and neither said so.**

Three tables move to `(tool_id, plan_key)`. SQLite cannot alter a primary key, so each is rebuilt and copied — **proven against a database in the old shape**: stored vendor key intact, members and connection carried onto the plan their subscription named, no orphans, idempotent on restart.

Every card button carried the tool and every handler did `find(s => s.tool_id === k)`, which returns whichever plan sorts first. **Editing your Max seats would have opened the Teams contract; importing users into one would have replaced the other's list.** They carry the subscription now.

The page's own `bSubMonthly`/`bSpendParts`, run against three plans on one tool:

```
per subscription : Team=1000  Max 20=270  Max 5=108
page total       : GBP 1378.00
old model showed : 1000   (one plan only)
```

Four decisions, all about not producing a *plausible* wrong number:

- **Ambiguity is refused, not guessed** — a member write that doesn't name a plan, on a tool with two, gets `claude has 2 subscriptions (max-20, team) - say which plan this is for`. Guessing moves seats between contracts and the total still looks fine.
- **The picker no longer treats a tool as used up.** It says which plans are linked and stays selectable. Only a licence genuinely billed twice is disabled — the `covers` rule still catches that, it just no longer mistakes two plans for one double-bill.
- **Renaming works** — editing sends `plan_key`, so Team → Teams updates the row instead of quietly creating a second.
- **Orphan adoption** — a key can still be stored and synced *before* the subscription is written down; those rows are adopted when the tool's first subscription appears.

## 2. The review queue's answer went nowhere

`firezone-client-tunnel` turned up on a real estate — **the first time the process-candidate path has fired outside a seeded demo.** It's a VPN tunnel daemon: it resolves DNS for everything behind the tunnel, so naming it says "something on this device, through the VPN", the same non-answer as a stub resolver.

But the queue offered only *add to registry* or *dismiss*, and dismissing cleared the card while leaving the process on the Agentic view **for ever** — `agentic_from` never consulted candidate decisions. A question whose answer went nowhere.

There's a third disposition now: **the name identifies no program.** That's a fact about the *name*, so it reaches every view that reads one, and the receiver stops asking about it.

## 3. VPN clients are a category, not a one-off

Tailscale, OpenVPN, WireGuard, Cloudflare WARP, AnyConnect, GlobalProtect, Zscaler, Netskope and the rest join the floor, on the same reasoning that put `svchost` and `taskhostw` there. The queue handles the tail.

## 4. `stable` comes out of Warp's exe_names

It solved the mystery it was added for, and it is *a word*. Any process literally named `stable` was being silently excused as Warp. The queue can ask instead.

## 5. The overview queue emptied itself

Adding a candidate to the registry set `CAND = null` and called `render()` — but the queue is only ever fetched by `load()`, behind a check for whether the widget is on the overview. So it drew an empty queue and left the rest invisible until a manual reload. Three handlers had that shape; there's one `reloadDerived()` now.

## Checked

Suites: registry 23, portal 627, scanner 210, receiver 300. Plus collector parity, `build.py --check`, both byte-identical invariants, chart copies, shellcheck.

Two things worth knowing before this ships:

- **The migration runs on the live database at receiver start.** Proven and idempotent, but it rebuilds three tables — worth a copy of the state volume first.
- **I have not seen the budget page render two plans in a browser.** The arithmetic is exercised directly and the suites pass, but the managed-mode UI needs a login I avoided. That click-through is still owed.
