### PR TITLE
A process can belong to a tool you already have

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.25.0
+version: 0.25.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.25.0"
+appVersion: "0.25.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.1
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.1
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/derive.py
+++ b/portal/app/derive.py
@@ -1497,7 +1497,7 @@ def scheduler_coverage(devices):
     }
 
 
-def agentic_from(findings, reg=None, not_attributable=()):
+def agentic_from(findings, reg=None, not_attributable=(), aliases=None):
     """What runs without a person, and how far it can reach.
 
     Every other view here starts from something somebody did. This one
@@ -1525,6 +1525,11 @@ def agentic_from(findings, reg=None, not_attributable=()):
     # whose answer went nowhere - dismissing the row cleared the card and
     # left the process on this page for ever.
     ruled_out = {normalise_process(n) for n in (not_attributable or ())} - {""}
+    # Process names an operator has attributed to a tool the registry knows.
+    # A vendor's binary is often named nothing like its product - Warp's is
+    # "stable" - and the registry cannot carry every one of those without
+    # guessing. Said once in the review queue, read here.
+    known |= {normalise_process(n) for n in (aliases or {})} - {""}
 
     # Which MCP servers sit on each machine, so a chain can say what the
     # thing running there could reach.

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1171,6 +1171,22 @@ def evidence_snapshot(request: Request,
     return JSONResponse(doc)
 
 
+def _process_aliases(request):
+    """Process names an operator has attributed to a registry tool, or {}
+    when there is no receiver to ask."""
+    if not RECEIVER_URL:
+        return {}
+    token = request.cookies.get(SESSION_COOKIE, "")
+    if not token:
+        return {}
+    try:
+        out = managed.receiver_request(
+            RECEIVER_URL, "GET", "/admin/candidates/process-aliases", token)
+    except Exception:
+        return {}
+    return (out or {}).get("aliases") or {}
+
+
 def _not_attributable(request):
     """Process names an operator has ruled out from the review queue.
 
@@ -1238,7 +1254,8 @@ def agentic(request: Request,
     def build():
         out = derive.agentic_from(_findings_cached(hours, request),
                                   _registry(request),
-                                  _not_attributable(request))
+                                  _not_attributable(request),
+                                  _process_aliases(request))
         # Whether an empty page is an answer or an absence. The collector
         # version lives on the receiver's device rows, not in any finding -
         # the same field Fleet shows. None means the question could not be
@@ -2697,6 +2714,21 @@ def api_candidates(_=Depends(require_auth), token: str = Depends(_admin_forward)
     defined. The receiver annotates each row resolved/dismissed; what to
     show is the page's business, so this forwards unfiltered."""
     return _receiver("GET", "/admin/candidates", token)
+
+
+class CandidateBelongsTo(BaseModel):
+    model_config = {"extra": "forbid"}
+    key: str = Field(min_length=1, max_length=200)
+    tool_id: str = Field(min_length=1, max_length=100)
+
+
+@app.post("/api/candidates/belongs-to")
+def api_candidate_belongs_to(req: CandidateBelongsTo, _=Depends(require_auth),
+                             token: str = Depends(_admin_forward)):
+    return _receiver(
+        "POST", "/admin/candidates/%s/belongs-to"
+        % urllib.parse.quote(req.key, safe=""), token,
+        {"tool_id": req.tool_id})
 
 
 @app.post("/api/candidates/not-attributable")

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2319,7 +2319,15 @@ const WIDGETS = {
         <td style="color:var(--mut)">${c.devices || 0} device${c.devices === 1 ? '' : 's'}
           ${c.confidence ? ' · ' + esc(c.confidence) : ''}</td>
         <td style="white-space:nowrap">
-          ${c.kind === 'process' ? `<button class="mini" data-act="cand-noattr"
+          ${c.kind === 'process' ? `<select class="mfield" id="cb-${esc(c.key)}"
+            style="min-width:130px;font-size:12px"
+            title="A vendor's binary is often named nothing like its product - Warp's is called stable, after its release channel. Say which tool this is and every view that reads a process name gets it.">
+            <option value="">belongs to…</option>
+            ${(REGTOOLS || []).slice().sort((a, b) => a.name.localeCompare(b.name))
+              .map(t => `<option value="${esc(t.id)}">${esc(t.name)}</option>`).join('')}
+          </select>
+          <button class="mini" data-act="cand-belongs" data-key="${esc(c.key)}">Link</button>
+          <button class="mini" data-act="cand-noattr"
             data-key="${esc(c.key)}" title="This name identifies no program - a resolver, a service host, a VPN tunnel that resolves for everything behind it. Recorded once and honoured everywhere a process name is read.">Names nothing</button> ` : ''}<button class="btn" data-act="cand-add" data-key="${esc(c.key)}">Add to registry</button>
           <button class="btn" data-act="cand-dismiss" data-key="${esc(c.key)}">Dismiss</button>
         </td></tr>`).join('')}</table>
@@ -8426,6 +8434,26 @@ async function managedAction(act, el) {
     view = 'registry'; detail = null;
     history.replaceState(null, '', '#registry');
     drawNav(); render(); return;
+  }
+  if (act === 'cand-belongs') {
+    // The third answer the queue could not give: this process IS a tool you
+    // already have, under a name nothing would guess. Recorded once rather
+    // than guessed at in a release - which is how "stable" came to silently
+    // excuse every process with that name.
+    const key = el.getAttribute('data-key');
+    const tool = _val('cb-' + key);
+    if (!tool) { alert('Pick which tool this process belongs to.'); return; }
+    const r = await mfetch('/api/candidates/belongs-to',
+      {method: 'POST', body: JSON.stringify({key, tool_id: tool})});
+    if (!r.ok) {
+      if (r.status === 401) { sessionLost(); return; }
+      let d = r.statusText; try { d = (await r.json()).detail || d; } catch (e) {}
+      alert('Could not link that: ' + d);
+    } else {
+      CAND = (CAND || []).filter(x => x.key !== key);
+      AGENTIC = null;   // that page shows this process as a mystery today
+    }
+    render(); return;
   }
   if (act === 'cand-noattr') {
     // Not a dismissal. Dismissing says "not a tool" and closes the card;

--- a/portal/tests/test_portal.py
+++ b/portal/tests/test_portal.py
@@ -1757,3 +1757,31 @@ def test_a_real_bespoke_client_is_untouched_by_other_rulings():
                 evidence="DNS lookup for api.anthropic.com (via curl)"),
     ], REG_BIN, not_attributable=["firezone-client-tunnel"])
     assert out["agents"][0]["process"] == "curl"
+
+
+def test_a_process_attributed_to_a_tool_stops_being_a_mystery():
+    """Warp's macOS binary is called "stable", after its release channel.
+    Carrying that in the registry meant any process named stable was
+    silently excused as Warp, so it came out - and the queue asks instead.
+    An operator's answer has to reach this page, or the queue is again a
+    question whose answer goes nowhere."""
+    f = finding(tool="warp", surface="network", device="D1",
+                evidence="DNS lookup for app.warp.dev (via stable)")
+    assert derive.agentic_from([f], REG_BIN)["agents"][0]["process"] == "stable"
+    out = derive.agentic_from([f], REG_BIN, aliases={"stable": "warp"})
+    assert out["agents"] == []
+
+
+def test_an_alias_matches_the_name_in_every_shape():
+    f = finding(tool="warp", surface="network", device="D1",
+                evidence="DNS lookup for app.warp.dev (via Stable.exe)")
+    out = derive.agentic_from([f], REG_BIN, aliases={"stable": "warp"})
+    assert out["agents"] == []
+
+
+def test_attributing_one_name_does_not_excuse_another():
+    out = derive.agentic_from([
+        finding(tool="claude", surface="network", device="D1",
+                evidence="DNS lookup for api.anthropic.com (via curl)"),
+    ], REG_BIN, aliases={"stable": "warp"})
+    assert out["agents"][0]["process"] == "curl"

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -2866,9 +2866,12 @@ def _note_process_candidates(f: Finding):
         return
     if name.lower() in _BROWSERS or any(x in _BROWSERS for x in stems):
         return
-    # Already answered. Asking again is how a review queue becomes something
-    # nobody reads.
-    if name.strip().lower() in set(STATE.dispositioned_names("not_attributable")):
+    # Already answered, either way. Asking again is how a review queue
+    # becomes something nobody reads.
+    low = name.strip().lower()
+    if low in set(STATE.dispositioned_names("not_attributable")):
+        return
+    if low in STATE.process_aliases():
         return
     if not _CANDIDATE_TEXT.match(name):
         return
@@ -2939,6 +2942,52 @@ def mark_candidate_not_attributable(key: str,
             key, "not_attributable", _admin_actor(authorization)):
         raise HTTPException(404, "no candidate with that key")
     return {"not_attributable": key}
+
+
+class CandidateBelongsTo(BaseModel):
+    model_config = {"extra": "forbid"}
+    tool_id: str = Field(min_length=1, max_length=100)
+
+
+@app.post("/admin/candidates/{key}/belongs-to")
+def mark_candidate_belongs_to(key: str, req: CandidateBelongsTo,
+                              authorization: str = Header(default="")):
+    """This process is a tool the registry already knows, under a name
+    nothing would guess.
+
+    Warp's macOS binary is called "stable", after its release channel. That
+    name was briefly carried in the registry and had to come out: it is a
+    word, and any process called "stable" was being silently excused as Warp.
+    An operator can say it once here instead - which is the same trade the
+    candidates queue makes everywhere else, a maintained guess replaced by an
+    observed fact somebody confirmed.
+
+    The tool must already exist. Inventing one from a process name is what
+    "add to registry" is for, and it produces a tool with no domains that
+    matches nothing.
+    """
+    _admin_auth(authorization, write=True)
+    if not re.fullmatch(r"[a-z0-9_:-]{1,100}", key):
+        raise HTTPException(422, "malformed candidate key")
+    if not key.startswith("process:"):
+        raise HTTPException(
+            422, "only a process candidate can belong to a tool")
+    known = {t.get("id") for t in (_merged_registry() or {}).get("tools", [])}
+    if req.tool_id not in known:
+        raise HTTPException(
+            422, "no tool %s in the registry - define it first, or use "
+                 "\"add to registry\" to create it" % req.tool_id[:60])
+    if not STATE.set_candidate_disposition(
+            key, "belongs_to", _admin_actor(authorization), tool=req.tool_id):
+        raise HTTPException(404, "no candidate with that key")
+    return {"belongs_to": req.tool_id, "key": key}
+
+
+@app.get("/admin/candidates/process-aliases")
+def get_process_aliases(authorization: str = Header(default="")):
+    """Process name -> tool, for the views that read process names."""
+    _admin_auth(authorization)
+    return {"aliases": STATE.process_aliases()}
 
 
 @app.get("/admin/candidates/not-attributable")
@@ -3274,15 +3323,20 @@ def put_budget_subscription(req: BudgetSubscriptionWrite,
         same_tool = other["tool_id"] == req.tool_id
         if same_tool and other.get("plan_key") == pk:
             continue                      # this subscription, being edited
+        if same_tool:
+            # Two plans of one product entitle the same tools. A Max seat
+            # includes Claude Code exactly as a Team seat does, so their
+            # covered sets are SUPPOSED to be identical - different
+            # contracts, different people, different member lists, and the
+            # spend is each subscription's own seats times its own price.
+            #
+            # The first pass at this only excused the tool itself, so adding
+            # Max 20 beside Team was refused the moment either named a
+            # second tool. The rule is about one licence modelled twice,
+            # which is a thing that happens between DIFFERENT tools.
+            continue
         mine = set(covers)
         theirs = set(other.get("covers") or []) | {other["tool_id"]}
-        if same_tool:
-            # Two plans on one tool BOTH cover that tool, and that is the
-            # whole point: a Teams contract and a handful of Max seats are
-            # two subscriptions for the same product. The double-billing
-            # rule still holds for everything else they claim to cover.
-            mine.discard(req.tool_id)
-            theirs.discard(req.tool_id)
         clash = sorted(mine & theirs)
         if clash:
             raise HTTPException(

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -153,11 +153,16 @@ CREATE TABLE IF NOT EXISTS candidates (
   last_seen    TEXT NOT NULL,
   dismissed_at TEXT,
   dismissed_by TEXT NOT NULL DEFAULT '',
-  -- "" | "not_attributable". Dismissing says "not a tool"; this says the
-  -- name identifies no program at all - a resolver, a service host, a VPN
-  -- tunnel that resolves for everything behind it. Different claim, and
-  -- unlike a dismissal it has to reach the views that read process names.
-  disposition  TEXT NOT NULL DEFAULT ''
+  -- "" | "not_attributable" | "belongs_to". Dismissing says "not a tool".
+  -- not_attributable says the name identifies no program at all - a
+  -- resolver, a service host, a VPN tunnel that resolves for everything
+  -- behind it. belongs_to says it identifies a program the registry already
+  -- knows, under a name nothing would guess: Warp's macOS binary is called
+  -- "stable" after its release channel. All three close the card; only the
+  -- last two reach the views that read process names.
+  disposition  TEXT NOT NULL DEFAULT '',
+  -- The tool a belongs_to disposition points at.
+  disposition_tool TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS finding_status (
   key    TEXT PRIMARY KEY,
@@ -294,8 +299,9 @@ _BUDGET_SUB_COLUMNS_ADDED = (
 
 _CANDIDATE_COLUMNS_ADDED = (
     # A decision about the NAME rather than the thing: this identifies no
-    # program, so no view should present it as one.
+    # program, or it identifies one the registry already knows.
     ("disposition", "TEXT NOT NULL DEFAULT ''"),
+    ("disposition_tool", "TEXT NOT NULL DEFAULT ''"),
 )
 
 
@@ -1992,7 +1998,7 @@ class State:
         return out
 
     def set_candidate_disposition(self, key: str, disposition: str,
-                                  by: str = "") -> bool:
+                                  by: str = "", tool: str = "") -> bool:
         """Record what a name IS, as distinct from dismissing the row.
 
         Dismissing says "not a tool" and stops the queue asking. This says
@@ -2002,9 +2008,9 @@ class State:
         """
         with self._lock:
             cur = self._db.execute(
-                "UPDATE candidates SET disposition = ?, dismissed_at = ?,"
-                " dismissed_by = ? WHERE key = ?",
-                (disposition, _now(), by, key))
+                "UPDATE candidates SET disposition = ?, disposition_tool = ?,"
+                " dismissed_at = ?, dismissed_by = ? WHERE key = ?",
+                (disposition, tool, _now(), by, key))
             self._db.commit()
             return cur.rowcount > 0
 
@@ -2015,6 +2021,23 @@ class State:
                 "SELECT name FROM candidates WHERE disposition = ?",
                 (disposition,)).fetchall()
         return sorted({(r["name"] or "").strip().lower() for r in rows} - {""})
+
+    def process_aliases(self) -> dict:
+        """Process name -> the registry tool it belongs to.
+
+        Vendors ship binaries named nothing like their product: Warp's is
+        "stable", after the release channel. The registry cannot carry every
+        one of those and guessing them in a release is how "stable" came to
+        silently excuse any process with that name. An operator says it once,
+        here, and every view that reads a process name gets it.
+        """
+        with self._lock:
+            rows = self._db.execute(
+                "SELECT name, disposition_tool FROM candidates"
+                " WHERE disposition = 'belongs_to' AND disposition_tool != ''"
+            ).fetchall()
+        return {(r["name"] or "").strip().lower(): r["disposition_tool"]
+                for r in rows if (r["name"] or "").strip()}
 
     def dismiss_candidate(self, key: str, by: str = "") -> bool:
         with self._lock:

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.1
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/receiver/tests/test_budget.py
+++ b/receiver/tests/test_budget.py
@@ -826,3 +826,29 @@ def test_two_plans_on_one_tool_are_not_a_double_billed_licence(managed):
     r = client.put("/admin/budget/subscription", headers=ADMIN,
                    json=_sub("cursor", "Pro", 5, 20, covers=["claude-code"]))
     assert r.status_code == 422 and "already covered" in r.json()["detail"]
+
+
+def test_a_second_plan_may_cover_the_same_tools(managed):
+    """A Max seat includes Claude Code exactly as a Team seat does, so two
+    plans of one product cover the same set on purpose. The first pass at
+    the plan rework only excused the tool itself, so adding Max 20 beside
+    Team was refused the moment either named a second tool."""
+    a = _sub("claude", "Team", 40, 25, covers=["claude-code"])
+    assert client.put("/admin/budget/subscription", headers=ADMIN,
+                      json=a).status_code == 200
+    b = _sub("claude", "Max 20", 3, 100, covers=["claude-code"])
+    r = client.put("/admin/budget/subscription", headers=ADMIN, json=b)
+    assert r.status_code == 200, r.text
+    subs = client.get("/admin/budget", headers=ADMIN).json()["subscriptions"]
+    claude = sorted(x["plan_key"] for x in subs if x["tool_id"] == "claude")
+    assert claude == ["max-20", "team"]
+
+
+def test_a_different_tool_still_cannot_claim_a_covered_one(managed):
+    """The rule it exists for is untouched: one licence modelled as two
+    subscriptions bills it twice and halves every observed-use answer."""
+    client.put("/admin/budget/subscription", headers=ADMIN,
+               json=_sub("claude", "Team", 40, 25, covers=["claude-code"]))
+    r = client.put("/admin/budget/subscription", headers=ADMIN,
+                   json=_sub("cursor", "Pro", 5, 20, covers=["claude-code"]))
+    assert r.status_code == 422 and "already covered" in r.json()["detail"]

--- a/receiver/tests/test_candidates.py
+++ b/receiver/tests/test_candidates.py
@@ -327,3 +327,46 @@ def test_only_a_process_can_be_called_unattributable(managed):
     key = rows[0]["key"]
     r = client.post("/admin/candidates/%s/not-attributable" % key, headers=ADMIN)
     assert r.status_code == 422
+
+
+def test_a_process_can_belong_to_a_tool_the_registry_knows(managed, monkeypatch):
+    """Vendors ship binaries named nothing like their product: Warp's macOS
+    one is "stable", after the release channel. That name was briefly carried
+    in the registry and had to come out - it is a word, and any process
+    called stable was being silently excused as Warp. An operator says it
+    once here instead."""
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", {"claude"})
+    monkeypatch.setattr(main, "_merged_registry",
+                        lambda: {"tools": [{"id": "warp", "name": "Warp"}]})
+    client.post("/report", json=_dns("stable", host="app.warp.dev"), headers=AUTH)
+    r = client.post("/admin/candidates/process:stable/belongs-to",
+                    headers=ADMIN, json={"tool_id": "warp"})
+    assert r.status_code == 200, r.text
+    got = client.get("/admin/candidates/process-aliases", headers=ADMIN).json()
+    assert got["aliases"] == {"stable": "warp"}
+
+
+def test_it_will_not_point_at_a_tool_that_does_not_exist(managed, monkeypatch):
+    """Inventing a tool from a process name is what "add to registry" is for,
+    and it produces a tool with no domains that matches nothing."""
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", {"claude"})
+    monkeypatch.setattr(main, "_merged_registry",
+                        lambda: {"tools": [{"id": "warp", "name": "Warp"}]})
+    client.post("/report", json=_dns("stable", host="app.warp.dev"), headers=AUTH)
+    r = client.post("/admin/candidates/process:stable/belongs-to",
+                    headers=ADMIN, json={"tool_id": "nonesuch"})
+    assert r.status_code == 422 and "no tool nonesuch" in r.json()["detail"]
+
+
+def test_an_attributed_name_is_not_asked_about_again(managed, monkeypatch):
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", {"claude"})
+    monkeypatch.setattr(main, "_merged_registry",
+                        lambda: {"tools": [{"id": "warp", "name": "Warp"}]})
+    client.post("/report", json=_dns("stable", host="app.warp.dev"), headers=AUTH)
+    client.post("/admin/candidates/process:stable/belongs-to",
+                headers=ADMIN, json={"tool_id": "warp"})
+    client.post("/report", json=_dns("stable", host="app.warp.dev", device="D2"),
+                headers=AUTH)
+    rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
+    assert [c for c in rows if c["kind"] == "process"
+            and not c.get("dismissed_at")] == []


### PR DESCRIPTION
Two things, both found by running the product.

## `stable` arrived in the queue and none of the buttons fitted

Warp's macOS binary is called `stable`, after its release channel. It was in the registry for one release and came out again in 0.25.0 — it is *a word*, and any process named `stable` was being silently excused as Warp. The queue asks instead. That was the point.

But the queue could only offer three answers and **none of them was true**:

| | why not |
|---|---|
| **Add to registry** | invents a tool called `stable` with no domains, matching nothing, beside the Warp that already exists — and a portal entry cannot extend a shipped tool anyway, `_merged_registry` drops it on an id collision |
| **Names nothing** | false. It names Warp. |
| **Dismiss** | closes the card and leaves the process on the Agentic view **for ever** — the exact failure the third disposition was added to fix |

So there's a fourth: **belongs to a tool the registry knows**, picked from the tools that exist. Refused if the tool doesn't — inventing one from a process name is what *add to registry* is for, and it produces something that matches nothing.

Recorded once, read by every view that reads a process name, and the receiver stops asking. Same trade the queue makes everywhere else: a maintained guess replaced by an observed fact somebody confirmed. Guessing `stable` in a release is precisely what went wrong.

## A second plan could not cover the same tools

```
Not saved: claude-code is already covered by the claude Team subscription
```

Wrong, and mine. The covers rule I shipped in 0.25.0 excused only the *tool itself* when comparing two plans of one product, so the moment either named a second tool they collided — which is every real Claude subscription, since Team and Max both include Claude Code.

A Max seat includes Claude Code exactly as a Team seat does. **Their covered sets are supposed to be identical**: different contracts, different people, different member lists, and the spend is each subscription's own seats times its own price.

The rule exists to catch one licence modelled as two subscriptions, which happens between *different* tools. That half is untouched and still tested:

```
claude/Team covers claude-code, then claude/Max 20 covers claude-code  -> allowed
claude/Team covers claude-code, then cursor/Pro covers claude-code     -> 422
```

## Checked

Suites: registry 23, portal 630, scanner 210, receiver 305. Plus collector parity, `build.py --check`, both byte-identical invariants, chart copies, identifier guard.

Not verified: the picker rendering in a browser. Same standing gap as the budget page — managed mode needs a login I've avoided.
