### PR TITLE
Say what the registry already thinks it is

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.25.2
+version: 0.26.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.25.2"
+appVersion: "0.26.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.2
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.26.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.2
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.26.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2322,8 +2322,14 @@ const WIDGETS = {
           ${c.kind === 'mcp_server' ? ' <span class="pill p-acc">MCP server</span>' : ''}
           ${c.kind === 'process' ? ' <span class="pill p-warn">process</span>' : ''}
           <div style="color:var(--mut);font-size:12px">
-          ${esc(c.kind === 'mcp_server' ? (c.evidence || '')
-                                        : (c.domains || []).join(', '))}</div></td>
+          ${esc(c.kind === 'mcp_server' || c.kind === 'process'
+                  ? (c.evidence || '') : (c.domains || []).join(', '))}</div>
+          ${c.kind === 'process' && c.suggested_tool ? `<div style="font-size:12px">
+            <span class="pill p-acc">looks like ${esc(
+              ((REGTOOLS || []).find(t => t.id === c.suggested_tool) || {}).name
+              || c.suggested_tool)}</span>
+            <span style="color:var(--mut)">it reached a host the registry knows as
+            that tool — confirm or change below</span></div>` : ''}</td>
         <td style="color:var(--mut)">${c.devices || 0} device${c.devices === 1 ? '' : 's'}
           ${c.confidence ? ' · ' + esc(c.confidence) : ''}</td>
         <td style="white-space:nowrap">
@@ -2332,7 +2338,8 @@ const WIDGETS = {
             title="A vendor's binary is often named nothing like its product - Warp's is called stable, after its release channel. Say which tool this is and every view that reads a process name gets it.">
             <option value="">belongs to…</option>
             ${(REGTOOLS || []).slice().sort((a, b) => a.name.localeCompare(b.name))
-              .map(t => `<option value="${esc(t.id)}">${esc(t.name)}</option>`).join('')}
+              .map(t => `<option value="${esc(t.id)}"${
+                t.id === c.suggested_tool ? ' selected' : ''}>${esc(t.name)}</option>`).join('')}
           </select>
           <button class="mini" data-act="cand-belongs" data-key="${esc(c.key)}">Link</button>`
           // An empty dropdown reads as "no tools exist", which is never the

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -2878,7 +2878,18 @@ def _note_process_candidates(f: Finding):
     if STATE.observe_candidate(
             _candidate_key("process", name), "process", name,
             (f.evidence or "")[:500], "network",
-            f.device if f.device != "unknown" else ""):
+            f.device if f.device != "unknown" else "",
+            # What the registry already thinks this is. By the time this runs
+            # the finding's tool has been resolved from the domain it
+            # reached, so "stable reached app.warp.dev" is known here - and
+            # asking an operator what "stable" is, with the answer one
+            # variable away, is a question nobody should have to research.
+            #
+            # A suggestion only. curl reaching api.anthropic.com is a script
+            # somebody wrote, not Claude, and applying this automatically
+            # would delete the exact finding this view exists for.
+            suggested_tool=(f.tool or "") if (f.tool or "") in _REGISTRY_IDS
+            else ""):
         _notify_webhook(
             "ai-guard: %r reached a model host and is not a tool, a browser"
             " or a system process this knows - now in the review queue"

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -162,7 +162,18 @@ CREATE TABLE IF NOT EXISTS candidates (
   -- last two reach the views that read process names.
   disposition  TEXT NOT NULL DEFAULT '',
   -- The tool a belongs_to disposition points at.
-  disposition_tool TEXT NOT NULL DEFAULT ''
+  disposition_tool TEXT NOT NULL DEFAULT '',
+  -- What the registry already thinks this is. A process candidate is raised
+  -- from a finding whose tool has ALREADY been resolved from the domain it
+  -- reached, so "stable reached app.warp.dev" is known at the moment the
+  -- question is asked. Carrying it turns "what is this?" into "is this
+  -- Warp?", which is a question an operator can answer without knowing that
+  -- Warp names its binary after a release channel.
+  --
+  -- A suggestion, never applied on its own: curl reaching api.anthropic.com
+  -- is a script somebody wrote, not Claude, and that is the whole signal the
+  -- agentic view exists for.
+  suggested_tool TEXT NOT NULL DEFAULT ''
 );
 CREATE TABLE IF NOT EXISTS finding_status (
   key    TEXT PRIMARY KEY,
@@ -302,6 +313,7 @@ _CANDIDATE_COLUMNS_ADDED = (
     # program, or it identifies one the registry already knows.
     ("disposition", "TEXT NOT NULL DEFAULT ''"),
     ("disposition_tool", "TEXT NOT NULL DEFAULT ''"),
+    ("suggested_tool", "TEXT NOT NULL DEFAULT ''"),
 )
 
 
@@ -1850,7 +1862,8 @@ class State:
             rows = self._db.execute(
                 "SELECT key, kind, name, vendor, category, confidence,"
                 " domains, devices, evidence, source, first_seen, last_seen,"
-                " dismissed_at, dismissed_by, disposition FROM candidates"
+                " dismissed_at, dismissed_by, disposition, suggested_tool"
+                " FROM candidates"
                 " ORDER BY last_seen DESC"
             ).fetchall()
         out = []
@@ -1890,7 +1903,8 @@ class State:
         return fresh
 
     def observe_candidate(self, key: str, kind: str, name: str,
-                          evidence: str, source: str, device: str = ""):
+                          evidence: str, source: str, device: str = "",
+                          suggested_tool: str = ""):
         """An ingest-time sighting, as opposed to a scanner's whole-picture
         report: insert the candidate if it is new, refresh last_seen if it
         is not, and count the reporting device once. devices becomes the
@@ -1908,9 +1922,17 @@ class State:
             ).fetchone() is None
             self._db.execute(
                 "INSERT INTO candidates (key, kind, name, evidence, source,"
-                " first_seen, last_seen) VALUES (?, ?, ?, ?, ?, ?, ?)"
-                " ON CONFLICT(key) DO UPDATE SET last_seen = excluded.last_seen",
-                (key, kind, name, evidence, source, now, now),
+                " first_seen, last_seen, suggested_tool)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+                " ON CONFLICT(key) DO UPDATE SET"
+                " last_seen = excluded.last_seen,"
+                # A later sighting can supply the suggestion an earlier one
+                # lacked, but never blank one already recorded.
+                " suggested_tool = CASE WHEN excluded.suggested_tool != ''"
+                " THEN excluded.suggested_tool"
+                " ELSE candidates.suggested_tool END",
+                (key, kind, name, evidence, source, now, now,
+                 suggested_tool),
             )
             if device:
                 self._db.execute(

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.25.2
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.26.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/receiver/tests/test_candidates.py
+++ b/receiver/tests/test_candidates.py
@@ -370,3 +370,46 @@ def test_an_attributed_name_is_not_asked_about_again(managed, monkeypatch):
     rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
     assert [c for c in rows if c["kind"] == "process"
             and not c.get("dismissed_at")] == []
+
+
+def test_a_process_candidate_carries_what_the_registry_thinks_it_is(managed, monkeypatch):
+    """By the time the candidate is raised, the finding's tool has already
+    been resolved from the domain it reached. Asking an operator what
+    "stable" is, with the answer one variable away, is a question nobody
+    should have to research - you would need to know Warp names its binary
+    after a release channel."""
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", {"claude"})
+    monkeypatch.setattr(main, "_REGISTRY_IDS", {"warp", "claude"})
+    client.post("/report", headers=AUTH, json=dict(
+        _dns("stable", host="app.warp.dev"), tool="warp"))
+    rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
+    got = [c for c in rows if c["kind"] == "process"][0]
+    assert got["suggested_tool"] == "warp"
+    assert "app.warp.dev" in got["evidence"]
+
+
+def test_the_suggestion_is_only_ever_a_suggestion(managed, monkeypatch):
+    """curl reaching api.anthropic.com is a script somebody wrote, not
+    Claude. The candidate still says what the registry thinks, and still
+    waits for a human - applying it would delete the exact finding the
+    agentic view exists for."""
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", set())
+    monkeypatch.setattr(main, "_REGISTRY_IDS", {"claude"})
+    client.post("/report", headers=AUTH, json=_dns("curl"))
+    rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
+    got = [c for c in rows if c["kind"] == "process"][0]
+    assert got["suggested_tool"] == "claude"     # said
+    assert got["disposition"] == ""              # not acted on
+    assert not got["dismissed_at"]               # still awaiting a decision
+
+
+def test_a_tool_the_registry_does_not_have_is_not_suggested(managed, monkeypatch):
+    """A suggestion pointing at nothing is worse than none: the picker could
+    not offer it, and the card would name a tool that does not exist."""
+    monkeypatch.setattr(main, "_KNOWN_PROCESSES", set())
+    monkeypatch.setattr(main, "_REGISTRY_IDS", {"claude"})
+    client.post("/report", headers=AUTH, json=dict(_dns("weird-agent"),
+                                                   tool="not-in-registry"))
+    rows = client.get("/admin/candidates", headers=ADMIN).json()["candidates"]
+    got = [c for c in rows if c["kind"] == "process"][0]
+    assert got["suggested_tool"] == ""


### PR DESCRIPTION
`stable` arrived in the review queue with a picker offering every tool in the registry and **no indication which one to choose**. Answering it required knowing that Warp names its macOS binary after a release channel — which is not something an operator should have to research about their own estate.

## The platform already knew

A process candidate is raised from a finding whose tool has **already been resolved from the domain it reached**:

```
main.py:3696   canonical = _DOMAIN_TO_TOOL.get(f.tool.lower())   ← app.warp.dev → warp
main.py:3714   _note_process_candidates(f)                       ← asks "what is stable?"
```

Eighteen lines apart. At the moment it asked the question, `f.tool` said `warp` — and the candidate threw it away.

## What it does now

The candidate carries the suggestion. The card reads:

> **stable** `process`
> `DNS lookup for app.warp.dev (via stable)`
> **looks like Warp** — it reached a host the registry knows as that tool, confirm or change below

…and the picker opens on Warp, so confirming is one click.

## It stays a suggestion

`curl` reaching `api.anthropic.com` resolves to `claude`, and **curl is not Claude** — it is a script somebody wrote, which is the entire signal the Agentic view exists for. Applying this automatically would delete the finding this week has been about.

So the card says what the registry thinks and still waits for a human. Same trade discovery makes when it classifies an unknown domain with Claude and still queues it.

A tool the registry doesn't have is **not suggested at all** — the picker couldn't offer it, and the card would name something that doesn't exist.

## Checked by rendering, not by reasoning

The row template was pulled out of the page and run against a `stable`, a `curl` and an MCP server:

```
stable: looks-like Warp    : true      curl : looks-like Claude  : true
stable: Warp preselected   : true      curl : Claude preselected : true
stable: evidence shown     : true      mcp  : no picker offered  : true
```

Not checking what a widget renders *from* is exactly what shipped an empty dropdown yesterday.

Suites: registry 23, portal 630, scanner 210, receiver 308. Plus collector parity and the identifier guard.
