### PR TITLE
Budget: a new plan hands its key to the import, and a headerless paste keeps its columns

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -6,14 +6,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.27.0
+version: 0.27.1
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.27.0"
+appVersion: "0.27.1"
 home: https://github.com/AmanSK5/shadow-ai-guard
 sources:
   - https://github.com/AmanSK5/shadow-ai-guard

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.27.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.27.1
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.27.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.27.1
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -6824,7 +6824,8 @@ function parseUsersCsv(text) {
   // and jane@example.com's cell.
   const hasHeader = !head.some(h => B_EMAIL_RE.test(h));
   const col = names => head.findIndex(h => names.some(n => h.includes(n)));
-  let iEmail, iName = -1, iRole = -1, iTier = -1;
+  let iEmail, iName = -1, iRole = -1, iTier = -1, guessed = false;
+  const ignored = [];
   if (hasHeader) {
     iEmail = col(['email', 'e-mail', 'mail']);
     iName = col(['name', 'member', 'user']);
@@ -6833,14 +6834,37 @@ function parseUsersCsv(text) {
     if (iEmail < 0) return {members: [], skipped: lines.length};
   } else {
     // No header: the email column is wherever the first row keeps its
-    // address.
-    iEmail = Math.max(0, row(lines[0]).findIndex(c => B_EMAIL_RE.test(c)));
+    // address. The other columns are named from what they hold, because
+    // "jane@corp.example,member,max 5" is the common paste and dropping
+    // "member" and "max 5" from it reads as a broken import. A column
+    // whose every value is a role word is the role; one whose values are
+    // account states is a status and is ignored; when exactly one column
+    // is left, it is the seat tier. Anything less certain is left unread
+    // and said so, rather than guessed.
+    const rows = lines.map(row);
+    iEmail = Math.max(0, rows[0].findIndex(c => B_EMAIL_RE.test(c)));
+    const width = Math.max(...rows.map(r => r.length));
+    const isRole = /^(owner|admin|administrator|member|members|user|users|viewer|guest|billing|manager|editor)$/i;
+    const isStatus = /^(active|inactive|invited|pending|suspended|deactivated|disabled|enabled)$/i;
+    const spare = [];
+    for (let c = 0; c < width; c++) {
+      if (c === iEmail) continue;
+      const vals = rows.map(r => (r[c] || '').trim()).filter(Boolean);
+      if (!vals.length) continue;
+      if (iRole < 0 && vals.every(v => isRole.test(v))) iRole = c;
+      else if (vals.every(v => isStatus.test(v))) ignored.push(c);
+      else spare.push(c);
+    }
+    if (spare.length === 1) iTier = spare[0];
+    guessed = iRole >= 0 || iTier >= 0;
   }
   const members = []; let skipped = 0, extra = 0;
   const seen = new Set();
   lines.slice(hasHeader ? 1 : 0).forEach(l => {
     const cells = row(l);
-    if (!hasHeader) extra = Math.max(extra, cells.filter(c => c).length - 1);
+    // Columns beyond the ones the paste could name.
+    if (!hasHeader) extra = Math.max(extra, cells.filter((c, i) => c && i !== iEmail
+      && i !== iRole && i !== iTier && !ignored.includes(i)).length);
     const email = (cells[iEmail] || '').toLowerCase();
     if (!B_EMAIL_RE.test(email) || seen.has(email)) { skipped++; return; }
     seen.add(email);
@@ -6862,7 +6886,7 @@ function parseUsersCsv(text) {
           // a delimiter mismatch over a support thread is slower than the
           // page just saying what it decided.
           map: {delim: delim === '\t' ? 'tabs' : delim === ';' ? 'semicolons' : 'commas',
-                header: hasHeader,
+                header: hasHeader, guessed,
                 cols: {email: iEmail, name: iName, role: iRole, tier: iTier}}};
 }
 
@@ -7640,16 +7664,16 @@ function budgetImport() {
     <button class="mini" data-act="b-csv-cancel">Cancel</button>
     ${parsed && parsed.members.length && !askPlan ? `<button class="mini" data-act="b-csv-save">import ${parsed.members.length} members</button>` : ''}
   </div>
-  ${parsed ? `${parsed.headerless ? `<p class="src-note" style="color:var(--warn)">These
-    rows carry more columns than the addresses, but with no header line to
-    name them only the emails can be kept. Paste again with the header row
-    included (e.g. name, email, role, seat tier) and role and seat tier
-    come through.</p>` : ''}
+  ${parsed ? `${parsed.headerless ? `<p class="src-note" style="color:var(--warn)">Some
+    columns in these rows could not be named from their values, and with no
+    header line they are left out. Paste again with the header row included
+    (e.g. name, email, role, seat tier) and every column comes through.</p>` : ''}
     ${parsed.missing && parsed.missing.tier ? `<p class="src-note" style="color:var(--warn)">No
     seat/tier column recognised in the header, so seat tiers will import
     empty and the tier table cannot count these users against seats.</p>` : ''}
     ${parsed.map ? `<p class="src-note">Read as: ${parsed.map.delim},
-    ${parsed.map.header ? 'header row found' : 'no header row'};
+    ${parsed.map.header ? 'header row found' : parsed.map.guessed
+      ? 'no header row, columns named from their values' : 'no header row'};
     ${ents(parsed.map.cols).map(([f, i]) =>
       `${f === 'tier' ? 'seat tier' : f} ${i >= 0 ? ordinal(i + 1) + ' column' : 'not found'}`)
       .join(', ')}.</p>` : ''}

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -7610,7 +7610,21 @@ function budgetCard(sub) {
 
 function budgetImport() {
   const parsed = BCSV && BCSV.parsed;
-  return `<h2>Import users — ${esc(BCSV.tool_id)}</h2>
+  // Which plan these people are on. Known when the import was opened from
+  // a plan's card or straight after linking; asked for when it is not and
+  // the tool has more than one, because the receiver will not guess.
+  const plans = (BUDGET && BUDGET.subscriptions || [])
+    .filter(x => x.tool_id === BCSV.tool_id);
+  const plan = plans.find(x => (x.plan_key || 'default') === BCSV.plan_key);
+  if (!BCSV.plan_key && plans.length === 1) BCSV.plan_key = plans[0].plan_key || 'default';
+  const askPlan = !BCSV.plan_key && plans.length > 1;
+  return `<h2>Import users — ${esc(BCSV.tool_id)}${plan && plan.plan ? ` · ${esc(plan.plan)}` : ''}</h2>
+  ${askPlan ? `<div class="note">${esc(BCSV.tool_id)} has ${plans.length} plans.
+    <label style="margin-left:6px">Import these people into
+      <select id="b-csv-plan" class="mfield" style="min-width:160px;display:inline-block;width:auto;margin-left:6px">
+        <option value="">choose a plan…</option>
+        ${plans.map(x => `<option value="${esc(x.plan_key || 'default')}">${esc(x.plan || x.plan_key || 'default')}</option>`).join('')}
+      </select></label></div>` : ''}
   <p class="lede">Paste the member export from the vendor's admin page
   (ChatGPT Business: Workspace settings → Members; Claude: Organization
   settings → Members, which exports name / email / role / status / seat
@@ -7624,7 +7638,7 @@ function budgetImport() {
   <div style="margin-top:8px;display:flex;gap:6px">
     <button class="mini" data-act="b-csv-parse">Preview</button>
     <button class="mini" data-act="b-csv-cancel">Cancel</button>
-    ${parsed && parsed.members.length ? `<button class="mini" data-act="b-csv-save">import ${parsed.members.length} members</button>` : ''}
+    ${parsed && parsed.members.length && !askPlan ? `<button class="mini" data-act="b-csv-save">import ${parsed.members.length} members</button>` : ''}
   </div>
   ${parsed ? `${parsed.headerless ? `<p class="src-note" style="color:var(--warn)">These
     rows carry more columns than the addresses, but with no header line to
@@ -7977,22 +7991,35 @@ async function budgetAction(act, el) {
       seat_tiers: w.tiers || []});
     if (!r) return;
     if (!r.ok) { BMSG = 'Not saved: ' + await _refusal(r); render(); return; }
+    // A new plan has no key until the receiver derives one from its name,
+    // and the receiver answers the save with the whole budget. Read the key
+    // back from there: the connection, the first sync and the CSV import
+    // that follow all name the plan, and the receiver refuses to guess once
+    // a tool has two - which is exactly when a second plan is being added.
+    let pk = w.plan_key || '';
+    try {
+      const saved = await r.json();
+      const mine = (saved.subscriptions || []).find(x => x.tool_id === w.tool_id
+        && (pk ? (x.plan_key || 'default') === pk
+               : (x.plan || '') === (w.plan || '')));
+      if (mine) pk = mine.plan_key || 'default';
+    } catch (e) { /* the wizard's own value is the fallback */ }
     if (w.source === 'api' && w.api_key) {
       r = await post('/api/budget/connection', {
-        tool_id: w.tool_id, plan_key: w.plan_key || '',
+        tool_id: w.tool_id, plan_key: pk,
         provider: w.provider, api_key: w.api_key});
       if (!r) return;
       if (!r.ok) { BMSG = 'Subscription saved, but the connection was refused: '
         + await _refusal(r); BUDGET = null; BWIZ = null; render(); return; }
       const s = await post('/api/budget/sync',
-                           {tool_id: w.tool_id, plan_key: w.plan_key || ''});
+                           {tool_id: w.tool_id, plan_key: pk});
       if (!s) return;
       const out = s.ok ? await s.json() : {ok: false, detail: await _refusal(s)};
       BMSG = out.ok ? `Linked. Synced ${out.count} members from the vendor.`
         : 'Linked, but the first sync failed: ' + out.detail;
     } else if (w.source === 'csv' && !w.editing) {
       BWIZ = null; BUDGET = null;
-      BCSV = {tool_id: w.tool_id, plan_key: w.plan_key || '',
+      BCSV = {tool_id: w.tool_id, plan_key: pk,
               text: '', parsed: null};
       BMSG = '';
       render(); return;
@@ -9797,6 +9824,12 @@ app.addEventListener('change', e => {
   if (e.target && e.target.id === 'bw-tool' && BWIZ) {
     BWIZ.tool_id = e.target.value;
     BWIZ.covers = null;
+    render();
+  }
+  if (e.target && e.target.id === 'b-csv-plan' && BCSV) {
+    BCSV.plan_key = e.target.value;
+    // The pasted text survives the re-render; the preview is rebuilt from it.
+    BCSV.text = (document.getElementById('b-csv') || {}).value || BCSV.text;
     render();
   }
 });

--- a/portal/tests/test_budget.py
+++ b/portal/tests/test_budget.py
@@ -272,3 +272,29 @@ def test_the_budget_page_lists_providers_as_a_list_not_a_chain():
     what applies to the tool being linked."""
     assert "ChatGPT Business has no admin API on that plan" not in INDEX
     assert "labels.slice(0, -1).join(', ')" in INDEX
+
+
+def test_a_new_plan_hands_its_key_to_what_follows():
+    """Linking a second plan on a tool with "CSV" as the source opened the
+    import with no plan key: the wizard passed on its own empty one, and the
+    receiver - rightly - refuses to guess between two plans. The wizard now
+    reads the key the receiver derived back from the save's answer and hands
+    it to the connection, the first sync and the import alike."""
+    html = (main.STATIC / "index.html").read_text()
+    save = html.split("if (act === 'b-save') {", 1)[1].split("if (act === 'b-sync')", 1)[0]
+    assert "const mine = (saved.subscriptions || []).find(x => x.tool_id === w.tool_id" in save
+    assert "if (mine) pk = mine.plan_key || 'default';" in save
+    assert "plan_key: w.plan_key || ''" not in save.split("let pk =", 1)[1]
+    assert save.count("plan_key: pk") == 3
+
+
+def test_the_import_asks_which_plan_when_it_does_not_know():
+    """The screen names the plan it is importing into, and when it has no key
+    on a tool with several plans it asks rather than letting the import fail
+    with the receiver's refusal after the paste."""
+    html = (main.STATIC / "index.html").read_text()
+    view = html.split("function budgetImport() {", 1)[1].split("\nfunction ", 1)[0]
+    assert "const askPlan = !BCSV.plan_key && plans.length > 1;" in view
+    assert 'id="b-csv-plan"' in view
+    assert "parsed.members.length && !askPlan" in view
+    assert "e.target.id === 'b-csv-plan' && BCSV" in html

--- a/portal/tests/test_budget.py
+++ b/portal/tests/test_budget.py
@@ -298,3 +298,20 @@ def test_the_import_asks_which_plan_when_it_does_not_know():
     assert 'id="b-csv-plan"' in view
     assert "parsed.members.length && !askPlan" in view
     assert "e.target.id === 'b-csv-plan' && BCSV" in html
+
+
+def test_a_headerless_paste_keeps_the_role_and_seat_it_plainly_carries():
+    """"jane@corp.example,member,max 5" is the common paste. With no header
+    line the parser kept only the address and dropped the other two, which
+    reads as a broken import. It now names a column from its values - all
+    role words is the role, account states are a status and ignored, the
+    one column left is the seat tier - and only says a column is unread
+    when it genuinely cannot name it."""
+    html = (main.STATIC / "index.html").read_text()
+    fn = html.split("function parseUsersCsv(text) {", 1)[1].split("\n}\n", 1)[0]
+    assert "const isRole = /^(owner|admin|administrator|member|members|user|users|viewer|guest|billing|manager|editor)$/i;" in fn
+    assert "const isStatus = /^(active|inactive|invited|pending|suspended|deactivated|disabled|enabled)$/i;" in fn
+    assert "if (spare.length === 1) iTier = spare[0];" in fn
+    assert "guessed = iRole >= 0 || iTier >= 0;" in fn
+    assert "&& i !== iRole && i !== iTier && !ignored.includes(i)).length" in fn
+    assert "'no header row, columns named from their values'" in html

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -61,7 +61,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.27.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.27.1
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
## What this fixes

**Importing members after linking a second plan failed.** Linking a plan with "CSV" as the source opened the import screen with no plan key: the wizard passed on the key it held, which is empty for a new plan because the receiver derives it from the plan name. With one plan on a tool the receiver fills the blank in itself, so this only appeared the moment a second plan was added, and the receiver then refused - rightly - to guess between the two. The API-key path had the same hole for its connection and first sync.

The wizard now reads the key back from the save's answer and hands it to the connection, the first sync and the import. The import screen names the plan it is importing into, and when it is opened without a key on a tool with several plans it asks which one before offering the import.

**A headerless paste lost its role and seat tier.** `jane@corp.example,member,max 5` kept only the address, by the parser's own rules, which reads as a broken import. Columns are now named from their values: every value a role word makes the column the role, every value an account state makes it a status and it is ignored, and when exactly one column is left it is the seat tier. Anything less certain stays unread and the preview says so.

## Not a bug

The tool picker lists tools, not plans. A tool that already has plans stays selectable and lists them; a further plan on the same tool is added by choosing the tool again with the new plan name.

## Release notes

- Portal-only change; the receiver is unchanged from 0.27.0.

## Verification

- Portal: 655 tests.
- Reproduced in the demo stack: Team already linked on Claude, Max 5 added with a CSV source, import succeeds and names the plan; the fallback picker appears for an import opened without a key; five paste shapes checked against the parser.
