### PR TITLE
A picker with nothing in it

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.25.1
+version: 0.25.2
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.25.1"
+appVersion: "0.25.2"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.1
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.2
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.1
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.2
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -1561,6 +1561,14 @@ async function load(force) {
       if (CFG.managed && CFG.managed.enabled && AUTH && AUTH.mode === 'login') {
         const cq = await mfetch('/api/candidates');
         if (cq.ok) CAND = (await cq.json()).candidates || [];
+        // The queue's "belongs to" picker offers registry tools, and every
+        // other fetch of them lives inside a VIEW - budget, registry,
+        // register, the wizard. The widget is on the overview, which visits
+        // none of those, so the picker rendered with nothing in it.
+        if (!REGTOOLS) {
+          const tr = await mfetch('/api/registry-tools');
+          if (tr.ok) REGTOOLS = (await tr.json()).tools || [];
+        }
       }
     }
     loadError = '';
@@ -2319,15 +2327,18 @@ const WIDGETS = {
         <td style="color:var(--mut)">${c.devices || 0} device${c.devices === 1 ? '' : 's'}
           ${c.confidence ? ' · ' + esc(c.confidence) : ''}</td>
         <td style="white-space:nowrap">
-          ${c.kind === 'process' ? `<select class="mfield" id="cb-${esc(c.key)}"
+          ${c.kind === 'process' ? ((REGTOOLS || []).length ? `<select class="mfield" id="cb-${esc(c.key)}"
             style="min-width:130px;font-size:12px"
             title="A vendor's binary is often named nothing like its product - Warp's is called stable, after its release channel. Say which tool this is and every view that reads a process name gets it.">
             <option value="">belongs to…</option>
             ${(REGTOOLS || []).slice().sort((a, b) => a.name.localeCompare(b.name))
               .map(t => `<option value="${esc(t.id)}">${esc(t.name)}</option>`).join('')}
           </select>
-          <button class="mini" data-act="cand-belongs" data-key="${esc(c.key)}">Link</button>
-          <button class="mini" data-act="cand-noattr"
+          <button class="mini" data-act="cand-belongs" data-key="${esc(c.key)}">Link</button>`
+          // An empty dropdown reads as "no tools exist", which is never the
+          // answer - it means the list did not load. Say that instead.
+          : `<span class="src-note" title="The registry tool list did not load, so there is nothing to point this at. Refresh the page.">belongs-to unavailable</span> `)
+          + `<button class="mini" data-act="cand-noattr"
             data-key="${esc(c.key)}" title="This name identifies no program - a resolver, a service host, a VPN tunnel that resolves for everything behind it. Recorded once and honoured everywhere a process name is read.">Names nothing</button> ` : ''}<button class="btn" data-act="cand-add" data-key="${esc(c.key)}">Add to registry</button>
           <button class="btn" data-act="cand-dismiss" data-key="${esc(c.key)}">Dismiss</button>
         </td></tr>`).join('')}</table>
@@ -7865,6 +7876,10 @@ async function reloadDerived() {
     try {
       const cq = await mfetch('/api/candidates');
       if (cq.ok) CAND = (await cq.json()).candidates || [];
+      // Nulled just above, and the queue's picker needs it. Leaving it for
+      // a view to fetch is what emptied the picker in the first place.
+      const tr = await mfetch('/api/registry-tools');
+      if (tr.ok) REGTOOLS = (await tr.json()).tools || [];
     } catch (e) { /* the queue simply stays unread until the next load */ }
   }
 }

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.1
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.2
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
The **belongs to…** dropdown shipped yesterday, rendered on the overview, and was **empty**.

## Why

Every fetch of the registry tool list lives inside a **view**:

```
budget()    registry()    register()    wizard()
```

The review queue is a **widget on the overview**, which visits none of them. So `(REGTOOLS || [])` was empty and the select rendered zero options — meaning the one action available for a process like Warp's `stable` was unavailable at the only place it is offered.

`reloadDerived()` had the same shape one layer down: it nulled `REGTOOLS` and left it for a view to fetch, which is the bug again.

The overview loads the list now, beside the candidates it already fetches.

## And it says why when it can't

An empty dropdown reads as **"no tools exist"**. That is never the answer — it means the list did not load, which is a different sentence. Both branches checked by rendering them:

```
WITH TOOLS -> select: true  | options: 3 | Link: true | Warp offered: true
NO TOOLS   -> select: false | says why: true | Link: false
```

With nothing to offer it shows `belongs-to unavailable` and drops the Link button, rather than inviting a click that cannot work.

## Checked

Suites: registry 23, portal 630, scanner 210, receiver 305. Plus collector parity and the identifier guard.

The picker itself was confirmed rendering in a browser — that half of the standing browser-check debt is now closed. **The budget page with two plans is still owed.**
