### PR TITLE
The console design: one order to the page, one stylesheet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - run: node --test portal/tests/astra_overview.test.cjs
+      - run: node --test portal/tests/overview_renderers.test.cjs
 
   helm:
     # helm ships on the ubuntu-latest runner image, so the normal path needs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,6 +295,14 @@ jobs:
       - run: pip install --require-hashes -r .github/requirements-ci.txt && pip install -e cli/ --no-deps
       - run: pytest cli/tests -q
 
+  portal-renderer-test:
+    # The Overview renderers run in Node against controlled data; the runner
+    # image ships Node, so no action is pulled for it.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: node --test portal/tests/astra_overview.test.cjs
+
   helm:
     # helm ships on the ubuntu-latest runner image, so the normal path needs
     # no download and no third-party action. The fallback pins a version and
@@ -775,7 +783,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    needs: [placeholder-guard, shellcheck, collector-delivery-state,
+    needs: [placeholder-guard, shellcheck, collector-delivery-state, portal-renderer-test,
             registry-validate, governance-validate,
             receiver-test, scanner-test, cli-test, portal-test, discovery-test,
             helm, demo-smoke, compose-smoke,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -694,6 +694,13 @@ jobs:
           # This proves provisioning parsed the file and registered it. It
           # does not prove the panels return data; that needs the datasource
           # to answer, which is a heavier check than a smoke test wants.
+          # Health answers before provisioning has registered the dashboard,
+          # so this asks a few times rather than once.
+          for _ in $(seq 1 30); do
+            curl -fsS 'http://127.0.0.1:3000/api/search?type=dash-db' \
+              | grep -q '"uid": *"ai-guard"' && break
+            sleep 2
+          done
           curl -fsS 'http://127.0.0.1:3000/api/search?type=dash-db' \
             | grep -q '"uid": *"ai-guard"' \
             || { echo "::error::the provisioned dashboard is not there"; exit 1; }

--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -10,14 +10,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.29.1
+version: 0.30.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.29.0"
+appVersion: "0.30.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 maintainers:
   - name: Aman Karir

--- a/cli/aiguardctl/__init__.py
+++ b/cli/aiguardctl/__init__.py
@@ -10,4 +10,4 @@ context and reports each step back so the portal can show it. Nothing in
 the platform gains a right over the deployment. See SECURITY.md,
 "Upgrading", in the project repository.
 """
-__version__ = "0.29.0"
+__version__ = "0.30.0"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiguardctl"
-version = "0.29.0"
+version = "0.30.0"
 description = "Upgrade a Shadow AI Guard deployment from your own machine, with your own credentials, while the portal shows the progress"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.29.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.30.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.29.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.30.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1142,9 +1142,9 @@ td{padding:12px 14px}
 body{font-size:13px;line-height:1.5}
 .shell{grid-template-columns:224px minmax(0,1fr)}
 aside{background:var(--side);border-color:var(--side-line)}
-.brand{height:auto;min-height:0;padding:12px 14px 0}
-.brand img{width:194px;max-height:58px;object-fit:contain;margin-bottom:-4px}
-.tenant-switch{border-color:var(--side-line);background:transparent;margin-top:5px}
+.brand{height:auto;min-height:0;padding:16px 14px 14px}
+.brand img{width:194px;max-height:58px;object-fit:contain}
+.tenant-switch{border-color:var(--side-line);background:transparent;margin-top:14px}
 .tenant-avatar{color:var(--pri);background:var(--sf2);border:1px solid var(--side-line)}
 .tenant-copy b{font-size:12px}
 .tenant-copy span{font-size:10px}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -819,7 +819,9 @@ body.auth .licard{width:100%}
   .print-head{display:block!important;margin:0 0 12px;font-size:10px;letter-spacing:.04em;color:#555!important}
   main#app .evidence-actions,main#app .view-meta,main#app .meta-export,main#app .tabaside{display:none!important}
   main#app *{border-color:#d7dbe2!important}
-  main#app .evidence-row{display:grid!important;grid-template-columns:34px minmax(150px,.8fr) 1.6fr auto!important;align-items:center!important}
+  main#app .evidence-row{display:grid!important;grid-template-columns:minmax(150px,.8fr) 1.6fr auto!important;align-items:center!important}
+  main#app .evidence-theme{display:flex!important;gap:10px!important}
+  main#app .astra-tool-filters,main#app .wform,main#app .astra-row-open,main#app .astra-tool-item>svg{display:none!important}
 }
 /* ---- the spend card lists its plans -------------------------------- */
 .budget-lines{margin:12px 0 4px}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -2,260 +2,360 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 /* Part of Shadow AI Guard, https://github.com/AmanSK5/shadow-ai-guard */
 
-/* Shadow AI Guard enterprise UI layer.
-   The portal's renderers, routes, data contracts and action hooks remain the
-   source of truth. This file changes visual hierarchy, not behaviour. */
-:root{
-  --bg:#f3f6fa;--fg:#17213a;--sf:#fff;--sf2:#f7f9fc;
-  --pri:#087b72;--acc:#285ed8;--warn:#a66107;--dstr:#c23842;
-  --mut:#68738a;--bd:#dfe5ed;--line:var(--bd);
-  --pri-soft:#e5f6f2;--acc-soft:#eaf0ff;--warn-soft:#fff4dc;--dstr-soft:#feebed;
-  --pop:#fff;--pop-bd:#cbd5e2;
-  --pop-shadow:0 24px 70px rgba(12,24,46,.2),0 4px 14px rgba(12,24,46,.1);
-  --chart:#118b80;--chart-soft:#118b801c;
-  --shadow:0 1px 2px rgba(18,29,52,.035),0 7px 20px rgba(18,29,52,.045);
-  --side:#0d182b;--side-ink:#edf3fb;--side-mut:#95a3b8;
-  --side-line:rgba(255,255,255,.075);--side-on:#1c2c46;--side-on-ink:#fff;
-  --radius:10px;--radius-sm:7px;
-}
-[data-theme=dark]{
-  --bg:#0c1321;--fg:#edf2f8;--sf:#131d2e;--sf2:#182337;
-  --pri:#45d7c0;--acc:#82a7ff;--warn:#f1bd5c;--dstr:#ff8991;
-  --mut:#a1aec2;--bd:#27344a;
-  --pri-soft:#12342f;--acc-soft:#182c59;--warn-soft:#392c13;--dstr-soft:#422229;
-  --pop:#1b273a;--pop-bd:#42516a;
-  --pop-shadow:0 28px 80px rgba(0,0,0,.62),0 4px 14px rgba(0,0,0,.45);
-  --chart:#51d2bd;--chart-soft:#51d2bd22;--shadow:none;
-  --side:#080f1d;--side-on:#18263d;--side-line:rgba(255,255,255,.07);
-}
+/* The enterprise skin, one cascade. Tokens, shell, then each page's
+   components in the order the portal renders them; responsive rules sit
+   beside what they adjust. The index.html base styles remain the source of
+   truth for behaviour; this file changes visual hierarchy, not behaviour. */
+:root{--pop:#fff;--pop-bd:#cbd5e2;--pop-shadow:0 24px 70px rgba(12,24,46,.2),0 4px 14px rgba(12,24,46,.1);--chart:#118b80;--chart-soft:#118b801c;--radius:10px;--radius-sm:7px}
+[data-theme=dark]{--pop-shadow:0 28px 80px rgba(0,0,0,.62),0 4px 14px rgba(0,0,0,.45)}
 html{background:var(--bg)}
 body{font:14px/1.5 Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;letter-spacing:-.004em}
-.shell{grid-template-columns:252px minmax(0,1fr)}
-.shell.collapsed{grid-template-columns:72px minmax(0,1fr)}
-aside{padding:0 0 14px;background:linear-gradient(180deg,var(--side),color-mix(in srgb,var(--side) 92%,#000));border-right:1px solid rgba(255,255,255,.055)}
-.brand{height:66px;min-height:66px;padding:13px 19px 10px}
-.brand img{width:172px;max-height:43px;object-fit:contain;object-position:left center}
-.brandline{margin:0 12px;border-color:var(--side-line)}
-.tenant-switch{margin:12px 11px 5px;padding:9px 10px;border:1px solid var(--side-line);background:rgba(255,255,255,.035);border-radius:9px;display:flex;align-items:center;gap:9px;color:var(--side-ink);min-height:47px}
-.tenant-avatar{width:27px;height:27px;flex:0 0 27px;border-radius:7px;display:grid;place-items:center;font-size:10px;font-weight:750;background:#223550;color:#8ee5d2}
-.tenant-copy{min-width:0;line-height:1.25;flex:1}.tenant-copy b,.tenant-copy span{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.tenant-copy b{font-size:11.5px;font-weight:650}.tenant-copy span{font-size:9.5px;color:var(--side-mut);margin-top:3px}.tenant-chev{color:#718097}
-.collapsed .tenant-switch{margin:12px 10px 5px;padding:8px;justify-content:center}.collapsed .tenant-copy,.collapsed .tenant-chev{display:none}
-aside nav{padding:7px 10px}
+aside{padding:0 0 14px;border-right:1px solid rgba(255,255,255,.055)}
+.brandline{border-color:var(--side-line)}
+.tenant-switch{border:1px solid var(--side-line);border-radius:9px;display:flex;align-items:center;gap:9px;color:var(--side-ink)}
+.tenant-avatar{flex:0 0 27px;border-radius:7px;display:grid;place-items:center;font-weight:750}
+.tenant-copy{min-width:0;line-height:1.25;flex:1}
+.tenant-copy b,.tenant-copy span{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.tenant-copy b{font-weight:650}
+.tenant-copy span{color:var(--side-mut);margin-top:3px}
+.collapsed .tenant-switch{margin:12px 10px 5px;padding:8px;justify-content:center}
+.collapsed .tenant-copy,.collapsed .tenant-chev{display:none}
 nav button{min-height:37px;margin:2px 0;padding:8px 10px;border-radius:7px;font-size:12.5px;font-weight:540;gap:11px;color:var(--side-mut);position:relative}
 nav button:before{content:"";position:absolute;left:0;top:8px;bottom:8px;width:2px;border-radius:4px;background:transparent}
-nav button.on{background:var(--side-on);color:var(--side-on-ink);box-shadow:inset 0 0 0 1px rgba(255,255,255,.025)}
-nav button.on:before{background:#4cddbc}nav button.on svg{color:#76e2ca}
-nav button:hover{background:rgba(255,255,255,.05)}nav .count{background:#472631;color:#ffb2ba;opacity:1;border-radius:99px;padding:0 6px;min-width:20px;text-align:center;font-size:9.5px}
-.fold{margin:7px 11px;width:calc(100% - 22px);border-radius:7px;border-color:var(--side-line);color:#7f8da2;background:rgba(255,255,255,.02)}
-.foot{margin-top:2px;padding:13px 18px 0;border-color:var(--side-line);font-size:10.5px;line-height:1.75}
-.topbar{height:64px;min-height:64px;padding:0 27px;gap:11px;background:color-mix(in srgb,var(--sf) 94%,transparent);backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px)}
+nav button.on:before{background:#4cddbc}
+nav button:hover{background:rgba(255,255,255,.05)}
+nav .count{background:#472631;color:#ffb2ba;opacity:1;border-radius:99px;padding:0 6px;min-width:20px;text-align:center;font-size:9.5px}
+.fold{margin:7px 11px;width:calc(100% - 22px);border-radius:7px;border-color:var(--side-line);background:rgba(255,255,255,.02)}
+.foot{margin-top:2px;border-color:var(--side-line)}
+.topbar{backdrop-filter:blur(16px);-webkit-backdrop-filter:blur(16px)}
 .mobile-nav{display:none;width:34px;height:34px;border:1px solid var(--bd);background:var(--sf);color:var(--mut);border-radius:var(--radius-sm);cursor:pointer}
-.top-context{display:none;min-width:0}.top-context b,.top-context span{display:block}.top-context b{font-size:11px}.top-context span{font-size:9px;color:var(--mut)}
-.search{flex:0 1 430px;min-height:34px;padding:7px 11px;border-radius:var(--radius-sm);background:var(--sf2);border-color:var(--bd)}
-.search input{font-size:12px}.search:focus-within{border-color:color-mix(in srgb,var(--acc) 60%,var(--bd));box-shadow:0 0 0 3px color-mix(in srgb,var(--acc-soft) 65%,transparent)}
+.top-context{display:none;min-width:0}
+.top-context b,.top-context span{display:block}
+.top-context b{font-size:11px}
+.top-context span{font-size:9px;color:var(--mut)}
+.search{flex:0 1 430px}
+.search:focus-within{border-color:color-mix(in srgb,var(--acc) 60%,var(--bd));box-shadow:0 0 0 3px color-mix(in srgb,var(--acc-soft) 65%,transparent)}
 .search-key{font-size:9px;color:var(--mut);padding:1px 5px;border:1px solid var(--bd);border-radius:4px;background:var(--sf);margin-left:auto}
-.live-state{display:flex;align-items:center;gap:7px;font-size:10px;color:var(--mut);white-space:nowrap}.live-state:before{content:"";width:6px;height:6px;border-radius:50%;background:var(--pri);box-shadow:0 0 0 3px var(--pri-soft)}
-.topbar .back{height:34px;margin:0;padding:6px 10px;border-radius:var(--radius-sm);font-size:11px;background:var(--sf)}
-.topbar #themebtn,.topbar #setupbell{width:34px;padding:0;place-items:center}
+.live-state{display:flex;align-items:center;gap:7px;font-size:10px;color:var(--mut);white-space:nowrap}
+.live-state:before{content:"";width:6px;height:6px;border-radius:50%;background:var(--pri);box-shadow:0 0 0 3px var(--pri-soft)}
+.topbar .back{margin:0;padding:6px 10px;border-radius:var(--radius-sm);background:var(--sf)}
+.topbar #themebtn,.topbar #setupbell{padding:0}
 .topbar #who{background:var(--sf2);font-family:inherit!important;font-size:10.5px!important;font-weight:650;max-width:160px;overflow:hidden;text-overflow:ellipsis}
 .topbar #signout{color:var(--mut)}
-main{max-width:1450px;padding:27px 30px 70px}
-.view-head{display:flex;gap:20px;align-items:flex-start;margin:1px 0 21px;min-width:0}
-.view-title{min-width:0}.view-kicker{text-transform:uppercase;letter-spacing:.095em;color:var(--pri);font-size:9.5px;font-weight:760;margin-bottom:4px}
-.view-head h2{font-size:23px;line-height:1.2;letter-spacing:-.027em;margin:0;font-weight:720}.view-head .lede{margin:6px 0 0;max-width:800px;line-height:1.52;font-size:12.5px;color:var(--mut)}
-.view-meta{margin-left:auto;display:flex;align-items:center;gap:7px;white-space:nowrap;padding-top:4px}.meta-chip{display:inline-flex;align-items:center;gap:6px;padding:5px 8px;border:1px solid var(--bd);background:var(--sf);border-radius:6px;font-size:9.5px;color:var(--mut)}.meta-chip.live:before{content:"";width:5px;height:5px;border-radius:50%;background:var(--pri)}
-.tabrow{margin:0 0 21px;border-bottom:1px solid var(--bd);align-items:flex-end;min-height:36px}
+.view-head{display:flex;align-items:flex-start;min-width:0}
+.view-title{min-width:0}
+.view-kicker{text-transform:uppercase}
+.view-head h2{line-height:1.2;margin:0}
+.view-head .lede{margin:6px 0 0;line-height:1.52;color:var(--mut)}
+.view-meta{margin-left:auto;display:flex;align-items:center;white-space:nowrap}
+.meta-chip{display:inline-flex;align-items:center;gap:6px;padding:5px 8px;border:1px solid var(--bd);background:var(--sf);border-radius:6px;font-size:9.5px;color:var(--mut)}
+.meta-chip.live:before{content:"";width:5px;height:5px;border-radius:50%;background:var(--pri)}
+.tabrow{margin:0 0 21px;border-bottom:1px solid var(--bd);align-items:flex-end}
 .tabs{border:0;background:transparent;padding:0;gap:19px;border-radius:0;margin:0;overflow:visible}
-.tabs button{position:relative;padding:4px 1px 10px;border-radius:0;font-size:11.5px;color:var(--mut)}
-.tabs button.on{background:transparent;color:var(--fg);font-weight:680}.tabs button.on:after{content:"";position:absolute;left:0;right:0;bottom:-1px;height:2px;background:var(--pri);border-radius:4px 4px 0 0}
-.tabaside{padding-bottom:7px}.tabaside button.mini{background:var(--sf)}
-.grid{gap:15px;margin-bottom:15px}.gitem{gap:15px}
+.tabs button{position:relative;padding:4px 1px 10px;border-radius:0;color:var(--mut)}
+.tabs button.on{background:transparent;color:var(--fg);font-weight:680}
+.tabs button.on:after{content:"";position:absolute;left:0;right:0;bottom:-1px;height:2px;background:var(--pri);border-radius:4px 4px 0 0}
+.tabaside button.mini{background:var(--sf)}
 .wcard,.card,.tcard,.ag-card,.ag-cov,.ag-limit{border-color:var(--bd);border-radius:var(--radius);box-shadow:var(--shadow)}
-.wcard{padding:16px 18px}.wcard h3{font-size:10px;letter-spacing:.075em;margin-bottom:12px;color:var(--mut)}.wcard h3 .count{background:var(--sf2);border:1px solid var(--bd);padding:1px 6px;border-radius:99px;color:var(--fg);font-size:9px;margin-left:5px}
-.gcard>.stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(125px,1fr));gap:0;overflow:hidden;background:var(--sf);border:1px solid var(--bd);border-radius:var(--radius);box-shadow:var(--shadow)}
-.gcard>.stats>div{border:0;border-right:1px solid var(--bd);border-radius:0;box-shadow:none;min-height:96px;padding:16px 17px;background:var(--sf)}
-.gcard>.stats>div:first-child{background:linear-gradient(135deg,var(--dstr-soft),var(--sf))}.gcard>.stats>div:last-child{border-right:0}.gcard>.stats dt{font-size:26px;font-weight:730}.gcard>.stats dd{font-size:10.5px;line-height:1.4}.stats div{border-radius:8px;box-shadow:none}
-.overview-posture{display:flex;align-items:center;gap:18px;padding:13px 16px;margin:0 0 15px;border:1px solid color-mix(in srgb,var(--warn) 25%,var(--bd));border-left:3px solid var(--warn);background:linear-gradient(90deg,var(--warn-soft),var(--sf) 55%);border-radius:var(--radius)}
-.overview-posture.good{border-color:color-mix(in srgb,var(--pri) 25%,var(--bd));border-left-color:var(--pri);background:linear-gradient(90deg,var(--pri-soft),var(--sf) 55%)}
-.posture-mark{width:34px;height:34px;flex:0 0 34px;border-radius:8px;display:grid;place-items:center;background:color-mix(in srgb,var(--warn) 13%,var(--sf));color:var(--warn);font-size:15px;font-weight:750}.overview-posture.good .posture-mark{background:var(--pri-soft);color:var(--pri)}
-.posture-copy{min-width:0}.posture-copy span{display:block;color:var(--mut);font-size:9.5px;text-transform:uppercase;letter-spacing:.07em;font-weight:700}.posture-copy strong{display:block;font-size:13px;margin-top:2px}.posture-copy p{margin:2px 0 0;color:var(--mut);font-size:10.5px}.posture-facts{margin-left:auto;display:flex;align-items:center;gap:20px}.posture-fact{padding-left:18px;border-left:1px solid var(--bd)}.posture-fact b,.posture-fact span{display:block}.posture-fact b{font-size:14px}.posture-fact span{font-size:9px;color:var(--mut)}
-.tcard{padding:0;overflow:hidden;margin-bottom:14px}.tcard>.cardhead,.tcard>h3,.tcard>p{margin-left:17px;margin-right:17px}.tcard>.cardhead{padding-top:14px}.tcard>p:first-child{padding-top:14px}
-table{font-size:12px}th{padding:9px 13px;background:var(--sf2);font-size:9px;letter-spacing:.065em;border-bottom-color:var(--bd);text-transform:uppercase}td{padding:10px 13px;font-size:11.5px;border-bottom-color:var(--bd)}tr[data-open]{cursor:pointer}tr[data-open]:hover td{background:var(--sf2)}
+.wcard h3{margin-bottom:12px}
+.gcard>.stats{display:grid;grid-template-columns:repeat(auto-fit,minmax(125px,1fr));gap:0;overflow:hidden;background:var(--sf);border:1px solid var(--bd)}
+.gcard>.stats>div{border:0;border-right:1px solid var(--bd);border-radius:0;box-shadow:none;background:var(--sf)}
+.gcard>.stats>div:last-child{border-right:0}
+.gcard>.stats dt{font-weight:730}
+.gcard>.stats dd{line-height:1.4}
+.stats div{border-radius:8px;box-shadow:none}
+.overview-posture{display:flex;align-items:center;margin:0 0 15px}
+.overview-posture.good{border-color:color-mix(in srgb,var(--pri) 25%,var(--bd));border-left-color:var(--pri)}
+.posture-mark{flex:0 0 34px;border-radius:8px;display:grid;place-items:center;font-weight:750}
+.posture-copy{min-width:0}
+.posture-copy span{display:block;text-transform:uppercase;letter-spacing:.07em;font-weight:700}
+.posture-copy strong{display:block}
+.posture-copy p{margin:2px 0 0}
+.posture-facts{margin-left:auto;display:flex;align-items:center;gap:20px}
+.posture-fact{border-left:1px solid var(--bd)}
+.posture-fact b,.posture-fact span{display:block}
+.tcard{padding:0;overflow:hidden}
+.tcard>.cardhead,.tcard>h3,.tcard>p{margin-left:17px;margin-right:17px}
+.tcard>.cardhead{padding-top:14px}
+.tcard>p:first-child{padding-top:14px}
+table{font-size:12px}
+th{border-bottom-color:var(--bd)}
+td{border-bottom-color:var(--bd)}
+tr[data-open]{cursor:pointer}
 table.plain th,table.plain td,.wcard table th,.wcard table td{padding-left:0;padding-right:8px;background:transparent}
-.card{padding:14px 16px;margin-bottom:9px;border-radius:9px}.card:hover{transform:translateY(-1px);border-color:color-mix(in srgb,var(--pri) 38%,var(--bd));box-shadow:0 8px 22px rgba(18,29,52,.08)}.card h3{font-size:13px}.card-name{font-size:13.5px}.card-meta{font-size:10px}
-.pill{border-radius:99px;padding:2px 7px;font-size:9.5px;font-weight:650;margin:1px 3px 1px 0}.p-warn{background:var(--dstr-soft);color:var(--dstr)}.p-amb{background:var(--warn-soft);color:var(--warn)}.p-ok{background:var(--pri-soft);color:var(--pri)}.p-acc{background:var(--acc-soft);color:var(--acc)}.p-mut{background:var(--sf2);color:var(--mut);box-shadow:inset 0 0 0 1px var(--bd)}
-h2{font-size:21px}.lede{font-size:12.5px;line-height:1.55}.src-note{font-size:10.5px;line-height:1.5}
-button.mini,.btn,.back{border-radius:var(--radius-sm);font-size:10.5px;font-weight:630;min-height:29px;padding:5px 10px}button.mini{background:var(--sf);border-color:var(--bd)}button.mini:hover{background:var(--sf2);border-color:color-mix(in srgb,var(--pri) 55%,var(--bd))}button.mini.pri{background:var(--pri);border-color:var(--pri);color:#fff}
-input,select,.mfield{border-color:var(--bd);background:var(--sf2);border-radius:var(--radius-sm);font-size:11.5px;min-height:34px}.mfield:focus,input:focus,select:focus{outline:0;border-color:var(--acc);box-shadow:0 0 0 3px var(--acc-soft)}
-.note{border-radius:8px;font-size:11.5px;line-height:1.5;padding:11px 13px}
-.drawer{width:min(560px,94vw);padding:20px 22px 50px;border-left:1px solid var(--bd);box-shadow:var(--pop-shadow)}.overlay{background:rgba(7,15,28,.42);backdrop-filter:blur(1px)}.drawer h2{font-size:20px}.dclose{width:32px;height:32px;border-radius:7px;background:var(--sf2);border-color:var(--bd);color:var(--mut)}
-dialog{border-radius:12px;border-color:var(--bd);box-shadow:var(--pop-shadow)}#setuppanel,#usermenu{border-radius:10px;border-color:var(--pop-bd);box-shadow:var(--pop-shadow)}
-.bars{gap:8px}.barrow{min-height:25px}.barrow .bf{background:linear-gradient(90deg,var(--pri),var(--chart))}.covrow{padding:3px 0}.covdots i{border-radius:3px}.setbar{border-radius:9px;border-color:var(--pri);box-shadow:0 8px 28px rgba(8,123,114,.12)}.ag-verdict{font-size:27px;letter-spacing:-.03em}.ag-node{border-radius:8px}.ag-gap{border-color:var(--dstr)}
+.card{margin-bottom:9px}
+.card h3{font-size:13px}
+.card-meta{font-size:10px}
+.pill{margin:1px 3px 1px 0}
+.p-warn{background:var(--dstr-soft);color:var(--dstr)}
+.p-amb{background:var(--warn-soft);color:var(--warn)}
+.p-ok{background:var(--pri-soft);color:var(--pri)}
+.p-acc{background:var(--acc-soft);color:var(--acc)}
+.p-mut{background:var(--sf2);color:var(--mut);box-shadow:inset 0 0 0 1px var(--bd)}
+h2{font-size:21px}
+.lede{font-size:12.5px;line-height:1.55}
+.src-note{font-size:10.5px;line-height:1.5}
+button.mini{background:var(--sf);border-color:var(--bd)}
+button.mini:hover{background:var(--sf2);border-color:color-mix(in srgb,var(--pri) 55%,var(--bd))}
+button.mini.pri{background:var(--pri);border-color:var(--pri);color:#fff}
+input,select,.mfield{border-color:var(--bd)}
+.mfield:focus,input:focus,select:focus{outline:0;border-color:var(--acc);box-shadow:0 0 0 3px var(--acc-soft)}
+.note{border-radius:8px;font-size:11.5px}
+.drawer{border-left:1px solid var(--bd);box-shadow:var(--pop-shadow)}
+.overlay{background:rgba(7,15,28,.42);backdrop-filter:blur(1px)}
+.dclose{width:32px;height:32px;border-radius:7px;background:var(--sf2);border-color:var(--bd);color:var(--mut)}
+dialog{border-radius:12px;border-color:var(--bd);box-shadow:var(--pop-shadow)}
+#setuppanel,#usermenu{border-radius:10px;border-color:var(--pop-bd);box-shadow:var(--pop-shadow)}
+.barrow .bf{background:linear-gradient(90deg,var(--pri),var(--chart))}
+.covrow{padding:3px 0}
+.covdots i{border-radius:3px}
+.setbar{border-radius:9px;border-color:var(--pri)}
+.ag-verdict{letter-spacing:-.03em}
+.ag-node{border-radius:8px}
+.ag-gap{border-color:var(--dstr)}
 @media(max-width:900px){
-  .shell,.shell.collapsed{display:block}.shell>div{min-width:0}
-  aside{position:fixed;z-index:90;left:0;top:0;bottom:0;width:252px;height:100vh;transform:translateX(-103%);transition:transform .2s ease;box-shadow:var(--pop-shadow)}body.nav-open aside{transform:none}
-  .mobile-nav{display:grid;place-items:center}.top-context{display:block}.topbar{padding:0 14px}.search{flex:1 1 220px}.search-key,#refresh{display:none}.live-state{display:none}
-  main{padding:21px 15px 55px}.view-head{flex-wrap:wrap}.view-meta{width:100%;margin-left:0;padding-top:0}.w6,.w4{flex-basis:100%}.posture-facts{display:none}.gcard>.stats{grid-template-columns:repeat(2,1fr)}.gcard>.stats>div{border-bottom:1px solid var(--bd)}.cards{grid-template-columns:1fr}
+  .shell,.shell.collapsed{display:block}
+  .shell>div{min-width:0}
+  aside{position:fixed;z-index:90;left:0;top:0;bottom:0;width:252px;height:100vh;transform:translateX(-103%);transition:transform .2s ease;box-shadow:var(--pop-shadow)}
+  body.nav-open aside{transform:none}
+  .mobile-nav{display:grid;place-items:center}
+  .top-context{display:block}
+  .topbar{padding:0 14px}
+  .search{flex:1 1 220px}
+  .search-key,#refresh{display:none}
+  .live-state{display:none}
+  main{padding:21px 15px 55px}
+  .view-head{flex-wrap:wrap}
+  .view-meta{width:100%;margin-left:0;padding-top:0}
+  .w6,.w4{flex-basis:100%}
+  .posture-facts{display:none}
+  .gcard>.stats{grid-template-columns:repeat(2,1fr)}
+  .gcard>.stats>div{border-bottom:1px solid var(--bd)}
+  .cards{grid-template-columns:1fr}
 }
 @media(max-width:560px){
-  .top-context,#freshness{display:none}.topbar #who .account-copy,.topbar #who .account-chevron{display:none}.topbar #who.account-button{padding:3px;gap:0}.search{min-width:0}.topbar{gap:7px}.topbar #signout{display:none!important}.view-head h2{font-size:21px}.tabs{gap:14px}.tabrow{overflow-x:auto;flex-wrap:nowrap}.tabaside{margin-left:auto}.overview-posture{align-items:flex-start}.gcard>.stats{grid-template-columns:1fr 1fr}.cards{display:block}table{min-width:620px}.tcard{overflow-x:auto}.drawer{padding-left:17px;padding-right:17px}
+  .top-context,#freshness{display:none}
+  .topbar #who .account-copy,.topbar #who .account-chevron{display:none}
+  .topbar #who.account-button{padding:3px;gap:0}
+  .search{min-width:0}
+  .topbar{gap:7px}
+  .topbar #signout{display:none!important}
+  .view-head h2{font-size:21px}
+  .tabs{gap:14px}
+  .tabrow{overflow-x:auto;flex-wrap:nowrap}
+  .tabaside{margin-left:auto}
+  .overview-posture{align-items:flex-start}
+  .gcard>.stats{grid-template-columns:1fr 1fr}
+  .cards{display:block}
+  table{min-width:620px}
+  .tcard{overflow-x:auto}
+  .drawer{padding-left:17px;padding-right:17px}
 }
-
 /* --------------------------------------------------------------------------
    Enterprise V2 — a stronger product composition.
    Mockup 1 is preserved on the ui/mockup-1 branch; these rules intentionally
    favour a more confident security-console hierarchy over generic cards.
    ----------------------------------------------------------------------- */
-:root{
-  --bg:#f3f6fa;--fg:#17213a;--sf:#fff;--sf2:#f8fafc;--mut:#68738a;--bd:#dfe5ed;
-  --pri:#087b72;--pri-soft:#e5f6f2;--acc:#285ed8;--acc-soft:#eaf0ff;
-  --warn:#a66107;--warn-soft:#fff4dc;--dstr:#c23842;--dstr-soft:#feebed;
-  --side:#101a2e;--side-on:#20304a;--side-mut:#9ba8bd;
-  --shadow:0 1px 2px rgba(18,29,52,.04),0 8px 24px rgba(18,29,52,.05);
-}
-[data-theme=dark]{--bg:#0c1321;--fg:#edf2f8;--sf:#131d2e;--sf2:#182337;
-  --mut:#a0acc0;--bd:#27344a;--pri:#42d4bc;--pri-soft:#12342f;
-  --acc:#7da2ff;--acc-soft:#182c59;--warn:#f2bd5b;--warn-soft:#392c13;
-  --dstr:#ff8991;--dstr-soft:#422229;--side:#080e1a;--side-on:#20304a;
-  --side-mut:#98a6ba;--shadow:none}
-.shell{grid-template-columns:252px minmax(0,1fr)}.shell.collapsed{grid-template-columns:72px minmax(0,1fr)}
-aside{background:linear-gradient(180deg,var(--side),#0c1527)}
-.brand{height:70px;min-height:70px;padding:14px 20px 11px}.brand img{width:184px}.brandline{margin:0 14px}
-.tenant-switch{margin:13px 12px 8px;padding:10px 11px;background:rgba(255,255,255,.04);border-color:rgba(255,255,255,.09);min-height:50px}
-.tenant-avatar{width:29px;height:29px;flex-basis:29px;background:linear-gradient(145deg,#24415d,#116c68);color:#c9fff0;font-size:11px}.tenant-copy b{font-size:12px}.tenant-copy span{font-size:9.5px}.estate-dot{display:inline-block;width:5px;height:5px;border-radius:50%;background:#46d59e;margin-right:4px;box-shadow:0 0 0 2px rgba(70,213,158,.12)}.estate-dot.off{background:#8a97a8;box-shadow:0 0 0 2px rgba(138,151,168,.14)}.estate-dot.warn{background:#f0a840;box-shadow:0 0 0 2px rgba(240,168,64,.16)}
-aside nav{padding:7px 10px 16px}.nav-area-block{padding:4px 0;border-top:1px solid var(--side-line)}
-.nav-area-block:first-child{border-top:0}.nav-pinned+.nav-area-block{border-top:0}.nav-area-trigger{min-height:39px;padding:8px 10px;
-  margin:0;font-size:12px;font-weight:630;color:var(--side-mut)}
-.nav-area-trigger.current{color:#eaf1fa}.nav-area-trigger svg{color:#8090a7}
-.nav-area-trigger.current svg,.nav-area-trigger.on svg{color:#72dfc8}
+:root{--acc-soft:#eaf0ff;--warn-soft:#fff4dc;--dstr-soft:#feebed}
+[data-theme=dark]{--acc-soft:#182c59;--warn-soft:#392c13;--dstr-soft:#422229}
+.shell.collapsed{grid-template-columns:72px minmax(0,1fr)}
+.brandline{margin:0 14px}
+.tenant-switch{margin:13px 12px 8px}
+.tenant-avatar{width:29px;height:29px;flex-basis:29px;font-size:11px}
+.estate-dot{display:inline-block;width:5px;height:5px;border-radius:50%;background:#46d59e;margin-right:4px;box-shadow:0 0 0 2px rgba(70,213,158,.12)}
+.estate-dot.off{background:#8a97a8;box-shadow:0 0 0 2px rgba(138,151,168,.14)}
+.estate-dot.warn{background:#f0a840;box-shadow:0 0 0 2px rgba(240,168,64,.16)}
+aside nav{padding:7px 10px 16px}
+.nav-area-block{border-top:1px solid var(--side-line)}
+.nav-area-block:first-child{border-top:0}
+.nav-pinned+.nav-area-block{border-top:0}
+.nav-area-trigger{padding:8px 10px;margin:0;font-weight:630}
+.nav-area-trigger svg{color:#8090a7}
 .nav-chevron{margin-left:auto;color:#66768e;font-size:16px;line-height:1;transition:transform .16s}
 .nav-area-block.expanded .nav-chevron{transform:rotate(90deg)}
-.nav-area-items{padding:0 0 4px}.nav-area-items[hidden]{display:none}
-nav button.nav-child{min-height:31px;padding:6px 10px 6px 40px;margin:1px 0;
-  font-size:11.25px;color:#8291a7}.nav-child .nav-dot{position:absolute;left:20px;
-  width:4px;height:4px;border-radius:50%;background:#52627a}
+.nav-area-items{padding:0 0 4px}
+.nav-area-items[hidden]{display:none}
+nav button.nav-child{padding:6px 10px 6px 40px;margin:1px 0}
+.nav-child .nav-dot{position:absolute;width:4px;height:4px;border-radius:50%}
 .nav-child.on .nav-dot{background:#55d9bd;box-shadow:0 0 0 3px rgba(85,217,189,.09)}
-nav button.on{background:linear-gradient(90deg,#1b2e48,var(--side-on));
-  box-shadow:inset 0 0 0 1px rgba(255,255,255,.025)}nav button.on:before{top:7px;bottom:7px}
-.nav-direct{margin-top:1px}.collapsed .nav-area-items,.collapsed .nav-chevron{display:none}
-.collapsed .nav-area-block{border-top:0;padding:1px 0}.collapsed nav button{min-height:39px}
-.fold{margin-top:auto}.foot{font-size:9.5px;color:#687991}
-.topbar{height:68px;min-height:68px;border-bottom-color:var(--bd);padding:0 30px;box-shadow:0 1px 0 rgba(16,24,40,.015)}
-.search{flex-basis:460px;background:var(--sf);border-color:#d9e0e9;box-shadow:0 1px 2px rgba(16,24,40,.025)}[data-theme=dark] .search{border-color:var(--bd)}
-.trust-state{display:flex;align-items:center;gap:6px;padding:5px 8px;border:1px solid color-mix(in srgb,var(--pri) 22%,var(--bd));border-radius:6px;background:var(--pri-soft);color:var(--pri);font-size:9.5px;font-weight:650;white-space:nowrap}.trust-state.off{color:var(--mut);background:var(--sf);border-color:var(--bd)}.trust-state.warn{color:var(--warn);background:var(--warn-soft);border-color:color-mix(in srgb,var(--warn) 30%,var(--bd))}
+nav button.on{box-shadow:inset 0 0 0 1px rgba(255,255,255,.025)}
+nav button.on:before{top:7px;bottom:7px}
+.nav-direct{margin-top:1px}
+.collapsed .nav-area-items,.collapsed .nav-chevron{display:none}
+.collapsed .nav-area-block{border-top:0;padding:1px 0}
+.collapsed nav button{min-height:39px}
+.fold{margin-top:auto}
+.topbar{border-bottom-color:var(--bd);box-shadow:0 1px 0 rgba(16,24,40,.015)}
+.search{border-color:#d9e0e9}
+[data-theme=dark] .search{border-color:var(--bd)}
+.trust-state{display:flex;align-items:center;gap:6px;padding:5px 8px;border:1px solid color-mix(in srgb,var(--pri) 22%,var(--bd));border-radius:6px;background:var(--pri-soft);color:var(--pri);font-size:9.5px;font-weight:650;white-space:nowrap}
+.trust-state.off{color:var(--mut);background:var(--sf);border-color:var(--bd)}
+.trust-state.warn{color:var(--warn);background:var(--warn-soft);border-color:color-mix(in srgb,var(--warn) 30%,var(--bd))}
 .topbar #signout{border-color:transparent;background:transparent}
-main{max-width:1540px;padding:30px 34px 80px}.view-head{margin-bottom:24px}.view-kicker{font-size:9px;color:var(--acc);letter-spacing:.12em}.view-head h2{font-size:25px;font-weight:735}.view-head .lede{max-width:880px;font-size:12px}.meta-chip{border-color:var(--bd);box-shadow:0 1px 2px rgba(16,24,40,.02)}
-.tabrow{min-height:38px;margin-bottom:25px}.tabs button{padding-bottom:11px;font-size:11px}.tabaside{padding-bottom:8px}
+.meta-chip{border-color:var(--bd);box-shadow:0 1px 2px rgba(16,24,40,.02)}
+.tabrow{min-height:38px;margin-bottom:25px}
+.tabs button{padding-bottom:11px;font-size:11px}
+.tabaside{padding-bottom:8px}
 .overview-posture{min-height:112px;padding:20px 22px;gap:16px;border:0;border-left:0;background:linear-gradient(112deg,#13283f,#102034 60%,#12283e);box-shadow:0 12px 30px rgba(11,20,36,.12);color:#fff;border-radius:12px;position:relative;overflow:hidden}
 .overview-posture:after{content:"";position:absolute;width:300px;height:300px;right:-90px;top:-185px;border:1px solid rgba(88,220,190,.12);border-radius:50%;box-shadow:0 0 0 42px rgba(88,220,190,.025),0 0 0 90px rgba(88,220,190,.018)}
 .overview-posture.good{border:0;background:linear-gradient(112deg,#102c34,#10252d 60%,#112a34)}
-.posture-mark{width:42px;height:42px;flex-basis:42px;border:1px solid rgba(255,164,173,.26);background:rgba(196,50,60,.18);color:#ff9ba2;font-size:17px;z-index:1}.overview-posture.good .posture-mark{border-color:rgba(100,236,195,.2);background:rgba(49,178,138,.16);color:#79e5c2}
-.posture-copy{z-index:1}.posture-copy span{color:#8fa1b7;font-size:8.5px}.posture-copy strong{font-size:16px;letter-spacing:-.015em;margin-top:4px}.posture-copy p{color:#aab7c8;font-size:10.5px;max-width:520px;margin-top:4px}
-.posture-facts,.posture-actions{z-index:1}.posture-fact{border-color:rgba(255,255,255,.1);padding-left:20px}.posture-fact b{font-size:17px}.posture-fact span{color:#94a5b9;font-size:8.5px}.posture-actions{display:flex;gap:7px;margin-left:4px}.posture-actions button.mini{background:rgba(255,255,255,.07);border-color:rgba(255,255,255,.15);color:#e9f0f7}.posture-actions button.mini:hover{background:rgba(255,255,255,.12)}.posture-actions button.mini.pri{background:#39bda6;border-color:#39bda6;color:#071c21}
-.grid{gap:17px}.gitem{gap:17px}.wcard,.tcard,.card,.ag-card,.ag-cov,.ag-limit{border-color:var(--bd);box-shadow:var(--shadow)}.wcard{padding:17px 19px}.wcard h3{font-size:9px;letter-spacing:.1em;color:#748096}
-.gcard>.stats{border-radius:11px;box-shadow:var(--shadow)}.gcard>.stats>div{padding:17px 18px;min-height:100px}.gcard>.stats>div:first-child{background:linear-gradient(145deg,var(--dstr-soft),var(--sf) 82%)}.gcard>.stats dt{font-size:27px;letter-spacing:-.04em}.gcard>.stats dd{font-size:10px}
-.tcard{border-radius:11px}th{height:36px;padding:9px 14px;color:#7a8597;background:#f8fafc;font-size:8.5px;letter-spacing:.08em}td{padding:11px 14px;font-size:11px}[data-theme=dark] th{background:var(--sf2)}
-tr[data-open]:hover td{background:color-mix(in srgb,var(--acc-soft) 38%,var(--sf))}.card{border-radius:10px;padding:15px 17px}.card:hover{transform:none;border-color:color-mix(in srgb,var(--acc) 35%,var(--bd));box-shadow:0 8px 24px rgba(16,24,40,.07)}
-.cards{gap:15px;grid-template-columns:repeat(auto-fill,minmax(430px,1fr))}.card-top{align-items:center}.card-name{font-size:13px}.card-section{font-size:8.5px;letter-spacing:.11em}.card-kv{font-size:11.5px}.card-kv dt{font-size:10px}
-.pill{padding:2.5px 7px;font-size:9px;font-weight:680}.p-warn{box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--dstr) 10%,transparent)}.p-ok{box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--pri) 10%,transparent)}
-button.mini,.btn,.back{min-height:31px;padding:6px 10px;font-size:10px}.mini.pri,button.mini.pri{box-shadow:0 1px 2px rgba(8,85,79,.18)}
-input,select,.mfield{min-height:36px;background:var(--sf);font-size:11px;box-shadow:0 1px 2px rgba(16,24,40,.025)}[data-theme=dark] input,[data-theme=dark] select,[data-theme=dark] .mfield{background:var(--sf2)}
-.note{border-width:1px;border-left-width:3px}.drawer{width:min(600px,95vw);padding:23px 26px 55px}.drawer h2{font-size:22px;letter-spacing:-.025em}.drawer .lede{font-size:11.5px}.drawer table{border:1px solid var(--bd);border-radius:8px;overflow:hidden}
-.ssow{grid-template-columns:310px 1fr;border-radius:12px;overflow:hidden;box-shadow:var(--shadow);background:var(--sf)}.ssrail{padding:21px 18px;background:color-mix(in srgb,var(--sf2) 85%,var(--sf))}.ssstep{padding:10px 9px}.ssstep.on{box-shadow:0 1px 3px rgba(16,24,40,.06);border:1px solid var(--bd)}.ssstep .t{font-size:11.5px}.ssstep .val,.ssstep .pend,.ssstep .need{font-size:10px}.ssmain{padding:27px 30px}.ssmain h4{font-size:17px;letter-spacing:-.015em}.setbar{bottom:16px;padding:11px 14px;background:color-mix(in srgb,var(--sf) 94%,transparent);backdrop-filter:blur(12px);box-shadow:0 10px 30px rgba(16,24,40,.12)}
-.licard{border:0!important;box-shadow:0 24px 70px rgba(10,21,38,.18)!important;border-radius:14px!important}.auth{background:radial-gradient(circle at 50% 0,var(--pri-soft),var(--bg) 38%)}.auth .topbar{background:transparent;border:0}.auth main{max-width:620px}
-.ag-card{padding:17px 19px}.ag-verdict{font-size:30px}.ag-node{padding:10px 12px}.ag-node b{font-size:8.5px}.ag-node i{font-size:11.5px}
-@media(max-width:1180px){.trust-state span{display:none}.trust-state{width:31px;height:31px;justify-content:center;padding:0}.posture-facts{gap:12px}.posture-fact{padding-left:12px}.posture-actions{flex-direction:column}}
-@media(max-width:900px){.shell,.shell.collapsed{display:block}aside{width:272px}.nav-zone-label{display:block}.nav-child{display:flex}.posture-actions{flex-direction:row;margin-left:auto}.view-meta{width:auto;margin-left:auto}.trust-state{display:none}}
-@media(max-width:680px){main{padding:22px 14px 55px}.view-meta{width:100%;margin-left:0}.overview-posture{flex-wrap:wrap}.posture-actions{width:100%;margin:4px 0 0 58px}.cards{grid-template-columns:1fr}.ssow{grid-template-columns:1fr}.ssrail{border-right:0;border-bottom:1px solid var(--bd)}.ssrail ol{display:flex;overflow-x:auto}.ssstep{min-width:190px}.ssstep::after{display:none}.ssmain{padding:20px 17px}}
+.posture-mark{width:42px;height:42px;flex-basis:42px;border:1px solid rgba(255,164,173,.26);background:rgba(196,50,60,.18);color:#ff9ba2;font-size:17px;z-index:1}
+.overview-posture.good .posture-mark{border-color:rgba(100,236,195,.2);background:rgba(49,178,138,.16);color:#79e5c2}
+.posture-copy{z-index:1}
+.posture-copy span{color:#8fa1b7;font-size:8.5px}
+.posture-copy strong{font-size:16px;letter-spacing:-.015em;margin-top:4px}
+.posture-copy p{color:#aab7c8;font-size:10.5px;max-width:520px;margin-top:4px}
+.posture-facts,.posture-actions{z-index:1}
+.posture-fact{border-color:rgba(255,255,255,.1);padding-left:20px}
+.posture-fact b{font-size:17px}
+.posture-fact span{color:#94a5b9;font-size:8.5px}
+.posture-actions{display:flex;gap:7px;margin-left:4px}
+.posture-actions button.mini{background:rgba(255,255,255,.07);border-color:rgba(255,255,255,.15);color:#e9f0f7}
+.posture-actions button.mini:hover{background:rgba(255,255,255,.12)}
+.posture-actions button.mini.pri{background:#39bda6;border-color:#39bda6;color:#071c21}
+.grid{gap:17px}
+.gitem{gap:17px}
+.wcard,.tcard,.card,.ag-card,.ag-cov,.ag-limit{border-color:var(--bd);box-shadow:var(--shadow)}
+.gcard>.stats{border-radius:11px;box-shadow:var(--shadow)}
+.gcard>.stats>div{padding:17px 18px;min-height:100px}
+.gcard>.stats dt{font-size:27px;letter-spacing:-.04em}
+.gcard>.stats dd{font-size:10px}
+th{height:36px;padding:9px 14px;background:#f8fafc}
+[data-theme=dark] th{background:var(--sf2)}
+tr[data-open]:hover td{background:color-mix(in srgb,var(--acc-soft) 38%,var(--sf))}
+.card{border-radius:10px;padding:15px 17px}
+.card:hover{transform:none;border-color:color-mix(in srgb,var(--acc) 35%,var(--bd));box-shadow:0 8px 24px rgba(16,24,40,.07)}
+.cards{gap:15px;grid-template-columns:repeat(auto-fill,minmax(430px,1fr))}
+.card-top{align-items:center}
+.card-name{font-size:13px}
+.card-section{font-size:8.5px}
+.card-kv{font-size:11.5px}
+.card-kv dt{font-size:10px}
+.p-warn{box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--dstr) 10%,transparent)}
+.p-ok{box-shadow:inset 0 0 0 1px color-mix(in srgb,var(--pri) 10%,transparent)}
+button.mini,.btn,.back{padding:6px 10px}
+.mini.pri,button.mini.pri{box-shadow:0 1px 2px rgba(8,85,79,.18)}
+input,select,.mfield{background:var(--sf);box-shadow:0 1px 2px rgba(16,24,40,.025)}
+[data-theme=dark] input,[data-theme=dark] select,[data-theme=dark] .mfield{background:var(--sf2)}
+.note{border-width:1px;border-left-width:3px}
+.drawer h2{font-size:22px}
+.drawer table{border:1px solid var(--bd);border-radius:8px;overflow:hidden}
+.ssow{grid-template-columns:310px 1fr;border-radius:12px;overflow:hidden;box-shadow:var(--shadow);background:var(--sf)}
+.ssrail{padding:21px 18px;background:color-mix(in srgb,var(--sf2) 85%,var(--sf))}
+.ssstep{padding:10px 9px}
+.ssstep.on{box-shadow:0 1px 3px rgba(16,24,40,.06);border:1px solid var(--bd)}
+.ssmain{padding:27px 30px}
+.ssmain h4{letter-spacing:-.015em}
+.setbar{bottom:16px;padding:11px 14px;background:color-mix(in srgb,var(--sf) 94%,transparent);backdrop-filter:blur(12px);box-shadow:0 10px 30px rgba(16,24,40,.12)}
+.licard{border:0!important;box-shadow:0 24px 70px rgba(10,21,38,.18)!important;border-radius:14px!important}
+.auth{background:radial-gradient(circle at 50% 0,var(--pri-soft),var(--bg) 38%)}
+.auth .topbar{background:transparent;border:0}
+.auth main{max-width:620px}
+.ag-card{padding:17px 19px}
+.ag-verdict{font-size:30px}
+.ag-node{padding:10px 12px}
+.ag-node b{font-size:8.5px}
+.ag-node i{font-size:11.5px}
+@media(max-width:1180px){
+  .trust-state span{display:none}
+  .trust-state{width:31px;height:31px;justify-content:center;padding:0}
+  .posture-facts{gap:12px}
+  .posture-fact{padding-left:12px}
+  .posture-actions{flex-direction:column}
+}
+@media(max-width:900px){
+  .shell,.shell.collapsed{display:block}
+  aside{width:272px}
+  .nav-zone-label{display:block}
+  .nav-child{display:flex}
+  .posture-actions{flex-direction:row;margin-left:auto}
+  .view-meta{width:auto;margin-left:auto}
+  .trust-state{display:none}
+}
+@media(max-width:680px){
+  main{padding:22px 14px 55px}
+  .view-meta{width:100%;margin-left:0}
+  .overview-posture{flex-wrap:wrap}
+  .posture-actions{width:100%;margin:4px 0 0 58px}
+  .cards{grid-template-columns:1fr}
+  .ssow{grid-template-columns:1fr}
+  .ssrail{border-right:0;border-bottom:1px solid var(--bd)}
+  .ssrail ol{display:flex;overflow-x:auto}
+  .ssstep{min-width:190px}
+  .ssstep::after{display:none}
+  .ssmain{padding:20px 17px}
+}
 @media(max-width:560px){
   html,body,.shell,.shell>div{max-width:100%;overflow-x:hidden}
   main{max-width:100%;overflow:hidden}
-  table{min-width:0}.tcard{max-width:100%;overflow-x:auto}.tcard>table{min-width:620px}
-  .wcard table{table-layout:auto}.wcard td,.wcard th{white-space:normal}
-  .posture-actions{margin-left:0}.posture-actions button{flex:1}
+  table{min-width:0}
+  .tcard{max-width:100%;overflow-x:auto}
+  .tcard>table{min-width:620px}
+  .wcard table{table-layout:auto}
+  .wcard td,.wcard th{white-space:normal}
+  .posture-actions{margin-left:0}
+  .posture-actions button{flex:1}
 }
-
 /* --------------------------------------------------------------------------
    V2 review refinements — denser investigation surfaces and quieter chrome.
    ----------------------------------------------------------------------- */
 .brand{justify-content:center}
-.brand img{object-position:center;width:190px}
+.brand img{object-position:center}
 .tenant-switch{width:calc(100% - 24px);font:inherit;text-align:left;cursor:pointer}
 .tenant-switch:hover{background:rgba(255,255,255,.07);border-color:rgba(104,224,199,.24)}
 .tenant-switch:focus-visible{outline:2px solid #55d9bd;outline-offset:2px}
-.tenant-chev{font-size:8px;letter-spacing:.02em;color:#788ba4}
-
-/* One search surface. Global form styling must not turn its input into a
-   second inset field. */
-.search{gap:10px;padding:8px 12px;background:var(--sf2);box-shadow:none}
-.search input,[data-theme=dark] .search input{min-height:0!important;padding:0!important;
-  border:0!important;background:transparent!important;box-shadow:none!important;
-  border-radius:0!important}
+.tenant-chev{letter-spacing:.02em}
+.search{gap:10px;box-shadow:none}
+.search input,[data-theme=dark] .search input{min-height:0!important;padding:0!important;border:0!important;background:transparent!important;box-shadow:none!important;border-radius:0!important}
 .search input:focus,[data-theme=dark] .search input:focus{box-shadow:none!important}
-
-/* Account actions belong to the account menu. Keep the bell as one icon
-   with one badge instead of three neighbouring visual signals. */
 .topbar #signout{display:none!important}
 .topbar #themebtn,.topbar #setupbell{width:34px;height:34px;display:grid;place-items:center}
 .topbar #themebtn{margin-left:auto!important}
 .account-wrap{position:relative;display:flex;align-items:center;margin-left:2px}
-.topbar #who.account-button{display:flex;align-items:center;gap:9px;width:auto;max-width:230px;
-  min-height:40px;margin:0;padding:4px 3px 4px 7px;border:0;border-radius:8px;
-  background:transparent!important;color:var(--fg);font:inherit!important;text-align:left;
-  cursor:pointer}.topbar #who.account-button:hover{background:var(--sf2)!important}
+.topbar #who.account-button{display:flex;align-items:center;gap:9px;width:auto;max-width:230px;min-height:40px;margin:0;padding:4px 3px 4px 7px;border:0;border-radius:8px;background:transparent!important;color:var(--fg);font:inherit!important;text-align:left;cursor:pointer}
+.topbar #who.account-button:hover{background:var(--sf2)!important}
 .topbar #who.account-button:focus-visible{outline:2px solid var(--acc);outline-offset:2px}
-.account-avatar{width:31px;height:31px;flex:0 0 31px;display:grid;place-items:center;
-  border-radius:8px;background:linear-gradient(145deg,#183e5e,#087b72);color:#fff;
-  font-size:11px;font-weight:760}.account-copy{display:block;min-width:0;line-height:1.15}
-.account-copy b,.account-copy span{display:block;max-width:145px;overflow:hidden;
-  text-overflow:ellipsis;white-space:nowrap}.account-copy b{font-size:11.5px;font-weight:700}
-.account-copy span{margin-top:2px;color:var(--mut);font-size:9.5px;font-weight:500}
+.account-avatar{flex:0 0 31px;display:grid;place-items:center;border-radius:8px;background:linear-gradient(145deg,#183e5e,#087b72);color:#fff;font-weight:760}
+.account-copy{display:block;min-width:0;line-height:1.15}
+.account-copy b,.account-copy span{display:block;max-width:145px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.account-copy b{font-weight:700}
+.account-copy span{margin-top:2px;color:var(--mut);font-weight:500}
 .account-chevron{margin:0 4px;color:var(--mut);font-size:12px}
 #usermenu .umhead strong,#usermenu .umhead span{display:block}
 #usermenu .umhead span{margin-top:2px;color:var(--mut);font-size:10px;font-weight:500}
 #setupbell{position:relative;gap:0;font-size:0}
 #setupbell .bdot{display:none}
-#setupbell .bcount{position:absolute;top:-5px;right:-5px;min-width:17px;height:17px;
-  padding:0 4px;display:grid;place-items:center;border-radius:99px;
-  background:var(--dstr);color:#fff;border:2px solid var(--sf);font-size:8.5px;
-  line-height:1;font-weight:750}
-#usermenu #signout-menu{border-top:1px solid var(--pop-bd);border-radius:0 0 7px 7px;
-  margin-top:4px;padding-top:10px;color:var(--dstr)}
-
-/* Use the available workspace. The previous reading-width cap made normal
-   data pages appear as though the layout ended before the browser did. */
-main{max-width:none;width:100%;margin:0}
+#setupbell .bcount{position:absolute;top:-5px;right:-5px;min-width:17px;height:17px;padding:0 4px;display:grid;place-items:center;border-radius:99px;background:var(--dstr);color:#fff;border:2px solid var(--sf);font-size:8.5px;line-height:1;font-weight:750}
+#usermenu #signout-menu{border-top:1px solid var(--pop-bd);border-radius:0 0 7px 7px;margin-top:4px;padding-top:10px;color:var(--dstr)}
+main{width:100%;margin:0}
 .view-title{flex:1}
-.view-head .lede{max-width:none}
-
-/* Restore the original neutral KPI tile: severity lives in the number, not
-   in a glossy block of colour. */
 .gcard>.stats>div:first-child{background:var(--sf)!important}
-
 /* The help disclosure belongs to the content inset of its parent card. */
 .map-help{margin:0 17px 14px!important}
 .map-help>div{margin-top:7px;color:var(--mut)}
-
 /* A device estate is an investigation table, not a stack of large cards. */
-.inventory-summary{display:flex;align-items:center;gap:0;margin:0 0 12px;
-  border:1px solid var(--bd);border-radius:9px;background:var(--sf);overflow:hidden}
-.inventory-summary span{display:flex;align-items:baseline;gap:6px;min-height:46px;
-  padding:12px 17px;border-right:1px solid var(--bd);color:var(--mut);font-size:10px}
-.inventory-summary span:last-child{border-right:0}.inventory-summary b{font-size:16px;
-  line-height:1;color:var(--fg)}.inventory-summary .risk b{color:var(--dstr)}
+.inventory-summary{display:flex;align-items:center;gap:0;margin:0 0 12px;border:1px solid var(--bd);background:var(--sf);overflow:hidden}
+.inventory-summary span{display:flex;border-right:1px solid var(--bd);color:var(--mut)}
+.inventory-summary span:last-child{border-right:0}
+.inventory-summary b{line-height:1;color:var(--fg)}
+.inventory-summary .risk b{color:var(--dstr)}
 .inventory-summary .attention b{color:var(--warn)}
 .device-inventory table{width:100%;table-layout:fixed}
-.device-inventory th:nth-child(1){width:21%}.device-inventory th:nth-child(2){width:16%}
-.device-inventory th:nth-child(3){width:23%}.device-inventory th:nth-child(4){width:23%}
+.device-inventory th:nth-child(1){width:21%}
+.device-inventory th:nth-child(2){width:16%}
+.device-inventory th:nth-child(3){width:23%}
+.device-inventory th:nth-child(4){width:23%}
 .device-inventory th:nth-child(5){width:17%}
-.device-inventory td{vertical-align:middle;height:60px}.device-inventory td strong{font-size:11.5px}
-.row-key{font-size:9px;color:var(--mut)}.cell-tags{display:flex;gap:3px;flex-wrap:wrap}
-.muted-value{color:var(--mut);font-size:10px}
+.device-inventory td{vertical-align:middle;height:60px}
+.row-key{color:var(--mut)}
+.cell-tags{display:flex;flex-wrap:wrap}
+.muted-value{color:var(--mut)}
 [data-theme=dark] tr[data-open]:hover td{background:#1a2940}
-
 @media(max-width:900px){
-  .brand{justify-content:flex-start}.brand img{object-position:left center}
-  .device-inventory table{min-width:880px}.inventory-summary{overflow-x:auto}
+  .brand{justify-content:flex-start}
+  .brand img{object-position:left center}
+  .device-inventory table{min-width:880px}
+  .inventory-summary{overflow-x:auto}
   .inventory-summary span{white-space:nowrap}
 }
 @media(max-width:560px){
@@ -263,408 +363,348 @@ main{max-width:none;width:100%;margin:0}
   .inventory-summary span{border-bottom:1px solid var(--bd)}
   .inventory-summary span:nth-child(2){border-right:0}
 }
-
 /* --------------------------------------------------------------------------
    AI Register — governance workspace rather than a grid of generic cards.
    ----------------------------------------------------------------------- */
-.register-overview{display:grid;grid-template-columns:minmax(255px,320px) 1fr;
-  border:1px solid var(--bd);border-radius:12px;background:var(--sf);
-  overflow:hidden;margin:0 0 17px;box-shadow:var(--shadow)}
-.register-score{padding:19px 21px;background:linear-gradient(135deg,#10283d,#102035);
-  color:#fff}.register-score-head{display:flex;justify-content:space-between;
-  align-items:baseline;gap:14px}.register-score-head span{font-size:9px;font-weight:740;
-  letter-spacing:.1em;text-transform:uppercase;color:#9badc0}
-.register-score-head strong{font-size:26px;letter-spacing:-.045em}
-.register-progress{height:5px;margin:13px 0 10px;border-radius:99px;
-  overflow:hidden;background:rgba(255,255,255,.1)}
-.register-progress i{display:block;height:100%;border-radius:inherit;
-  background:#4fd3b8;box-shadow:0 0 14px rgba(79,211,184,.25)}
-.register-score p{margin:0;color:#aebacc;font-size:10px;line-height:1.5}
+.register-overview{display:grid;border:1px solid var(--bd);border-radius:12px;background:var(--sf);overflow:hidden;margin:0 0 17px;box-shadow:var(--shadow)}
+.register-score{color:#fff}
+.register-score-head{display:flex;justify-content:space-between;align-items:baseline;gap:14px}
+.register-score-head span{font-weight:740;text-transform:uppercase}
+.register-score-head strong{letter-spacing:-.045em}
+.register-progress{height:5px;margin:13px 0 10px;border-radius:99px;overflow:hidden;background:rgba(255,255,255,.1)}
+.register-progress i{display:block;height:100%;border-radius:inherit;background:#4fd3b8;box-shadow:0 0 14px rgba(79,211,184,.25)}
+.register-score p{margin:0;line-height:1.5}
 .register-metrics{display:grid;grid-template-columns:repeat(3,1fr);margin:0}
-.register-metrics div{padding:15px 17px;border-left:1px solid var(--bd);
-  border-bottom:1px solid var(--bd);min-width:0}
+.register-metrics div{border-left:1px solid var(--bd);border-bottom:1px solid var(--bd);min-width:0}
 .register-metrics div:nth-child(n+4){border-bottom:0}
-.register-metrics dt{font-size:20px;font-weight:735;letter-spacing:-.035em}
-.register-metrics dd{margin:2px 0 0;color:var(--mut);font-size:9.5px;line-height:1.35}
-.register-metrics .attention dt{color:var(--warn)}.register-metrics .risk dt{color:var(--dstr)}
-
-.register-toolbar{display:flex;align-items:center;gap:16px;margin:0 0 9px;
-  padding:0 2px}.register-toolbar>div{display:flex;flex-direction:column;min-width:0}
-.register-toolbar strong{font-size:12px}.register-toolbar>div span{font-size:9.5px;color:var(--mut)}
-.register-legend{display:flex;align-items:center;gap:6px;margin-left:auto;
-  color:var(--mut);font-size:9px;white-space:nowrap}.register-legend i{width:7px;
-  height:7px;border-radius:2px;background:var(--warn)}
-.reg-export{display:inline-flex;align-items:center;min-height:30px;padding:5px 10px;
-  border:1px solid var(--bd);border-radius:var(--radius-sm);background:var(--sf);
-  color:var(--fg);font-size:10px;font-weight:650;text-decoration:none;white-space:nowrap}
+.register-metrics dt{font-weight:735;letter-spacing:-.035em}
+.register-metrics dd{margin:2px 0 0;color:var(--mut);line-height:1.35}
+.register-metrics .attention dt{color:var(--warn)}
+.register-metrics .risk dt{color:var(--dstr)}
+.register-toolbar{display:flex;align-items:center;padding:0 2px}
+.register-toolbar>div{display:flex;flex-direction:column;min-width:0}
+.register-toolbar>div span{font-size:9.5px;color:var(--mut)}
+.register-legend{display:flex;align-items:center;gap:6px;margin-left:auto;color:var(--mut);font-size:9px;white-space:nowrap}
+.register-legend i{width:7px;height:7px;border-radius:2px;background:var(--warn)}
+.reg-export{display:inline-flex;align-items:center;min-height:30px;padding:5px 10px;border:1px solid var(--bd);border-radius:var(--radius-sm);background:var(--sf);color:var(--fg);font-size:10px;font-weight:650;text-decoration:none;white-space:nowrap}
 .reg-export:hover{border-color:color-mix(in srgb,var(--pri) 55%,var(--bd));background:var(--sf2)}
-
-.register-list{display:flex;flex-direction:column;gap:8px;margin-bottom:18px}
-.register-record{position:relative;border:1px solid var(--bd);border-radius:10px;
-  background:var(--sf);box-shadow:var(--shadow);overflow:hidden}
-.register-record.needs-decision:before{content:"";position:absolute;z-index:1;
-  left:0;top:0;bottom:0;width:3px;background:var(--warn)}
+.register-list{display:flex;flex-direction:column;margin-bottom:18px}
+.register-record{position:relative;border:1px solid var(--bd);border-radius:10px;background:var(--sf);overflow:hidden}
+.register-record.needs-decision:before{content:"";position:absolute;z-index:1;left:0;top:0;bottom:0;width:3px;background:var(--warn)}
 .register-primary{display:grid;grid-template-columns:34px minmax(185px,1.55fr)
   minmax(110px,.8fr) minmax(82px,.62fr) minmax(96px,.68fr)
-  minmax(75px,.55fr) minmax(105px,.72fr) minmax(105px,.76fr);
-  gap:13px;align-items:center;padding:15px 17px 12px}
-.register-tool-mark{width:32px;height:32px;border-radius:8px;display:grid;
-  place-items:center;background:var(--acc-soft);color:var(--acc);font-size:12px;
-  font-weight:760}.needs-decision .register-tool-mark{background:var(--warn-soft);color:var(--warn)}
-.register-identity{min-width:0}.register-identity>strong{display:block;font-size:12.5px;
-  line-height:1.3;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.register-identity>span{display:block;margin-top:4px;color:var(--mut);font-size:9px;
-  white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.register-cell{min-width:0}.register-cell>span:first-child{display:block;margin-bottom:5px;
-  color:#778398;font-size:8px;font-weight:730;letter-spacing:.075em;text-transform:uppercase}
-.register-cell>b{display:block;font-size:11px;white-space:nowrap;overflow:hidden;
-  text-overflow:ellipsis}.register-cell small{display:block;color:var(--mut);font-size:9px;margin-top:2px}
-.register-cell .gov{gap:2px}.register-cell .gov-sub{font-size:8.5px}
-.register-cell .pill{font-size:8.5px}.register-risk-value{color:var(--dstr);font-size:16px!important}
-.register-zero{color:var(--mut);font-weight:560!important}.register-owner b{font-weight:620}
-.register-secondary{display:flex;align-items:center;gap:22px;min-height:39px;
-  padding:8px 17px 8px 64px;border-top:1px solid var(--bd);background:var(--sf2);
-  color:var(--mut);font-size:9px}
-.register-secondary>span{display:flex;align-items:center;gap:6px;min-width:0}
-.register-secondary>span>b{font-size:8px;text-transform:uppercase;letter-spacing:.06em;
-  color:#778398}.register-actions{margin-left:auto!important;gap:5px!important;white-space:nowrap}
-.register-actions button.mini{min-height:26px;padding:4px 8px;background:var(--sf)}
-.register-editor{display:grid;grid-template-columns:minmax(180px,260px) 1fr;gap:20px;
-  padding:17px 19px 19px 64px;border-top:1px solid var(--bd);background:var(--sf2)}
+  minmax(75px,.55fr) minmax(105px,.72fr) minmax(105px,.76fr);gap:13px;align-items:center;padding:15px 17px 12px}
+.register-tool-mark{width:32px;height:32px;border-radius:8px;display:grid;place-items:center;background:var(--acc-soft);color:var(--acc);font-size:12px;font-weight:760}
+.needs-decision .register-tool-mark{background:var(--warn-soft);color:var(--warn)}
+.register-identity{min-width:0}
+.register-identity>strong{display:block;line-height:1.3;overflow:hidden;text-overflow:ellipsis}
+.register-identity>span{display:block;margin-top:4px;color:var(--mut);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.register-cell{min-width:0}
+.register-cell>span:first-child{display:block;margin-bottom:5px;font-weight:730;text-transform:uppercase}
+.register-cell>b{display:block;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.register-cell small{display:block;color:var(--mut);font-size:9px;margin-top:2px}
+.register-cell .gov{gap:2px}
+.register-cell .gov-sub{font-size:8.5px}
+.register-cell .pill{font-size:8.5px}
+.register-risk-value{color:var(--dstr);font-size:16px!important}
+.register-zero{color:var(--mut);font-weight:560!important}
+.register-owner b{font-weight:620}
+.register-secondary{display:flex;align-items:center;min-height:39px;border-top:1px solid var(--bd);background:var(--sf2);color:var(--mut)}
+.register-secondary>span{display:flex;align-items:center;min-width:0}
+.register-secondary>span>b{text-transform:uppercase}
+.register-actions{margin-left:auto!important;gap:5px!important;white-space:nowrap}
+.register-actions button.mini{background:var(--sf)}
+.register-editor{display:grid;grid-template-columns:minmax(180px,260px) 1fr;gap:20px;padding:17px 19px 19px 64px;border-top:1px solid var(--bd);background:var(--sf2)}
 .register-editor>div:first-child>strong,.register-editor>div:first-child>span{display:block}
-.register-editor>div:first-child>strong{font-size:11.5px}.register-editor>div:first-child>span{
-  margin-top:4px;color:var(--mut);font-size:9.5px;line-height:1.45}
-.register-editor>div:last-child{display:grid!important;grid-template-columns:repeat(2,minmax(0,1fr));
-  gap:7px!important}.register-editor>div:last-child>div:last-child{grid-column:1/-1}
-.register-record>hr{margin:0 17px 10px 64px}.register-record>.card-section,
-.register-record>.exc{margin-left:64px;margin-right:17px}.register-record>.exc:last-child{margin-bottom:13px}
-
+.register-editor>div:first-child>span{margin-top:4px;color:var(--mut);line-height:1.45}
+.register-editor>div:last-child{display:grid!important;grid-template-columns:repeat(2,minmax(0,1fr));gap:7px!important}
+.register-editor>div:last-child>div:last-child{grid-column:1/-1}
+.register-record>.card-section, .register-record>.exc{margin-left:64px;margin-right:17px}
+.register-record>.exc:last-child{margin-bottom:13px}
 @media(max-width:1250px){
   .register-primary{grid-template-columns:34px minmax(190px,1.5fr) repeat(3,minmax(100px,1fr))}
   .register-primary>.register-cell:nth-child(6){grid-column:2}
   .register-primary>.register-cell:nth-child(7){grid-column:3}
   .register-primary>.register-cell:nth-child(8){grid-column:4/6}
-  .register-secondary{flex-wrap:wrap;gap:8px 18px}.register-actions{width:100%;margin-left:0!important}
+  .register-secondary{flex-wrap:wrap;gap:8px 18px}
+  .register-actions{width:100%;margin-left:0!important}
 }
 @media(max-width:800px){
-  .register-overview{grid-template-columns:1fr}.register-metrics div:nth-child(1){border-left:0}
+  .register-overview{grid-template-columns:1fr}
+  .register-metrics div:nth-child(1){border-left:0}
   .register-primary{grid-template-columns:38px 1fr;gap:10px 12px}
-  .register-primary>.register-cell:nth-child(n){grid-column:2;padding:0!important;display:grid;
-    grid-template-columns:125px 1fr;align-items:center}.register-cell>span:first-child{margin:0}
+  .register-primary>.register-cell:nth-child(n){grid-column:2;padding:0!important;display:grid;grid-template-columns:125px 1fr;align-items:center}
+  .register-cell>span:first-child{margin:0}
   .register-secondary{padding-left:17px;display:grid;grid-template-columns:1fr 1fr}
-  .register-actions{grid-column:1/-1;width:auto}.register-editor{grid-template-columns:1fr;padding-left:17px}
+  .register-actions{grid-column:1/-1;width:auto}
+  .register-editor{grid-template-columns:1fr;padding-left:17px}
   .register-record>hr,.register-record>.card-section,.register-record>.exc{margin-left:17px}
 }
 @media(max-width:560px){
-  .register-metrics{grid-template-columns:1fr 1fr}.register-metrics div:nth-child(n){border-bottom:1px solid var(--bd)}
-  .register-metrics div:nth-child(odd){border-left:0}.register-metrics div:nth-last-child(-n+2){border-bottom:0}
-  .register-toolbar{align-items:flex-end;flex-wrap:wrap}.register-legend{margin-left:0}.reg-export{margin-left:auto}
-  .register-secondary{grid-template-columns:1fr}.register-actions{grid-column:1}
+  .register-metrics{grid-template-columns:1fr 1fr}
+  .register-metrics div:nth-child(n){border-bottom:1px solid var(--bd)}
+  .register-metrics div:nth-child(odd){border-left:0}
+  .register-metrics div:nth-last-child(-n+2){border-bottom:0}
+  .register-toolbar{align-items:flex-end;flex-wrap:wrap}
+  .register-legend{margin-left:0}
+  .reg-export{margin-left:auto}
+  .register-secondary{grid-template-columns:1fr}
+  .register-actions{grid-column:1}
   .register-editor>div:last-child{grid-template-columns:1fr}
 }
-
 /* --------------------------------------------------------------------------
    Overview refinement — truthful executive summary and decision workflow.
    ----------------------------------------------------------------------- */
 .gcard{container-type:inline-size}
-.overview-executive{display:grid;grid-template-columns:minmax(245px,285px) 1fr;
-  min-width:0;border:1px solid var(--bd);border-radius:12px;background:var(--sf);
-  overflow:hidden;box-shadow:var(--shadow)}
-.executive-posture{padding:19px 21px;
-  background:linear-gradient(120deg,color-mix(in srgb,var(--pri-soft) 70%,var(--sf)),var(--sf));
-  color:var(--fg)}.executive-posture>span{display:block;color:var(--mut);font-size:8.5px;
-  font-weight:760;letter-spacing:.1em;text-transform:uppercase}
-.executive-posture>strong{display:block;margin-top:9px;font-size:24px;line-height:1.05;
-  letter-spacing:-.045em}.needs-attention .executive-posture>strong{color:var(--dstr)}
-.healthy .executive-posture>strong{color:var(--pri)}.executive-posture>p{margin:9px 0 0;
-  color:var(--mut);font-size:9.5px}.executive-actions{display:flex;gap:6px;margin-top:14px}
-.executive-actions button.mini{min-height:27px;background:color-mix(in srgb,var(--sf) 82%,transparent);
-  border-color:var(--bd);color:var(--fg)}
+.overview-executive{display:grid;min-width:0;border:1px solid var(--bd);background:var(--sf);overflow:hidden;box-shadow:var(--shadow)}
+.executive-posture{color:var(--fg)}
+.executive-posture>span{text-transform:uppercase}
+.executive-posture>strong{display:block;margin-top:9px}
+.needs-attention .executive-posture>strong{color:var(--dstr)}
+.healthy .executive-posture>strong{color:var(--pri)}
+.executive-actions{display:flex}
 .executive-actions button.mini:hover{background:var(--sf)}
-[data-theme=dark] .executive-actions button.mini{background:rgba(255,255,255,.06);
-  border-color:rgba(255,255,255,.14);color:#eaf0f7}
+[data-theme=dark] .executive-actions button.mini{background:rgba(255,255,255,.06);border-color:rgba(255,255,255,.14);color:#eaf0f7}
 [data-theme=dark] .executive-actions button.mini:hover{background:rgba(255,255,255,.11)}
-.executive-metrics{display:grid;grid-template-columns:repeat(4,1fr);margin:0}
-.executive-metrics>div{min-width:0;padding:18px 17px;border-left:1px solid var(--bd)}
-.executive-metrics dt{font-size:25px;font-weight:740;line-height:1;letter-spacing:-.045em}
-.executive-metrics dt.risk{color:var(--dstr)}.executive-metrics dt.attention{color:var(--warn)}
-.executive-metrics dt.good{color:var(--pri)}.executive-metrics dd{margin:9px 0 0;
-  color:#748096;font-size:8.5px;font-weight:730;letter-spacing:.065em;text-transform:uppercase}
-.executive-metrics small{display:block;margin-top:7px;color:var(--mut);font-size:9px;
-  line-height:1.4}.executive-metrics .trend{vertical-align:middle}
+.executive-metrics{display:grid;margin:0}
+.executive-metrics>div{min-width:0}
+.executive-metrics dt.risk{color:var(--dstr)}
+.executive-metrics dt.attention{color:var(--warn)}
+.executive-metrics dt.good{color:var(--pri)}
+.executive-metrics small{display:block}
 .editing .gcard.notitle>.overview-executive{margin-top:38px}
-
-.decision-widget{padding:0;overflow:hidden}.decision-widget-head{display:flex;
-  align-items:flex-start;gap:12px;padding:16px 17px 13px}
-.decision-widget-head>div{min-width:0;flex:1}.decision-widget h3{margin:0;color:var(--fg);
-  font-size:12.5px;letter-spacing:-.01em;text-transform:none}
+.decision-widget{padding:0;overflow:hidden}
+.decision-widget-head{display:flex;align-items:flex-start;gap:12px;padding:16px 17px 13px}
+.decision-widget-head>div{min-width:0;flex:1}
+.decision-widget h3{margin:0;letter-spacing:-.01em;text-transform:none}
 .decision-widget-head p{margin:3px 0 0;color:var(--mut);font-size:9.5px}
-.decision-widget-head>.count{margin-left:auto;background:var(--warn-soft);color:var(--warn);
-  border:1px solid color-mix(in srgb,var(--warn) 18%,var(--bd));border-radius:99px;
-  padding:2px 7px;font-size:9px;font-weight:740}
+.decision-widget-head>.count{margin-left:auto;background:var(--warn-soft);color:var(--warn);border:1px solid color-mix(in srgb,var(--warn) 18%,var(--bd));border-radius:99px;padding:2px 7px;font-size:9px;font-weight:740}
 .decision-section{border-top:1px solid var(--bd)}
-.decision-section-head{display:flex;align-items:center;gap:10px;padding:11px 17px;
-  background:var(--sf2)}.decision-section-head>div{min-width:0;flex:1}
+.decision-section-head{display:flex;align-items:center;gap:10px;padding:11px 17px;background:var(--sf2)}
+.decision-section-head>div{min-width:0;flex:1}
 .decision-section-head strong,.decision-section-head span{display:block}
-.decision-section-head strong{font-size:10px}.decision-section-head>div>span{margin-top:2px;
-  color:var(--mut);font-size:8.5px}.decision-section-head>.count{padding:1px 6px;
-  border:1px solid var(--bd);border-radius:99px;color:var(--mut);font-size:8.5px}
-.candidate-list{padding:0 17px}.decision-candidate{display:grid;
-  grid-template-columns:minmax(0,1fr) auto;gap:8px 15px;padding:12px 0;
-  border-top:1px solid var(--bd)}.decision-candidate:first-child{border-top:0}
-.candidate-identity{min-width:0}.candidate-identity>strong{font-size:11px}
-.candidate-identity>p{margin:4px 0 0;color:var(--mut);font-size:9.5px;
-  line-height:1.45;overflow-wrap:anywhere}.candidate-suggestion{display:flex;align-items:center;
-  gap:6px;flex-wrap:wrap;margin-top:6px;color:var(--mut);font-size:9px}
-.candidate-scope{text-align:right;white-space:nowrap}.candidate-scope b,.candidate-scope span{display:block}
-.candidate-scope b{font-size:13px}.candidate-scope span{color:var(--mut);font-size:8.5px}
-.candidate-actions{grid-column:1/-1;display:flex;align-items:center;justify-content:flex-end;
-  gap:5px;flex-wrap:wrap}.candidate-actions button.mini{min-height:27px;padding:4px 8px}
+.decision-section-head strong{font-size:10px}
+.decision-section-head>div>span{margin-top:2px;color:var(--mut);font-size:8.5px}
+.decision-section-head>.count{padding:1px 6px;border:1px solid var(--bd);border-radius:99px;color:var(--mut);font-size:8.5px}
+.candidate-list{padding:0 17px}
+.decision-candidate{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:8px 15px;padding:12px 0;border-top:1px solid var(--bd)}
+.decision-candidate:first-child{border-top:0}
+.candidate-identity{min-width:0}
+.candidate-identity>strong{font-size:11px}
+.candidate-identity>p{margin:4px 0 0;color:var(--mut);font-size:9.5px;line-height:1.45;overflow-wrap:anywhere}
+.candidate-suggestion{display:flex;align-items:center;gap:6px;flex-wrap:wrap;margin-top:6px;color:var(--mut);font-size:9px}
+.candidate-scope{text-align:right;white-space:nowrap}
+.candidate-scope b,.candidate-scope span{display:block}
+.candidate-scope b{font-size:13px}
+.candidate-scope span{color:var(--mut);font-size:8.5px}
+.candidate-actions{grid-column:1/-1;display:flex;align-items:center;justify-content:flex-end;gap:5px;flex-wrap:wrap}
+.candidate-actions button.mini{min-height:27px;padding:4px 8px}
 .candidate-linker{display:flex;align-items:center;gap:5px;margin-right:auto;min-width:0}
 .candidate-linker select.mfield{min-height:29px;width:210px;font-size:9.5px}
-.undecided-list{padding:0 17px}.undecided-list>a{display:grid;
-  grid-template-columns:minmax(130px,1fr) auto 82px;align-items:center;gap:10px;
-  min-height:42px;border-top:1px solid var(--bd);color:var(--fg);text-decoration:none}
-.undecided-list>a:first-child{border-top:0}.undecided-list>a:hover{color:var(--pri)}
-.undecided-list>a>strong{font-size:10.5px}.undecided-list>a>span{display:flex;gap:4px}
+.undecided-list{padding:0 17px}
+.undecided-list>a{display:grid;grid-template-columns:minmax(130px,1fr) auto 82px;align-items:center;gap:10px;min-height:42px;border-top:1px solid var(--bd);color:var(--fg);text-decoration:none}
+.undecided-list>a:first-child{border-top:0}
+.undecided-list>a:hover{color:var(--pri)}
+.undecided-list>a>strong{font-size:10.5px}
+.undecided-list>a>span{display:flex;gap:4px}
 .undecided-list time{text-align:right;color:var(--mut);font-size:9px}
-.decision-footer{display:flex;align-items:center;gap:12px;padding:10px 17px;
-  border-top:1px solid var(--bd);background:var(--sf2);font-size:9px;color:var(--mut)}
+.decision-footer{display:flex;align-items:center;gap:12px;padding:10px 17px;border-top:1px solid var(--bd);background:var(--sf2);font-size:9px;color:var(--mut)}
 .decision-footer a{margin-left:auto;color:var(--pri);font-weight:680;text-decoration:none}
-
-.exposure-trend-card{padding:18px 20px}.trend-heading h3{margin:0;color:var(--fg);
-  font-size:14px;letter-spacing:-.015em;text-transform:none}.trend-heading p{margin:2px 0 0;
-  color:var(--mut);font-size:10px}.exposure-chart{display:flex;flex-direction:column;
-  margin-top:5px}.exposure-chart>.clegend{order:-1;align-self:flex-end;margin:-28px 0 15px;
-  font-size:9.5px}.exposure-trend-card .tchart svg{height:190px}
-.exposure-trend-card .chart .line{stroke-width:2.5}.exposure-trend-card .chart .line.ctx{
-  stroke:color-mix(in srgb,var(--mut) 70%,transparent);stroke-dasharray:5 5}
-.exposure-trend-card .tdays{font-size:9px}.exposure-trend-card>.src-note{margin-bottom:0}
-
+.exposure-trend-card{padding:18px 20px}
+.trend-heading h3{margin:0;color:var(--fg);font-size:14px;letter-spacing:-.015em;text-transform:none}
+.trend-heading p{margin:2px 0 0;color:var(--mut);font-size:10px}
+.exposure-chart{display:flex;flex-direction:column;margin-top:5px}
+.exposure-chart>.clegend{order:-1;align-self:flex-end;margin:-28px 0 15px;font-size:9.5px}
+.exposure-trend-card .tchart svg{height:190px}
+.exposure-trend-card .chart .line{stroke-width:2.5}
+.exposure-trend-card .chart .line.ctx{stroke:color-mix(in srgb,var(--mut) 70%,transparent);stroke-dasharray:5 5}
+.exposure-trend-card .tdays{font-size:9px}
+.exposure-trend-card>.src-note{margin-bottom:0}
 @container (min-width:851px){
-  .decision-candidate{grid-template-columns:minmax(0,1fr) auto auto;
-    align-items:center;column-gap:11px}.candidate-actions{grid-column:auto;flex-wrap:nowrap}
+  .decision-candidate{grid-template-columns:minmax(0,1fr) auto auto;align-items:center;column-gap:11px}
+  .candidate-actions{grid-column:auto;flex-wrap:nowrap}
   .candidate-linker select.mfield{width:180px}
 }
 @container (max-width:850px){
-  .overview-executive{grid-template-columns:1fr}.executive-posture{padding:17px 19px}
-  .executive-posture>strong{font-size:20px}.executive-metrics{grid-template-columns:1fr 1fr}
+  .overview-executive{grid-template-columns:1fr}
+  .executive-posture{padding:17px 19px}
+  .executive-posture>strong{font-size:20px}
+  .executive-metrics{grid-template-columns:1fr 1fr}
   .executive-metrics>div{border-top:1px solid var(--bd);padding:15px 16px}
   .executive-metrics>div:nth-child(odd){border-left:0}
 }
 @container (max-width:560px){
   .candidate-list,.undecided-list{padding-left:13px;padding-right:13px}
-  .decision-candidate{grid-template-columns:1fr auto}.candidate-actions{justify-content:flex-start}
-  .candidate-linker{width:100%;margin-right:0}.candidate-linker select.mfield{flex:1;width:auto}
-  .undecided-list>a{grid-template-columns:1fr auto}.undecided-list time{grid-column:1/-1;
-    text-align:left;margin-top:-8px;padding-bottom:7px}.decision-footer{align-items:flex-start}
+  .decision-candidate{grid-template-columns:1fr auto}
+  .candidate-actions{justify-content:flex-start}
+  .candidate-linker{width:100%;margin-right:0}
+  .candidate-linker select.mfield{flex:1;width:auto}
+  .undecided-list>a{grid-template-columns:1fr auto}
+  .undecided-list time{grid-column:1/-1;text-align:left;margin-top:-8px;padding-bottom:7px}
+  .decision-footer{align-items:flex-start}
   .exposure-chart>.clegend{align-self:flex-start;margin:8px 0 12px}
   .exposure-trend-card .tchart svg{height:145px}
 }
-
-/* Settings catalogue: deployment switches are distinct from each person's
-   saved Overview arrangement, so the two controls no longer look interchangeable. */
 .widget-picker{min-width:0;font-family:Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}
-.widget-picker-head,.widget-picker-foot{display:flex;
-  align-items:center;gap:12px}.widget-picker-head{margin-bottom:10px}
+.widget-picker-head,.widget-picker-foot{display:flex;align-items:center;gap:12px}
+.widget-picker-head{margin-bottom:10px}
 .widget-picker-head>div,.widget-picker-foot>div{min-width:0;flex:1}
-.widget-picker-head strong,.widget-picker-head span,.widget-picker-foot strong,
-.widget-picker-foot span{display:block}.widget-picker-head strong{font-size:11px}
-.widget-picker-head>div>span,.widget-picker-foot>div>span{margin-top:2px;color:var(--mut);
-  font-size:9.5px;line-height:1.4}.widget-enabled-count{flex:0 0 auto;padding:2px 7px;
-  border:1px solid color-mix(in srgb,var(--pri) 20%,var(--bd));border-radius:99px;
-  background:var(--pri-soft);color:var(--pri);font-size:9px;font-weight:700}
-.widget-choice-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));
-  gap:7px}.widget-choice{position:relative;display:grid;grid-template-columns:34px 1fr;
-  align-items:start;gap:10px;min-width:0;padding:11px;border:1px solid var(--bd);
-  border-radius:8px;background:var(--sf);cursor:pointer;transition:border-color .15s,background .15s}
+.widget-picker-head strong,.widget-picker-head span,.widget-picker-foot strong, .widget-picker-foot span{display:block}
+.widget-picker-head strong{font-size:11px}
+.widget-picker-head>div>span,.widget-picker-foot>div>span{margin-top:2px;color:var(--mut);font-size:9.5px;line-height:1.4}
+.widget-enabled-count{flex:0 0 auto;padding:2px 7px;border:1px solid color-mix(in srgb,var(--pri) 20%,var(--bd));border-radius:99px;background:var(--pri-soft);color:var(--pri);font-size:9px;font-weight:700}
+.widget-choice-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:7px}
+.widget-choice{position:relative;display:grid;grid-template-columns:34px 1fr;align-items:start;gap:10px;min-width:0;padding:11px;border:1px solid var(--bd);border-radius:8px;background:var(--sf);cursor:pointer;transition:border-color .15s,background .15s}
 .widget-choice:hover{border-color:color-mix(in srgb,var(--pri) 42%,var(--bd));background:var(--sf2)}
-.widget-choice:has(input:checked){border-color:color-mix(in srgb,var(--pri) 28%,var(--bd));
-  background:#f1faf8}
-[data-theme=dark] .widget-choice:has(input:checked){background:#142a2e;
-  border-color:#27504f}
+.widget-choice:has(input:checked){border-color:color-mix(in srgb,var(--pri) 28%,var(--bd));background:#f1faf8}
+[data-theme=dark] .widget-choice:has(input:checked){background:#142a2e;border-color:#27504f}
 .widget-choice input{position:absolute;opacity:0;width:1px;height:1px;pointer-events:none}
-.widget-switch{position:relative;width:32px;height:18px;margin-top:1px;border-radius:99px;
-  background:color-mix(in srgb,var(--mut) 35%,var(--sf));box-shadow:inset 0 0 0 1px var(--bd)}
-.widget-switch:after{content:"";position:absolute;left:3px;top:3px;width:12px;height:12px;
-  border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(10,20,38,.22);transition:transform .16s}
+.widget-switch{position:relative;width:32px;height:18px;margin-top:1px;border-radius:99px;background:color-mix(in srgb,var(--mut) 35%,var(--sf));box-shadow:inset 0 0 0 1px var(--bd)}
+.widget-switch:after{content:"";position:absolute;left:3px;top:3px;width:12px;height:12px;border-radius:50%;background:#fff;box-shadow:0 1px 3px rgba(10,20,38,.22);transition:transform .16s}
 .widget-choice input:checked+.widget-switch{background:var(--pri);box-shadow:none}
 .widget-choice input:checked+.widget-switch:after{transform:translateX(14px)}
 .widget-choice input:focus-visible+.widget-switch{outline:2px solid var(--acc);outline-offset:2px}
 .widget-choice-copy,.widget-choice-copy>span{display:block;min-width:0}
 .widget-choice-title{color:var(--fg);font-size:10.5px;font-weight:690;text-transform:capitalize}
 .widget-choice-desc{margin-top:2px;color:var(--mut);font-size:9.5px;line-height:1.4}
-.widget-choice-meta{margin-top:7px;color:var(--mut);font-size:8px;text-transform:uppercase;
-  letter-spacing:.055em}.widget-choice-meta .mono{text-transform:none;letter-spacing:0}
-.widget-picker-foot{margin-top:10px;padding:10px 11px;border:1px solid var(--bd);
-  border-radius:8px;background:var(--sf2)}.widget-picker-foot strong{font-size:9.5px}
-.widget-picker-foot button{flex:0 0 auto}.widget-picker-save{background:var(--pri)!important;
-  border-color:var(--pri)!important;color:#fff!important}
-
-/* ISO evidence is an index, not a faux compliance dashboard. The hierarchy
-   makes provenance, coverage and human review obvious without inventing a score. */
-.evidence-summary{display:grid;grid-template-columns:minmax(300px,1.2fr) 1fr;
-  margin-bottom:15px;border:1px solid var(--bd);border-radius:12px;background:var(--sf);
-  overflow:hidden;box-shadow:var(--shadow)}
+.widget-choice-meta{margin-top:7px;color:var(--mut);font-size:8px;text-transform:uppercase;letter-spacing:.055em}
+.widget-choice-meta .mono{text-transform:none;letter-spacing:0}
+.widget-picker-foot{margin-top:10px;padding:10px 11px;border:1px solid var(--bd);border-radius:8px;background:var(--sf2)}
+.widget-picker-foot strong{font-size:9.5px}
+.widget-picker-foot button{flex:0 0 auto}
+.widget-picker-save{background:var(--pri)!important;border-color:var(--pri)!important;color:#fff!important}
+.evidence-summary{display:grid;grid-template-columns:minmax(300px,1.2fr) 1fr;margin-bottom:15px;border:1px solid var(--bd);border-radius:12px;background:var(--sf);overflow:hidden;box-shadow:var(--shadow)}
 .evidence-summary-lead{padding:19px 21px;background:linear-gradient(135deg,#edf9f6,
   #f7fbfa 68%,var(--sf));border-right:1px solid var(--bd)}
-.evidence-summary-lead>span{display:block;color:var(--pri);font-size:8.5px;font-weight:760;
-  letter-spacing:.09em;text-transform:uppercase}.evidence-summary-lead>strong{display:block;
-  margin-top:7px;font-size:16px;letter-spacing:-.02em}.evidence-summary-lead>p{margin:5px 0 12px;
-  color:var(--mut);font-size:9.5px}.evidence-actions{display:flex;align-items:center;
-  gap:7px;flex-wrap:wrap}.evidence-download,.evidence-print{display:inline-flex!important;
-  align-items:center;justify-content:center;width:auto;text-decoration:none;background:transparent!important}
+.evidence-summary-lead>span{display:block;color:var(--pri);font-size:8.5px;font-weight:760;letter-spacing:.09em;text-transform:uppercase}
+.evidence-summary-lead>strong{display:block;margin-top:7px;letter-spacing:-.02em}
+.evidence-summary-lead>p{margin:5px 0 12px;color:var(--mut);font-size:9.5px}
+.evidence-actions{display:flex;align-items:center;gap:7px;flex-wrap:wrap}
+.evidence-download,.evidence-print{display:inline-flex!important;align-items:center;justify-content:center;width:auto;text-decoration:none;background:transparent!important}
 .evidence-download{color:var(--pri)!important;border-color:color-mix(in srgb,var(--pri) 38%,var(--bd))!important}
 .evidence-print{background:var(--pri)!important;border-color:var(--pri)!important;color:#fff!important}
-.evidence-actions .mini{min-height:30px;padding:5px 9px;font-size:9.5px}
+.evidence-actions .mini{padding:5px 9px}
 .evidence-summary dl{display:grid;grid-template-columns:repeat(3,1fr);margin:0}
 .evidence-summary dl>div{padding:19px 17px;border-left:1px solid var(--bd)}
-.evidence-summary dl>div:first-child{border-left:0}.evidence-summary dt{font-size:23px;
-  font-weight:740;letter-spacing:-.04em}.evidence-summary .attention dt{color:var(--warn)}
-.evidence-summary .clear dt{color:var(--pri)}.evidence-summary dd{margin:8px 0 0;
-  color:var(--mut);font-size:8.5px;font-weight:720;text-transform:uppercase;
-  letter-spacing:.06em}.evidence-summary dd small{display:block;margin-top:5px;font-size:8.5px;
-  font-weight:450;line-height:1.35;letter-spacing:0;text-transform:none}
+.evidence-summary dl>div:first-child{border-left:0}
+.evidence-summary dt{font-weight:740;letter-spacing:-.04em}
+.evidence-summary .attention dt{color:var(--warn)}
+.evidence-summary .clear dt{color:var(--pri)}
+.evidence-summary dd{margin:8px 0 0;color:var(--mut);font-size:8.5px;font-weight:720;text-transform:uppercase;letter-spacing:.06em}
+.evidence-summary dd small{display:block;margin-top:5px;font-size:8.5px;font-weight:450;line-height:1.35;letter-spacing:0;text-transform:none}
 [data-theme=dark] .evidence-summary-lead{background:linear-gradient(135deg,#123236,
   #102a36 58%,#112138)}
-.evidence-panel{margin-bottom:15px;border:1px solid var(--bd);border-radius:12px;
-  background:var(--sf);overflow:hidden;box-shadow:var(--shadow)}
-.evidence-panel-head{display:flex;align-items:flex-start;gap:12px;padding:15px 17px;
-  border-bottom:1px solid var(--bd)}.evidence-panel-head>div{min-width:0;flex:1}
-.evidence-panel-head h3{margin:0;color:var(--fg);font-size:12.5px;text-transform:none;
-  letter-spacing:-.01em}.evidence-panel-head p{margin:2px 0 0;color:var(--mut);font-size:9.5px}
-.evidence-panel-head>span{padding:2px 7px;border:1px solid var(--bd);border-radius:99px;
-  color:var(--mut);font-size:8.5px}.evidence-columns,.evidence-row{display:grid;
-  grid-template-columns:minmax(185px,.75fr) minmax(360px,2fr) minmax(120px,.55fr);
-  gap:18px;align-items:center}.evidence-columns{padding:8px 17px;background:var(--sf2);
-  color:var(--mut);font-size:8px;font-weight:740;letter-spacing:.07em;text-transform:uppercase}
+.evidence-panel{margin-bottom:15px;border:1px solid var(--bd);border-radius:12px;background:var(--sf);overflow:hidden;box-shadow:var(--shadow)}
+.evidence-panel-head{display:flex;align-items:flex-start;gap:12px;padding:15px 17px;border-bottom:1px solid var(--bd)}
+.evidence-panel-head>div{min-width:0;flex:1}
+.evidence-panel-head h3{margin:0;color:var(--fg);font-size:12.5px;text-transform:none;letter-spacing:-.01em}
+.evidence-panel-head p{margin:2px 0 0;color:var(--mut);font-size:9.5px}
+.evidence-panel-head>span{padding:2px 7px;border:1px solid var(--bd);border-radius:99px;color:var(--mut);font-size:8.5px}
+.evidence-columns,.evidence-row{display:grid;grid-template-columns:minmax(185px,.75fr) minmax(360px,2fr) minmax(120px,.55fr);gap:18px;align-items:center}
+.evidence-columns{padding:8px 17px;background:var(--sf2);color:var(--mut);font-size:8px;font-weight:740;letter-spacing:.07em;text-transform:uppercase}
 .evidence-row{min-height:53px;padding:9px 17px;border-top:1px solid var(--bd)}
-.evidence-row:first-child{border-top:0}.evidence-theme{display:flex;align-items:center;gap:10px;
-  min-width:0}.evidence-theme>span{display:grid;place-items:center;width:25px;height:25px;
-  flex:0 0 25px;border-radius:6px;background:var(--sf2);color:var(--mut);font-size:8px;
-  font-weight:720}.evidence-theme strong{font-size:10.5px}.evidence-statement{color:var(--mut);
-  font-size:10.5px}.evidence-statement b{color:var(--fg)}.evidence-source a{display:inline-flex;
-  align-items:center;gap:5px;color:var(--pri);font-size:10px;font-weight:650;text-decoration:none}
-.evidence-source a:hover{text-decoration:underline}.evidence-source>span{color:var(--mut);font-size:10px}
-.evidence-review{display:grid;grid-template-columns:minmax(220px,.65fr) 1.35fr;margin-bottom:15px;
-  border:1px solid var(--bd);border-radius:12px;background:var(--sf);overflow:hidden}
+.evidence-row:first-child{border-top:0}
+.evidence-theme{display:flex;align-items:center;gap:10px;min-width:0}
+.evidence-theme>span{display:grid;place-items:center;width:25px;height:25px;flex:0 0 25px;border-radius:6px;background:var(--sf2);color:var(--mut);font-size:8px;font-weight:720}
+.evidence-theme strong{font-size:10.5px}
+.evidence-statement{color:var(--mut);font-size:10.5px}
+.evidence-statement b{color:var(--fg)}
+.evidence-source a{display:inline-flex;align-items:center;gap:5px;color:var(--pri);font-size:10px;font-weight:650;text-decoration:none}
+.evidence-source a:hover{text-decoration:underline}
+.evidence-source>span{color:var(--mut);font-size:10px}
+.evidence-review{display:grid;grid-template-columns:minmax(220px,.65fr) 1.35fr;margin-bottom:15px;border:1px solid var(--bd);border-radius:12px;background:var(--sf);overflow:hidden}
 .evidence-review-copy{padding:17px;background:var(--sf2);border-right:1px solid var(--bd)}
-.evidence-review-copy>span{color:var(--warn);font-size:8.5px;font-weight:740;
-  letter-spacing:.08em;text-transform:uppercase}.evidence-review-copy h3{margin:5px 0 0;
-  color:var(--fg);font-size:13px;text-transform:none;letter-spacing:-.01em}
+.evidence-review-copy>span{color:var(--warn);font-size:8.5px;font-weight:740;letter-spacing:.08em;text-transform:uppercase}
+.evidence-review-copy h3{margin:5px 0 0;color:var(--fg);font-size:13px;text-transform:none;letter-spacing:-.01em}
 .evidence-review-copy p{margin:5px 0 0;color:var(--mut);font-size:9.5px}
-.evidence-review-items{padding:7px 17px}.evidence-review-items>a{display:grid;
-  grid-template-columns:7px 1fr auto;align-items:center;gap:9px;min-height:35px;
-  border-top:1px solid var(--bd);color:var(--fg);font-size:10px;text-decoration:none}
-.evidence-review-items>a:first-child{border-top:0}.evidence-review-items>a:hover{color:var(--pri)}
+.evidence-review-items{padding:7px 17px}
+.evidence-review-items>a{display:grid;grid-template-columns:7px 1fr auto;align-items:center;gap:9px;min-height:35px;border-top:1px solid var(--bd);color:var(--fg);font-size:10px;text-decoration:none}
+.evidence-review-items>a:first-child{border-top:0}
+.evidence-review-items>a:hover{color:var(--pri)}
 .review-marker{width:6px;height:6px;border-radius:50%;background:var(--warn)}
 .evidence-review-items>p{margin:10px 0;color:var(--mut);font-size:10px}
-.evidence-footnote{display:flex;gap:13px;padding:11px 14px;border:1px dashed var(--bd);
-  border-radius:8px;color:var(--mut);font-size:9.5px}.evidence-footnote strong{flex:0 0 auto;
-  color:var(--fg);font-size:9.5px}.evidence-footnote p{margin:0}
-
-.view-meta .meta-chip,.view-meta button.mini,.meta-export{min-height:36px;padding:7px 11px;
-  border-radius:7px;font-size:10.5px;font-weight:630}
-.meta-export{display:inline-flex!important;align-items:center;color:var(--fg)!important;
-  text-decoration:none;background:var(--sf);border:1px solid var(--bd)}
+.evidence-footnote{display:flex;gap:13px;padding:11px 14px;border:1px dashed var(--bd);border-radius:8px;color:var(--mut);font-size:9.5px}
+.evidence-footnote strong{flex:0 0 auto;color:var(--fg);font-size:9.5px}
+.evidence-footnote p{margin:0}
+.view-meta .meta-chip,.view-meta button.mini,.meta-export{min-height:36px;padding:7px 11px;border-radius:7px;font-size:10.5px;font-weight:630}
+.meta-export{display:inline-flex!important;align-items:center;color:var(--fg)!important;text-decoration:none;background:var(--sf);border:1px solid var(--bd)}
 .meta-export:hover{background:var(--sf2);border-color:color-mix(in srgb,var(--pri) 45%,var(--bd))}
 @media(min-width:901px){
   /* The sidebar owns section navigation on desktop. These tabs survive as a
      compact navigation fallback when the sidebar moves off canvas. */
   .tabrow{display:none}
 }
-
 @media(max-width:900px){
-  .widget-choice-grid{grid-template-columns:1fr}.widget-picker-foot{align-items:flex-start;flex-wrap:wrap}
-  .evidence-summary{grid-template-columns:1fr}.evidence-summary-lead{border-right:0;border-bottom:1px solid var(--bd)}
-  .evidence-columns{display:none}.evidence-row{grid-template-columns:minmax(150px,.8fr) 1.6fr}
-  .evidence-source{grid-column:2}.evidence-review{grid-template-columns:1fr}
+  .widget-choice-grid{grid-template-columns:1fr}
+  .widget-picker-foot{align-items:flex-start;flex-wrap:wrap}
+  .evidence-summary{grid-template-columns:1fr}
+  .evidence-summary-lead{border-right:0;border-bottom:1px solid var(--bd)}
+  .evidence-columns{display:none}
+  .evidence-row{grid-template-columns:minmax(150px,.8fr) 1.6fr}
+  .evidence-source{grid-column:2}
+  .evidence-review{grid-template-columns:1fr}
   .evidence-review-copy{border-right:0;border-bottom:1px solid var(--bd)}
 }
 @media(max-width:600px){
-  .evidence-summary dl{grid-template-columns:1fr}.evidence-summary dl>div{border-left:0;border-top:1px solid var(--bd)}
-  .evidence-row{grid-template-columns:1fr;gap:5px;padding:12px 14px}.evidence-source{grid-column:1;margin-left:35px}
-  .evidence-statement{margin-left:35px}.evidence-footnote{display:block}.evidence-footnote p{margin-top:4px}
+  .evidence-summary dl{grid-template-columns:1fr}
+  .evidence-summary dl>div{border-left:0;border-top:1px solid var(--bd)}
+  .evidence-row{grid-template-columns:1fr;gap:5px;padding:12px 14px}
+  .evidence-source{grid-column:1;margin-left:35px}
+  .evidence-statement{margin-left:35px}
+  .evidence-footnote{display:block}
+  .evidence-footnote p{margin-top:4px}
 }
-
 /* --------------------------------------------------------------------------
    Navigation and authentication finish — compact should still mean usable.
    ----------------------------------------------------------------------- */
 .brand{border:0;background:transparent;cursor:pointer;width:100%;text-align:center}
 .brand:focus-visible{outline:2px solid #55d9bd;outline-offset:-4px;border-radius:7px}
-
 /* A diagnostic key/value pair is information, not code. Explicit serials,
    paths and tokens still opt into .mono individually. This also prevents a
    select inherited from a key/value row from unexpectedly becoming mono. */
 .kv dd,.kv dd input,.kv dd select,.kv dd textarea{font-family:inherit;font-variant-numeric:tabular-nums}
-
 .nav-pinned{padding:2px 0 7px;margin:0 0 4px;border-bottom:1px solid var(--side-line)}
-.nav-pinned>span{display:block;padding:4px 10px 3px;color:#718097;font-size:8px;
-  font-weight:750;letter-spacing:.11em;text-transform:uppercase}
-.nav-child-row{position:relative}.nav-child-row .nav-child{width:100%;padding-right:42px}
-.nav-pin{position:absolute!important;right:8px!important;top:50%;transform:translateY(-50%);
-  z-index:2;display:grid!important;place-items:center;min-height:22px!important;width:22px!important;
-  margin:0!important;padding:0!important;border:0!important;background:transparent!important;
-  color:#64748c!important;font-size:12px!important;opacity:0;cursor:pointer}
-.nav-child-row:hover .nav-pin,.nav-pin:focus-visible,.nav-pin.pinned{opacity:1}.nav-pin.pinned{color:#f2bd5b!important}
+.nav-pinned>span{display:block;padding:4px 10px 3px;color:#718097;font-size:8px;font-weight:750;letter-spacing:.11em;text-transform:uppercase}
+.nav-child-row{position:relative}
+.nav-child-row .nav-child{width:100%}
+.nav-pin{position:absolute!important;right:8px!important;top:50%;transform:translateY(-50%);z-index:2;display:grid!important;place-items:center;min-height:22px!important;width:22px!important;margin:0!important;padding:0!important;border:0!important;background:transparent!important;color:#64748c!important;font-size:12px!important;opacity:0;cursor:pointer}
+.nav-child-row:hover .nav-pin,.nav-pin:focus-visible,.nav-pin.pinned{opacity:1}
+.nav-pin.pinned{color:#f2bd5b!important}
 .nav-pin:hover{color:#f2bd5b!important;background:rgba(242,189,91,.1)!important;border-radius:5px}
 .collapsed .nav-pinned,.collapsed .nav-pin{display:none!important}
-
-#navflyout{position:fixed;z-index:75;width:212px;padding:7px;background:var(--side);
-  border:1px solid rgba(255,255,255,.12);border-radius:9px;box-shadow:0 18px 45px rgba(2,8,20,.38)}
-#navflyout[hidden]{display:none}#navflyout .navfly-title{display:block;padding:5px 8px 6px;
-  color:#91a0b6;font-size:8px;font-weight:750;letter-spacing:.1em;text-transform:uppercase}
-#navflyout button{display:block;width:100%;min-height:33px;padding:7px 9px;border:0;border-radius:6px;
-  background:transparent;color:#b8c4d5;text-align:left;font:600 11px/1.35 Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;cursor:pointer}
-#navflyout button:hover,#navflyout button.on{background:var(--side-on);color:#fff}
-
-/* showLogin renders only the authentication card. The application shell is
-   normally a grid, so make the signed-out branch a real centring context
-   rather than depending on the content card's old margin. */
+#navflyout{position:fixed;z-index:75;width:212px;padding:7px;background:var(--side);border:1px solid rgba(255,255,255,.12);border-radius:9px;box-shadow:0 18px 45px rgba(2,8,20,.38)}
+#navflyout[hidden]{display:none}
+#navflyout .navfly-title{display:block;padding:5px 8px 6px;color:#91a0b6;font-size:8px;font-weight:750;letter-spacing:.1em;text-transform:uppercase}
+#navflyout button{display:block;width:100%;min-height:33px;padding:7px 9px;border:0;border-radius:6px;background:transparent;text-align:left;font:600 11px/1.35 Inter,ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;cursor:pointer}
+#navflyout button:hover,#navflyout button.on{background:var(--side-on)}
 body.auth .shell{display:block;min-height:100vh}
 body.auth .shell>div{min-height:100vh;display:grid;place-items:center}
-body.auth main{width:min(470px,calc(100vw - 32px));max-width:470px!important;margin:0!important;
-  padding:0!important}
+body.auth main{width:min(470px,calc(100vw - 32px));max-width:470px!important;margin:0!important;padding:0!important}
 body.auth #app>div{width:100%;margin:0!important}
 body.auth .licard{width:100%}
-@media(max-width:560px){body.auth main{width:min(100% - 28px,470px);padding-top:20px!important}}
-
-/* Discovery summary numbers are a compact estate scorecard: each signal
-   receives the same visual weight, rather than leaving an unexplained empty
-   half of the surface after four short labels. */
+@media(max-width:560px){
+  body.auth main{width:min(100% - 28px,470px);padding-top:20px!important}
+}
 .inventory-summary span{flex:1 1 0;min-width:0}
-
 /* Budget linking is a focused financial workflow. Give its fields a shared
    readable measure and make the tier table a real form table, so the column
    labels describe the inputs beneath them rather than visually colliding. */
 .budget-wizard .kv{grid-template-columns:170px minmax(0,560px);max-width:760px;gap:10px 16px}
 .budget-wizard .kv dd{min-width:0}
 .budget-wizard .kv dd>.mfield{width:100%!important;max-width:560px}
-.budget-wizard .kv .bw-tool-picker{min-height:46px;height:46px;padding-left:14px;
-  border-color:color-mix(in srgb,var(--acc) 70%,var(--bd));background:color-mix(in srgb,var(--acc-soft) 33%,var(--sf));
-  color:var(--fg);font-size:13px;font-weight:680;box-shadow:0 0 0 1px color-mix(in srgb,var(--acc) 16%,transparent)}
+.budget-wizard .kv .bw-tool-picker{min-height:46px;height:46px;padding-left:14px;border-color:color-mix(in srgb,var(--acc) 70%,var(--bd));background:color-mix(in srgb,var(--acc-soft) 33%,var(--sf));color:var(--fg);font-size:13px;font-weight:680;box-shadow:0 0 0 1px color-mix(in srgb,var(--acc) 16%,transparent)}
 .budget-wizard .kv .bw-tool-picker:focus{border-color:var(--acc);box-shadow:0 0 0 3px var(--acc-soft)}
-.budget-wizard .kv .bw-provider-picker{min-height:42px;height:42px;font-size:12px;
-  font-weight:630;border-color:color-mix(in srgb,var(--acc) 45%,var(--bd));background:var(--sf)}
-
-/* Tables stay tables: stable columns with faint guides, a quiet header band,
-   and scanable rows. This makes a wide estate inventory legible without
-   turning every collection into a stack of oversized cards. */
+.budget-wizard .kv .bw-provider-picker{min-height:42px;height:42px;font-size:12px;font-weight:630;border-color:color-mix(in srgb,var(--acc) 45%,var(--bd));background:var(--sf)}
 .tcard table{border-collapse:separate;border-spacing:0}
-.tcard th+th,.tcard td+td{border-left:1px solid color-mix(in srgb,var(--bd) 72%,transparent)}
 .tcard tbody tr:nth-child(even) td{background:color-mix(in srgb,var(--sf2) 38%,transparent)}
 .tcard tbody tr:hover td{background:color-mix(in srgb,var(--acc-soft) 43%,var(--sf))}
-.tcard td{line-height:1.45}.tcard td:first-child{color:var(--fg)}
+.tcard td{line-height:1.45}
+.tcard td:first-child{color:var(--fg)}
 [data-theme=dark] .tcard tbody tr:nth-child(even) td{background:rgba(255,255,255,.012)}
 [data-theme=dark] .tcard tbody tr:hover td{background:#1a2940}
-
-/* Sources is a repeated operational matrix. Each surface carries the same
-   five answers, so their columns must line up identically from Endpoint to
-   MCP — an operator can compare a silent Browser source with a reporting
-   Network source without re-learning the layout. */
-.source-group>.cardhead{min-height:58px;margin:0!important;padding:0 18px!important;
-  align-items:center;border-bottom:1px solid var(--bd);background:var(--sf2)}
-.source-group>.cardhead h3{line-height:1}.source-group>.cardhead .pill{margin:0}
+.source-group>.cardhead{min-height:58px;margin:0!important;padding:0 18px!important;align-items:center;border-bottom:1px solid var(--bd);background:var(--sf2)}
+.source-group>.cardhead h3{line-height:1}
+.source-group>.cardhead .pill{margin:0}
 .source-table{width:100%;table-layout:fixed}
 .source-table th:nth-child(1),.source-table td:nth-child(1){width:31%}
 .source-table th:nth-child(2),.source-table td:nth-child(2){width:19%}
@@ -672,11 +712,12 @@ body.auth .licard{width:100%}
 .source-table th:nth-child(4),.source-table td:nth-child(4){width:15%}
 .source-table th:nth-child(5),.source-table td:nth-child(5){width:19%}
 .source-table td{vertical-align:middle;min-height:62px}
-@media(max-width:900px){.source-table{min-width:880px}}
+@media(max-width:900px){
+  .source-table{min-width:880px}
+}
 .budget-wizard .srcpick{max-width:760px}
 .budget-wizard .tiers{border-collapse:separate;border-spacing:0 7px;margin:11px 0 7px}
-.budget-wizard .tiers thead th{height:auto;padding:0 10px 4px 0;background:transparent;
-  color:#778398;font-size:8.5px;line-height:1.3}
+.budget-wizard .tiers thead th{height:auto;padding:0 10px 4px 0;background:transparent;color:#778398;font-size:8.5px;line-height:1.3}
 .budget-wizard .tiers tbody td{padding:0 8px 0 0;vertical-align:middle;border:0}
 .budget-wizard .tiers .mfield{height:38px;min-height:38px}
 .budget-wizard .tiers .linetot{padding-top:0;white-space:nowrap;font-variant-numeric:tabular-nums}
@@ -685,33 +726,24 @@ body.auth .licard{width:100%}
   .budget-wizard .kv{grid-template-columns:1fr;gap:5px;max-width:none}
   .budget-wizard .tiers{min-width:620px}
 }
-
-/* System health is operational context, not a stack of settings cards. The
-   summary answers "is the estate observable?" first; the cards below retain
-   the evidence needed to diagnose a failed answer without wasting a full
-   viewport on two-column key/value rows. */
-.health-summary{display:grid;grid-template-columns:minmax(290px,1.1fr) 1fr;
-  overflow:hidden;margin:0 0 14px;border:1px solid var(--bd);border-radius:12px;
-  background:var(--sf);box-shadow:var(--shadow)}
-.health-summary-copy{padding:19px 21px;background:linear-gradient(135deg,#edf9f6,#f7fbfa 72%,var(--sf));
-  border-right:1px solid var(--bd)}
+.health-summary{display:grid;grid-template-columns:minmax(290px,1.1fr) 1fr;overflow:hidden;margin:0 0 14px;border:1px solid var(--bd);border-radius:12px;background:var(--sf);box-shadow:var(--shadow)}
+.health-summary-copy{padding:19px 21px;background:linear-gradient(135deg,#edf9f6,#f7fbfa 72%,var(--sf));border-right:1px solid var(--bd)}
 .health-summary.attention .health-summary-copy{background:linear-gradient(135deg,#fff7e9,#fcfaf5 72%,var(--sf))}
-.health-summary-copy>span,.health-card-head>div>span,.health-deployment>div>span,.health-activity .health-card-head>div>span{display:block;
-  color:var(--pri);font-size:8.5px;font-weight:760;letter-spacing:.09em;text-transform:uppercase}
+.health-summary-copy>span,.health-card-head>div>span,.health-deployment>div>span,.health-activity .health-card-head>div>span{display:block;color:var(--pri);font-size:8.5px;font-weight:760;letter-spacing:.09em;text-transform:uppercase}
 .health-summary.attention .health-summary-copy>span{color:var(--warn)}
 .health-summary-copy>strong{display:block;margin-top:7px;color:var(--fg);font-size:17px;letter-spacing:-.025em}
 .health-summary-copy>p{margin:5px 0 0;color:var(--mut);font-size:10px;line-height:1.45}
 .health-summary>dl{display:grid;grid-template-columns:repeat(3,1fr);margin:0}
 .health-summary>dl>div{padding:20px 17px;border-left:1px solid var(--bd)}
-.health-summary>dl>div:first-child{border-left:0}.health-summary dt{color:var(--fg);font-size:22px;font-weight:740;
-  letter-spacing:-.04em;font-variant-numeric:tabular-nums}.health-summary dd{margin:7px 0 0;color:var(--mut);
-  font-size:8px;font-weight:740;letter-spacing:.075em;text-transform:uppercase;line-height:1.35}
+.health-summary>dl>div:first-child{border-left:0}
+.health-summary dt{color:var(--fg);font-size:22px;font-weight:740;letter-spacing:-.04em;font-variant-numeric:tabular-nums}
+.health-summary dd{margin:7px 0 0;color:var(--mut);font-size:8px;font-weight:740;letter-spacing:.075em;text-transform:uppercase;line-height:1.35}
 .health-intro{margin:0 0 13px;color:var(--mut);font-size:10.5px;line-height:1.5}
 .health-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:13px;margin-bottom:13px}
-.health-card,.health-activity{min-width:0;padding:16px 18px;border:1px solid var(--bd);border-radius:11px;
-  background:var(--sf);box-shadow:var(--shadow)}
+.health-card,.health-activity{min-width:0;padding:16px 18px;border:1px solid var(--bd);border-radius:11px;background:var(--sf);box-shadow:var(--shadow)}
 .health-card.needs-attention{border-color:color-mix(in srgb,var(--warn) 48%,var(--bd));box-shadow:inset 3px 0 0 var(--warn),var(--shadow)}
-.health-card-head{display:flex;align-items:flex-start;gap:12px;margin-bottom:13px}.health-card-head>div{min-width:0;flex:1}
+.health-card-head{display:flex;align-items:flex-start;gap:12px;margin-bottom:13px}
+.health-card-head>div{min-width:0;flex:1}
 .health-card-head h3{margin:4px 0 0;color:var(--fg);font-size:13px;letter-spacing:-.015em;text-transform:none}
 .health-card-head>.pill,.health-card-head>span:last-child{flex:0 0 auto;margin-top:1px}
 .health-card-head>span:last-child:not(.pill){color:var(--mut);font-size:9px;font-variant-numeric:tabular-nums}
@@ -719,59 +751,68 @@ body.auth .licard{width:100%}
 .health-facts>div{min-width:0;padding:9px 0;border-top:1px solid var(--bd)}
 .health-facts dt{margin:0 0 4px;color:var(--mut);font-size:8px;font-weight:730;letter-spacing:.065em;text-transform:uppercase}
 .health-facts dd{margin:0;overflow-wrap:anywhere;color:var(--fg);font-size:10.5px;font-weight:620;font-variant-numeric:tabular-nums}
-.health-facts dd>span{color:var(--mut);font-weight:450}.health-note{margin:11px 0 0;padding:9px 10px;
-  border:1px solid var(--bd);border-radius:7px;background:var(--sf2);color:var(--mut);font-size:9.5px;line-height:1.5}
-.health-note.warning{border-left:3px solid var(--warn)}.health-note.danger{border-left:3px solid var(--dstr);color:var(--dstr)}
-.health-note b{margin-right:4px;color:var(--fg)}.health-deployment{display:grid;grid-template-columns:minmax(250px,.9fr) 1.4fr;
-  gap:20px;align-items:center;margin-bottom:13px;padding:16px 18px;border:1px dashed var(--bd);border-radius:11px;background:var(--sf)}
-.health-deployment h3{margin:4px 0 0;color:var(--fg);font-size:12.5px;letter-spacing:-.01em}.health-deployment p{margin:5px 0 0;color:var(--mut);font-size:9.5px;line-height:1.45}
-.health-deployment dl{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px;margin:0}.health-deployment dl>div{min-width:0}
+.health-facts dd>span{color:var(--mut);font-weight:450}
+.health-note{margin:11px 0 0;padding:9px 10px;border:1px solid var(--bd);border-radius:7px;background:var(--sf2);color:var(--mut);font-size:9.5px;line-height:1.5}
+.health-note.warning{border-left:3px solid var(--warn)}
+.health-note.danger{border-left:3px solid var(--dstr);color:var(--dstr)}
+.health-note b{margin-right:4px;color:var(--fg)}
+.health-deployment{display:grid;grid-template-columns:minmax(250px,.9fr) 1.4fr;gap:20px;align-items:center;margin-bottom:13px;padding:16px 18px;border:1px dashed var(--bd);border-radius:11px;background:var(--sf)}
+.health-deployment h3{margin:4px 0 0;color:var(--fg);font-size:12.5px;letter-spacing:-.01em}
+.health-deployment p{margin:5px 0 0;color:var(--mut);font-size:9.5px;line-height:1.45}
+.health-deployment dl{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:10px;margin:0}
+.health-deployment dl>div{min-width:0}
 .health-deployment dt{margin-bottom:4px;color:var(--mut);font-size:8px;font-weight:730;letter-spacing:.065em;text-transform:uppercase}
 .health-deployment dd{margin:0;overflow-wrap:anywhere;color:var(--fg);font-size:10px;font-weight:620}
-.health-activity{margin-bottom:4px;padding:0;overflow:hidden}.health-activity .health-card-head{align-items:center;margin:0;padding:15px 18px;border-bottom:1px solid var(--bd)}
-.health-activity table{margin:0}.health-activity .health-note{margin:0;border-width:1px 0 0;border-radius:0;background:var(--sf2)}
+.health-activity{margin-bottom:4px;padding:0;overflow:hidden}
+.health-activity .health-card-head{align-items:center;margin:0;padding:15px 18px;border-bottom:1px solid var(--bd)}
+.health-activity table{margin:0}
+.health-activity .health-note{margin:0;border-width:1px 0 0;border-radius:0;background:var(--sf2)}
 [data-theme=dark] .health-summary-copy{background:linear-gradient(135deg,#123236,#102a36 63%,#112138)}
 [data-theme=dark] .health-summary.attention .health-summary-copy{background:linear-gradient(135deg,#352b19,#29231a 63%,#172134)}
-@media(max-width:900px){.health-summary{grid-template-columns:1fr}.health-summary-copy{border-right:0;border-bottom:1px solid var(--bd)}
-  .health-grid{grid-template-columns:1fr}.health-deployment{grid-template-columns:1fr;gap:13px}}
-@media(max-width:600px){.health-summary>dl{grid-template-columns:1fr}.health-summary>dl>div{border-left:0;border-top:1px solid var(--bd)}
-  .health-facts{grid-template-columns:1fr}.health-deployment dl{grid-template-columns:1fr}.health-card,.health-activity{padding-left:14px;padding-right:14px}
-  .health-activity{padding:0}.health-activity .health-card-head{padding-left:14px;padding-right:14px}}
-
+@media(max-width:900px){
+  .health-summary{grid-template-columns:1fr}
+  .health-summary-copy{border-right:0;border-bottom:1px solid var(--bd)}
+  .health-grid{grid-template-columns:1fr}
+  .health-deployment{grid-template-columns:1fr;gap:13px}
+}
+@media(max-width:600px){
+  .health-summary>dl{grid-template-columns:1fr}
+  .health-summary>dl>div{border-left:0;border-top:1px solid var(--bd)}
+  .health-facts{grid-template-columns:1fr}
+  .health-deployment dl{grid-template-columns:1fr}
+  .health-card,.health-activity{padding-left:14px;padding-right:14px}
+  .health-activity{padding:0}
+  .health-activity .health-card-head{padding-left:14px;padding-right:14px}
+}
 /* ---- the reporting window control, in every view header ------------- */
-.window-pick{cursor:pointer;gap:5px;min-height:29px;padding:5px 10px;border-radius:var(--radius-sm);font-size:10.5px;font-weight:630;color:var(--fg)}
+.window-pick{cursor:pointer;gap:5px;padding:5px 10px;border-radius:var(--radius-sm);font-size:10.5px;font-weight:630;color:var(--fg)}
 .window-pick{flex:0 0 auto}
 .window-pick select{font:inherit;font-size:10.5px;font-weight:650;color:var(--fg);border:0;outline:0;cursor:pointer;margin:0;width:auto;min-width:0;min-height:0;box-shadow:none;appearance:none;-webkit-appearance:none;padding:0 16px 0 0;background:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%238a97a8' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>") right center no-repeat;background-size:10px 10px}
-@media(max-width:900px){.window-pick{min-height:31px;padding:6px 10px;font-size:10px}}
+@media(max-width:900px){
+  .window-pick{min-height:31px;padding:6px 10px;font-size:10px}
+}
 .window-pick select:focus-visible{outline:2px solid var(--acc);outline-offset:2px;border-radius:3px}
 .window-pick option{color:#111;background:#fff}
-
 /* ---- the finder under the search box --------------------------------- */
 .search{position:relative}
-#qresults{position:absolute;left:-1px;right:-1px;top:calc(100% + 6px);z-index:70;padding:6px;max-height:60vh;overflow:auto;
-  background:var(--pop);border:1px solid var(--pop-bd);border-radius:9px;box-shadow:var(--pop-shadow)}
+#qresults{position:absolute;left:-1px;right:-1px;top:calc(100% + 6px);z-index:70;padding:6px;max-height:60vh;overflow:auto;background:var(--pop);border:1px solid var(--pop-bd);border-radius:9px;box-shadow:var(--pop-shadow)}
 #qresults[hidden]{display:none}
 .qr-head{padding:4px 9px 6px;font-size:8.5px;font-weight:700;letter-spacing:.09em;text-transform:uppercase;color:var(--mut)}
-.qr-item{display:flex;align-items:center;gap:8px;width:100%;text-align:left;padding:7px 9px;border:0;border-radius:6px;
-  background:transparent;color:var(--fg);font:inherit;font-size:12px;font-weight:600;cursor:pointer}
+.qr-item{display:flex;align-items:center;gap:8px;width:100%;text-align:left;padding:7px 9px;border:0;border-radius:6px;background:transparent;color:var(--fg);font:inherit;font-size:12px;font-weight:600;cursor:pointer}
 .qr-item:hover,.qr-item:focus-visible{background:var(--sf2);outline:0}
 .qr-kind{margin-left:auto;font-size:8.5px;font-weight:700;letter-spacing:.07em;text-transform:uppercase;color:var(--mut)}
 .qr-none{padding:6px 9px 8px;font-size:11.5px;color:var(--mut)}
-
 /* ---- print: the page, not the chrome; ink on paper ------------------- */
 @media print{
   aside,.topbar,.view-meta,#tour,#qresults,.tabrow,.nav-pinned{display:none!important}
   .shell,.shell.collapsed{display:block!important}
   main#app,main#app *{color:#111!important;background:transparent!important;box-shadow:none!important;text-shadow:none!important}
-  main#app .wcard,main#app table,main#app .gcard,main#app .executive-posture,main#app .evidence-summary,
-  main#app .health-card,main#app .health-summary,main#app .register-overview,main#app .tcard,main#app .budget-card{background:#fff!important;border:1px solid #bbb!important}
+  main#app .wcard,main#app table,main#app .gcard,main#app .executive-posture,main#app .evidence-summary, main#app .health-card,main#app .health-summary,main#app .register-overview,main#app .tcard,main#app .budget-card{background:#fff!important;border:1px solid #bbb!important}
   main#app .pill{border:1px solid #999!important}
 }
-
 /* ---- a fleet nobody heard from is not a healthy one ------------------- */
 .overview-executive.silent .executive-posture strong{color:var(--mut)}
 .overview-executive.silent .executive-posture{background:var(--sf)}
-
 /* ---- the print stamp: which estate, which window, when --------------- */
 .print-head{display:none}
 @media print{
@@ -780,46 +821,114 @@ body.auth .licard{width:100%}
   main#app *{border-color:#d7dbe2!important}
   main#app .evidence-row{display:grid!important;grid-template-columns:34px minmax(150px,.8fr) 1.6fr auto!important;align-items:center!important}
 }
-
 /* ---- the spend card lists its plans -------------------------------- */
 .budget-lines{margin:12px 0 4px}
-.budget-lines td{padding:7px 6px;font-size:12px;vertical-align:middle}
+.budget-lines td{padding:7px 6px;vertical-align:middle}
 .budget-lines td:first-child{font-weight:650;padding-left:0}
 .budget-lines td.num{text-align:right;white-space:nowrap;color:var(--mut)}
 .budget-lines td:first-child .pill{margin-left:4px}
-
 /* ---- budget mockup 2: a restrained subscription ledger ------------- */
-.budget-card{position:relative;margin:18px 0;padding:0;overflow:hidden;border:1px solid var(--bd);border-radius:8px;background:var(--sf);box-shadow:none}
+.budget-card{position:relative;padding:0;overflow:hidden;border:1px solid var(--bd);background:var(--sf);box-shadow:none}
 .budget-card.has-review{border-left:3px solid var(--warn)}
-.budget-card>summary{display:block;list-style:none;cursor:pointer}.budget-card>summary::-webkit-details-marker{display:none}.budget-card-summary:focus-visible{outline:2px solid var(--acc);outline-offset:-3px}.budget-card[open] .budget-card-summary{border-bottom:1px solid var(--bd)}
+.budget-card>summary{display:block;list-style:none;cursor:pointer}
+.budget-card>summary::-webkit-details-marker{display:none}
+.budget-card-summary:focus-visible{outline:2px solid var(--acc);outline-offset:-3px}
+.budget-card[open] .budget-card-summary{border-bottom:1px solid var(--bd)}
 .budget-card-head{display:grid;grid-template-columns:minmax(0,1fr) auto;gap:24px;align-items:start;padding:18px 20px 16px;border-bottom:0;background:var(--sf)}
-.budget-card-identity{min-width:0}.budget-eyebrow,.budget-section-head>div>span{display:block;margin:0 0 5px;color:var(--acc);font-size:8px;font-weight:760;letter-spacing:.12em;text-transform:uppercase}
-.budget-card-title{display:block;color:var(--fg);font-size:18px;font-weight:720;line-height:1.2;letter-spacing:-.03em}.budget-card-title .pill{vertical-align:2px;margin-left:5px}.budget-card-copy{display:block;margin-top:5px;color:var(--mut);font-size:10px;line-height:1.5}.budget-card-copy span{padding:0 3px}
-.budget-card-state{display:flex;flex:0 0 auto;align-items:flex-end;justify-content:flex-end;gap:9px;flex-wrap:wrap}.budget-renewal{padding:4px 7px;border:1px solid var(--bd);border-radius:4px;color:var(--mut);font-size:9px;font-variant-numeric:tabular-nums;white-space:nowrap}.budget-disclosure{flex-basis:100%;color:var(--acc);font-size:9px;font-weight:670;text-align:right}.budget-disclosure b{display:inline-block;margin-left:4px;font-size:13px;line-height:8px;transition:transform .16s ease}.budget-card[open] .budget-disclosure b{transform:rotate(180deg)}
+.budget-card-identity{min-width:0}
+.budget-eyebrow,.budget-section-head>div>span{display:block;margin:0 0 5px;color:var(--acc);font-size:8px;font-weight:760;letter-spacing:.12em;text-transform:uppercase}
+.budget-card-title{display:block;color:var(--fg);font-weight:720;line-height:1.2;letter-spacing:-.03em}
+.budget-card-title .pill{vertical-align:2px;margin-left:5px}
+.budget-card-copy{display:block;margin-top:5px;color:var(--mut);font-size:10px;line-height:1.5}
+.budget-card-copy span{padding:0 3px}
+.budget-card-state{display:flex;flex:0 0 auto;align-items:flex-end;justify-content:flex-end;gap:9px;flex-wrap:wrap}
+.budget-renewal{padding:4px 7px;border:1px solid var(--bd);border-radius:4px;color:var(--mut);font-size:9px;font-variant-numeric:tabular-nums;white-space:nowrap}
+.budget-disclosure{flex-basis:100%;color:var(--acc);font-size:9px;font-weight:670;text-align:right}
+.budget-disclosure b{display:inline-block;margin-left:4px;font-size:13px;line-height:8px;transition:transform .16s ease}
+.budget-card[open] .budget-disclosure b{transform:rotate(180deg)}
 .budget-card-body>.note{margin:0 20px 14px;padding:8px 10px;border-left:2px solid var(--warn);border-radius:0;background:var(--sf2);font-size:9.5px}
 .budget-kpis{display:grid;grid-template-columns:1.25fr repeat(3,minmax(0,1fr));margin:0;border-top:1px solid var(--bd);border-bottom:1px solid var(--bd);background:var(--sf2)}
-.budget-kpis>span{position:relative;min-width:0;padding:12px 20px 13px;border-right:1px solid var(--bd)}.budget-kpis>span:last-child{border-right:0}.budget-kpis strong{display:block;margin:0;color:var(--fg);font-size:19px;font-weight:720;letter-spacing:-.035em;font-variant-numeric:tabular-nums}.budget-kpis em{display:block;margin:4px 0 3px;color:var(--mut);font-size:7.5px;font-style:normal;font-weight:760;letter-spacing:.085em;text-transform:uppercase}.budget-kpis small{display:block;min-height:13px;color:var(--mut);font-size:9px;line-height:1.35}.budget-kpis .attention{background:transparent}.budget-kpis .attention strong{color:var(--warn)}.budget-kpis .clear strong{color:var(--pri)}
-.budget-card-body>.src-note{margin:9px 20px 0}.budget-tier-section,.budget-insights{margin:16px 20px 0;border:0;border-top:1px solid var(--bd);border-radius:0;overflow:visible;background:transparent}
-.budget-section-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 0 9px;border-bottom:0;background:transparent}.budget-section-head h4{margin:0;color:var(--fg);font-size:12px;letter-spacing:-.01em}.budget-section-head>span{color:var(--mut);font-size:9px;white-space:nowrap}
-.budget-tier-section+.src-note,.budget-tier-section+.budget-data-note{margin:9px 20px 0}.budget-tier-table{width:100%;margin:0;border:1px solid var(--bd);border-collapse:separate;border-spacing:0;border-radius:5px;overflow:hidden;table-layout:fixed}.budget-tier-table th{padding:8px 10px;background:var(--sf2);color:var(--mut);font-size:7.5px;letter-spacing:.09em;text-transform:uppercase}.budget-tier-table td{padding:10px;border-top:1px solid var(--bd);color:var(--fg);font-size:10px;font-weight:590}.budget-tier-table td:first-child{font-weight:690}.budget-tier-table .num{text-align:right;white-space:nowrap;font-variant-numeric:tabular-nums}.budget-tier-table th.num{text-align:right}.budget-tier-table:not(.has-covers) th:first-child{width:34%}.budget-tier-table:not(.has-covers) th.num{width:16.5%}.budget-tier-table.has-covers th:first-child{width:22%}.budget-tier-table.has-covers th.num{width:13%}.budget-tier-table.has-covers th:last-child{width:26%}
-.budget-insights{padding:0 0 15px}.budget-data-note{margin:0 0 10px;padding:8px 10px;border-left:2px solid var(--bd);border-radius:0;background:var(--sf2);color:var(--mut);font-size:9.5px;line-height:1.5}.budget-data-note.budget-warning{border-left-color:var(--warn);color:var(--warn)}
-.budget-details{margin:0;border:0;border-top:1px solid var(--bd);border-radius:0;background:transparent}.budget-details summary{padding:10px 0;color:var(--fg);font-size:10px;font-weight:660;cursor:pointer}.budget-details summary:hover{color:var(--acc)}.budget-details[open] summary{border-bottom:1px solid var(--bd)}.budget-details>p,.budget-details>ul{margin:9px 0}.budget-details>ul{padding-left:16px;color:var(--mut);font-size:9.5px;line-height:1.55}.budget-details>table{width:100%;margin:0 0 10px}.budget-details>table th{font-size:7.5px}.budget-details>table td{font-size:9px}.budget-details.budget-warning summary{color:var(--warn)}.budget-details.budget-risk summary{color:var(--dstr)}
-.budget-card-actions{display:flex;justify-content:space-between;gap:14px;align-items:center;margin:0 20px;padding:13px 0 15px;border-top:1px solid var(--bd);background:var(--sf)}.budget-actions-main,.budget-add-member{display:flex;align-items:center;gap:6px;flex-wrap:wrap}.budget-add-member{margin-left:auto}.budget-add-member>span{margin-right:2px;color:var(--mut);font-size:8px;font-weight:740;letter-spacing:.075em;text-transform:uppercase}.budget-add-member .mfield{width:165px;min-width:0;height:30px;min-height:30px;padding:5px 8px;font-size:9.5px}.budget-add-member .mfield+ .mfield{width:96px}
-[data-theme=dark] .budget-card-head{background:#101a2a}[data-theme=dark] .budget-kpis{background:#111d2e}[data-theme=dark] .budget-card-body>.note,[data-theme=dark] .budget-data-note{background:#111c2c}
-@media(max-width:900px){.budget-kpis{grid-template-columns:repeat(2,minmax(0,1fr))}.budget-kpis>span:nth-child(2){border-right:0}.budget-kpis>span:nth-child(-n+2){border-bottom:1px solid var(--bd)}.budget-card-actions{align-items:flex-start;flex-direction:column}.budget-add-member{margin-left:0}}
-@media(max-width:600px){.budget-card{margin-left:0;margin-right:0}.budget-card-head{display:flex;padding:14px;gap:10px;flex-direction:column}.budget-card-state{align-items:flex-start;justify-content:flex-start}.budget-disclosure{text-align:left}.budget-kpis>span{padding:12px 14px}.budget-tier-section,.budget-insights{margin-left:14px;margin-right:14px}.budget-tier-section{overflow-x:auto}.budget-tier-table{min-width:570px}.budget-card-body>.src-note,.budget-tier-section+.src-note,.budget-tier-section+.budget-data-note{margin-left:14px;margin-right:14px}.budget-card-actions{margin-left:14px;margin-right:14px}.budget-add-member{width:100%}.budget-add-member .mfield{flex:1 1 140px}.budget-details>table{min-width:560px}}
-
+.budget-kpis>span{position:relative;min-width:0;border-right:1px solid var(--bd)}
+.budget-kpis>span:last-child{border-right:0}
+.budget-kpis strong{display:block;margin:0;color:var(--fg);font-weight:720;letter-spacing:-.035em;font-variant-numeric:tabular-nums}
+.budget-kpis em{display:block;margin:4px 0 3px;color:var(--mut);font-size:7.5px;font-style:normal;font-weight:760;letter-spacing:.085em;text-transform:uppercase}
+.budget-kpis small{display:block;min-height:13px;color:var(--mut);font-size:9px;line-height:1.35}
+.budget-kpis .attention{background:transparent}
+.budget-kpis .attention strong{color:var(--warn)}
+.budget-kpis .clear strong{color:var(--pri)}
+.budget-card-body>.src-note{margin:9px 20px 0}
+.budget-tier-section,.budget-insights{margin:16px 20px 0;border:0;border-top:1px solid var(--bd);border-radius:0;overflow:visible;background:transparent}
+.budget-section-head{display:flex;align-items:center;justify-content:space-between;gap:12px;padding:12px 0 9px;border-bottom:0;background:transparent}
+.budget-section-head h4{margin:0;color:var(--fg);font-size:12px;letter-spacing:-.01em}
+.budget-section-head>span{color:var(--mut);font-size:9px;white-space:nowrap}
+.budget-tier-section+.src-note,.budget-tier-section+.budget-data-note{margin:9px 20px 0}
+.budget-tier-table{width:100%;margin:0;border:1px solid var(--bd);border-collapse:separate;border-spacing:0;border-radius:5px;overflow:hidden;table-layout:fixed}
+.budget-tier-table th{padding:8px 10px;background:var(--sf2);color:var(--mut);font-size:7.5px;letter-spacing:.09em;text-transform:uppercase}
+.budget-tier-table td{padding:10px;border-top:1px solid var(--bd);color:var(--fg);font-size:10px;font-weight:590}
+.budget-tier-table td:first-child{font-weight:690}
+.budget-tier-table .num{text-align:right;white-space:nowrap;font-variant-numeric:tabular-nums}
+.budget-tier-table th.num{text-align:right}
+.budget-tier-table:not(.has-covers) th:first-child{width:34%}
+.budget-tier-table:not(.has-covers) th.num{width:16.5%}
+.budget-tier-table.has-covers th:first-child{width:22%}
+.budget-tier-table.has-covers th.num{width:13%}
+.budget-tier-table.has-covers th:last-child{width:26%}
+.budget-insights{padding:0 0 15px}
+.budget-data-note{margin:0 0 10px;padding:8px 10px;border-left:2px solid var(--bd);border-radius:0;background:var(--sf2);color:var(--mut);font-size:9.5px;line-height:1.5}
+.budget-data-note.budget-warning{border-left-color:var(--warn);color:var(--warn)}
+.budget-details{margin:0;border:0;border-top:1px solid var(--bd);border-radius:0;background:transparent}
+.budget-details summary{padding:10px 0;color:var(--fg);font-size:10px;font-weight:660;cursor:pointer}
+.budget-details summary:hover{color:var(--acc)}
+.budget-details[open] summary{border-bottom:1px solid var(--bd)}
+.budget-details>p,.budget-details>ul{margin:9px 0}
+.budget-details>ul{padding-left:16px;color:var(--mut);font-size:9.5px;line-height:1.55}
+.budget-details>table{width:100%;margin:0 0 10px}
+.budget-details>table th{font-size:7.5px}
+.budget-details>table td{font-size:9px}
+.budget-details.budget-warning summary{color:var(--warn)}
+.budget-details.budget-risk summary{color:var(--dstr)}
+.budget-card-actions{display:flex;justify-content:space-between;align-items:center;margin:0 20px;padding:13px 0 15px;border-top:1px solid var(--bd);background:var(--sf)}
+.budget-actions-main,.budget-add-member{display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.budget-add-member{margin-left:auto}
+.budget-add-member>span{margin-right:2px;color:var(--mut);font-size:8px;font-weight:740;letter-spacing:.075em;text-transform:uppercase}
+.budget-add-member .mfield{width:165px;min-width:0;padding:5px 8px;font-size:9.5px}
+.budget-add-member .mfield+ .mfield{width:96px}
+[data-theme=dark] .budget-card-head{background:#101a2a}
+[data-theme=dark] .budget-kpis{background:#111d2e}
+[data-theme=dark] .budget-card-body>.note,[data-theme=dark] .budget-data-note{background:#111c2c}
+@media(max-width:900px){
+  .budget-kpis{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .budget-kpis>span:nth-child(2){border-right:0}
+  .budget-kpis>span:nth-child(-n+2){border-bottom:1px solid var(--bd)}
+  .budget-card-actions{align-items:flex-start;flex-direction:column}
+  .budget-add-member{margin-left:0}
+}
+@media(max-width:600px){
+  .budget-card{margin-left:0;margin-right:0}
+  .budget-card-head{display:flex;padding:14px;gap:10px;flex-direction:column}
+  .budget-card-state{align-items:flex-start;justify-content:flex-start}
+  .budget-disclosure{text-align:left}
+  .budget-kpis>span{padding:12px 14px}
+  .budget-tier-section,.budget-insights{margin-left:14px;margin-right:14px}
+  .budget-tier-section{overflow-x:auto}
+  .budget-tier-table{min-width:570px}
+  .budget-card-body>.src-note,.budget-tier-section+.src-note,.budget-tier-section+.budget-data-note{margin-left:14px;margin-right:14px}
+  .budget-card-actions{margin-left:14px;margin-right:14px}
+  .budget-add-member{width:100%}
+  .budget-add-member .mfield{flex:1 1 140px}
+  .budget-details>table{min-width:560px}
+}
 /* ---- the window: a label on every page but the Overview ------------- */
 .window-label{font-weight:600;color:var(--fg)}
 .window-field{display:inline-flex;align-items:center;min-width:340px;padding:0 10px}
 .window-field select{font:inherit;font-size:11.5px;color:var(--fg);border:0;outline:0;width:100%;min-width:0;min-height:0;box-shadow:none;cursor:pointer;margin:0;appearance:none;-webkit-appearance:none;padding:0 18px 0 0;background:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%238a97a8' stroke-width='2.4' stroke-linecap='round' stroke-linejoin='round'><path d='M6 9l6 6 6-6'/></svg>") right center no-repeat;background-size:11px 11px}
-
 /* ---- a fifth health card takes the whole row rather than leaving a hole -- */
 .health-card.health-wide{grid-column:1/-1}
 .health-card.health-wide .health-facts{grid-template-columns:repeat(4,minmax(0,1fr))}
 .health-card.health-wide .how pre{max-width:none}
-@media(max-width:900px){.health-card.health-wide .health-facts{grid-template-columns:repeat(2,minmax(0,1fr))}}
-
+@media(max-width:900px){
+  .health-card.health-wide .health-facts{grid-template-columns:repeat(2,minmax(0,1fr))}
+}
 /* ---- the upgrade tracker on System health ------------------------------ */
 .upgrade-run{margin-top:12px;padding:12px 14px;border:1px solid var(--bd);border-radius:8px;background:var(--sf2)}
 .upgrade-run-head{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:12px}
@@ -827,7 +936,6 @@ body.auth .licard{width:100%}
 .upgrade-steps{margin:10px 0 0;padding:0;list-style:none;display:grid;gap:5px}
 .upgrade-steps li{font-size:11.5px;display:flex;align-items:center;gap:8px}
 .upgrade-steps li>span:last-child:not(.pill){color:var(--mut);font-size:10.5px}
-
 /* The approval page: one health card, the code beside the facts, one note, actions under both. */
 .cli-grant-body{display:grid;grid-template-columns:minmax(220px,.8fr) 1.6fr;gap:12px 32px;align-items:start}
 .cli-grant-code{padding:12px 14px;border:1px solid var(--bd);border-radius:9px;background:var(--sf2)}
@@ -838,4 +946,557 @@ body.auth .licard{width:100%}
 .cli-grant-facts>div:nth-child(-n+2){border-top:0;padding-top:0}
 .cli-grant-actions{display:flex;flex-wrap:wrap;align-items:center;gap:8px 14px;margin-top:13px}
 .cli-grant-actions .src-note{margin:0;flex:1 1 320px}
-@media (max-width:760px){.cli-grant-body{grid-template-columns:1fr}}
+@media (max-width:760px){
+  .cli-grant-body{grid-template-columns:1fr}
+}
+/* Astra V1: readable type, consistent controls and responsive workspaces.
+   Presentation only: the existing renderers and action hooks own behaviour. */
+body{-webkit-font-smoothing:antialiased}
+button,a,input,select,summary{touch-action:manipulation}
+button:focus-visible,a:focus-visible,summary:focus-visible{outline:2px solid var(--acc);outline-offset:3px}
+aside{overflow:hidden}
+aside>*{flex-shrink:0}
+aside nav{flex:1 1 auto;min-height:0;overflow-y:auto;overscroll-behavior:contain;scrollbar-width:thin}
+.tenant-switch{padding:12px;min-height:60px;margin-bottom:14px}
+.tenant-chev{font-size:0;width:10px;flex:0 0 10px}
+.tenant-chev::after{content:"›";font-size:19px;color:#a7b5c8}
+nav button.nav-child{font-size:12px;min-height:36px}
+.nav-area-block{padding:7px 0}
+.nav-child .nav-dot{background:#7d90aa}
+.foot{line-height:1.65}
+.search{flex-basis:440px;border-radius:8px}
+.topbar #refresh{font-size:11px;min-height:34px}
+.account-copy span,#freshness{font-size:11px}
+.view-head{margin-bottom:24px}
+.view-kicker{margin-bottom:6px}
+.view-head .lede,.lede{font-size:13px;line-height:1.65;max-width:92ch}
+.view-meta .meta-chip,.view-meta button.mini,.meta-export,.window-pick select{font-size:12px}
+button.mini,.btn,.back,.reg-export{font-size:12px;min-height:34px;padding:6px 11px}
+button.mini.pri,.mini.pri{background:var(--pri);color:#fff}
+.src-note,.note,.card-meta,.card-section,.row-key,.muted-value{font-size:11px}
+.note{padding:13px 16px;line-height:1.6;margin-bottom:18px}
+.card-section{letter-spacing:.06em}
+th{color:var(--mut)}
+td{padding:12px 14px}
+.device-inventory td strong{font-size:13px}
+.wcard .bars,.wcard .covrow,.wcard table td{font-size:12px}
+.bars{gap:10px}
+.barrow{min-height:28px}
+.wcard .src-note{line-height:1.6;margin-top:14px}
+.exposure-trend-card .trend-heading h3{font-size:15px;color:var(--fg);letter-spacing:-.01em}
+.trend-heading p,.exposure-chart>.clegend,.exposure-trend-card .tdays{font-size:11px}
+/* A compact posture header leaves room for the observations below it. */
+.executive-posture{grid-template-columns:1fr auto}
+.executive-posture>span{grid-column:1}
+.executive-posture>strong{grid-column:1}
+.executive-posture>p{grid-column:1}
+.executive-actions{margin:0}
+.executive-metrics>div{border-top:0;border-left:1px solid var(--bd)}
+.executive-metrics>div:first-child{border-left:0}
+.executive-metrics dt{font-variant-numeric:tabular-nums}
+.executive-metrics dd{margin-top:10px}
+.decision-widget h3{font-size:14px;color:var(--fg)}
+.decision-widget-head p,.decision-section-head>div>span,.candidate-identity>p, .candidate-suggestion,.decision-footer,.undecided-list time{font-size:11px}
+.candidate-identity>strong,.undecided-list>a>strong,.decision-section-head strong{font-size:12px}
+.register-overview{grid-template-columns:minmax(250px,.85fr) 1.65fr}
+.register-score{background:#172d40;padding:22px}
+.register-score-head span{font-size:11px;color:#bdccda;letter-spacing:.07em}
+.register-score-head strong{font-size:32px;font-variant-numeric:tabular-nums}
+.register-score p{font-size:12px;color:#bdccda}
+.register-metrics div{padding:15px 20px}
+.register-metrics dt{font-size:24px;font-variant-numeric:tabular-nums}
+.register-metrics dd{font-size:11px}
+.register-toolbar{margin:24px 0 12px;gap:12px}
+.register-toolbar strong{font-size:14px}
+.register-toolbar>div span,.register-legend{font-size:11px}
+.register-list{gap:12px}
+.register-record{box-shadow:none;container-type:inline-size}
+.register-identity>strong{font-size:14px;white-space:normal}
+.register-identity>span{font-size:11px}
+.register-cell>span:first-child{font-size:10px;color:var(--mut);letter-spacing:.035em}
+.register-cell>b{font-size:13px}
+.register-cell small,.register-cell .gov-sub,.register-cell .pill{font-size:11px}
+.register-secondary{font-size:11px;gap:10px 18px;flex-wrap:wrap;padding:10px 18px}
+.register-secondary>span{flex-wrap:wrap;gap:4px 6px}
+.register-secondary>span>b{font-size:10px;letter-spacing:.025em;color:var(--mut)}
+.register-actions{width:auto}
+.register-actions button.mini{min-height:32px;padding:5px 10px}
+.register-editor>div:first-child>strong{font-size:13px}
+.register-editor>div:first-child>span{font-size:12px}
+.register-record>hr{border:0;border-top:1px solid var(--bd);margin:0 18px 12px}
+.register-record>.card-section,.register-record>.exc{margin-left:18px;margin-right:18px}
+.register-record>.exc{font-size:12px;line-height:1.7}
+/* The same readable scale across finance, evidence and operational views. */
+.budget-card{border-radius:12px;margin:20px 0}
+.budget-card-title{font-size:20px}
+.budget-card-copy,.budget-renewal,.budget-disclosure,.budget-kpis small, .budget-data-note,.budget-details>ul,.budget-section-head>span, .budget-card-body>.note{font-size:12px}
+.budget-eyebrow,.budget-section-head>div>span,.budget-kpis em, .budget-add-member>span{font-size:10px;letter-spacing:.05em}
+.budget-kpis strong{font-size:26px}
+.budget-kpis>span{padding:17px 20px}
+.budget-section-head h4,.budget-details summary{font-size:13px}
+.budget-tier-table th,.budget-details>table th{font-size:10px;letter-spacing:.04em}
+.budget-tier-table td,.budget-details>table td,.budget-add-member .mfield{font-size:12px}
+.budget-add-member .mfield{min-height:35px;height:35px}
+.budget-card-actions{gap:14px;flex-wrap:wrap}
+.evidence-summary-lead>span,.evidence-summary dd,.evidence-columns, .evidence-review-copy>span,.health-deployment dt{font-size:10px}
+.evidence-summary-lead>strong{font-size:19px}
+.evidence-summary-lead>p,.evidence-summary dd small,.evidence-panel-head p, .evidence-review-copy p,.evidence-footnote,.evidence-footnote strong, .evidence-review-items>a,.evidence-statement,.evidence-source a, .evidence-source>span,.health-deployment dd{font-size:12px}
+.evidence-theme strong,.evidence-panel-head h3,.evidence-review-copy h3{font-size:13px}
+.evidence-summary dt{font-size:28px}
+.evidence-actions .mini{font-size:12px;min-height:35px}
+[data-theme=dark] .evidence-print{color:#082d28!important}
+.evidence-row{padding-top:14px;padding-bottom:14px}
+.ssstep .t{font-size:13px}
+.ssstep .val,.ssstep .pend,.ssstep .need{font-size:11px}
+.ssmain h4{font-size:19px}
+.drawer .lede{font-size:13px}
+@media(min-width:901px){
+  .register-primary{grid-template-columns:36px minmax(160px,1.5fr) repeat(3,minmax(96px,1fr));padding:18px;gap:14px 18px}
+  .register-primary>.register-cell:nth-child(6){grid-column:2}
+  .register-primary>.register-cell:nth-child(7){grid-column:3}
+  .register-primary>.register-cell:nth-child(8){grid-column:4/6}
+}
+@media(min-width:1440px){
+  .register-primary{grid-template-columns:36px minmax(175px,1.6fr) minmax(110px,1fr)
+      minmax(85px,.8fr) minmax(115px,1fr) minmax(65px,.6fr) minmax(100px,1fr) minmax(100px,1fr);gap:14px}
+  .register-primary>.register-cell:nth-child(n){grid-column:auto}
+}
+@media(max-width:1100px){
+  .topbar{gap:9px;padding:0 20px}
+  .topbar #refresh{display:none}
+  .search{min-width:0;flex:1}
+  main{padding:26px 20px 56px}
+  .view-head{flex-wrap:wrap;gap:12px}
+  .view-meta{flex-wrap:wrap}
+  .register-overview{grid-template-columns:1fr}
+  .register-metrics{grid-template-columns:repeat(3,minmax(0,1fr))}
+  .register-score{padding:18px 20px}
+  .register-metrics div:nth-child(3n+1){border-left:0}
+  .register-metrics div:nth-child(-n+3){border-bottom:1px solid var(--bd)}
+}
+@media(max-width:900px){
+  .shell,.shell.collapsed{display:block}
+  aside{box-shadow:none}
+  body.nav-open aside{box-shadow:var(--pop-shadow)}
+  .topbar{height:64px;min-height:64px}
+  .register-primary{grid-template-columns:36px minmax(0,1fr);padding:18px;gap:12px 16px}
+  .register-primary>.register-cell:nth-child(n){grid-column:2;display:grid;grid-template-columns:minmax(125px,.8fr) 1fr;align-items:center}
+  .register-primary .register-cell>span:first-child{margin:0}
+  .register-primary .register-cell>small{grid-column:2}
+  .register-primary .register-cell>.pill,.register-primary .register-cell>.gov{justify-self:start}
+  .register-secondary{display:flex}
+  .register-actions{width:auto;margin-left:auto!important}
+  .evidence-footnote{flex-wrap:wrap}
+}
+@container (max-width:650px){
+  .executive-posture{grid-template-columns:1fr;padding:18px}
+  .executive-actions{grid-column:1;grid-row:auto;margin-top:10px;flex-wrap:wrap}
+  .executive-metrics{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .executive-metrics>div{padding:18px}
+  .executive-metrics>div:nth-child(n+3){border-top:1px solid var(--bd)}
+  .executive-metrics>div:nth-child(odd){border-left:0}
+}
+@media(max-width:560px){
+  html,body{overflow-x:clip}
+  .shell,.shell>div{overflow:visible;min-width:0}
+  main{overflow:visible;min-width:0}
+  main{padding:22px 16px 48px}
+  .topbar{padding:0 12px;gap:8px}
+  .search input{font-size:12px}
+  .view-head h2{font-size:25px}
+  .view-meta{width:100%;margin:0;justify-content:flex-start}
+  .view-head .lede{font-size:13px}
+  .register-toolbar{align-items:center;flex-wrap:wrap}
+  .register-toolbar>div{flex-basis:100%}
+  .register-metrics{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .register-metrics div:nth-child(n){border-left:1px solid var(--bd);border-bottom:1px solid var(--bd)}
+  .register-metrics div:nth-child(odd){border-left:0}
+  .register-metrics div:nth-last-child(-n+2){border-bottom:0}
+  .register-identity>strong{font-size:14px}
+  .register-primary{gap:12px;padding:16px}
+  .register-primary>.register-cell:nth-child(n){grid-column:1/-1;grid-template-columns:minmax(115px,1fr) 1fr}
+  .register-secondary>span{width:100%}
+  .register-actions{margin-left:0!important}
+  .register-editor{padding:16px}
+  .budget-kpis>span{padding:16px}
+  .budget-kpis strong{font-size:24px}
+  .budget-card-head{padding:16px}
+  .budget-card-state{flex-direction:row;align-items:center;gap:8px;width:100%}
+  .budget-disclosure{flex-basis:auto;margin-left:auto}
+  .wcard{padding:17px}
+  .wcard table{display:block;max-width:100%;overflow-x:auto}
+  .evidence-summary dl{grid-template-columns:repeat(3,minmax(0,1fr))}
+  .evidence-summary dl>div{padding:17px 12px;border-top:0;border-left:1px solid var(--bd)}
+  .evidence-summary dl>div:first-child{border-left:0}
+  .evidence-summary dd{font-size:9px;letter-spacing:.035em}
+  .evidence-summary dd small{font-size:11px}
+  .drawer{padding:20px 17px 45px}
+}
+@media (prefers-reduced-motion:reduce){
+  *,*::before,*::after{scroll-behavior:auto!important;transition:none!important;animation:none!important}
+}
+/* Astra integrated design: the V2 composition, using the portal's real brand,
+   routes, telemetry, setup controls and configurable widgets. */
+:root{--bg:#f4f6f8;--fg:#22313e;--sf:#fff;--sf2:#edf2f5;--mut:#5c6c7c;--bd:#d6dfe5;--line:var(--bd);--pri:#14735f;--pri-soft:#e1f2ed;--acc:#486fbd;--dstr:#b93b51;--warn:#8d601b;--side:#eef2f5;--side-ink:#22313e;--side-mut:#5c6c7c;--side-line:#d6dfe5;--side-on:#deeee8;--side-on-ink:#14735f;--astra-tint:#edf4f4;--astra-frame:#bdd7cd;--shadow:0 4px 20px #17334a03}
+[data-theme=dark]{--bg:#0b1017;--fg:#e8eef3;--sf:#111a24;--sf2:#18232f;--mut:#95a6b6;--bd:#263340;--pri:#7bdfc4;--pri-soft:#153831;--acc:#a7b8e4;--dstr:#ff8e9b;--warn:#eac078;--side:#0e141c;--side-ink:#e8eef3;--side-mut:#95a6b6;--side-line:#263340;--side-on:#1c332f;--side-on-ink:#7bdfc4;--astra-tint:#14232b;--astra-frame:#34504d;--chart:#63c8b0;--chart-soft:#63c8b01a;--pop:#18232f;--pop-bd:#354756;--shadow:0 8px 28px #00000013}
+body{font-size:13px;line-height:1.5}
+.shell{grid-template-columns:224px minmax(0,1fr)}
+aside{background:var(--side);border-color:var(--side-line)}
+.brand{height:78px;min-height:78px;padding:10px 14px}
+.brand img{width:194px;max-height:58px;object-fit:contain}
+.tenant-switch{border-color:var(--side-line);background:transparent;margin-top:5px}
+.tenant-avatar{color:var(--pri);background:var(--sf2);border:1px solid var(--side-line)}
+.tenant-copy b{font-size:12px}
+.tenant-copy span{font-size:10px}
+.tenant-chev{color:var(--side-mut)}
+.nav-area-trigger{font-size:12px;min-height:36px;color:var(--side-mut)}
+.nav-area-trigger.current{color:var(--side-ink)}
+.nav-area-trigger.current svg,.nav-area-trigger.on svg{color:var(--pri)}
+nav button.nav-child{color:var(--side-mut)}
+nav button.nav-child.on{color:var(--side-on-ink)}
+.nav-pin.pinned,.nav-pin:hover{color:var(--warn)!important}
+#navflyout{border-color:var(--side-line)}
+#navflyout button{color:var(--side-mut)}
+#navflyout button:hover,#navflyout button.on{color:var(--side-on-ink)}
+.nav-child{min-height:33px!important;font-size:12px!important;white-space:nowrap}
+.nav-child-row .nav-child{padding-left:32px;padding-right:36px}
+.nav-child .nav-dot{left:16px}
+.nav-child .count{flex-shrink:0;margin-left:8px}
+nav button.on{background:var(--side-on);color:var(--side-on-ink)}
+nav button.on svg{color:var(--pri)}
+.nav-section-label{font-size:9px;letter-spacing:1px;color:var(--side-mut)}
+.foot{color:var(--side-mut);padding:12px 17px 0;font-size:10px}
+.fold{min-height:27px;color:var(--side-mut)}
+.topbar{height:58px;min-height:58px;padding:0 26px;gap:10px;background:var(--bg)}
+.search{min-height:32px;max-width:410px;padding:6px 10px;background:var(--sf)}
+.search input{font-size:11px}
+.topbar .back{min-height:30px;height:30px;font-size:11px}
+.account-copy b{font-size:11px}
+.account-copy span{font-size:9px}
+.account-avatar{width:28px;height:28px;font-size:11px}
+.account-button{gap:8px;min-height:34px!important}
+main{padding:28px 28px 50px;max-width:1580px}
+.view-head{margin:0 0 24px;gap:16px}
+.view-head h2{font-size:28px;font-weight:630;letter-spacing:-.035em}
+.view-kicker{font-size:9px;letter-spacing:1.4px;color:var(--mut);font-weight:600}
+.view-head .lede{font-size:12px;margin-top:8px;max-width:640px}
+.view-meta{gap:7px;padding-top:16px;flex-wrap:wrap;justify-content:flex-end}
+.view-meta .mini,.meta-chip{font-size:10px;min-height:31px;padding:6px 9px}
+.window-pick{min-height:31px}
+.astra-density{background:transparent!important;color:var(--mut)}
+.astra-density[aria-pressed=true]{color:var(--pri);border-color:var(--pri)}
+.grid,.gitem{gap:18px}
+.grid{margin-bottom:18px}
+.wcard{padding:18px 20px;border-radius:10px}
+.wcard h3{font-size:13px;font-weight:600;letter-spacing:0;text-transform:none;color:var(--fg)}
+.wform button{font-size:9px;min-height:25px;padding:4px 7px}
+.wform{background:var(--bg);border-color:var(--bd);border-radius:5px}
+button.mini,.btn,.back{min-height:31px;font-size:11px;font-weight:550;border-radius:5px}
+input,select,.mfield{font-size:12px;min-height:33px;border-radius:5px}
+th{font-size:10px;text-transform:none;letter-spacing:0;font-weight:550}
+td{font-size:12px;padding-top:11px;padding-bottom:11px}
+.pill{border-radius:5px;font-weight:500}
+.drawer{width:min(490px,94vw);background:var(--sf);padding:24px 25px 45px}
+.drawer h2{font-weight:600;letter-spacing:-.5px}
+[data-theme=dark] button.mini.pri,[data-theme=dark] .mini.pri{color:#102e27}
+[data-theme=dark] .evidence-print,[data-theme=dark] .widget-picker-save{color:#102e27!important}
+.astra-icon{width:16px;height:16px;flex-shrink:0;vertical-align:middle}
+.astra-eyebrow{font-size:9px;color:var(--mut);text-transform:uppercase;letter-spacing:1px}
+.gcard[data-wk=stat_row]{flex-direction:column}
+.astra-estate-line{width:100%;display:flex;justify-content:space-between;align-items:center;gap:16px;margin:0 0 11px;color:var(--mut);font-size:10px}
+.astra-estate-line>span:first-child{text-transform:uppercase;font-size:9px;letter-spacing:1.2px}
+.overview-executive{grid-template-columns:1fr 1.35fr;border-color:var(--astra-frame);border-radius:10px}
+.executive-posture{display:flex;flex-direction:column;align-items:flex-start;gap:0;padding:23px 24px 18px;border-bottom:0;border-right:1px solid var(--astra-frame);background:linear-gradient(115deg,var(--pri-soft),var(--astra-tint))}
+.executive-posture>span{display:flex;align-items:center;gap:8px;font-size:10px;color:var(--mut);font-weight:600;letter-spacing:1.2px}
+.executive-posture>span svg{color:var(--pri);width:15px;height:15px}
+.executive-posture>strong{font-size:28px;line-height:1.2;font-weight:620;letter-spacing:-.9px;margin:16px 0 0}
+.executive-posture>p{font-size:12px;line-height:1.6;margin:9px 0 0;color:var(--mut)}
+.executive-actions{grid-column:auto;grid-row:auto;align-self:flex-start;gap:8px;margin-top:22px;flex-wrap:wrap}
+.executive-actions button.mini{min-height:33px;padding:8px 11px;font-size:11px;font-weight:550;border-color:var(--astra-frame);background:color-mix(in srgb,var(--sf) 25%,transparent);color:var(--fg)}
+.executive-actions button.mini[data-nav=personal]{background:var(--pri);border-color:var(--pri);color:var(--sf)}
+[data-theme=dark] .executive-actions button.mini[data-nav=personal]{color:#102e27}
+.astra-posture-note{display:block;font-size:10px;color:var(--mut);line-height:1.5;padding-top:20px;margin-top:auto}
+.executive-metrics{grid-template-columns:1fr 1fr}
+.executive-metrics>div{display:flex;flex-direction:column;padding:20px 21px;border:0;border-bottom:1px solid var(--bd);background:var(--sf)}
+.executive-metrics>div:nth-child(odd){border-right:1px solid var(--bd)}
+.executive-metrics>div:nth-child(n+3){border-bottom:0}
+.executive-metrics dd{order:-1;margin:0 0 12px;color:var(--mut);text-transform:none;font-size:11px;letter-spacing:0;font-weight:450}
+.executive-metrics dt{font-size:30px;line-height:1;letter-spacing:-1px;font-weight:580}
+.executive-metrics small{font-size:10px;color:var(--mut);margin-top:9px;line-height:1.5}
+.astra-percent{font-size:18px;color:var(--mut);margin-left:2px;font-weight:400}
+.astra-denominator{font-size:17px;color:var(--mut);margin-left:8px;font-weight:400;letter-spacing:0}
+.executive-metrics .trend{font-size:9px;margin-left:9px;vertical-align:middle}
+.astra-panel-head{display:flex;justify-content:space-between;align-items:center;gap:12px;padding:19px 20px;min-width:0}
+.astra-panel-head h3{margin:0;font-size:13px}
+.astra-panel-head p{font-size:11px;color:var(--mut);margin:5px 0 0;line-height:1.5}
+.astra-focus-card,.astra-visibility-card,.astra-tools-card{padding:0;overflow:hidden}
+.astra-action{display:flex;align-items:flex-start;text-align:left;width:100%;gap:13px;padding:19px 20px;border:0;border-top:1px solid var(--bd);background:transparent;color:var(--fg);border-radius:0;cursor:pointer;font-family:inherit}
+.astra-action:hover{background:var(--sf2)}
+.astra-action>svg{margin-top:9px;width:14px;height:14px;color:var(--mut)}
+.astra-action-icon{display:grid;place-items:center;width:32px;height:32px;flex-shrink:0;border-radius:7px;background:var(--sf2);color:var(--mut)}
+.astra-action-copy{min-width:0;flex:1}
+.astra-action-copy strong{display:block;font-size:12px;font-weight:550;line-height:1.4;margin:1px 0 5px}
+.astra-action-copy>span{display:block;font-size:11px;color:var(--mut);line-height:1.5}
+.astra-action-copy small{display:flex;align-items:center;gap:9px;flex-wrap:wrap;font-size:10px;color:var(--mut);line-height:1.5;margin-top:11px}
+.astra-badge{display:inline-block;border-radius:4px;font-size:10px;line-height:1.2;font-weight:500;white-space:nowrap;padding:3px 6px;background:var(--sf2);color:var(--mut)}
+.astra-badge.risk,.astra-action-icon.risk{color:var(--dstr);background:color-mix(in srgb,var(--dstr) 8%,var(--sf))}
+.astra-badge.attention,.astra-action-icon.attention{color:var(--warn);background:color-mix(in srgb,var(--warn) 8%,var(--sf))}
+.astra-badge.governance,.astra-action-icon.governance{color:var(--acc);background:color-mix(in srgb,var(--acc) 8%,var(--sf))}
+.astra-badge.good,.astra-action-icon.good{color:var(--pri);background:var(--pri-soft)}
+.astra-queue-details{border-top:1px solid var(--bd)}
+.astra-queue-details>summary{padding:13px 20px;color:var(--mut);font-size:10px;cursor:pointer;line-height:1.5}
+.astra-queue-details>summary span{float:right;margin-left:10px;color:var(--pri)}
+.astra-queue-details>.wcard{border:0;box-shadow:none;border-radius:0;margin:0;width:100%;max-width:100%;padding:0}
+.astra-queue-details .decision-widget-head{padding:16px 20px}
+.astra-queue-details>.wcard>h3,.astra-queue-details>.wcard>.lede{margin:16px 20px}
+.astra-empty{margin:20px;font-size:12px;line-height:1.6;color:var(--mut)}
+.astra-coverage-overview{display:flex;align-items:center;gap:24px;padding:4px 20px 18px}
+.astra-ring-block{display:flex;flex-direction:column;align-items:center;gap:8px;flex-shrink:0}
+.astra-ring{position:relative;width:96px;height:96px;flex-shrink:0}
+.astra-ring>svg{width:100%;height:100%;transform:rotate(-90deg);fill:none;stroke-width:7px}
+.astra-ring-track{stroke:var(--bd)}
+.astra-ring-value{stroke:var(--pri);stroke-linecap:butt}
+.astra-ring>div{position:absolute;inset:0;display:flex;justify-content:center;align-items:center}
+.astra-ring strong{font-size:22px;font-weight:560;letter-spacing:-.8px;line-height:1;font-variant-numeric:tabular-nums}
+.astra-ring strong span{font-size:12px;color:var(--mut);font-weight:400;margin-left:1px}
+.astra-ring-caption{font-size:9px;color:var(--mut);text-transform:uppercase;letter-spacing:.9px;white-space:nowrap}
+.astra-coverage-legend{flex:1;min-width:0}
+.astra-coverage-legend p{display:flex;align-items:center;gap:8px;color:var(--mut);font-size:11px;margin:11px 0;line-height:1.4}
+.astra-coverage-legend p b{margin-left:auto;font-weight:550;color:var(--fg)}
+.astra-coverage-legend i{height:6px;width:6px;border-radius:50%;background:var(--pri);flex-shrink:0}
+.astra-coverage-legend i.gap{background:var(--warn)}
+.astra-coverage-legend small{display:block;font-size:10px;line-height:1.5;color:var(--mut);margin-top:15px}
+.astra-source-heading{display:flex;align-items:center;flex-wrap:wrap;gap:9px;padding:14px 20px 0;border-top:1px solid var(--bd)}
+.astra-source-heading h4{margin:0;font-size:11px;font-weight:550}
+.astra-source-heading>span:not(.wform){margin-left:auto;font-size:10px;color:var(--mut)}
+.astra-source-heading .wform{float:none;margin-left:auto}
+.astra-source-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px 24px;padding:16px 20px}
+.astra-source-grid .covrow,.astra-source-grid .meterrow{display:flex;align-items:center;gap:8px;min-width:0;padding:0;font-size:10px}
+.astra-source-grid .covrow>span:first-child,.astra-source-grid .meterrow>span:first-child{width:52px;text-transform:capitalize;font-size:10px}
+.astra-source-grid .covrow .dots{flex:1;display:flex;justify-content:flex-end;gap:3px;min-width:0}
+.astra-source-grid .dots i{height:10px;width:5px;border-radius:1px;background:var(--bd)}
+.astra-source-grid .dots i.on{background:var(--pri)}
+.astra-source-grid .covrow>b,.astra-source-grid .meterrow>b{font-size:10px;min-width:20px;font-weight:450;text-align:right}
+.astra-source-grid .meterrow .track{flex:1;min-width:25px}
+.astra-panel-footer{display:flex;align-items:center;justify-content:space-between;gap:15px;padding:12px 20px;border-top:1px solid var(--bd);color:var(--mut);font-size:10px}
+.astra-panel-footer .mini{display:inline-flex;align-items:center;gap:8px;padding:0;border:0;background:transparent;color:var(--pri);min-height:22px;font-size:10px}
+.astra-panel-footer .astra-icon{width:13px;height:13px}
+.astra-coverage-note{font-size:10px;padding:0 20px 13px;color:var(--mut)}
+.astra-coverage-note summary{cursor:pointer}
+.astra-coverage-note p{font-size:11px;margin:10px 0 0}
+.astra-tools-card .astra-panel-head{gap:20px;flex-wrap:wrap}
+.astra-tools-card h3{display:flex;align-items:center;flex-wrap:wrap;gap:9px;flex:1}
+.astra-tools-card h3>.wform{order:1;margin-left:6px;float:none}
+.astra-tools-card h3>.count{font-size:10px;margin:0;border-radius:4px;padding:2px 5px}
+.astra-tool-filters{display:flex;align-items:center;gap:3px;background:var(--bg);padding:3px;border:1px solid var(--bd);border-radius:6px}
+.astra-tool-filters button{font:inherit;color:var(--mut);background:transparent;padding:6px 8px;border-radius:4px;font-size:10px;border:0;cursor:pointer}
+.astra-tool-filters button.on{background:var(--sf2);color:var(--fg)}
+.astra-table-scroll{overflow:auto;max-width:100%;scrollbar-width:thin}
+.astra-inventory{width:100%;min-width:760px;border-collapse:collapse;font-variant-numeric:tabular-nums}
+.wcard .astra-inventory th,.wcard .astra-inventory td{white-space:nowrap}
+.wcard .astra-inventory th{font-size:10px;font-weight:500;background:var(--sf2);border-top:1px solid var(--bd)}
+.wcard .astra-inventory td{font-size:11px;background:transparent}
+.astra-inventory tr:hover td{background:var(--sf2)}
+.astra-inventory tr:last-child td{border-bottom:0}
+.astra-tool-button{display:flex;gap:10px;align-items:center;font:inherit;border:0;background:none;color:var(--fg);padding:0;text-align:left;cursor:pointer}
+.astra-tool-button strong{font-size:12px;font-weight:550;display:block;line-height:1.4}
+.astra-tool-button small{font-size:10px;color:var(--mut);display:block;margin-top:3px}
+.astra-tool-initial{display:grid;place-items:center;width:28px;height:28px;border-radius:6px;border:1px solid var(--bd);background:var(--sf2);font-size:12px;flex-shrink:0}
+.astra-surface{display:inline-block;font-size:10px;border:1px solid var(--bd);border-radius:4px;padding:2px 5px;color:var(--mut);margin:2px 4px 2px 0}
+.astra-muted{font-size:10px;color:var(--mut)}
+.astra-row-open{display:grid;place-items:center;width:26px;height:26px;border:0;background:none;color:var(--mut);cursor:pointer}
+.astra-row-open svg{width:13px;height:13px}
+.astra-inventory .spark{width:66px;max-width:66px}
+.astra-tool-bars{padding:5px 20px 15px}
+.astra-table-note{font-size:10px;margin:0;padding:0 20px 13px}
+.gcard[data-wk=review_queue],.gcard[data-wk=detection_coverage]{height:100%}
+.astra-visibility-card,.astra-focus-card{display:flex;flex-direction:column}
+.astra-visibility-card>.astra-source-grid,.astra-focus-card>.astra-queue-details{flex:1 0 auto}
+.astra-focus-card>.astra-queue-details{display:flex;flex-direction:column;justify-content:flex-end}
+.gcard[data-wk=review_queue]>.wcard,.gcard[data-wk=detection_coverage]>.wcard{min-height:100%}
+.editing .astra-tool-filters{display:none}
+.editing .astra-panel-head{padding-top:45px}
+.editing .astra-source-heading .wform{display:none}
+.astra-compact main{padding-top:21px}
+.astra-compact .view-head{margin-bottom:18px}
+.astra-compact .grid,.astra-compact .gitem{gap:14px}
+.astra-compact .executive-metrics>div{padding:15px 19px}
+.astra-compact .executive-posture{padding-top:18px;padding-bottom:15px}
+.astra-compact .astra-action{padding-top:13px;padding-bottom:13px}
+.astra-compact .astra-panel-head{padding-top:14px;padding-bottom:14px}
+.astra-compact .astra-inventory td{padding-top:8px;padding-bottom:8px}
+.astra-compact .wcard:not(.astra-focus-card):not(.astra-tools-card):not(.astra-visibility-card):not(.astra-widget){padding:14px 18px}
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
+/* Supporting widgets share the panel grammar: head, body, footer. */
+.wcard .stats{gap:10px;margin:0 0 14px}
+.wcard .stats div{padding:12px 14px;border-radius:7px;box-shadow:none;background:var(--sf2);border:1px solid var(--bd)}
+.wcard .stats dt{font-size:22px;font-weight:580;letter-spacing:-.6px;line-height:1.15;overflow-wrap:anywhere}
+.wcard .stats dd{font-size:10.5px;margin-top:4px;line-height:1.4}
+.wcard h3 .count{display:inline-block;vertical-align:middle;margin-left:7px;padding:2px 6px;font-size:10px;font-weight:500;opacity:1;color:var(--mut);background:var(--sf2);border:1px solid var(--bd);border-radius:4px}
+.astra-people-table{min-width:0}
+.wcard .astra-people-table th,.wcard .astra-people-table td{padding:10px 20px;white-space:normal}
+.astra-people-table td:first-child{font-weight:550}
+.wcard .astra-inventory th,.wcard .astra-inventory td{padding:10px 14px}
+.astra-activity-count{font-size:12px;font-weight:550}
+.budget-lines td{font-size:11.5px}
+.wcard>h3{margin-bottom:12px}
+.wcard .lede{font-size:12px;line-height:1.55}
+.wcard>table td{font-size:11.5px}
+/* Inventory pages: one table grammar, shared with the Overview's tool table. */
+/* Running text runs to the edge of its column, as prose does; the caps the
+     earlier layers set (640px, 800px, 92ch) wrapped sentences at half width. */
+.view-head .lede,.lede,.wcard .lede,.tcard>p.lede,.astra-panel-head p,.executive-posture>p{max-width:none}
+.view-head .view-title{flex:1 1 auto}
+.tcard{border-radius:10px;margin-bottom:18px}
+.tcard th+th,.tcard td+td{border-left:0}
+.tcard th{height:auto;padding:10px 16px;font-size:10px;font-weight:550;letter-spacing:0;text-transform:none;color:var(--mut);background:var(--sf2);border-bottom:1px solid var(--bd)}
+.tcard td{padding:11px 16px;font-size:11.5px;border-bottom:1px solid var(--bd);vertical-align:middle}
+.tcard tbody tr:last-child td,.tcard tr:last-child td{border-bottom:0}
+.tcard td strong{font-weight:550;font-size:12px}
+.tcard>p.src-note{margin:0;padding:10px 16px 12px;border-top:1px solid var(--bd)}
+.tcard>.cardhead,.tcard>h3,.tcard>p.lede{margin-left:16px;margin-right:16px}
+.tcard>p.lede{font-size:11.5px;margin-bottom:8px}
+.tcard tr[data-open]{cursor:pointer}
+.tcard tr[data-open]:hover td{background:var(--sf2)}
+.tcard tr.astra-settled td{color:var(--mut)}
+.tcard tr.astra-settled td strong{color:var(--mut)}
+.astra-row-actions{white-space:nowrap}
+.astra-row-actions .mini{min-height:27px;padding:3px 9px;font-size:10.5px}
+.astra-row-actions .mfield{min-height:27px;font-size:11px}
+.astra-tool-chip{display:inline-block;margin:2px 4px 2px 0;padding:2px 7px;border:1px solid var(--bd);border-radius:4px;background:var(--sf2);color:var(--fg);font-size:10.5px;line-height:1.4;white-space:nowrap}
+.astra-id{display:block;margin-top:2px;font-size:10px;color:var(--mut);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.cell-tags{gap:4px}
+.muted-value{font-size:10.5px}
+.row-key{font-size:10px}
+.pill{font-size:10px;padding:2px 6px;line-height:1.4}
+/* Page-level counts share the executive metric proportions. */
+#app>.stats{gap:12px;margin:0 0 18px}
+#app>.stats div{padding:16px 18px;border-radius:9px;box-shadow:none}
+#app>.stats dt{font-size:26px;font-weight:580;letter-spacing:-.8px;line-height:1.1}
+#app>.stats dd{font-size:11px;margin-top:6px}
+.inventory-summary{border-radius:9px;margin-bottom:18px}
+.inventory-summary span{min-height:56px;padding:0 20px;font-size:11px;gap:8px;align-items:center}
+.inventory-summary b{position:relative;top:-1px}
+.inventory-summary b{font-size:22px;font-weight:580;letter-spacing:-.6px}
+/* Supporting widgets: head, body, footer; sized to content, never stretched
+     into dead space; the same geometry in comfortable, compact and edit modes. */
+.astra-widget{padding:0;overflow:hidden;display:flex;flex-direction:column;min-height:100%}
+.astra-widget>.astra-panel-head{padding-bottom:14px}
+.astra-widget>.astra-table-scroll,.astra-widget>.astra-notes,.astra-widget>.astra-empty{flex:1 0 auto}
+.astra-widget>.astra-panel-footer{margin-top:auto}
+.editing .gcard[data-wk=stat_row]>.astra-estate-line{margin-top:38px}
+.editing .gcard[data-wk=stat_row]>.overview-executive{margin-top:0}
+.astra-widget-lede{margin:0 20px 14px;font-size:12px;line-height:1.55;color:var(--mut)}
+.astra-widget-lede b{color:var(--fg);font-weight:600}
+.astra-widget>.astra-empty{margin:0 20px 18px}
+.astra-tiles{display:grid;grid-template-columns:1.45fr 1fr 1fr;gap:10px;margin:0 20px 14px}
+.astra-tiles-2{grid-template-columns:repeat(2,minmax(0,1fr))}
+.astra-tiles>div{min-width:0;padding:12px 14px;border:1px solid var(--bd);border-radius:8px;background:var(--sf2)}
+.astra-tiles dt{margin:0;font-size:21px;font-weight:580;letter-spacing:-.6px;line-height:1.1;font-variant-numeric:tabular-nums;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.astra-tiles>div:first-child dt{font-size:20px}
+.astra-tiles dt.risk{color:var(--dstr)}
+.astra-tiles dt.attention{color:var(--warn)}
+.astra-tiles dd{margin:5px 0 0;font-size:10.5px;line-height:1.4;color:var(--mut)}
+.astra-tiles dd span{white-space:nowrap}
+.astra-widget-table{min-width:0}
+.wcard .astra-widget-table th,.wcard .astra-widget-table td{padding:9px 20px;white-space:normal}
+.wcard .astra-widget-table th:first-child,.wcard .astra-widget-table td:first-child{padding-left:20px}
+.astra-widget-table td strong{display:block;font-size:12px;font-weight:550}
+.astra-widget-table td small{display:block;margin-top:2px;font-size:10px;color:var(--mut)}
+.astra-widget-table tr[data-nav]{cursor:pointer}
+.wcard .astra-widget-table .num{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap;width:1%}
+.astra-widget-table th.num{text-align:right}
+.astra-silent-table td:last-child{color:var(--mut);font-size:11px;line-height:1.5}
+.astra-silent-table td:last-child i{font-style:normal;margin:0 6px;color:var(--bd)}
+.astra-silent-table td:first-child strong{text-transform:capitalize}
+.astra-notes{list-style:none;margin:0 20px 16px;padding:0;display:flex;flex-direction:column;gap:8px}
+.astra-notes li{position:relative;padding-left:14px;font-size:11px;line-height:1.5;color:var(--mut)}
+.astra-notes li::before{content:"";position:absolute;left:0;top:7px;width:5px;height:5px;border-radius:50%;background:var(--mut)}
+.astra-notes li.attention{color:var(--fg)}
+.astra-notes li.attention::before{background:var(--warn)}
+.astra-compact .astra-widget>.astra-panel-head{padding-top:14px;padding-bottom:11px}
+.astra-compact .astra-tiles{margin-bottom:11px;gap:8px}
+.astra-compact .astra-tiles>div{padding:10px 12px}
+.astra-compact .wcard .astra-widget-table th,.astra-compact .wcard .astra-widget-table td{padding-top:7px;padding-bottom:7px}
+.astra-compact .astra-notes{margin-bottom:12px}
+.astra-compact .astra-coverage-overview{padding-bottom:14px}
+.editing .astra-widget>.astra-panel-head{padding-top:45px}
+.editing .astra-panel-head .astra-eyebrow{display:none}
+/* The tool inventory below table width: a list drawn from the same rows. */
+.astra-tool-list{display:none;list-style:none;margin:0;padding:0;border-top:1px solid var(--bd)}
+.astra-tool-list li+li{border-top:1px solid var(--bd)}
+.astra-tool-item{display:flex;align-items:center;gap:12px;width:100%;padding:11px 20px;border:0;background:transparent;color:var(--fg);font:inherit;text-align:left;cursor:pointer}
+.astra-tool-item:hover{background:var(--sf2)}
+.astra-tool-item>svg{flex-shrink:0;width:13px;height:13px;color:var(--mut)}
+.astra-tool-main{flex:1;min-width:0}
+.astra-tool-main strong{display:block;font-size:12px;font-weight:550;line-height:1.3}
+.astra-tool-main small{display:block;margin-top:2px;font-size:10px;color:var(--mut);line-height:1.4;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.astra-tool-nums{display:flex;flex-direction:column;align-items:flex-end;min-width:38px;flex-shrink:0}
+.astra-tool-nums b{font-size:13px;font-weight:560;font-variant-numeric:tabular-nums;line-height:1.2}
+.astra-tool-nums i{font-style:normal;font-size:9px;color:var(--mut);letter-spacing:.3px}
+.astra-tool-flag{min-width:52px;flex-shrink:0;text-align:right}
+.astra-tool-flag .astra-badge{display:inline-block}
+.astra-compact .astra-tool-item{padding-top:8px;padding-bottom:8px}
+@container (max-width:760px){
+  .astra-tools-card .astra-table-scroll{display:none}
+  .astra-tools-card .astra-tool-list{display:block}
+  .astra-tools-card .astra-panel-head{align-items:flex-start;flex-direction:column;gap:10px}
+  .astra-tools-card .astra-table-note{display:none}
+}
+@container (max-width:430px){
+  .astra-tool-cloud,.astra-tool-flag{display:none}
+  .astra-tool-item{gap:10px;padding-left:16px;padding-right:16px}
+}
+@container (max-width:700px){
+  .overview-executive{grid-template-columns:1fr}
+  .executive-posture{border-right:0;border-bottom:1px solid var(--astra-frame);padding:20px}
+  .executive-actions{grid-column:auto;grid-row:auto}
+  .executive-metrics{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .executive-metrics>div{padding:18px}
+  .executive-metrics dd{min-height:30px;font-size:11px;margin-bottom:9px}
+  .astra-tools-card .astra-panel-head{align-items:flex-start;gap:12px}
+  .astra-tool-filters{margin-left:0}
+}
+@container (max-width:420px){
+  .astra-eyebrow{display:none}
+  .astra-action{padding:16px;gap:10px}
+  .astra-panel-head{padding:17px 16px}
+  .astra-source-grid{gap:12px 15px;padding-left:16px;padding-right:16px}
+  .astra-coverage-overview{gap:15px;padding-left:16px;padding-right:16px}
+  .astra-ring{width:86px;height:86px}
+  .astra-coverage-legend p{font-size:10px;gap:6px}
+  .astra-source-heading{padding-left:16px;padding-right:16px}
+  .astra-panel-footer{padding-left:16px;padding-right:16px;flex-wrap:wrap;gap:8px}
+}
+@media(max-width:1100px){
+  .topbar{padding:0 20px;gap:8px}
+  .search{max-width:none}
+  main{padding:24px 22px 45px}
+  .view-head{flex-wrap:wrap;gap:12px}
+  .view-meta{padding-top:0;margin-left:auto}
+}
+@media(max-width:900px){
+  .shell,.shell.collapsed{display:block}
+  aside{width:244px}
+  .topbar{padding:0 14px;height:56px;min-height:56px}
+  main{padding:23px 16px 45px}
+  .view-meta{width:auto;justify-content:flex-start;margin-left:0}
+}
+@media(max-width:560px){
+  .view-head h2{font-size:26px}
+  .view-head .lede{font-size:12px}
+  .view-meta{gap:6px;flex-wrap:wrap}
+  .view-meta .mini,.meta-chip{font-size:10px}
+  .topbar{gap:6px;padding:0 10px}
+  .search input{font-size:11px}
+  .search{padding:6px 8px}
+  .astra-estate-line{align-items:flex-start;gap:10px;font-size:9px}
+  .astra-estate-line>span:last-child{text-align:right;max-width:48%}
+  .executive-posture>strong{font-size:27px}
+  .executive-metrics dt{font-size:29px}
+  .astra-posture-note{font-size:10px}
+  .astra-tool-filters{width:100%}
+  .astra-tool-filters button{flex:1}
+  .astra-tools-card h3{flex-basis:100%}
+  .astra-queue-details>summary span{float:none;display:block;margin:5px 0 0 13px}
+}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1142,8 +1142,8 @@ td{padding:12px 14px}
 body{font-size:13px;line-height:1.5}
 .shell{grid-template-columns:224px minmax(0,1fr)}
 aside{background:var(--side);border-color:var(--side-line)}
-.brand{height:78px;min-height:78px;padding:10px 14px}
-.brand img{width:194px;max-height:58px;object-fit:contain}
+.brand{height:60px;min-height:60px;padding:10px 14px 6px}
+.brand img{width:184px;max-height:42px;object-fit:contain}
 .tenant-switch{border-color:var(--side-line);background:transparent;margin-top:5px}
 .tenant-avatar{color:var(--pri);background:var(--sf2);border:1px solid var(--side-line)}
 .tenant-copy b{font-size:12px}
@@ -1317,15 +1317,6 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .editing .astra-tool-filters{display:none}
 .editing .astra-panel-head{padding-top:45px}
 .editing .astra-source-heading .wform{display:none}
-.astra-compact main{padding-top:21px}
-.astra-compact .view-head{margin-bottom:18px}
-.astra-compact .grid,.astra-compact .gitem{gap:14px}
-.astra-compact .executive-metrics>div{padding:15px 19px}
-.astra-compact .executive-posture{padding-top:18px;padding-bottom:15px}
-.astra-compact .astra-action{padding-top:13px;padding-bottom:13px}
-.astra-compact .astra-panel-head{padding-top:14px;padding-bottom:14px}
-.astra-compact .astra-inventory td{padding-top:8px;padding-bottom:8px}
-.astra-compact .wcard:not(.astra-focus-card):not(.astra-tools-card):not(.astra-visibility-card):not(.astra-widget){padding:14px 18px}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 /* Supporting widgets share the panel grammar: head, body, footer. */
 .wcard .stats{gap:10px;margin:0 0 14px}
@@ -1414,12 +1405,6 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .astra-notes li::before{content:"";position:absolute;left:0;top:7px;width:5px;height:5px;border-radius:50%;background:var(--mut)}
 .astra-notes li.attention{color:var(--fg)}
 .astra-notes li.attention::before{background:var(--warn)}
-.astra-compact .astra-widget>.astra-panel-head{padding-top:14px;padding-bottom:11px}
-.astra-compact .astra-tiles{margin-bottom:11px;gap:8px}
-.astra-compact .astra-tiles>div{padding:10px 12px}
-.astra-compact .wcard .astra-widget-table th,.astra-compact .wcard .astra-widget-table td{padding-top:7px;padding-bottom:7px}
-.astra-compact .astra-notes{margin-bottom:12px}
-.astra-compact .astra-coverage-overview{padding-bottom:14px}
 .editing .astra-widget>.astra-panel-head{padding-top:45px}
 .editing .astra-panel-head .astra-eyebrow{display:none}
 /* The tool inventory below table width: a list drawn from the same rows. */
@@ -1436,7 +1421,6 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .astra-tool-nums i{font-style:normal;font-size:9px;color:var(--mut);letter-spacing:.3px}
 .astra-tool-flag{min-width:52px;flex-shrink:0;text-align:right}
 .astra-tool-flag .astra-badge{display:inline-block}
-.astra-compact .astra-tool-item{padding-top:8px;padding-bottom:8px}
 @container (max-width:760px){
   .astra-tools-card .astra-table-scroll{display:none}
   .astra-tools-card .astra-tool-list{display:block}
@@ -1500,3 +1484,63 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
   .astra-tools-card h3{flex-basis:100%}
   .astra-queue-details>summary span{float:none;display:block;margin:5px 0 0 13px}
 }
+
+/* Compact density: the same pages at roughly four fifths of the room. Type
+   steps down a size, every panel loses a third of its padding, rows lose a
+   third of their height. Comfortable is the default; the choice is per account. */
+.astra-compact{font-size:12px}
+.astra-compact main{padding:18px 22px 40px}
+.astra-compact .view-head{margin-bottom:14px}
+.astra-compact .view-head h2{font-size:22px}
+.astra-compact .view-head .lede{font-size:11.5px;margin-top:5px}
+.astra-compact .view-meta .mini,.astra-compact .meta-chip{min-height:28px;font-size:10px}
+.astra-compact .grid,.astra-compact .gitem{gap:10px}
+.astra-compact .grid{margin-bottom:10px}
+.astra-compact .wcard,.astra-compact .tcard,.astra-compact .overview-executive{border-radius:8px}
+.astra-compact .astra-estate-line{margin-bottom:7px}
+.astra-compact .executive-posture{padding:14px 18px 12px}
+.astra-compact .executive-posture>strong{font-size:22px;margin-top:10px}
+.astra-compact .executive-posture>p{margin-top:6px;font-size:11.5px}
+.astra-compact .executive-actions{margin-top:14px;gap:6px}
+.astra-compact .executive-actions button.mini{min-height:29px;padding:5px 10px;font-size:10.5px}
+.astra-compact .astra-posture-note{padding-top:12px}
+.astra-compact .executive-metrics>div{padding:12px 16px}
+.astra-compact .executive-metrics dt{font-size:24px}
+.astra-compact .executive-metrics dd{margin-bottom:8px;font-size:10.5px}
+.astra-compact .executive-metrics small{margin-top:6px}
+.astra-compact .astra-panel-head{padding:12px 16px 10px}
+.astra-compact .astra-panel-head p{margin-top:3px}
+.astra-compact .astra-action{padding:10px 16px;gap:11px}
+.astra-compact .astra-action-icon{width:28px;height:28px}
+.astra-compact .astra-action-copy small{margin-top:6px}
+.astra-compact .astra-queue-details>summary{padding:9px 16px}
+.astra-compact .astra-panel-footer{padding:9px 16px}
+.astra-compact .wcard .astra-inventory th,.astra-compact .wcard .astra-inventory td{padding:6px 12px}
+.astra-compact .wcard .astra-inventory td{font-size:11px}
+.astra-compact .astra-tool-initial{width:24px;height:24px;font-size:11px}
+.astra-compact .astra-tool-button strong{font-size:11.5px}
+.astra-compact .astra-tool-item{padding:7px 16px}
+.astra-compact .tcard th{padding:8px 12px}
+.astra-compact .tcard td{padding:7px 12px;font-size:11px}
+.astra-compact .inventory-summary span{min-height:44px;padding:0 14px}
+.astra-compact .inventory-summary b{font-size:18px}
+.astra-compact #app>.stats{gap:8px;margin-bottom:12px}
+.astra-compact #app>.stats div{padding:11px 14px}
+.astra-compact #app>.stats dt{font-size:22px}
+.astra-compact .wcard:not(.astra-focus-card):not(.astra-tools-card):not(.astra-visibility-card):not(.astra-widget){padding:12px 14px}
+.astra-compact .wcard>h3{margin-bottom:8px}
+.astra-compact .astra-tiles{margin:0 16px 10px;gap:8px}
+.astra-compact .astra-tiles>div{padding:8px 11px}
+.astra-compact .astra-tiles dt{font-size:18px}
+.astra-compact .astra-widget-lede,.astra-compact .astra-notes,.astra-compact .astra-widget>.astra-empty{margin-left:16px;margin-right:16px;margin-bottom:10px}
+.astra-compact .wcard .astra-widget-table th,.astra-compact .wcard .astra-widget-table td{padding:6px 16px}
+.astra-compact .astra-coverage-overview{padding:0 16px 12px;gap:16px}
+.astra-compact .astra-ring{width:80px;height:80px}
+.astra-compact .astra-ring strong{font-size:19px}
+.astra-compact .astra-coverage-legend p{margin:7px 0}
+.astra-compact .astra-source-heading{padding:10px 16px 0}
+.astra-compact .astra-source-grid{padding:10px 16px;gap:8px 20px}
+.astra-compact .exposure-trend-card .exposure-chart{min-height:0}
+.astra-compact .register-card,.astra-compact .budget-card,.astra-compact .health-card{border-radius:8px}
+.astra-compact .bars{gap:6px}
+.astra-compact .barrow{min-height:24px}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -821,7 +821,7 @@ body.auth .licard{width:100%}
   main#app *{border-color:#d7dbe2!important}
   main#app .evidence-row{display:grid!important;grid-template-columns:minmax(150px,.8fr) 1.6fr auto!important;align-items:center!important}
   main#app .evidence-theme{display:flex!important;gap:10px!important}
-  main#app .astra-tool-filters,main#app .wform,main#app .astra-row-open,main#app .astra-tool-item>svg{display:none!important}
+  main#app .ui-tool-filters,main#app .wform,main#app .ui-row-open,main#app .ui-tool-item>svg{display:none!important}
 }
 /* ---- the spend card lists its plans -------------------------------- */
 .budget-lines{margin:12px 0 4px}
@@ -951,7 +951,7 @@ body.auth .licard{width:100%}
 @media (max-width:760px){
   .cli-grant-body{grid-template-columns:1fr}
 }
-/* Astra V1: readable type, consistent controls and responsive workspaces.
+/* Readable type, consistent controls and responsive workspaces.
    Presentation only: the existing renderers and action hooks own behaviour. */
 body{-webkit-font-smoothing:antialiased}
 button,a,input,select,summary{touch-action:manipulation}
@@ -1137,10 +1137,10 @@ td{padding:12px 14px}
 @media (prefers-reduced-motion:reduce){
   *,*::before,*::after{scroll-behavior:auto!important;transition:none!important;animation:none!important}
 }
-/* Astra integrated design: the V2 composition, using the portal's real brand,
+/* The console layer: the composition the portal uses, with its real brand,
    routes, telemetry, setup controls and configurable widgets. */
-:root{--bg:#f4f6f8;--fg:#22313e;--sf:#fff;--sf2:#edf2f5;--mut:#5c6c7c;--bd:#d6dfe5;--line:var(--bd);--pri:#14735f;--pri-soft:#e1f2ed;--acc:#486fbd;--dstr:#b93b51;--warn:#8d601b;--side:#eef2f5;--side-ink:#22313e;--side-mut:#5c6c7c;--side-line:#d6dfe5;--side-on:#deeee8;--side-on-ink:#14735f;--astra-tint:#edf4f4;--astra-frame:#bdd7cd;--shadow:0 4px 20px #17334a03}
-[data-theme=dark]{--bg:#0b1017;--fg:#e8eef3;--sf:#111a24;--sf2:#18232f;--mut:#95a6b6;--bd:#263340;--pri:#7bdfc4;--pri-soft:#153831;--acc:#a7b8e4;--dstr:#ff8e9b;--warn:#eac078;--side:#0e141c;--side-ink:#e8eef3;--side-mut:#95a6b6;--side-line:#263340;--side-on:#1c332f;--side-on-ink:#7bdfc4;--astra-tint:#14232b;--astra-frame:#34504d;--chart:#63c8b0;--chart-soft:#63c8b01a;--pop:#18232f;--pop-bd:#354756;--shadow:0 8px 28px #00000013}
+:root{--bg:#f4f6f8;--fg:#22313e;--sf:#fff;--sf2:#edf2f5;--mut:#5c6c7c;--bd:#d6dfe5;--line:var(--bd);--pri:#14735f;--pri-soft:#e1f2ed;--acc:#486fbd;--dstr:#b93b51;--warn:#8d601b;--side:#eef2f5;--side-ink:#22313e;--side-mut:#5c6c7c;--side-line:#d6dfe5;--side-on:#deeee8;--side-on-ink:#14735f;--ui-tint:#edf4f4;--ui-frame:#bdd7cd;--shadow:0 4px 20px #17334a03}
+[data-theme=dark]{--bg:#0b1017;--fg:#e8eef3;--sf:#111a24;--sf2:#18232f;--mut:#95a6b6;--bd:#263340;--pri:#7bdfc4;--pri-soft:#153831;--acc:#a7b8e4;--dstr:#ff8e9b;--warn:#eac078;--side:#0e141c;--side-ink:#e8eef3;--side-mut:#95a6b6;--side-line:#263340;--side-on:#1c332f;--side-on-ink:#7bdfc4;--ui-tint:#14232b;--ui-frame:#34504d;--chart:#63c8b0;--chart-soft:#63c8b01a;--pop:#18232f;--pop-bd:#354756;--shadow:0 8px 28px #00000013}
 body{font-size:13px;line-height:1.5}
 .shell{grid-template-columns:224px minmax(0,1fr)}
 aside{background:var(--side);border-color:var(--side-line)}
@@ -1185,8 +1185,8 @@ main{padding:28px 28px 50px;max-width:1580px}
 .view-meta{gap:7px;padding-top:16px;flex-wrap:wrap;justify-content:flex-end}
 .view-meta .mini,.meta-chip{font-size:10px;min-height:31px;padding:6px 9px}
 .window-pick{min-height:31px}
-.astra-density{background:transparent!important;color:var(--mut)}
-.astra-density[aria-pressed=true]{color:var(--pri);border-color:var(--pri)}
+.ui-density{background:transparent!important;color:var(--mut)}
+.ui-density[aria-pressed=true]{color:var(--pri);border-color:var(--pri)}
 .grid,.gitem{gap:18px}
 .grid{margin-bottom:18px}
 .wcard{padding:18px 20px;border-radius:10px}
@@ -1202,22 +1202,22 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .drawer h2{font-weight:600;letter-spacing:-.5px}
 [data-theme=dark] button.mini.pri,[data-theme=dark] .mini.pri{color:#102e27}
 [data-theme=dark] .evidence-print,[data-theme=dark] .widget-picker-save{color:#102e27!important}
-.astra-icon{width:16px;height:16px;flex-shrink:0;vertical-align:middle}
-.astra-eyebrow{font-size:9px;color:var(--mut);text-transform:uppercase;letter-spacing:1px}
+.ui-icon{width:16px;height:16px;flex-shrink:0;vertical-align:middle}
+.ui-eyebrow{font-size:9px;color:var(--mut);text-transform:uppercase;letter-spacing:1px}
 .gcard[data-wk=stat_row]{flex-direction:column}
-.astra-estate-line{width:100%;display:flex;justify-content:space-between;align-items:center;gap:16px;margin:0 0 11px;color:var(--mut);font-size:10px}
-.astra-estate-line>span:first-child{text-transform:uppercase;font-size:9px;letter-spacing:1.2px}
-.overview-executive{grid-template-columns:1fr 1.35fr;border-color:var(--astra-frame);border-radius:10px}
-.executive-posture{display:flex;flex-direction:column;align-items:flex-start;gap:0;padding:23px 24px 18px;border-bottom:0;border-right:1px solid var(--astra-frame);background:linear-gradient(115deg,var(--pri-soft),var(--astra-tint))}
+.ui-estate-line{width:100%;display:flex;justify-content:space-between;align-items:center;gap:16px;margin:0 0 11px;color:var(--mut);font-size:10px}
+.ui-estate-line>span:first-child{text-transform:uppercase;font-size:9px;letter-spacing:1.2px}
+.overview-executive{grid-template-columns:1fr 1.35fr;border-color:var(--ui-frame);border-radius:10px}
+.executive-posture{display:flex;flex-direction:column;align-items:flex-start;gap:0;padding:23px 24px 18px;border-bottom:0;border-right:1px solid var(--ui-frame);background:linear-gradient(115deg,var(--pri-soft),var(--ui-tint))}
 .executive-posture>span{display:flex;align-items:center;gap:8px;font-size:10px;color:var(--mut);font-weight:600;letter-spacing:1.2px}
 .executive-posture>span svg{color:var(--pri);width:15px;height:15px}
 .executive-posture>strong{font-size:28px;line-height:1.2;font-weight:620;letter-spacing:-.9px;margin:16px 0 0}
 .executive-posture>p{font-size:12px;line-height:1.6;margin:9px 0 0;color:var(--mut)}
 .executive-actions{grid-column:auto;grid-row:auto;align-self:flex-start;gap:8px;margin-top:22px;flex-wrap:wrap}
-.executive-actions button.mini{min-height:33px;padding:8px 11px;font-size:11px;font-weight:550;border-color:var(--astra-frame);background:color-mix(in srgb,var(--sf) 25%,transparent);color:var(--fg)}
+.executive-actions button.mini{min-height:33px;padding:8px 11px;font-size:11px;font-weight:550;border-color:var(--ui-frame);background:color-mix(in srgb,var(--sf) 25%,transparent);color:var(--fg)}
 .executive-actions button.mini[data-nav=personal]{background:var(--pri);border-color:var(--pri);color:var(--sf)}
 [data-theme=dark] .executive-actions button.mini[data-nav=personal]{color:#102e27}
-.astra-posture-note{display:block;font-size:10px;color:var(--mut);line-height:1.5;padding-top:20px;margin-top:auto}
+.ui-posture-note{display:block;font-size:10px;color:var(--mut);line-height:1.5;padding-top:20px;margin-top:auto}
 .executive-metrics{grid-template-columns:1fr 1fr}
 .executive-metrics>div{display:flex;flex-direction:column;padding:20px 21px;border:0;border-bottom:1px solid var(--bd);background:var(--sf)}
 .executive-metrics>div:nth-child(odd){border-right:1px solid var(--bd)}
@@ -1225,100 +1225,100 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .executive-metrics dd{order:-1;margin:0 0 12px;color:var(--mut);text-transform:none;font-size:11px;letter-spacing:0;font-weight:450}
 .executive-metrics dt{font-size:30px;line-height:1;letter-spacing:-1px;font-weight:580}
 .executive-metrics small{font-size:10px;color:var(--mut);margin-top:9px;line-height:1.5}
-.astra-percent{font-size:18px;color:var(--mut);margin-left:2px;font-weight:400}
-.astra-denominator{font-size:17px;color:var(--mut);margin-left:8px;font-weight:400;letter-spacing:0}
+.ui-percent{font-size:18px;color:var(--mut);margin-left:2px;font-weight:400}
+.ui-denominator{font-size:17px;color:var(--mut);margin-left:8px;font-weight:400;letter-spacing:0}
 .executive-metrics .trend{font-size:9px;margin-left:9px;vertical-align:middle}
-.astra-panel-head{display:flex;justify-content:space-between;align-items:center;gap:12px;padding:19px 20px;min-width:0}
-.astra-panel-head h3{margin:0;font-size:13px}
-.astra-panel-head p{font-size:11px;color:var(--mut);margin:5px 0 0;line-height:1.5}
-.astra-focus-card,.astra-visibility-card,.astra-tools-card{padding:0;overflow:hidden}
-.astra-action{display:flex;align-items:flex-start;text-align:left;width:100%;gap:13px;padding:19px 20px;border:0;border-top:1px solid var(--bd);background:transparent;color:var(--fg);border-radius:0;cursor:pointer;font-family:inherit}
-.astra-action:hover{background:var(--sf2)}
-.astra-action>svg{margin-top:9px;width:14px;height:14px;color:var(--mut)}
-.astra-action-icon{display:grid;place-items:center;width:32px;height:32px;flex-shrink:0;border-radius:7px;background:var(--sf2);color:var(--mut)}
-.astra-action-copy{min-width:0;flex:1}
-.astra-action-copy strong{display:block;font-size:12px;font-weight:550;line-height:1.4;margin:1px 0 5px}
-.astra-action-copy>span{display:block;font-size:11px;color:var(--mut);line-height:1.5}
-.astra-action-copy small{display:flex;align-items:center;gap:9px;flex-wrap:wrap;font-size:10px;color:var(--mut);line-height:1.5;margin-top:11px}
-.astra-badge{display:inline-block;border-radius:4px;font-size:10px;line-height:1.2;font-weight:500;white-space:nowrap;padding:3px 6px;background:var(--sf2);color:var(--mut)}
-.astra-badge.risk,.astra-action-icon.risk{color:var(--dstr);background:color-mix(in srgb,var(--dstr) 8%,var(--sf))}
-.astra-badge.attention,.astra-action-icon.attention{color:var(--warn);background:color-mix(in srgb,var(--warn) 8%,var(--sf))}
-.astra-badge.governance,.astra-action-icon.governance{color:var(--acc);background:color-mix(in srgb,var(--acc) 8%,var(--sf))}
-.astra-badge.good,.astra-action-icon.good{color:var(--pri);background:var(--pri-soft)}
-.astra-queue-details{border-top:1px solid var(--bd)}
-.astra-queue-details>summary{padding:13px 20px;color:var(--mut);font-size:10px;cursor:pointer;line-height:1.5}
-.astra-queue-details>summary span{float:right;margin-left:10px;color:var(--pri)}
-.astra-queue-details>.wcard{border:0;box-shadow:none;border-radius:0;margin:0;width:100%;max-width:100%;padding:0}
-.astra-queue-details .decision-widget-head{padding:16px 20px}
-.astra-queue-details>.wcard>h3,.astra-queue-details>.wcard>.lede{margin:16px 20px}
-.astra-empty{margin:20px;font-size:12px;line-height:1.6;color:var(--mut)}
-.astra-coverage-overview{display:flex;align-items:center;gap:24px;padding:4px 20px 18px}
-.astra-ring-block{display:flex;flex-direction:column;align-items:center;gap:8px;flex-shrink:0}
-.astra-ring{position:relative;width:96px;height:96px;flex-shrink:0}
-.astra-ring>svg{width:100%;height:100%;transform:rotate(-90deg);fill:none;stroke-width:7px}
-.astra-ring-track{stroke:var(--bd)}
-.astra-ring-value{stroke:var(--pri);stroke-linecap:butt}
-.astra-ring>div{position:absolute;inset:0;display:flex;justify-content:center;align-items:center}
-.astra-ring strong{font-size:22px;font-weight:560;letter-spacing:-.8px;line-height:1;font-variant-numeric:tabular-nums}
-.astra-ring strong span{font-size:12px;color:var(--mut);font-weight:400;margin-left:1px}
-.astra-ring-caption{font-size:9px;color:var(--mut);text-transform:uppercase;letter-spacing:.9px;white-space:nowrap}
-.astra-coverage-legend{flex:1;min-width:0}
-.astra-coverage-legend p{display:flex;align-items:center;gap:8px;color:var(--mut);font-size:11px;margin:11px 0;line-height:1.4}
-.astra-coverage-legend p b{margin-left:auto;font-weight:550;color:var(--fg)}
-.astra-coverage-legend i{height:6px;width:6px;border-radius:50%;background:var(--pri);flex-shrink:0}
-.astra-coverage-legend i.gap{background:var(--warn)}
-.astra-coverage-legend small{display:block;font-size:10px;line-height:1.5;color:var(--mut);margin-top:15px}
-.astra-source-heading{display:flex;align-items:center;flex-wrap:wrap;gap:9px;padding:14px 20px 0;border-top:1px solid var(--bd)}
-.astra-source-heading h4{margin:0;font-size:11px;font-weight:550}
-.astra-source-heading>span:not(.wform){margin-left:auto;font-size:10px;color:var(--mut)}
-.astra-source-heading .wform{float:none;margin-left:auto}
-.astra-source-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px 24px;padding:16px 20px}
-.astra-source-grid .covrow,.astra-source-grid .meterrow{display:flex;align-items:center;gap:8px;min-width:0;padding:0;font-size:10px}
-.astra-source-grid .covrow>span:first-child,.astra-source-grid .meterrow>span:first-child{width:52px;text-transform:capitalize;font-size:10px}
-.astra-source-grid .covrow .dots{flex:1;display:flex;justify-content:flex-end;gap:3px;min-width:0}
-.astra-source-grid .dots i{height:10px;width:5px;border-radius:1px;background:var(--bd)}
-.astra-source-grid .dots i.on{background:var(--pri)}
-.astra-source-grid .covrow>b,.astra-source-grid .meterrow>b{font-size:10px;min-width:20px;font-weight:450;text-align:right}
-.astra-source-grid .meterrow .track{flex:1;min-width:25px}
-.astra-panel-footer{display:flex;align-items:center;justify-content:space-between;gap:15px;padding:12px 20px;border-top:1px solid var(--bd);color:var(--mut);font-size:10px}
-.astra-panel-footer .mini{display:inline-flex;align-items:center;gap:8px;padding:0;border:0;background:transparent;color:var(--pri);min-height:22px;font-size:10px}
-.astra-panel-footer .astra-icon{width:13px;height:13px}
-.astra-coverage-note{font-size:10px;padding:0 20px 13px;color:var(--mut)}
-.astra-coverage-note summary{cursor:pointer}
-.astra-coverage-note p{font-size:11px;margin:10px 0 0}
-.astra-tools-card .astra-panel-head{gap:20px;flex-wrap:wrap}
-.astra-tools-card h3{display:flex;align-items:center;flex-wrap:wrap;gap:9px;flex:1}
-.astra-tools-card h3>.wform{order:1;margin-left:6px;float:none}
-.astra-tools-card h3>.count{font-size:10px;margin:0;border-radius:4px;padding:2px 5px}
-.astra-tool-filters{display:flex;align-items:center;gap:3px;background:var(--bg);padding:3px;border:1px solid var(--bd);border-radius:6px}
-.astra-tool-filters button{font:inherit;color:var(--mut);background:transparent;padding:6px 8px;border-radius:4px;font-size:10px;border:0;cursor:pointer}
-.astra-tool-filters button.on{background:var(--sf2);color:var(--fg)}
-.astra-table-scroll{overflow:auto;max-width:100%;scrollbar-width:thin}
-.astra-inventory{width:100%;min-width:760px;border-collapse:collapse;font-variant-numeric:tabular-nums}
-.wcard .astra-inventory th,.wcard .astra-inventory td{white-space:nowrap}
-.wcard .astra-inventory th{font-size:10px;font-weight:500;background:var(--sf2);border-top:1px solid var(--bd)}
-.wcard .astra-inventory td{font-size:11px;background:transparent}
-.astra-inventory tr:hover td{background:var(--sf2)}
-.astra-inventory tr:last-child td{border-bottom:0}
-.astra-tool-button{display:flex;gap:10px;align-items:center;font:inherit;border:0;background:none;color:var(--fg);padding:0;text-align:left;cursor:pointer}
-.astra-tool-button strong{font-size:12px;font-weight:550;display:block;line-height:1.4}
-.astra-tool-button small{font-size:10px;color:var(--mut);display:block;margin-top:3px}
-.astra-tool-initial{display:grid;place-items:center;width:28px;height:28px;border-radius:6px;border:1px solid var(--bd);background:var(--sf2);font-size:12px;flex-shrink:0}
-.astra-surface{display:inline-block;font-size:10px;border:1px solid var(--bd);border-radius:4px;padding:2px 5px;color:var(--mut);margin:2px 4px 2px 0}
-.astra-muted{font-size:10px;color:var(--mut)}
-.astra-row-open{display:grid;place-items:center;width:26px;height:26px;border:0;background:none;color:var(--mut);cursor:pointer}
-.astra-row-open svg{width:13px;height:13px}
-.astra-inventory .spark{width:66px;max-width:66px}
-.astra-tool-bars{padding:5px 20px 15px}
-.astra-table-note{font-size:10px;margin:0;padding:0 20px 13px}
+.ui-panel-head{display:flex;justify-content:space-between;align-items:center;gap:12px;padding:19px 20px;min-width:0}
+.ui-panel-head h3{margin:0;font-size:13px}
+.ui-panel-head p{font-size:11px;color:var(--mut);margin:5px 0 0;line-height:1.5}
+.ui-focus-card,.ui-visibility-card,.ui-tools-card{padding:0;overflow:hidden}
+.ui-action{display:flex;align-items:flex-start;text-align:left;width:100%;gap:13px;padding:19px 20px;border:0;border-top:1px solid var(--bd);background:transparent;color:var(--fg);border-radius:0;cursor:pointer;font-family:inherit}
+.ui-action:hover{background:var(--sf2)}
+.ui-action>svg{margin-top:9px;width:14px;height:14px;color:var(--mut)}
+.ui-action-icon{display:grid;place-items:center;width:32px;height:32px;flex-shrink:0;border-radius:7px;background:var(--sf2);color:var(--mut)}
+.ui-action-copy{min-width:0;flex:1}
+.ui-action-copy strong{display:block;font-size:12px;font-weight:550;line-height:1.4;margin:1px 0 5px}
+.ui-action-copy>span{display:block;font-size:11px;color:var(--mut);line-height:1.5}
+.ui-action-copy small{display:flex;align-items:center;gap:9px;flex-wrap:wrap;font-size:10px;color:var(--mut);line-height:1.5;margin-top:11px}
+.ui-badge{display:inline-block;border-radius:4px;font-size:10px;line-height:1.2;font-weight:500;white-space:nowrap;padding:3px 6px;background:var(--sf2);color:var(--mut)}
+.ui-badge.risk,.ui-action-icon.risk{color:var(--dstr);background:color-mix(in srgb,var(--dstr) 8%,var(--sf))}
+.ui-badge.attention,.ui-action-icon.attention{color:var(--warn);background:color-mix(in srgb,var(--warn) 8%,var(--sf))}
+.ui-badge.governance,.ui-action-icon.governance{color:var(--acc);background:color-mix(in srgb,var(--acc) 8%,var(--sf))}
+.ui-badge.good,.ui-action-icon.good{color:var(--pri);background:var(--pri-soft)}
+.ui-queue-details{border-top:1px solid var(--bd)}
+.ui-queue-details>summary{padding:13px 20px;color:var(--mut);font-size:10px;cursor:pointer;line-height:1.5}
+.ui-queue-details>summary span{float:right;margin-left:10px;color:var(--pri)}
+.ui-queue-details>.wcard{border:0;box-shadow:none;border-radius:0;margin:0;width:100%;max-width:100%;padding:0}
+.ui-queue-details .decision-widget-head{padding:16px 20px}
+.ui-queue-details>.wcard>h3,.ui-queue-details>.wcard>.lede{margin:16px 20px}
+.ui-empty{margin:20px;font-size:12px;line-height:1.6;color:var(--mut)}
+.ui-coverage-overview{display:flex;align-items:center;gap:24px;padding:4px 20px 18px}
+.ui-ring-block{display:flex;flex-direction:column;align-items:center;gap:8px;flex-shrink:0}
+.ui-ring{position:relative;width:96px;height:96px;flex-shrink:0}
+.ui-ring>svg{width:100%;height:100%;transform:rotate(-90deg);fill:none;stroke-width:7px}
+.ui-ring-track{stroke:var(--bd)}
+.ui-ring-value{stroke:var(--pri);stroke-linecap:butt}
+.ui-ring>div{position:absolute;inset:0;display:flex;justify-content:center;align-items:center}
+.ui-ring strong{font-size:22px;font-weight:560;letter-spacing:-.8px;line-height:1;font-variant-numeric:tabular-nums}
+.ui-ring strong span{font-size:12px;color:var(--mut);font-weight:400;margin-left:1px}
+.ui-ring-caption{font-size:9px;color:var(--mut);text-transform:uppercase;letter-spacing:.9px;white-space:nowrap}
+.ui-coverage-legend{flex:1;min-width:0}
+.ui-coverage-legend p{display:flex;align-items:center;gap:8px;color:var(--mut);font-size:11px;margin:11px 0;line-height:1.4}
+.ui-coverage-legend p b{margin-left:auto;font-weight:550;color:var(--fg)}
+.ui-coverage-legend i{height:6px;width:6px;border-radius:50%;background:var(--pri);flex-shrink:0}
+.ui-coverage-legend i.gap{background:var(--warn)}
+.ui-coverage-legend small{display:block;font-size:10px;line-height:1.5;color:var(--mut);margin-top:15px}
+.ui-source-heading{display:flex;align-items:center;flex-wrap:wrap;gap:9px;padding:14px 20px 0;border-top:1px solid var(--bd)}
+.ui-source-heading h4{margin:0;font-size:11px;font-weight:550}
+.ui-source-heading>span:not(.wform){margin-left:auto;font-size:10px;color:var(--mut)}
+.ui-source-heading .wform{float:none;margin-left:auto}
+.ui-source-grid{display:grid;grid-template-columns:1fr 1fr;gap:10px 24px;padding:16px 20px}
+.ui-source-grid .covrow,.ui-source-grid .meterrow{display:flex;align-items:center;gap:8px;min-width:0;padding:0;font-size:10px}
+.ui-source-grid .covrow>span:first-child,.ui-source-grid .meterrow>span:first-child{width:52px;text-transform:capitalize;font-size:10px}
+.ui-source-grid .covrow .dots{flex:1;display:flex;justify-content:flex-end;gap:3px;min-width:0}
+.ui-source-grid .dots i{height:10px;width:5px;border-radius:1px;background:var(--bd)}
+.ui-source-grid .dots i.on{background:var(--pri)}
+.ui-source-grid .covrow>b,.ui-source-grid .meterrow>b{font-size:10px;min-width:20px;font-weight:450;text-align:right}
+.ui-source-grid .meterrow .track{flex:1;min-width:25px}
+.ui-panel-footer{display:flex;align-items:center;justify-content:space-between;gap:15px;padding:12px 20px;border-top:1px solid var(--bd);color:var(--mut);font-size:10px}
+.ui-panel-footer .mini{display:inline-flex;align-items:center;gap:8px;padding:0;border:0;background:transparent;color:var(--pri);min-height:22px;font-size:10px}
+.ui-panel-footer .ui-icon{width:13px;height:13px}
+.ui-coverage-note{font-size:10px;padding:0 20px 13px;color:var(--mut)}
+.ui-coverage-note summary{cursor:pointer}
+.ui-coverage-note p{font-size:11px;margin:10px 0 0}
+.ui-tools-card .ui-panel-head{gap:20px;flex-wrap:wrap}
+.ui-tools-card h3{display:flex;align-items:center;flex-wrap:wrap;gap:9px;flex:1}
+.ui-tools-card h3>.wform{order:1;margin-left:6px;float:none}
+.ui-tools-card h3>.count{font-size:10px;margin:0;border-radius:4px;padding:2px 5px}
+.ui-tool-filters{display:flex;align-items:center;gap:3px;background:var(--bg);padding:3px;border:1px solid var(--bd);border-radius:6px}
+.ui-tool-filters button{font:inherit;color:var(--mut);background:transparent;padding:6px 8px;border-radius:4px;font-size:10px;border:0;cursor:pointer}
+.ui-tool-filters button.on{background:var(--sf2);color:var(--fg)}
+.ui-table-scroll{overflow:auto;max-width:100%;scrollbar-width:thin}
+.ui-inventory{width:100%;min-width:760px;border-collapse:collapse;font-variant-numeric:tabular-nums}
+.wcard .ui-inventory th,.wcard .ui-inventory td{white-space:nowrap}
+.wcard .ui-inventory th{font-size:10px;font-weight:500;background:var(--sf2);border-top:1px solid var(--bd)}
+.wcard .ui-inventory td{font-size:11px;background:transparent}
+.ui-inventory tr:hover td{background:var(--sf2)}
+.ui-inventory tr:last-child td{border-bottom:0}
+.ui-tool-button{display:flex;gap:10px;align-items:center;font:inherit;border:0;background:none;color:var(--fg);padding:0;text-align:left;cursor:pointer}
+.ui-tool-button strong{font-size:12px;font-weight:550;display:block;line-height:1.4}
+.ui-tool-button small{font-size:10px;color:var(--mut);display:block;margin-top:3px}
+.ui-tool-initial{display:grid;place-items:center;width:28px;height:28px;border-radius:6px;border:1px solid var(--bd);background:var(--sf2);font-size:12px;flex-shrink:0}
+.ui-surface{display:inline-block;font-size:10px;border:1px solid var(--bd);border-radius:4px;padding:2px 5px;color:var(--mut);margin:2px 4px 2px 0}
+.ui-muted{font-size:10px;color:var(--mut)}
+.ui-row-open{display:grid;place-items:center;width:26px;height:26px;border:0;background:none;color:var(--mut);cursor:pointer}
+.ui-row-open svg{width:13px;height:13px}
+.ui-inventory .spark{width:66px;max-width:66px}
+.ui-tool-bars{padding:5px 20px 15px}
+.ui-table-note{font-size:10px;margin:0;padding:0 20px 13px}
 .gcard[data-wk=review_queue],.gcard[data-wk=detection_coverage]{height:100%}
-.astra-visibility-card,.astra-focus-card{display:flex;flex-direction:column}
-.astra-visibility-card>.astra-source-grid,.astra-focus-card>.astra-queue-details{flex:1 0 auto}
-.astra-focus-card>.astra-queue-details{display:flex;flex-direction:column;justify-content:flex-end}
+.ui-visibility-card,.ui-focus-card{display:flex;flex-direction:column}
+.ui-visibility-card>.ui-source-grid,.ui-focus-card>.ui-queue-details{flex:1 0 auto}
+.ui-focus-card>.ui-queue-details{display:flex;flex-direction:column;justify-content:flex-end}
 .gcard[data-wk=review_queue]>.wcard,.gcard[data-wk=detection_coverage]>.wcard{min-height:100%}
-.editing .astra-tool-filters{display:none}
-.editing .astra-panel-head{padding-top:45px}
-.editing .astra-source-heading .wform{display:none}
+.editing .ui-tool-filters{display:none}
+.editing .ui-panel-head{padding-top:45px}
+.editing .ui-source-heading .wform{display:none}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 /* Supporting widgets share the panel grammar: head, body, footer. */
 .wcard .stats{gap:10px;margin:0 0 14px}
@@ -1326,11 +1326,11 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .wcard .stats dt{font-size:22px;font-weight:580;letter-spacing:-.6px;line-height:1.15;overflow-wrap:anywhere}
 .wcard .stats dd{font-size:10.5px;margin-top:4px;line-height:1.4}
 .wcard h3 .count{display:inline-block;vertical-align:middle;margin-left:7px;padding:2px 6px;font-size:10px;font-weight:500;opacity:1;color:var(--mut);background:var(--sf2);border:1px solid var(--bd);border-radius:4px}
-.astra-people-table{min-width:0}
-.wcard .astra-people-table th,.wcard .astra-people-table td{padding:10px 20px;white-space:normal}
-.astra-people-table td:first-child{font-weight:550}
-.wcard .astra-inventory th,.wcard .astra-inventory td{padding:10px 14px}
-.astra-activity-count{font-size:12px;font-weight:550}
+.ui-people-table{min-width:0}
+.wcard .ui-people-table th,.wcard .ui-people-table td{padding:10px 20px;white-space:normal}
+.ui-people-table td:first-child{font-weight:550}
+.wcard .ui-inventory th,.wcard .ui-inventory td{padding:10px 14px}
+.ui-activity-count{font-size:12px;font-weight:550}
 .budget-lines td{font-size:11.5px}
 .wcard>h3{margin-bottom:12px}
 .wcard .lede{font-size:12px;line-height:1.55}
@@ -1338,7 +1338,7 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 /* Inventory pages: one table grammar, shared with the Overview's tool table. */
 /* Running text runs to the edge of its column, as prose does; the caps the
      earlier layers set (640px, 800px, 92ch) wrapped sentences at half width. */
-.view-head .lede,.lede,.wcard .lede,.tcard>p.lede,.astra-panel-head p,.executive-posture>p{max-width:none}
+.view-head .lede,.lede,.wcard .lede,.tcard>p.lede,.ui-panel-head p,.executive-posture>p{max-width:none}
 .view-head .view-title{flex:1 1 auto}
 .tcard{border-radius:10px;margin-bottom:18px}
 .tcard th+th,.tcard td+td{border-left:0}
@@ -1351,13 +1351,13 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .tcard>p.lede{font-size:11.5px;margin-bottom:8px}
 .tcard tr[data-open]{cursor:pointer}
 .tcard tr[data-open]:hover td{background:var(--sf2)}
-.tcard tr.astra-settled td{color:var(--mut)}
-.tcard tr.astra-settled td strong{color:var(--mut)}
-.astra-row-actions{white-space:nowrap}
-.astra-row-actions .mini{min-height:27px;padding:3px 9px;font-size:10.5px}
-.astra-row-actions .mfield{min-height:27px;font-size:11px}
-.astra-tool-chip{display:inline-block;margin:2px 4px 2px 0;padding:2px 7px;border:1px solid var(--bd);border-radius:4px;background:var(--sf2);color:var(--fg);font-size:10.5px;line-height:1.4;white-space:nowrap}
-.astra-id{display:block;margin-top:2px;font-size:10px;color:var(--mut);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
+.tcard tr.ui-settled td{color:var(--mut)}
+.tcard tr.ui-settled td strong{color:var(--mut)}
+.ui-row-actions{white-space:nowrap}
+.ui-row-actions .mini{min-height:27px;padding:3px 9px;font-size:10.5px}
+.ui-row-actions .mfield{min-height:27px;font-size:11px}
+.ui-tool-chip{display:inline-block;margin:2px 4px 2px 0;padding:2px 7px;border:1px solid var(--bd);border-radius:4px;background:var(--sf2);color:var(--fg);font-size:10.5px;line-height:1.4;white-space:nowrap}
+.ui-id{display:block;margin-top:2px;font-size:10px;color:var(--mut);font-family:ui-monospace,SFMono-Regular,Menlo,monospace}
 .cell-tags{gap:4px}
 .muted-value{font-size:10.5px}
 .row-key{font-size:10px}
@@ -1373,103 +1373,103 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .inventory-summary b{font-size:22px;font-weight:580;letter-spacing:-.6px}
 /* Supporting widgets: head, body, footer; sized to content, never stretched
      into dead space; the same geometry in comfortable, compact and edit modes. */
-.astra-widget{padding:0;overflow:hidden;display:flex;flex-direction:column;min-height:100%}
-.astra-widget>.astra-panel-head{padding-bottom:14px}
-.astra-widget>.astra-table-scroll,.astra-widget>.astra-notes,.astra-widget>.astra-empty{flex:1 0 auto}
-.astra-widget>.astra-panel-footer{margin-top:auto}
-.editing .gcard[data-wk=stat_row]>.astra-estate-line{margin-top:38px}
+.ui-widget{padding:0;overflow:hidden;display:flex;flex-direction:column;min-height:100%}
+.ui-widget>.ui-panel-head{padding-bottom:14px}
+.ui-widget>.ui-table-scroll,.ui-widget>.ui-notes,.ui-widget>.ui-empty{flex:1 0 auto}
+.ui-widget>.ui-panel-footer{margin-top:auto}
+.editing .gcard[data-wk=stat_row]>.ui-estate-line{margin-top:38px}
 .editing .gcard[data-wk=stat_row]>.overview-executive{margin-top:0}
-.astra-widget-lede{margin:0 20px 14px;font-size:12px;line-height:1.55;color:var(--mut)}
-.astra-widget-lede b{color:var(--fg);font-weight:600}
-.astra-widget>.astra-empty{margin:0 20px 18px}
-.astra-tiles{display:grid;grid-template-columns:1.45fr 1fr 1fr;gap:10px;margin:0 20px 14px}
-.astra-tiles-2{grid-template-columns:repeat(2,minmax(0,1fr))}
-.astra-tiles>div{min-width:0;padding:12px 14px;border:1px solid var(--bd);border-radius:8px;background:var(--sf2)}
-.astra-tiles dt{margin:0;font-size:21px;font-weight:580;letter-spacing:-.6px;line-height:1.1;font-variant-numeric:tabular-nums;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
-.astra-tiles>div:first-child dt{font-size:20px}
-.astra-tiles dt.risk{color:var(--dstr)}
-.astra-tiles dt.attention{color:var(--warn)}
-.astra-tiles dd{margin:5px 0 0;font-size:10.5px;line-height:1.4;color:var(--mut)}
-.astra-tiles dd span{white-space:nowrap}
-.astra-widget-table{min-width:0}
-.wcard .astra-widget-table th,.wcard .astra-widget-table td{padding:9px 20px;white-space:normal}
-.wcard .astra-widget-table th:first-child,.wcard .astra-widget-table td:first-child{padding-left:20px}
-.astra-widget-table td strong{display:block;font-size:12px;font-weight:550}
-.astra-widget-table td small{display:block;margin-top:2px;font-size:10px;color:var(--mut)}
-.astra-widget-table tr[data-nav]{cursor:pointer}
-.wcard .astra-widget-table .num{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap;width:1%}
-.wcard .astra-widget-table th:last-child,.wcard .astra-widget-table td:last-child{text-align:right;width:1%;white-space:nowrap}
-.wcard .astra-widget-table th:first-child,.wcard .astra-widget-table td:first-child{width:auto}
-.astra-widget-table td small.astra-col-s{display:block}
+.ui-widget-lede{margin:0 20px 14px;font-size:12px;line-height:1.55;color:var(--mut)}
+.ui-widget-lede b{color:var(--fg);font-weight:600}
+.ui-widget>.ui-empty{margin:0 20px 18px}
+.ui-tiles{display:grid;grid-template-columns:1.45fr 1fr 1fr;gap:10px;margin:0 20px 14px}
+.ui-tiles-2{grid-template-columns:repeat(2,minmax(0,1fr))}
+.ui-tiles>div{min-width:0;padding:12px 14px;border:1px solid var(--bd);border-radius:8px;background:var(--sf2)}
+.ui-tiles dt{margin:0;font-size:21px;font-weight:580;letter-spacing:-.6px;line-height:1.1;font-variant-numeric:tabular-nums;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.ui-tiles>div:first-child dt{font-size:20px}
+.ui-tiles dt.risk{color:var(--dstr)}
+.ui-tiles dt.attention{color:var(--warn)}
+.ui-tiles dd{margin:5px 0 0;font-size:10.5px;line-height:1.4;color:var(--mut)}
+.ui-tiles dd span{white-space:nowrap}
+.ui-widget-table{min-width:0}
+.wcard .ui-widget-table th,.wcard .ui-widget-table td{padding:9px 20px;white-space:normal}
+.wcard .ui-widget-table th:first-child,.wcard .ui-widget-table td:first-child{padding-left:20px}
+.ui-widget-table td strong{display:block;font-size:12px;font-weight:550}
+.ui-widget-table td small{display:block;margin-top:2px;font-size:10px;color:var(--mut)}
+.ui-widget-table tr[data-nav]{cursor:pointer}
+.wcard .ui-widget-table .num{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap;width:1%}
+.wcard .ui-widget-table th:last-child,.wcard .ui-widget-table td:last-child{text-align:right;width:1%;white-space:nowrap}
+.wcard .ui-widget-table th:first-child,.wcard .ui-widget-table td:first-child{width:auto}
+.ui-widget-table td small.ui-col-s{display:block}
 /* Columns and rows by the card's width: S keeps the identity and the verdict, M adds the
    working figures, L adds the detail. Ten rows are drawn; S shows four, M six, L ten. */
-.astra-widget-table .astra-col-l{display:none}
-.astra-widget-table tbody tr:nth-child(n+7){display:none}
+.ui-widget-table .ui-col-l{display:none}
+.ui-widget-table tbody tr:nth-child(n+7){display:none}
 @container (min-width:720px){
-  .astra-widget-table .astra-col-l{display:table-cell}
-  .astra-widget-table td small.astra-col-s{display:none}
-  .astra-widget-table tbody tr:nth-child(n+7){display:table-row}
-  .astra-widget-table tbody tr:nth-child(n+11){display:none}
+  .ui-widget-table .ui-col-l{display:table-cell}
+  .ui-widget-table td small.ui-col-s{display:none}
+  .ui-widget-table tbody tr:nth-child(n+7){display:table-row}
+  .ui-widget-table tbody tr:nth-child(n+11){display:none}
 }
 @container (max-width:430px){
-  .astra-widget-table .astra-col-m{display:none}
-  .astra-widget-table tbody tr:nth-child(n+5){display:none}
+  .ui-widget-table .ui-col-m{display:none}
+  .ui-widget-table tbody tr:nth-child(n+5){display:none}
 }
-.astra-widget-table th.num{text-align:right}
-.astra-silent-table td:last-child{color:var(--mut);font-size:11px;line-height:1.5}
-.astra-silent-table td:last-child i{font-style:normal;margin:0 6px;color:var(--bd)}
-.astra-silent-table td:first-child strong{text-transform:capitalize}
-.astra-notes{list-style:none;margin:0 20px 16px;padding:0;display:flex;flex-direction:column;gap:8px}
-.astra-notes li{position:relative;padding-left:14px;font-size:11px;line-height:1.5;color:var(--mut)}
-.astra-notes li::before{content:"";position:absolute;left:0;top:7px;width:5px;height:5px;border-radius:50%;background:var(--mut)}
-.astra-notes li.attention{color:var(--fg)}
-.astra-notes li.attention::before{background:var(--warn)}
-.editing .astra-widget>.astra-panel-head{padding-top:45px}
-.editing .astra-panel-head .astra-eyebrow{display:none}
+.ui-widget-table th.num{text-align:right}
+.ui-silent-table td:last-child{color:var(--mut);font-size:11px;line-height:1.5}
+.ui-silent-table td:last-child i{font-style:normal;margin:0 6px;color:var(--bd)}
+.ui-silent-table td:first-child strong{text-transform:capitalize}
+.ui-notes{list-style:none;margin:0 20px 16px;padding:0;display:flex;flex-direction:column;gap:8px}
+.ui-notes li{position:relative;padding-left:14px;font-size:11px;line-height:1.5;color:var(--mut)}
+.ui-notes li::before{content:"";position:absolute;left:0;top:7px;width:5px;height:5px;border-radius:50%;background:var(--mut)}
+.ui-notes li.attention{color:var(--fg)}
+.ui-notes li.attention::before{background:var(--warn)}
+.editing .ui-widget>.ui-panel-head{padding-top:45px}
+.editing .ui-panel-head .ui-eyebrow{display:none}
 /* The tool inventory below table width: a list drawn from the same rows. */
-.astra-tool-list{display:none;list-style:none;margin:0;padding:0;border-top:1px solid var(--bd)}
-.astra-tool-list li+li{border-top:1px solid var(--bd)}
-.astra-tool-item{display:flex;align-items:center;gap:12px;width:100%;padding:11px 20px;border:0;background:transparent;color:var(--fg);font:inherit;text-align:left;cursor:pointer}
-.astra-tool-item:hover{background:var(--sf2)}
-.astra-tool-item>svg{flex-shrink:0;width:13px;height:13px;color:var(--mut)}
-.astra-tool-main{flex:1;min-width:0}
-.astra-tool-main strong{display:block;font-size:12px;font-weight:550;line-height:1.3}
-.astra-tool-main small{display:block;margin-top:2px;font-size:10px;color:var(--mut);line-height:1.4;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-.astra-tool-nums{display:flex;flex-direction:column;align-items:flex-end;min-width:38px;flex-shrink:0}
-.astra-tool-nums b{font-size:13px;font-weight:560;font-variant-numeric:tabular-nums;line-height:1.2}
-.astra-tool-nums i{font-style:normal;font-size:9px;color:var(--mut);letter-spacing:.3px}
-.astra-tool-flag{min-width:52px;flex-shrink:0;text-align:right}
-.astra-tool-flag .astra-badge{display:inline-block}
+.ui-tool-list{display:none;list-style:none;margin:0;padding:0;border-top:1px solid var(--bd)}
+.ui-tool-list li+li{border-top:1px solid var(--bd)}
+.ui-tool-item{display:flex;align-items:center;gap:12px;width:100%;padding:11px 20px;border:0;background:transparent;color:var(--fg);font:inherit;text-align:left;cursor:pointer}
+.ui-tool-item:hover{background:var(--sf2)}
+.ui-tool-item>svg{flex-shrink:0;width:13px;height:13px;color:var(--mut)}
+.ui-tool-main{flex:1;min-width:0}
+.ui-tool-main strong{display:block;font-size:12px;font-weight:550;line-height:1.3}
+.ui-tool-main small{display:block;margin-top:2px;font-size:10px;color:var(--mut);line-height:1.4;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.ui-tool-nums{display:flex;flex-direction:column;align-items:flex-end;min-width:38px;flex-shrink:0}
+.ui-tool-nums b{font-size:13px;font-weight:560;font-variant-numeric:tabular-nums;line-height:1.2}
+.ui-tool-nums i{font-style:normal;font-size:9px;color:var(--mut);letter-spacing:.3px}
+.ui-tool-flag{min-width:52px;flex-shrink:0;text-align:right}
+.ui-tool-flag .ui-badge{display:inline-block}
 @container (max-width:760px){
-  .astra-tools-card .astra-table-scroll{display:none}
-  .astra-tools-card .astra-tool-list{display:block}
-  .astra-tools-card .astra-panel-head{align-items:flex-start;flex-direction:column;gap:10px}
-  .astra-tools-card .astra-table-note{display:none}
+  .ui-tools-card .ui-table-scroll{display:none}
+  .ui-tools-card .ui-tool-list{display:block}
+  .ui-tools-card .ui-panel-head{align-items:flex-start;flex-direction:column;gap:10px}
+  .ui-tools-card .ui-table-note{display:none}
 }
 @container (max-width:430px){
-  .astra-tool-cloud,.astra-tool-flag{display:none}
-  .astra-tool-item{gap:10px;padding-left:16px;padding-right:16px}
+  .ui-tool-cloud,.ui-tool-flag{display:none}
+  .ui-tool-item{gap:10px;padding-left:16px;padding-right:16px}
 }
 @container (max-width:700px){
   .overview-executive{grid-template-columns:1fr}
-  .executive-posture{border-right:0;border-bottom:1px solid var(--astra-frame);padding:20px}
+  .executive-posture{border-right:0;border-bottom:1px solid var(--ui-frame);padding:20px}
   .executive-actions{grid-column:auto;grid-row:auto}
   .executive-metrics{grid-template-columns:repeat(2,minmax(0,1fr))}
   .executive-metrics>div{padding:18px}
   .executive-metrics dd{min-height:30px;font-size:11px;margin-bottom:9px}
-  .astra-tools-card .astra-panel-head{align-items:flex-start;gap:12px}
-  .astra-tool-filters{margin-left:0}
+  .ui-tools-card .ui-panel-head{align-items:flex-start;gap:12px}
+  .ui-tool-filters{margin-left:0}
 }
 @container (max-width:420px){
-  .astra-eyebrow{display:none}
-  .astra-action{padding:16px;gap:10px}
-  .astra-panel-head{padding:17px 16px}
-  .astra-source-grid{gap:12px 15px;padding-left:16px;padding-right:16px}
-  .astra-coverage-overview{gap:15px;padding-left:16px;padding-right:16px}
-  .astra-ring{width:86px;height:86px}
-  .astra-coverage-legend p{font-size:10px;gap:6px}
-  .astra-source-heading{padding-left:16px;padding-right:16px}
-  .astra-panel-footer{padding-left:16px;padding-right:16px;flex-wrap:wrap;gap:8px}
+  .ui-eyebrow{display:none}
+  .ui-action{padding:16px;gap:10px}
+  .ui-panel-head{padding:17px 16px}
+  .ui-source-grid{gap:12px 15px;padding-left:16px;padding-right:16px}
+  .ui-coverage-overview{gap:15px;padding-left:16px;padding-right:16px}
+  .ui-ring{width:86px;height:86px}
+  .ui-coverage-legend p{font-size:10px;gap:6px}
+  .ui-source-heading{padding-left:16px;padding-right:16px}
+  .ui-panel-footer{padding-left:16px;padding-right:16px;flex-wrap:wrap;gap:8px}
 }
 @media(max-width:1100px){
   .topbar{padding:0 20px;gap:8px}
@@ -1493,74 +1493,74 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
   .topbar{gap:6px;padding:0 10px}
   .search input{font-size:11px}
   .search{padding:6px 8px}
-  .astra-estate-line{align-items:flex-start;gap:10px;font-size:9px}
-  .astra-estate-line>span:last-child{text-align:right;max-width:48%}
+  .ui-estate-line{align-items:flex-start;gap:10px;font-size:9px}
+  .ui-estate-line>span:last-child{text-align:right;max-width:48%}
   .executive-posture>strong{font-size:27px}
   .executive-metrics dt{font-size:29px}
-  .astra-posture-note{font-size:10px}
-  .astra-tool-filters{width:100%}
-  .astra-tool-filters button{flex:1}
-  .astra-tools-card h3{flex-basis:100%}
-  .astra-queue-details>summary span{float:none;display:block;margin:5px 0 0 13px}
+  .ui-posture-note{font-size:10px}
+  .ui-tool-filters{width:100%}
+  .ui-tool-filters button{flex:1}
+  .ui-tools-card h3{flex-basis:100%}
+  .ui-queue-details>summary span{float:none;display:block;margin:5px 0 0 13px}
 }
 
 /* Compact density: the same pages at roughly four fifths of the room. Type
    steps down a size, every panel loses a third of its padding, rows lose a
    third of their height. Comfortable is the default; the choice is per account. */
-.astra-compact{font-size:12px}
-.astra-compact main{padding:18px 22px 40px}
-.astra-compact .view-head{margin-bottom:14px}
-.astra-compact .view-head h2{font-size:22px}
-.astra-compact .view-head .lede{font-size:11.5px;margin-top:5px}
-.astra-compact .view-meta .mini,.astra-compact .meta-chip{min-height:28px;font-size:10px}
-.astra-compact .grid,.astra-compact .gitem{gap:10px}
-.astra-compact .grid{margin-bottom:10px}
-.astra-compact .wcard,.astra-compact .tcard,.astra-compact .overview-executive{border-radius:8px}
-.astra-compact .astra-estate-line{margin-bottom:7px}
-.astra-compact .executive-posture{padding:14px 18px 12px}
-.astra-compact .executive-posture>strong{font-size:22px;margin-top:10px}
-.astra-compact .executive-posture>p{margin-top:6px;font-size:11.5px}
-.astra-compact .executive-actions{margin-top:14px;gap:6px}
-.astra-compact .executive-actions button.mini{min-height:29px;padding:5px 10px;font-size:10.5px}
-.astra-compact .astra-posture-note{padding-top:12px}
-.astra-compact .executive-metrics>div{padding:12px 16px}
-.astra-compact .executive-metrics dt{font-size:24px}
-.astra-compact .executive-metrics dd{margin-bottom:8px;font-size:10.5px}
-.astra-compact .executive-metrics small{margin-top:6px}
-.astra-compact .astra-panel-head{padding:12px 16px 10px}
-.astra-compact .astra-panel-head p{margin-top:3px}
-.astra-compact .astra-action{padding:10px 16px;gap:11px}
-.astra-compact .astra-action-icon{width:28px;height:28px}
-.astra-compact .astra-action-copy small{margin-top:6px}
-.astra-compact .astra-queue-details>summary{padding:9px 16px}
-.astra-compact .astra-panel-footer{padding:9px 16px}
-.astra-compact .wcard .astra-inventory th,.astra-compact .wcard .astra-inventory td{padding:6px 12px}
-.astra-compact .wcard .astra-inventory td{font-size:11px}
-.astra-compact .astra-tool-initial{width:24px;height:24px;font-size:11px}
-.astra-compact .astra-tool-button strong{font-size:11.5px}
-.astra-compact .astra-tool-item{padding:7px 16px}
-.astra-compact .tcard th{padding:8px 12px}
-.astra-compact .tcard td{padding:7px 12px;font-size:11px}
-.astra-compact .inventory-summary span{min-height:44px;padding:0 14px}
-.astra-compact .inventory-summary b{font-size:18px}
-.astra-compact #app>.stats{gap:8px;margin-bottom:12px}
-.astra-compact #app>.stats div{padding:11px 14px}
-.astra-compact #app>.stats dt{font-size:22px}
-.astra-compact .wcard:not(.astra-focus-card):not(.astra-tools-card):not(.astra-visibility-card):not(.astra-widget){padding:12px 14px}
-.astra-compact .wcard>h3{margin-bottom:8px}
-.astra-compact .astra-tiles{margin:0 16px 10px;gap:8px}
-.astra-compact .astra-tiles>div{padding:8px 11px}
-.astra-compact .astra-tiles dt{font-size:18px}
-.astra-compact .astra-widget-lede,.astra-compact .astra-notes,.astra-compact .astra-widget>.astra-empty{margin-left:16px;margin-right:16px;margin-bottom:10px}
-.astra-compact .wcard .astra-widget-table th,.astra-compact .wcard .astra-widget-table td{padding:6px 16px}
-.astra-compact .astra-coverage-overview{padding:0 16px 12px;gap:16px}
-.astra-compact .astra-ring{width:80px;height:80px}
-.astra-compact .astra-ring strong{font-size:19px}
-.astra-compact .astra-coverage-legend p{margin:7px 0}
-.astra-compact .astra-source-heading{padding:10px 16px 0}
-.astra-compact .astra-source-grid{padding:10px 16px;gap:8px 20px}
-.astra-compact .exposure-trend-card .exposure-chart{min-height:0}
-.astra-compact .register-card,.astra-compact .budget-card,.astra-compact .health-card{border-radius:8px}
-.astra-compact .bars{gap:6px}
-.astra-compact .barrow{min-height:24px}
-.wcard .astra-silent-table th:last-child,.wcard .astra-silent-table td:last-child{text-align:left;width:auto;white-space:normal}
+.ui-compact{font-size:12px}
+.ui-compact main{padding:18px 22px 40px}
+.ui-compact .view-head{margin-bottom:14px}
+.ui-compact .view-head h2{font-size:22px}
+.ui-compact .view-head .lede{font-size:11.5px;margin-top:5px}
+.ui-compact .view-meta .mini,.ui-compact .meta-chip{min-height:28px;font-size:10px}
+.ui-compact .grid,.ui-compact .gitem{gap:10px}
+.ui-compact .grid{margin-bottom:10px}
+.ui-compact .wcard,.ui-compact .tcard,.ui-compact .overview-executive{border-radius:8px}
+.ui-compact .ui-estate-line{margin-bottom:7px}
+.ui-compact .executive-posture{padding:14px 18px 12px}
+.ui-compact .executive-posture>strong{font-size:22px;margin-top:10px}
+.ui-compact .executive-posture>p{margin-top:6px;font-size:11.5px}
+.ui-compact .executive-actions{margin-top:14px;gap:6px}
+.ui-compact .executive-actions button.mini{min-height:29px;padding:5px 10px;font-size:10.5px}
+.ui-compact .ui-posture-note{padding-top:12px}
+.ui-compact .executive-metrics>div{padding:12px 16px}
+.ui-compact .executive-metrics dt{font-size:24px}
+.ui-compact .executive-metrics dd{margin-bottom:8px;font-size:10.5px}
+.ui-compact .executive-metrics small{margin-top:6px}
+.ui-compact .ui-panel-head{padding:12px 16px 10px}
+.ui-compact .ui-panel-head p{margin-top:3px}
+.ui-compact .ui-action{padding:10px 16px;gap:11px}
+.ui-compact .ui-action-icon{width:28px;height:28px}
+.ui-compact .ui-action-copy small{margin-top:6px}
+.ui-compact .ui-queue-details>summary{padding:9px 16px}
+.ui-compact .ui-panel-footer{padding:9px 16px}
+.ui-compact .wcard .ui-inventory th,.ui-compact .wcard .ui-inventory td{padding:6px 12px}
+.ui-compact .wcard .ui-inventory td{font-size:11px}
+.ui-compact .ui-tool-initial{width:24px;height:24px;font-size:11px}
+.ui-compact .ui-tool-button strong{font-size:11.5px}
+.ui-compact .ui-tool-item{padding:7px 16px}
+.ui-compact .tcard th{padding:8px 12px}
+.ui-compact .tcard td{padding:7px 12px;font-size:11px}
+.ui-compact .inventory-summary span{min-height:44px;padding:0 14px}
+.ui-compact .inventory-summary b{font-size:18px}
+.ui-compact #app>.stats{gap:8px;margin-bottom:12px}
+.ui-compact #app>.stats div{padding:11px 14px}
+.ui-compact #app>.stats dt{font-size:22px}
+.ui-compact .wcard:not(.ui-focus-card):not(.ui-tools-card):not(.ui-visibility-card):not(.ui-widget){padding:12px 14px}
+.ui-compact .wcard>h3{margin-bottom:8px}
+.ui-compact .ui-tiles{margin:0 16px 10px;gap:8px}
+.ui-compact .ui-tiles>div{padding:8px 11px}
+.ui-compact .ui-tiles dt{font-size:18px}
+.ui-compact .ui-widget-lede,.ui-compact .ui-notes,.ui-compact .ui-widget>.ui-empty{margin-left:16px;margin-right:16px;margin-bottom:10px}
+.ui-compact .wcard .ui-widget-table th,.ui-compact .wcard .ui-widget-table td{padding:6px 16px}
+.ui-compact .ui-coverage-overview{padding:0 16px 12px;gap:16px}
+.ui-compact .ui-ring{width:80px;height:80px}
+.ui-compact .ui-ring strong{font-size:19px}
+.ui-compact .ui-coverage-legend p{margin:7px 0}
+.ui-compact .ui-source-heading{padding:10px 16px 0}
+.ui-compact .ui-source-grid{padding:10px 16px;gap:8px 20px}
+.ui-compact .exposure-trend-card .exposure-chart{min-height:0}
+.ui-compact .register-card,.ui-compact .budget-card,.ui-compact .health-card{border-radius:8px}
+.ui-compact .bars{gap:6px}
+.ui-compact .barrow{min-height:24px}
+.wcard .ui-silent-table th:last-child,.wcard .ui-silent-table td:last-child{text-align:left;width:auto;white-space:normal}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1396,6 +1396,23 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .astra-widget-table td small{display:block;margin-top:2px;font-size:10px;color:var(--mut)}
 .astra-widget-table tr[data-nav]{cursor:pointer}
 .wcard .astra-widget-table .num{text-align:right;font-variant-numeric:tabular-nums;white-space:nowrap;width:1%}
+.wcard .astra-widget-table th:last-child,.wcard .astra-widget-table td:last-child{text-align:right;width:1%;white-space:nowrap}
+.wcard .astra-widget-table th:first-child,.wcard .astra-widget-table td:first-child{width:auto}
+.astra-widget-table td small.astra-col-s{display:block}
+/* Columns and rows by the card's width: S keeps the identity and the verdict, M adds the
+   working figures, L adds the detail. Ten rows are drawn; S shows four, M six, L ten. */
+.astra-widget-table .astra-col-l{display:none}
+.astra-widget-table tbody tr:nth-child(n+7){display:none}
+@container (min-width:720px){
+  .astra-widget-table .astra-col-l{display:table-cell}
+  .astra-widget-table td small.astra-col-s{display:none}
+  .astra-widget-table tbody tr:nth-child(n+7){display:table-row}
+  .astra-widget-table tbody tr:nth-child(n+11){display:none}
+}
+@container (max-width:430px){
+  .astra-widget-table .astra-col-m{display:none}
+  .astra-widget-table tbody tr:nth-child(n+5){display:none}
+}
 .astra-widget-table th.num{text-align:right}
 .astra-silent-table td:last-child{color:var(--mut);font-size:11px;line-height:1.5}
 .astra-silent-table td:last-child i{font-style:normal;margin:0 6px;color:var(--bd)}
@@ -1544,3 +1561,4 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .astra-compact .register-card,.astra-compact .budget-card,.astra-compact .health-card{border-radius:8px}
 .astra-compact .bars{gap:6px}
 .astra-compact .barrow{min-height:24px}
+.wcard .astra-silent-table th:last-child,.wcard .astra-silent-table td:last-child{text-align:left;width:auto;white-space:normal}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1142,8 +1142,8 @@ td{padding:12px 14px}
 body{font-size:13px;line-height:1.5}
 .shell{grid-template-columns:224px minmax(0,1fr)}
 aside{background:var(--side);border-color:var(--side-line)}
-.brand{height:60px;min-height:60px;padding:10px 14px 6px}
-.brand img{width:184px;max-height:42px;object-fit:contain}
+.brand{height:auto;min-height:0;padding:12px 14px 0}
+.brand img{width:194px;max-height:58px;object-fit:contain;margin-bottom:-4px}
 .tenant-switch{border-color:var(--side-line);background:transparent;margin-top:5px}
 .tenant-avatar{color:var(--pri);background:var(--sf2);border:1px solid var(--side-line)}
 .tenant-copy b{font-size:12px}

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2507,10 +2507,12 @@ const WIDGETS = {
              person behind it, so revoking a sign-on does not stop them.`
           : 'All of them run under an identity somebody can be asked about.'}</p>
         ${loose.length ? `<div class="astra-table-scroll"><table class="astra-inventory astra-widget-table">
-          <thead><tr><th>Device</th><th>Schedule</th><th>Answers to</th></tr></thead>
-          <tbody>${loose.slice(0, 5).map(a => `<tr>
-            <td><strong>${esc(label(a.device, G.devices[a.device] || {}))}</strong></td>
-            <td class="astra-muted">${esc(a.trigger || a.evidence || '')}</td>
+          <thead><tr><th>Device</th><th class="astra-col-l">Runs</th><th class="astra-col-m">Schedule</th><th class="astra-col-l">Reaches</th><th>Answers to</th></tr></thead>
+          <tbody>${loose.slice(0, 10).map(a => `<tr>
+            <td><strong>${esc(label(a.device, G.devices[a.device] || {}))}</strong>${a.os ? `<small class="astra-col-s">${esc(a.os)}</small>` : ''}</td>
+            <td class="astra-col-l">${a.tool ? esc(astraToolName(a.tool)) : a.process ? `<span class="mono">${esc(a.process)}</span>` : '<span class="astra-muted">—</span>'}</td>
+            <td class="astra-col-m astra-muted">${esc(a.trigger || a.evidence || '')}</td>
+            <td class="astra-col-l">${(a.reach || []).length ? (a.reach || []).slice(0, 3).map(x => `<span class="astra-surface">${esc(x)}</span>`).join('') + ((a.reach || []).length > 3 ? ` <span class="astra-muted">+${a.reach.length - 3}</span>` : '') : '<span class="astra-muted">nothing configured</span>'}</td>
             <td>${a.process
               ? '<span class="astra-badge risk">no tool we know</span>'
               : '<span class="astra-badge risk">' + esc(a.identity || 'unattributed') + '</span>'}</td>
@@ -2589,15 +2591,19 @@ const WIDGETS = {
       <div><dt>${subs.length}</dt><dd>tools linked</dd></div>
       <div><dt${unob ? ' class="attention"' : ''}>${unob}</dt><dd>paid seats never observed</dd></div>
     </dl>
-    <div class="astra-table-scroll"><table class="astra-inventory astra-widget-table">
-      <thead><tr><th>Subscription</th><th class="num">Monthly</th><th class="num">Seats in use</th><th>Review</th></tr></thead>
+    <div class="astra-table-scroll"><table class="astra-inventory astra-widget-table astra-spend-table">
+      <thead><tr><th>Subscription</th><th class="astra-col-l">Plan</th><th class="num astra-col-m">Monthly</th>
+        <th class="num astra-col-m">Seats in use</th><th class="num astra-col-l">Observed</th><th class="astra-col-l">Renews</th><th>Review</th></tr></thead>
       <tbody>${subs.map(sub => {
         const r = bReconcile(sub);
         const seats = (sub.seat_tiers || []).reduce((x, t) => x + (t.seats || 0), 0);
         return `<tr data-nav="budget">
-          <td><strong>${esc(astraToolName(sub.tool_id))}</strong>${sub.plan ? `<small>${esc(sub.plan)}</small>` : ''}</td>
-          <td class="num">${bMoney(bSubMonthly(sub), sub.currency)}</td>
-          <td class="num">${r.matched.length} of ${seats}</td>
+          <td><strong>${esc(astraToolName(sub.tool_id))}</strong>${sub.plan ? `<small class="astra-col-s">${esc(sub.plan)}</small>` : ''}</td>
+          <td class="astra-col-l">${esc(sub.plan || '—')}</td>
+          <td class="num astra-col-m">${bMoney(bSubMonthly(sub), sub.currency)}</td>
+          <td class="num astra-col-m">${r.matched.length} of ${seats}</td>
+          <td class="num astra-col-l">${r.matched.length + r.strangers.length}</td>
+          <td class="astra-col-l astra-muted">${sub.renewal_date ? esc(sub.renewal_date) : '—'}</td>
           <td>${r.unobserved.length ? `<span class="astra-badge attention">${r.unobserved.length} idle</span>` : ''}${r.strangers.length
             ? ` <span class="astra-badge governance">${r.strangers.length} unseated</span>` : ''}${!r.unobserved.length && !r.strangers.length ? '<span class="astra-muted">Nothing flagged</span>' : ''}</td></tr>`;
       }).join('')}</tbody></table></div>
@@ -2630,13 +2636,19 @@ const WIDGETS = {
   },
 
   recent_personal_accounts: () => {
-    const pa = (G.personal_accounts || []).slice(0, 6);
-    const body = pa.length ? `<div class="astra-table-scroll"><table class="astra-inventory astra-people-table">
-      <thead><tr><th>Person</th><th>Account</th><th>AI tool</th><th>Last seen</th></tr></thead>
+    // Ten rows are drawn; the card's width decides how many show and which
+    // columns (CSS, by container). The footer count is the whole window.
+    const pa = (G.personal_accounts || []).slice(0, 10);
+    const body = pa.length ? `<div class="astra-table-scroll"><table class="astra-inventory astra-widget-table astra-people-table">
+      <thead><tr><th>Person</th><th>Account</th><th class="astra-col-m">AI tool</th><th class="astra-col-l">Device</th>
+        <th class="astra-col-l">Surface</th><th class="astra-col-l">Source</th><th>Last seen</th></tr></thead>
       <tbody>${pa.map(r => `<tr>
-        <td>${esc(r.user || r.device_name || r.device)}</td>
+        <td><strong>${esc(r.user || r.device_name || r.device)}</strong></td>
         <td><span class="astra-badge risk">${esc(r.account_domain)}</span></td>
-        <td>${esc(astraToolInfo(r.tool).name || r.tool)}</td>
+        <td class="astra-col-m">${esc(astraToolInfo(r.tool).name || r.tool)}</td>
+        <td class="astra-col-l">${esc(r.device_name || r.device || '—')}</td>
+        <td class="astra-col-l">${(r.surfaces || []).map(x => `<span class="astra-surface">${esc(x)}</span>`).join('') || '<span class="astra-muted">—</span>'}</td>
+        <td class="astra-col-l">${(r.sources || []).map(x => astraSourceChip(x)).join('') || '<span class="astra-muted">—</span>'}</td>
         <td class="astra-muted">${esc((r.last_seen || '').slice(0, 10))}</td>
       </tr>`).join('')}</tbody></table></div>`
       : dataOk()

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -6,7 +6,8 @@
 -->
 
 <meta charset="utf-8">
-<title>ai-guard portal</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Shadow AI Guard</title>
 <style>
 /* Light is the default and dark is the [data-theme=dark] overlay. The
    variable names are load-bearing: views reference them inline, so both
@@ -989,7 +990,8 @@ a.libtn:hover{border-color:var(--pri)}
       <div class="search">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><circle cx="11" cy="11" r="7"/><path d="M20 20l-3.8-3.8"/></svg>
         <input id="q" placeholder="Search this view, or jump to a page, tool or device…"
-          autocomplete="off" aria-autocomplete="list" aria-controls="qresults">
+          autocomplete="off" aria-label="Search tools, devices and pages"
+          aria-autocomplete="list" aria-controls="qresults">
         <span class="search-key" aria-hidden="true">/</span>
         <div id="qresults" role="listbox" hidden></div>
       </div>
@@ -1017,7 +1019,7 @@ a.libtn:hover{border-color:var(--pri)}
       </span>
       <span id="whowrap" class="account-wrap">
         <button id="who" class="account-button" style="display:none"
-          aria-haspopup="true" aria-expanded="false">
+          aria-label="Account menu" aria-haspopup="true" aria-expanded="false">
           <span class="account-avatar" id="who-avatar" aria-hidden="true"></span>
           <span class="account-copy"><b id="who-name"></b><span id="who-role"></span></span>
           <span class="account-chevron" aria-hidden="true">⌄</span>
@@ -2266,267 +2268,132 @@ function trendChart(days, a, b, aLabel, bLabel) {
   </div>`;
 }
 
-const WIDGETS = {
 
-  // What runs with no person behind it, small enough to sit on an overview.
-  // The count is the headline; the rows are the ones with nothing to revoke,
-  // because a scheduled job under a real account is not the finding.
-  agentic: () => {
-    if (!AGENTIC) return `<div class="wcard w6"><h3>Running on its own</h3>
-      <p class="lede">Not read yet - open Agentic AI.</p></div>`;
-    const c = AGENTIC.counts || {};
-    const loose = (AGENTIC.agents || []).filter(
-      a => a.autonomous && !a.accountable);
-    return `<div class="wcard w6"><h3>Running on its own
-      <span class="count">${c.autonomous || 0}</span></h3>
-      ${!c.autonomous ? `<p class="lede">Nothing reported starting itself.${
-        c.unrecognised ? ` ${c.unrecognised} process${c.unrecognised === 1 ? '' : 'es'}
-        reached a model unrecognised, which is a different question.` : ''} That is either
-        true or the collectors have not been updated to look - Health says which.</p>`
-      : `<p class="lede">${c.unaccountable
-          ? `<b>${c.unaccountable}</b> of them answer to nobody: a credential with no
-             person behind it, so revoking a sign-on does not stop them.`
-          : 'All of them run under an identity somebody can be asked about.'}</p>
-        ${loose.length ? `<table>${loose.slice(0, 5).map(a => `<tr>
-          <td>${esc(label(a.device, G.devices[a.device] || {}))}
-            <div style="color:var(--mut);font-size:12px">${esc(a.trigger || a.evidence || '')}</div></td>
-          <td style="color:var(--mut)">${a.process
-            ? '<span class="pill p-warn">no tool we know</span>'
-            : '<span class="pill p-warn">' + esc(a.identity || 'unattributed') + '</span>'}</td>
-          </tr>`).join('')}</table>` : ''}
-        <p class="src-note" style="margin-top:8px"><a href="#agentic">Open Agentic AI</a></p>`}
-    </div>`;
-  },
-
-  stat_row: () => {
-    const devs = ents(G.devices), pa = G.personal_accounts || [];
-    const gaps = devs.filter(([,d]) => d.scanner_seen && !d.collector_seen);
-    // "New" is relative to the window, capped at a week: in a 30-day
-    // window a week is still what somebody means by recent.
-    const freshH = Math.min(hoursNow(), 168);
-    const week = Date.now()/1000 - freshH*3600;
-    const fresh = pa.filter(r => r.first_seen &&
-      Date.parse(r.first_seen)/1000 > week).length;
-    const tr = G.trends || {};
-    // Accepted-with-a-reason rows leave the headline count: the tile is
-    // "what needs someone", and an answered finding no longer does.
-    const open = PSTAT
-      ? pa.filter(r => (PSTAT[paKey(r)] || {}).status !== 'accepted') : pa;
-    // People and unattributed devices remain separate: a machine is not a
-    // person, even when it is the only identity the finding carries.
-    const named = new Set(pa.filter(r => r.user).map(r => r.user));
-    const anon = new Set(pa.filter(r => !r.user && r.device).map(r => r.device));
-    const affectedTools = new Set(pa.map(r => r.tool)).size;
-    const tools = ents(G.tools).length;
-    const covered = Math.max(0, devs.length - gaps.length);
-    const coverage = devs.length ? Math.round(covered / devs.length * 100) : 0;
-    const attention = open.length || gaps.length;
-    // "Healthy" needs something to have looked: a fleet where no source
-    // reported in this window has zero of everything, and zero is not a
-    // clean bill. The status read is the same one the top-bar badge uses.
-    const silent = !S || !S.reporting;
-    const mood = silent ? 'silent' : attention ? 'needs-attention' : 'healthy';
-    return `<div class="overview-executive w12 ${mood}"
-      data-tour="stats">
-      <section class="executive-posture">
-        <span>Overall posture</span>
-        <strong>${silent ? 'Nothing reporting' : attention ? 'Needs attention' : 'Monitoring healthy'}</strong>
-        <p>${silent
-          ? 'No detection source reported in this window. These counts are missing data, not a clean result.'
-          : `${open.length} open personal account${open.length === 1 ? '' : 's'} ·
-          ${gaps.length} coverage gap${gaps.length === 1 ? '' : 's'}`}</p>
-        <div class="executive-actions">
-          ${open.length ? '<button class="mini" data-nav="personal">Review accounts</button>' : ''}
-          <button class="mini" data-nav="coverage">Verify coverage</button>
-        </div>
-      </section>
-      <dl class="executive-metrics">
-        <div><dt${open.length ? ' class="risk"' : ''}>${open.length}${trendChip(tr.personal, true)}</dt>
-          <dd>Open personal accounts</dd><small>${fresh} first seen in the last ${fmtWindow(freshH)}${
-            open.length !== pa.length ? ` · ${pa.length - open.length} accepted` : ''}</small></div>
-        <div><dt>${named.size}</dt><dd>Affected people</dd>
-          <small>${anon.size ? anon.size + ' unattributed device' + (anon.size === 1 ? '' : 's') : 'Every device is attributed'}</small></div>
-        <div><dt>${tools}</dt><dd>AI tools observed</dd>
-          <small>${affectedTools} linked to personal-account use</small></div>
-        <div><dt class="${gaps.length ? 'attention' : 'good'}">${coverage}%</dt>
-          <dd>Detection coverage</dd><small>${covered} of ${devs.length} devices · ${gaps.length} gaps</small></div>
-      </dl>
-    </div>`;
-  },
-
-  budget_spend: () => {
-    // Managed mode only, and quiet until the budget has been fetched
-    // (load() fetches it when this widget is configured). A tile of
-    // zeros on a deployment that never linked a tool would be noise.
-    if (!BUDGET) return '';
-    const subs = BUDGET.subscriptions || [];
-    if (!subs.length) {
-      return `<div class="wcard w6"><h3>AI spend</h3>
-      <p class="lede">Nothing linked yet. The Budget view records what
-      each AI tool costs and joins it against observed use.</p>
-      <p class="src-note"><button class="mini" data-nav="budget">Open Budget</button></p></div>`;
-    }
-    const next = subs.filter(s => s.renewal_date)
-      .sort((a, b) => a.renewal_date.localeCompare(b.renewal_date))[0];
-    const unob = subs.reduce((a, s) =>
-      a + bReconcile(s).unobserved.length, 0);
-    return `<div class="wcard w6"><h3>AI spend</h3>
-    <dl class="stats" style="margin-bottom:0">
-      <div><dt>${(() => { const c = bConverted(subs);
-        return c ? bMoney(c.total, bPrefCur()) : bSpendParts(subs).join(' + '); })()}</dt>
-        <dd>tracked / month${(() => { const c = bConverted(subs);
-        return c ? ` (${bSpendParts(subs).join(' + ')}, ECB ${esc(c.date)})` : ''; })()}</dd></div>
-      <div><dt>${subs.length}</dt><dd>tools linked</dd></div>
-      <div><dt${unob ? ' style="color:var(--warn)"' : ''}>${unob}</dt><dd>paid seats never observed</dd></div>
-    </dl>
-    <table class="plain budget-lines">${subs.map(sub => {
-      const r = bReconcile(sub);
-      const seats = (sub.seat_tiers || []).reduce((x, t) => x + (t.seats || 0), 0);
-      return `<tr data-nav="budget" style="cursor:pointer">
-        <td>${esc(sub.tool_id)}${sub.plan ? ` <span class="pill p-mut">${esc(sub.plan)}</span>` : ''}</td>
-        <td class="num">${bMoney(bSubMonthly(sub), sub.currency)}<span class="src-note"> /month</span></td>
-        <td class="num">${r.matched.length} of ${seats} seat${seats === 1 ? '' : 's'} in use</td>
-        <td class="num">${r.unobserved.length
-          ? `<span class="pill p-warn">${r.unobserved.length} idle</span>` : ''}${r.strangers.length
-          ? ` <span class="pill p-amb">${r.strangers.length} unseated</span>` : ''}</td></tr>`;
-    }).join('')}</table>
-    <p class="src-note">${next ? `next renewal: ${esc(next.tool_id)} ${when(next.renewal_date)} · ` : ''}<button class="mini" data-nav="budget">Open Budget</button></p></div>`;
-  },
-
-  top_tools: () => {
-    const tr = G.trends || {}, series = tr.tools || {}, firsts = tr.tool_first_seen || {};
-    const twoDays = Date.now() - 2*86400000;
-    const rows = ents(G.tools)
-      .sort((a,b)=>(b[1].devices||[]).length-(a[1].devices||[]).length).slice(0,7);
-    const bars = widgetForm('top_tools') === 'bar';
-    return `<div class="wcard w6"><h3>${formToggle('top_tools')}Top tools</h3>
-    ${rows.length ? (bars ? barRows(rows.map(([k,t]) =>
-      [k, (t.devices||[]).length || (t.identities||[]).length]), 'devices', 'tool')
-    : `<table class="plain">${rows.map(([k,t])=>{
-      const isNew = firsts[k] && Date.parse(firsts[k]) > twoDays;
-      return `<tr data-open="tool" data-key="${esc(k)}" style="cursor:pointer">
-        <td>${esc(k)}${isNew ? ' <span class="pill p-amb">new</span>' : ''}</td>
-        <td>${spark(series[k])}</td>
-        <td class="num">${(t.devices||[]).length || (t.identities||[]).length}</td></tr>`;
-    }).join('')}</table>`)
-    + `<p class="src-note">${bars
-      ? 'Devices per tool over the last ' + fmtWindow(hoursNow())
-        + '. Click a tool to open it, or switch to the table for one bar '
-        + 'per day.'
-      : 'One bar per day for the last ' + fmtWindow(hoursNow())
-        + ', left to right. Click a tool to open it.'}</p>`
-    : '<p class="lede">Nothing reported yet.</p>'}</div>`;
-  },
-
-  recent_personal_accounts: () => {
-    const pa = (G.personal_accounts || []).slice(0, 6);
-    return `<div class="wcard w6"><h3>Recent personal accounts</h3>
-    ${pa.length ? `<table>${pa.map(r=>`<tr>
-      <td>${esc(r.user || r.device_name || r.device)}</td>
-      <td><span class="pill p-warn">${esc(r.account_domain)}</span></td>
-      <td>${esc(r.tool)}</td>
-      <td style="color:var(--mut)">${esc((r.last_seen||'').slice(0,10))}</td>
-    </tr>`).join('')}</table>`
-    : dataOk()
-      ? '<p class="lede">None seen. That is a result, not an absence of one.</p>'
-      : '<p class="lede">Nothing to show: the findings could not be read.</p>'}
-    </div>`;
-  },
-
-  detection_coverage: () => {
-    if (!S) return '<div class="wcard w4"><h3>Detection coverage</h3><p class="lede">No status available.</p></div>';
-    // One square per source, filled when it reports: 1/5 should look like
-    // four dark squares, not a bar length to squint at.
-    const meter = widgetForm('detection_coverage') === 'meter';
-    return `<div class="wcard w4"><h3>${formToggle('detection_coverage')}Detection coverage</h3>
-    <p class="src-note" style="margin:0 0 8px">Dedicated sources reporting per
-    surface. A surface can still be covered by another source: MCP servers turn
-    up in endpoint collector findings whether or not the MCP scanner runs.</p>
-    ${meter ? (S.groups||[]).map(g => `<div class="meterrow"
-        data-ctip="${esc(g.group + ' · ' + g.reporting + ' of ' + g.total
-                         + ' dedicated sources reporting')}">
-        <span>${esc(g.group)}</span>
-        <span class="track"><span class="fill" style="width:${
-          g.total ? Math.round(g.reporting / g.total * 100) : 0}%"></span></span>
-        <b>${g.reporting}/${g.total}</b></div>`).join('')
-    : (S.groups||[]).map(g=>{
-      const dots = g.total <= 14
-        ? `<span class="dots">${Array.from({length: g.total}, (_, i) =>
-            `<i class="${i < g.reporting ? 'on' : ''}"></i>`).join('')}</span>`
-        : spark([g.reporting, g.total - g.reporting]);
-      // A surface's dedicated SOURCES, not the surface itself: the
-      // estate can see MCP servers through endpoint collectors while
-      // the dedicated mcp scanner is not deployed, and "mcp 0/1" read
-      // as "we have no MCP visibility" when the product was showing
-      // eight servers two views away.
-      return `<div class="covrow" title="Dedicated sources for the ${esc(g.group)} surface that are reporting. Other sources can still produce findings for it.">
-        <span>${esc(g.group)}</span>${dots}
-        <b>${g.reporting}/${g.total}</b></div>`;
-    }).join('')}</div>`;
-  },
-
-  // The change dimension, which the estate has had all along and shown
-  // only as 18px sparklines inside stat tiles. Every other number on this
-  // page is a total over the window: 23 personal accounts reads the same
-  // whether it was 12 last week or 40.
-  activity_trend: () => {
-    const tr = G.trends || {}, days = tr.days || [];
-    if (days.length < 2) return `<div class="wcard w6 exposure-trend-card"><h3>Personal-account exposure</h3>
-      <p class="lede">Not enough days in the window to draw a trend yet.</p></div>`;
-    return `<div class="wcard w6 exposure-trend-card">
-    <div class="trend-heading"><div><h3>Personal-account exposure</h3>
-      <p>Daily detections against reporting coverage</p></div></div>
-    <div class="exposure-chart">${trendChart(days,
-      tr.personal || days.map(() => 0), tr.devices || days.map(() => 0),
-      'personal-account detections', 'reporting devices')}</div>
-    <p class="src-note">Real findings per day, not a synthetic risk score.
-      Reporting devices provide the confidence check: both lines falling
-      together can mean the fleet went quiet rather than exposure improved.</p></div>`;
-  },
-
-  source_health: () => {
-    if (!S) return '';
-    const silent = (S.groups||[]).flatMap(g=>(g.sources||[]).filter(r=>!r.reporting));
-    return `<div class="wcard w4"><h3>Silent sources</h3>
-    ${silent.length ? silent.slice(0,8).map(r=>
-      `<div style="font-size:12px;margin:4px 0"><span class="pill p-mut">${esc(r.source)}</span></div>`
-    ).join('') : '<p class="lede">Every listed source is reporting.</p>'}</div>`;
-  },
-
-  paste_guard: () => {
-    // Native rather than an embedded Grafana panel. This number is derived by
-    // the portal now, so embedding an iframe to show it meant a card in
-    // Grafana's typography sitting beside cards in the portal's, with a title
-    // we could not restyle because it renders cross-origin.
-    //
-    // Two numbers, not four. The overview is a glance: is the guard running,
-    // and did somebody ignore it. Warned and blocked are the detail behind
-    // that, and they have a page. Four stat cells also clipped in a
-    // third-width card on a narrower content area, which is the same lesson
-    // the register learned the long way.
-    if (!PG) return '<div class="wcard w4"><h3>Paste guard</h3>'
-      + '<p class="lede">No paste guard data.</p></div>';
-    const over = PG.overridden || 0, live = PG.guard_devices || 0;
-    const warned = PG.warned || 0;
-    const versions = (PG.guard_versions || []).length;
-    const warnMode = (PG.guard_modes || []).some(m => m.mode === 'warn');
-    return `<div class="wcard w4"><h3>Paste guard</h3>
-      <dl class="stats" style="margin:0;grid-template-columns:repeat(2,1fr)">
-        <div><dt${live ? '' : ' style="color:var(--dstr)"'}>${live}</dt><dd>devices</dd></div>
-        <div><dt${over ? ' style="color:var(--dstr)"' : ''}>${over}</dt><dd>overridden</dd></div>
-      </dl>
-      ${warnMode && warned ? `<p class="src-note" style="color:var(--warn);font-style:normal">
-        In block mode, ${warned} warned paste${warned === 1 ? '' : 's'} would have
-        been stopped outright - the breakdown is on the Paste guard page.</p>` : ''}
-      <p class="src-note">${live
-        ? `The guard is running on ${live} device${live === 1 ? '' : 's'}${
-             versions > 1 ? ` (${versions} versions)` : ''}, so low numbers
-           here genuinely mean few risky pastes.`
-        : `No device has checked in yet, so zero here means "not deployed",
-           not "nobody pasted anything".`}</p></div>`;
-  },
-
-  review_queue: () => {
+// Astra presentation helpers: use the same graph, lifecycle and register reads
+// as the working views. No demo fixtures or network calls live in renderers.
+let ASTRA_PERSONAL_TOOLS = false;
+function astraOverviewFacts() {
+  const devices = ents(G.devices), personal = G.personal_accounts || [];
+  const open = PSTAT
+    ? personal.filter(r => (PSTAT[paKey(r)] || {}).status !== 'accepted') : personal;
+  const gaps = devices.filter(([,d]) => d.scanner_seen && !d.collector_seen);
+  const collectors = devices.filter(([,d]) => d.collector_seen).length;
+  const toolIds = Object.keys(G.tools || {});
+  const rows = REG && Array.isArray(REG.rows)
+    ? REG.rows.filter(r => toolIds.includes(r.id)) : null;
+  const recorded = rows && rows.filter(r => ['governance','portal'].includes(r.status_source));
+  return {known: dataOk(), personal, open, devices, gaps, collectors, toolIds,
+    coverage: devices.length ? Math.round(collectors / devices.length * 100) : null,
+    rows, recorded,
+    undecided: recorded ? toolIds.length - recorded.length : null,
+    overdue: rows ? rows.filter(r => r.days_overdue > 0).length : null,
+    people: new Set(personal.filter(r => r.user).map(r => r.user)).size,
+    unnamed: new Set(personal.filter(r => !r.user && r.device).map(r => r.device)).size};
+}
+function astraToolInfo(id) {
+  return ((REG && REG.rows) || []).find(r => r.id === id)
+    || (REGTOOLS || []).find(r => r.id === id) || {name:id, vendor:''};
+}
+// Registry names for identifiers, and catalogue labels for source ids, so
+// the inventory pages read the way the Overview does. The id stays in the
+// title, and search still matches it.
+function astraToolName(id) { return astraToolInfo(id).name || id; }
+function astraToolChip(id, cls) {
+  return `<span class="astra-tool-chip${cls ? ' ' + cls : ''}" title="${esc(id)}">${esc(astraToolName(id))}</span>`;
+}
+function astraSourceLabel(id) {
+  const src = ((S && S.groups) || []).flatMap(g => g.sources || []).find(x => x.source === id);
+  return src && src.label ? src.label : id;
+}
+function astraSourceChip(id) {
+  return `<span class="astra-tool-chip" title="${esc(id)}">${esc(astraSourceLabel(id))}</span>`;
+}
+function astraIcon(name) {
+  const paths = {
+    accounts:'<circle cx="9" cy="8" r="3"/><path d="M3 21v-3a6 6 0 0 1 12 0v3m1-16a3 3 0 0 1 0 6m2 4a5 5 0 0 1 3 5"/>',
+    coverage:'<rect x="3" y="3" width="18" height="13" rx="2"/><path d="M12 16v5m-5 0h10"/>',
+    register:'<path d="M5 3h14v18H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2ZM7 3v18m4-13h4m-4 4h4"/>',
+    shield:NAVICONS.governance,
+    arrow:'<path d="M4 12h16m-6-6 6 6-6 6"/>'
+  };
+  return `<svg class="astra-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+    stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths[name] || paths.arrow}</svg>`;
+}
+function astraFocusRows(f) {
+  if (!f.known) return '<p class="astra-empty">Findings are unavailable. Check System health before interpreting these counts.</p>';
+  const action = (route, icon, mood, title, text, badge, note) => `
+    <button class="astra-action" data-nav="${route}">
+      <span class="astra-action-icon ${mood}">${astraIcon(icon)}</span>
+      <span class="astra-action-copy"><strong>${title}</strong><span>${text}</span>
+        <small><b class="astra-badge ${mood}">${badge}</b>${note}</small></span>${astraIcon('arrow')}</button>`;
+  const names = [...new Set(f.open.map(r => r.tool))].slice(0,4)
+    .map(id => esc(astraToolInfo(id).name || id)).join(' · ');
+  return action('personal','accounts',f.open.length ? 'risk' : 'good',
+    f.open.length ? 'Review personal AI accounts' : 'Personal accounts reviewed',
+    f.open.length ? 'Follow up on activity in accounts outside your corporate domains.' : 'No open personal-account findings in this window.',
+    `${f.open.length} open`, names || 'View findings and recorded outcomes')
+    + action('coverage','coverage',f.gaps.length ? 'attention' : 'good',
+      f.gaps.length ? 'Close the collector coverage gaps' : 'Review detection coverage',
+      `${f.gaps.length} scanner-observed device${f.gaps.length === 1 ? '' : 's'} without a collector signal.`,
+      `${f.gaps.length} gaps`, 'Verify enrollment and reporting')
+    + action('register','register','governance','Complete the AI register',
+      f.undecided === null ? 'Register data is unavailable; open the register to check it.'
+        : `${f.undecided} discovered tool${f.undecided === 1 ? '' : 's'} without a recorded decision.`,
+      f.overdue === null ? 'Not read' : f.overdue ? `${f.overdue} overdue review${f.overdue === 1 ? '' : 's'}`
+        : `${f.recorded.length} decisions`, 'Confirm ownership and permitted use');
+}
+function astraToolsTable(rows) {
+  const f = astraOverviewFacts(), series = (G.trends || {}).tools || {};
+  return `<div class="astra-table-scroll" tabindex="0" role="region" aria-label="Discovered tools table">
+    <table class="astra-inventory"><thead><tr><th>AI tool</th><th>Observed surfaces</th>
+      <th class="num" aria-sort="descending">Devices ↓</th><th class="num">Cloud identities</th>
+      <th>Personal accounts</th><th>Activity</th><th><span class="sr-only">Details</span></th></tr></thead>
+    <tbody>${rows.map(([id,t]) => {
+      const info = astraToolInfo(id), name = info.name || id;
+      const n = f.open.filter(r => r.tool === id).length;
+      return `<tr data-open="tool" data-key="${esc(id)}">
+        <td><button class="astra-tool-button" data-open="tool" data-key="${esc(id)}"
+          aria-label="View ${esc(name)} details"><span class="astra-tool-initial" aria-hidden="true">${esc(name.slice(0,1).toUpperCase())}</span>
+          <span><strong>${esc(name)}</strong><small>${esc(info.vendor || id)}</small></span></button></td>
+        <td>${(t.surfaces || []).map(x => `<span class="astra-surface">${esc(x)}</span>`).join('')}</td>
+        <td class="num">${(t.devices || []).length}</td><td class="num">${(t.identities || []).length}</td>
+        <td>${n ? `<span class="astra-badge risk">${n} open</span>` : '<span class="astra-muted">None observed</span>'}</td>
+        <td>${astraActivity(series[id], name)}</td>
+        <td><button class="astra-row-open" data-open="tool" data-key="${esc(id)}" aria-label="Inspect ${esc(name)}">${astraIcon('arrow')}</button></td>
+      </tr>`;
+    }).join('')}</tbody></table></div>
+    ${astraToolsList(rows)}`;
+}
+// The same inventory as a list, for a card narrower than the table can
+// be. Which one shows is the container's width, in CSS; both are drawn
+// from the same rows so a size change never re-fetches or re-sorts.
+function astraToolsList(rows) {
+  const f = astraOverviewFacts(), series = (G.trends || {}).tools || {};
+  return `<ul class="astra-tool-list" aria-label="Discovered tools">${rows.map(([id,t]) => {
+    const info = astraToolInfo(id), name = info.name || id;
+    const n = f.open.filter(r => r.tool === id).length;
+    const days = series[id] || [], total = days.reduce((a, b) => a + b, 0);
+    return `<li><button class="astra-tool-item" data-open="tool" data-key="${esc(id)}" aria-label="View ${esc(name)} details">
+      <span class="astra-tool-initial" aria-hidden="true">${esc(name.slice(0,1).toUpperCase())}</span>
+      <span class="astra-tool-main"><strong>${esc(name)}</strong>
+        <small>${esc(info.vendor || id)}${(t.surfaces || []).length ? ' · ' + esc((t.surfaces || []).join(', ')) : ''}${total ? ` · ${total} in ${esc(fmtWindow(hoursNow()))}` : ''}</small></span>
+      <span class="astra-tool-nums"><b>${(t.devices || []).length}</b><i>devices</i></span>
+      <span class="astra-tool-nums astra-tool-cloud"><b>${(t.identities || []).length}</b><i>cloud</i></span>
+      <span class="astra-tool-flag">${n ? `<span class="astra-badge risk">${n} open</span>` : ''}</span>
+      ${astraIcon('arrow')}</button></li>`;
+  }).join('')}</ul>`;
+}
+// Findings per day as a sparkline once the window holds enough days to
+// make a shape; below that a single bar reads as a glitch, so the total
+// for the window is written out instead.
+function astraActivity(series, name) {
+  const days = series || [], total = days.reduce((a, b) => a + b, 0);
+  const tip = esc(name + ': findings over the last ' + fmtWindow(hoursNow()));
+  if (days.length >= 3 && days.some(v => v)) return `<span data-ctip="${tip}">${spark(days)}</span>`;
+  return total ? `<span data-ctip="${tip}"><b class="astra-activity-count">${total}</b><span class="astra-muted"> in ${esc(fmtWindow(hoursNow()))}</span></span>`
+    : '<span class="astra-muted">None in window</span>';
+}
+function astraReviewQueueDetail() {
     // The queue that replaces a weekly review pipeline: observed tools no
     // one has decided about. Recording the decision IS the acknowledgment,
     // so an empty queue means exactly what it says. Not-in-registry rows
@@ -2614,6 +2481,309 @@ const WIDGETS = {
     </section>`}
     <div class="decision-footer"><span>Recording a decision clears the tool from this queue.</span>
       <a href="#register">Open AI register</a></div></div>`;
+}
+
+const WIDGETS = {
+
+  // What runs with no person behind it, small enough to sit on an overview.
+  // The count is the headline; the rows are the ones with nothing to revoke,
+  // because a scheduled job under a real account is not the finding.
+  agentic: () => {
+    const head = (n) => `<div class="astra-panel-head"><div><h3>Running on its own${n === undefined ? '' : ` <span class="count">${n}</span>`}</h3>
+      <p>AI that starts itself, and who answers for it</p></div><span class="astra-eyebrow">Agentic</span></div>`;
+    if (!AGENTIC) return `<div class="wcard w6 astra-widget astra-agentic-card">${head()}
+      <p class="astra-empty">Not read yet. Open Agentic AI.</p>
+      <div class="astra-panel-footer"><span></span><button class="mini" data-nav="agentic">Open Agentic AI ${astraIcon('arrow')}</button></div></div>`;
+    const c = AGENTIC.counts || {};
+    const loose = (AGENTIC.agents || []).filter(
+      a => a.autonomous && !a.accountable);
+    const body = !c.autonomous
+      ? `<p class="astra-empty">Nothing reported starting itself.${
+        c.unrecognised ? ` ${c.unrecognised} process${c.unrecognised === 1 ? '' : 'es'}
+        reached a model unrecognised, which is a different question.` : ''} That is either
+        true or the collectors have not been updated to look. System health says which.</p>`
+      : `<p class="astra-widget-lede">${c.unaccountable
+          ? `<b>${c.unaccountable}</b> of ${c.autonomous} answer to nobody: a credential with no
+             person behind it, so revoking a sign-on does not stop them.`
+          : 'All of them run under an identity somebody can be asked about.'}</p>
+        ${loose.length ? `<div class="astra-table-scroll"><table class="astra-inventory astra-widget-table">
+          <thead><tr><th>Device</th><th>Schedule</th><th>Answers to</th></tr></thead>
+          <tbody>${loose.slice(0, 5).map(a => `<tr>
+            <td><strong>${esc(label(a.device, G.devices[a.device] || {}))}</strong></td>
+            <td class="astra-muted">${esc(a.trigger || a.evidence || '')}</td>
+            <td>${a.process
+              ? '<span class="astra-badge risk">no tool we know</span>'
+              : '<span class="astra-badge risk">' + esc(a.identity || 'unattributed') + '</span>'}</td>
+          </tr>`).join('')}</tbody></table></div>` : ''}`;
+    return `<div class="wcard w6 astra-widget astra-agentic-card">${head(c.autonomous || 0)}
+      ${body}
+      <div class="astra-panel-footer"><span>${c.unrecognised ? `${c.unrecognised} unrecognised process${c.unrecognised === 1 ? '' : 'es'} reached a model` : ''}</span>
+        <button class="mini" data-nav="agentic">Open Agentic AI ${astraIcon('arrow')}</button></div>
+    </div>`;
+  },
+
+  stat_row: () => {
+    const f = astraOverviewFacts(), open = f.open, gaps = f.gaps;
+    const freshH = Math.min(hoursNow(), 168), week = Date.now()/1000 - freshH*3600;
+    const fresh = f.personal.filter(r => r.first_seen && Date.parse(r.first_seen)/1000 > week).length;
+    const tr = G.trends || {};
+    const attention = open.length || gaps.length;
+    const silent = !S || !S.reporting;
+    const mood = !f.known ? 'silent' : silent ? 'silent' : attention ? 'needs-attention' : 'healthy';
+    const value = n => f.known ? n : '—';
+    return `<div class="astra-estate-line"><span>Your estate at a glance</span>
+      <span>${f.known ? `${f.devices.length} observed devices · last ${esc(fmtWindow(hoursNow()))}` : 'Findings unavailable'}</span></div>
+    <div class="overview-executive w12 ${mood}" data-tour="stats">
+      <section class="executive-posture">
+        <span>${astraIcon('shield')}Overall posture</span>
+        <strong>${!f.known ? 'Data unavailable' : silent ? 'Nothing reporting' : attention ? 'Needs attention' : 'Monitoring healthy'}</strong>
+        <p>${!f.known ? 'The findings could not be read. Open System health to check the connection.' : silent
+          ? 'No detection source reported in this window. These counts are missing data, not a clean result.'
+          : `${open.length} open personal account${open.length === 1 ? '' : 's'} · ${gaps.length} coverage gap${gaps.length === 1 ? '' : 's'}`}</p>
+        <div class="executive-actions">
+          ${open.length && f.known ? '<button class="mini" data-nav="personal">Review accounts</button>' : ''}
+          <button class="mini" data-nav="coverage">Verify coverage</button>
+        </div>
+        <small class="astra-posture-note">${f.known
+          ? `${f.people} people named in personal-account findings${f.unnamed ? ` · ${f.unnamed} unnamed devices` : ''}`
+          : 'Do not interpret unavailable data as a clean result.'}</small>
+      </section>
+      <dl class="executive-metrics">
+        <div><dt${open.length ? ' class="risk"' : ''}>${value(open.length)}${f.known ? trendChip(tr.personal, true) : ''}</dt>
+          <dd>Open personal accounts</dd><small>${f.known ? `${fresh} first seen in the last ${fmtWindow(freshH)}${
+            open.length !== f.personal.length ? ` · ${f.personal.length - open.length} accepted` : ''}` : 'Findings unavailable'}</small></div>
+        <div><dt>${value(f.toolIds.length)}</dt><dd>AI tools observed</dd>
+          <small>Across endpoint, browser and cloud sources</small></div>
+        <div><dt>${f.known && f.coverage !== null ? f.coverage + '<span class="astra-percent">%</span>' : '—'}</dt>
+          <dd>Collector coverage</dd><small>${f.known ? `${f.collectors} of ${f.devices.length} observed devices` : 'Findings unavailable'}</small></div>
+        <div><dt>${f.known && f.recorded ? f.recorded.length + '<span class="astra-denominator">/ ' + f.toolIds.length + '</span>' : '—'}</dt>
+          <dd>Register decisions</dd><small>${!f.known || !f.recorded ? 'Register data unavailable'
+            : `${f.undecided} tools without a recorded decision`}</small></div>
+      </dl>
+    </div>`;
+  },
+
+  budget_spend: () => {
+    // Managed mode only, and quiet until the budget has been fetched
+    // (load() fetches it when this widget is configured). A tile of
+    // zeros on a deployment that never linked a tool would be noise.
+    if (!BUDGET) return '';
+    const subs = BUDGET.subscriptions || [];
+    const head = `<div class="astra-panel-head"><div><h3>AI spend</h3><p>Tracked subscriptions against observed use</p></div>
+      <span class="astra-eyebrow">Budget</span></div>`;
+    if (!subs.length) {
+      return `<div class="wcard w6 astra-widget astra-spend-card">${head}
+      <p class="astra-empty">Nothing linked yet. The Budget view records what
+      each AI tool costs and joins it against observed use.</p>
+      <div class="astra-panel-footer"><span></span><button class="mini" data-nav="budget">Open Budget ${astraIcon('arrow')}</button></div></div>`;
+    }
+    const next = subs.filter(s => s.renewal_date)
+      .sort((a, b) => a.renewal_date.localeCompare(b.renewal_date))[0];
+    const unob = subs.reduce((a, s) =>
+      a + bReconcile(s).unobserved.length, 0);
+    const conv = bConverted(subs);
+    return `<div class="wcard w6 astra-widget astra-spend-card">${head}
+    <dl class="astra-tiles">
+      <div><dt>${conv ? bMoney(conv.total, bPrefCur()) : bSpendParts(subs).join(' + ')}</dt>
+        <dd>tracked per month${conv ? ` <span title="${esc(bSpendParts(subs).join(' + '))}">· ECB ${esc(conv.date)}</span>` : ''}</dd></div>
+      <div><dt>${subs.length}</dt><dd>tools linked</dd></div>
+      <div><dt${unob ? ' class="attention"' : ''}>${unob}</dt><dd>paid seats never observed</dd></div>
+    </dl>
+    <div class="astra-table-scroll"><table class="astra-inventory astra-widget-table">
+      <thead><tr><th>Subscription</th><th class="num">Monthly</th><th class="num">Seats in use</th><th>Review</th></tr></thead>
+      <tbody>${subs.map(sub => {
+        const r = bReconcile(sub);
+        const seats = (sub.seat_tiers || []).reduce((x, t) => x + (t.seats || 0), 0);
+        return `<tr data-nav="budget">
+          <td><strong>${esc(astraToolName(sub.tool_id))}</strong>${sub.plan ? `<small>${esc(sub.plan)}</small>` : ''}</td>
+          <td class="num">${bMoney(bSubMonthly(sub), sub.currency)}</td>
+          <td class="num">${r.matched.length} of ${seats}</td>
+          <td>${r.unobserved.length ? `<span class="astra-badge attention">${r.unobserved.length} idle</span>` : ''}${r.strangers.length
+            ? ` <span class="astra-badge governance">${r.strangers.length} unseated</span>` : ''}${!r.unobserved.length && !r.strangers.length ? '<span class="astra-muted">Nothing flagged</span>' : ''}</td></tr>`;
+      }).join('')}</tbody></table></div>
+    <div class="astra-panel-footer"><span>${next ? `Next renewal: ${esc(astraToolName(next.tool_id))} ${when(next.renewal_date)}` : 'No renewal dates recorded'}</span>
+      <button class="mini" data-nav="budget">Open Budget ${astraIcon('arrow')}</button></div></div>`;
+  },
+
+  top_tools: () => {
+    const f = astraOverviewFacts();
+    const rows = ents(G.tools).filter(([id]) => {
+      const info = astraToolInfo(id);
+      return (match(id) || match(info.name || '') || match(info.vendor || ''))
+        && (!ASTRA_PERSONAL_TOOLS || f.open.some(r => r.tool === id));
+    }).sort((a,b)=>(b[1].devices||[]).length-(a[1].devices||[]).length);
+    const bars = widgetForm('top_tools') === 'bar';
+    return `<div class="wcard ${bars ? 'w6' : 'w12'} astra-tools-card">
+      <div class="astra-panel-head"><h3>${formToggle('top_tools')}Discovered AI tools <span class="count">${f.toolIds.length}</span></h3>
+        <div class="astra-tool-filters" role="group" aria-label="Filter discovered tools">
+          <button class="${!ASTRA_PERSONAL_TOOLS ? 'on' : ''}" data-act="astra-tools-filter" data-filter="all" aria-pressed="${!ASTRA_PERSONAL_TOOLS}">All tools</button>
+          <button class="${ASTRA_PERSONAL_TOOLS ? 'on' : ''}" data-act="astra-tools-filter" data-filter="personal" aria-pressed="${ASTRA_PERSONAL_TOOLS}">Personal accounts</button>
+        </div></div>
+      ${!f.known ? '<p class="astra-empty">Findings are unavailable.</p>' : rows.length ? (bars
+        ? '<div class="astra-tool-bars">' + barRows(rows.map(([k,t]) => [k,(t.devices||[]).length]), 'devices', 'tool') + '</div>'
+        : astraToolsTable(rows)) : '<p class="astra-empty">No tools match this view.</p>'}
+      <div class="astra-panel-footer"><span>${f.known ? `${rows.length} of ${f.toolIds.length} discovered tools` : 'No data available'}</span>
+        <button class="mini" data-nav="tools">Open discovered tools ${astraIcon('arrow')}</button></div>
+      <p class="src-note astra-table-note">${bars ? 'Observed devices per tool. Cloud-only tools may have zero associated devices.'
+        : 'One bar per day for the last ' + fmtWindow(hoursNow()) + ', written as a total when the window holds fewer than three days. Devices and cloud identities are counted separately.'}</p>
+    </div>`;
+  },
+
+  recent_personal_accounts: () => {
+    const pa = (G.personal_accounts || []).slice(0, 6);
+    const body = pa.length ? `<div class="astra-table-scroll"><table class="astra-inventory astra-people-table">
+      <thead><tr><th>Person</th><th>Account</th><th>AI tool</th><th>Last seen</th></tr></thead>
+      <tbody>${pa.map(r => `<tr>
+        <td>${esc(r.user || r.device_name || r.device)}</td>
+        <td><span class="astra-badge risk">${esc(r.account_domain)}</span></td>
+        <td>${esc(astraToolInfo(r.tool).name || r.tool)}</td>
+        <td class="astra-muted">${esc((r.last_seen || '').slice(0, 10))}</td>
+      </tr>`).join('')}</tbody></table></div>`
+      : dataOk()
+        ? '<p class="astra-empty">None seen. That is a result, not an absence of one.</p>'
+        : '<p class="astra-empty">Nothing to show: the findings could not be read.</p>';
+    return `<div class="wcard w6 astra-widget astra-people-card">
+      <div class="astra-panel-head"><div><h3>Recent personal accounts</h3>
+        <p>Latest activity in accounts outside your corporate domains</p></div>
+        <span class="astra-eyebrow">Last ${esc(fmtWindow(hoursNow()))}</span></div>
+      ${body}
+      <div class="astra-panel-footer"><span>${pa.length ? `${(G.personal_accounts || []).length} in this window` : ''}</span>
+        <button class="mini" data-nav="personal">Open personal accounts ${astraIcon('arrow')}</button></div>
+    </div>`;
+  },
+
+  detection_coverage: () => {
+    if (!S) return '<div class="wcard w4"><h3>Detection coverage</h3><p class="lede">No status available.</p></div>';
+    // One square per source, filled when it reports: 1/5 should look like
+    // four dark squares, not a bar length to squint at.
+    const meter = widgetForm('detection_coverage') === 'meter';
+    const f = astraOverviewFacts();
+    return `<div class="wcard w6 astra-visibility-card">
+    <div class="astra-panel-head"><div><h3>Visibility across your estate</h3><p>Collector signals across observed devices</p></div>${astraIcon('shield')}</div>
+    <div class="astra-coverage-overview">
+      <div class="astra-ring-block">
+        <div class="astra-ring" role="img" aria-label="${f.known && f.coverage !== null ? `${f.collectors} of ${f.devices.length} devices have a collector signal` : 'Collector coverage unavailable'}">
+          <svg viewBox="0 0 112 112" aria-hidden="true"><circle class="astra-ring-track" cx="56" cy="56" r="48"/>
+            <circle class="astra-ring-value" cx="56" cy="56" r="48" pathLength="100" stroke-dasharray="${f.known && f.devices.length ? f.collectors / f.devices.length * 100 : 0} 100"/></svg>
+          <div><strong>${f.known && f.coverage !== null ? f.coverage + '<span>%</span>' : '—'}</strong></div>
+        </div>
+        <small class="astra-ring-caption">Collector coverage</small>
+      </div>
+      <div class="astra-coverage-legend"><p><i></i>Collector observed <b>${f.known ? f.collectors : '—'}</b></p>
+        <p><i class="gap"></i>No collector signal <b>${f.known ? f.devices.length - f.collectors : '—'}</b></p>
+        <small>Of devices seen by any source in this window.</small></div>
+    </div>
+    <div class="astra-source-heading"><h4>Detection sources</h4><span>${S.reporting || 0}/${(S.groups || []).reduce((n,g) => n + g.total, 0)} reporting</span>${formToggle('detection_coverage')}</div>
+    <div class="astra-source-grid">
+    ${meter ? (S.groups||[]).map(g => `<div class="meterrow"
+        data-ctip="${esc(g.group + ' · ' + g.reporting + ' of ' + g.total
+                         + ' dedicated sources reporting')}">
+        <span>${esc(g.group)}</span>
+        <span class="track"><span class="fill" style="width:${
+          g.total ? Math.round(g.reporting / g.total * 100) : 0}%"></span></span>
+        <b>${g.reporting}/${g.total}</b></div>`).join('')
+    : (S.groups||[]).map(g=>{
+      const dots = g.total <= 14
+        ? `<span class="dots">${Array.from({length: g.total}, (_, i) =>
+            `<i class="${i < g.reporting ? 'on' : ''}"></i>`).join('')}</span>`
+        : spark([g.reporting, g.total - g.reporting]);
+      // A surface's dedicated SOURCES, not the surface itself: the
+      // estate can see MCP servers through endpoint collectors while
+      // the dedicated mcp scanner is not deployed, and "mcp 0/1" read
+      // as "we have no MCP visibility" when the product was showing
+      // eight servers two views away.
+      return `<div class="covrow" title="Dedicated sources for the ${esc(g.group)} surface that are reporting. Other sources can still produce findings for it.">
+        <span>${esc(g.group)}</span>${dots}
+        <b>${g.reporting}/${g.total}</b></div>`;
+    }).join('')}</div>
+    <div class="astra-panel-footer"><span>Source catalogue, not configured integrations</span><button class="mini" data-nav="setup">Review sources ${astraIcon('arrow')}</button></div>
+    <details class="astra-coverage-note"><summary>How to read coverage</summary><p class="src-note">Collector coverage uses devices observed by any source, not your entire company fleet. An unobserved source may be unconfigured or inapplicable. These are dedicated sources per surface; other sources can also produce findings for it.</p></details></div>`;
+  },
+
+  // The change dimension, which the estate has had all along and shown
+  // only as 18px sparklines inside stat tiles. Every other number on this
+  // page is a total over the window: 23 personal accounts reads the same
+  // whether it was 12 last week or 40.
+  activity_trend: () => {
+    const tr = G.trends || {}, days = tr.days || [];
+    if (days.length < 2) return `<div class="wcard w6 exposure-trend-card"><h3>Personal-account exposure</h3>
+      <p class="lede">Not enough days in the window to draw a trend yet.</p></div>`;
+    return `<div class="wcard w6 exposure-trend-card">
+    <div class="trend-heading"><div><h3>Personal-account exposure</h3>
+      <p>Daily detections against reporting coverage</p></div></div>
+    <div class="exposure-chart">${trendChart(days,
+      tr.personal || days.map(() => 0), tr.devices || days.map(() => 0),
+      'personal-account detections', 'reporting devices')}</div>
+    <p class="src-note">Real findings per day, not a synthetic risk score.
+      Reporting devices provide the confidence check: both lines falling
+      together can mean the fleet went quiet rather than exposure improved.</p></div>`;
+  },
+
+  source_health: () => {
+    if (!S) return '';
+    const groups = (S.groups || []).map(g => ({group: g.group, total: g.total,
+      silent: (g.sources || []).filter(r => !r.reporting)})).filter(g => g.silent.length);
+    const silent = groups.reduce((n, g) => n + g.silent.length, 0);
+    return `<div class="wcard w4 astra-widget astra-silent-card">
+      <div class="astra-panel-head"><div><h3>Silent sources <span class="count">${silent}</span></h3>
+        <p>In the catalogue, nothing reported in this window</p></div></div>
+      ${silent ? `<div class="astra-table-scroll"><table class="astra-inventory astra-widget-table astra-silent-table">
+        <thead><tr><th>Surface</th><th class="num">Silent</th><th>Sources</th></tr></thead>
+        <tbody>${groups.map(g => `<tr>
+          <td><strong>${esc(g.group)}</strong></td>
+          <td class="num">${g.silent.length} of ${g.total}</td>
+          <td>${g.silent.map(r => `<span title="${esc(r.source)}">${esc(r.label || r.source)}</span>`).join('<i>·</i>')}</td>
+        </tr>`).join('')}</tbody></table></div>`
+        : '<p class="astra-empty">Every listed source is reporting.</p>'}
+      <div class="astra-panel-footer"><span>Unconfigured or not applicable, not necessarily broken</span>
+        <button class="mini" data-nav="setup">Review sources ${astraIcon('arrow')}</button></div>
+    </div>`;
+  },
+
+  paste_guard: () => {
+    // Native rather than an embedded Grafana panel. This number is derived by
+    // the portal now, so embedding an iframe to show it meant a card in
+    // Grafana's typography sitting beside cards in the portal's, with a title
+    // we could not restyle because it renders cross-origin.
+    //
+    // Two numbers, not four. The overview is a glance: is the guard running,
+    // and did somebody ignore it. Warned and blocked are the detail behind
+    // that, and they have a page.
+    const head = `<div class="astra-panel-head"><div><h3>Paste guard</h3><p>Browser extension, on the devices it reached</p></div></div>`;
+    if (!PG) return `<div class="wcard w4 astra-widget astra-paste-card">${head}
+      <p class="astra-empty">No paste guard data.</p></div>`;
+    const over = PG.overridden || 0, live = PG.guard_devices || 0;
+    const warned = PG.warned || 0;
+    const versions = (PG.guard_versions || []).length;
+    const warnMode = (PG.guard_modes || []).some(m => m.mode === 'warn');
+    return `<div class="wcard w4 astra-widget astra-paste-card">${head}
+      <dl class="astra-tiles astra-tiles-2">
+        <div><dt${live ? '' : ' class="risk"'}>${live}</dt><dd>devices running the guard</dd></div>
+        <div><dt${over ? ' class="risk"' : ''}>${over}</dt><dd>warnings overridden</dd></div>
+      </dl>
+      <ul class="astra-notes">
+        ${warnMode && warned ? `<li class="attention">In block mode, ${warned} warned paste${warned === 1 ? '' : 's'} would have been stopped outright. The breakdown is on the Paste guard page.</li>` : ''}
+        <li>${live
+          ? `Running on ${live} device${live === 1 ? '' : 's'}${versions > 1 ? ` across ${versions} versions` : ''}, so low numbers here genuinely mean few risky pastes.`
+          : 'No device has checked in yet, so zero here means "not deployed", not "nobody pasted anything".'}</li>
+      </ul>
+      <div class="astra-panel-footer"><span>${warned ? `${warned} warned in this window` : 'Nothing warned in this window'}</span>
+        <button class="mini" data-nav="paste">Open Paste guard ${astraIcon('arrow')}</button></div></div>`;
+  },
+
+  review_queue: () => {
+    const f = astraOverviewFacts();
+    const candidates = (CAND || []).filter(c => !c.resolved && !c.dismissed_at);
+    return `<div class="wcard w6 astra-focus-card"><div class="astra-panel-head">
+      <div><h3>Where to focus</h3><p>Follow-ups across your AI estate</p></div>
+      <span class="astra-eyebrow">Action queue</span></div>
+      ${astraFocusRows(f)}
+      <details class="astra-queue-details">
+        <summary>Decision & discovery queue <span>${candidates.length
+          ? `${candidates.length} new discover${candidates.length === 1 ? 'y' : 'ies'}`
+          : f.undecided === null ? 'Register not read' : `${f.undecided} awaiting a decision`}</span></summary>
+        ${astraReviewQueueDetail()}
+      </details></div>`;
   },
 
   grafana: (w) => {
@@ -2796,7 +2966,7 @@ function overview() {
       col.map(k => cardOf(k)).join('')}</div>`;
   };
 
-  return `<h2>Overview</h2>
+  return `<h2>Overview</h2><p class="lede">Your AI estate. The exposure, the coverage, the next action.</p>
   ${truncNote(G.findings_truncated)}
   ${editing ? `<div class="oedit">
     <span>Drag a card between others to move it, or onto the middle of one
@@ -2844,8 +3014,8 @@ function devices() {
     <tbody>${rows.map(([k,d]) => `<tr data-open="device" data-key="${esc(k)}">
       <td><strong>${esc(label(k,d))}</strong><br><span class="mono row-key">${esc(k)}</span></td>
       <td>${d.person ? `<span class="pill p-ok">${esc(d.person)}</span>` : '<span class="muted-value">Unattributed</span>'}</td>
-      <td><div class="cell-tags">${(d.tools||[]).map(t=>`<span class="pill p-mut">${esc(t)}</span>`).join('') || '<span class="muted-value">None observed</span>'}</div></td>
-      <td><div class="cell-tags">${(d.personal_accounts||[]).map(a=>`<span class="pill p-warn">${esc(a)}</span>`).join('') || '<span class="muted-value">None</span>'}</div></td>
+      <td><div class="cell-tags">${(d.tools||[]).map(t=>astraToolChip(t)).join('') || '<span class="muted-value">None observed</span>'}</div></td>
+      <td><div class="cell-tags">${(d.personal_accounts||[]).map(a=>`<span class="astra-badge risk">${esc(a)}</span>`).join('') || '<span class="muted-value">None</span>'}</div></td>
       <td><div class="cell-tags">${(d.local_users||[]).map(u=>`<span class="pill p-mut">${esc(u)}</span>`).join('') || '<span class="muted-value">—</span>'}</div></td>
     </tr>`).join('')}</tbody>
   </table></div>`;
@@ -2985,12 +3155,12 @@ async function people() {
   const unattributed = ents(G.devices).filter(([,d]) => !d.person).length;
   return `<h2>People</h2><p class="lede">People named by cloud sources, which see accounts rather than machines. A device shows against a person only where the identity map links them.</p>
   ${identityMapPanel(unattributed)}
-  <div class="tcard"><table><tr><th>identity</th><th>tools</th><th>devices</th></tr>
-  ${rows.map(([k,i]) => `<tr><td>${esc(k)}${(i.aliases||[]).length
+  <div class="tcard"><table class="astra-page-table"><thead><tr><th>Identity</th><th>AI tools</th><th>Devices</th></tr></thead>
+  ${rows.map(([k,i]) => `<tr><td><strong>${esc(k)}</strong>${(i.aliases||[]).length
     ? `<br><span class="src-note" style="font-style:normal">also seen as
        ${(i.aliases).map(a => esc(a)).join(', ')}</span>` : ''}</td>
-    <td>${(i.tools||[]).map(t=>`<span class="pill p-mut">${esc(t)}</span>`).join('')}</td>
-    <td>${(i.devices||[]).map(d=>`<span class="pill p-acc">${esc(d)}</span>`).join('') || '<span class="pill p-mut">unmapped</span>'}</td></tr>`).join('')}
+    <td><div class="cell-tags">${(i.tools||[]).map(t=>astraToolChip(t)).join('')}</div></td>
+    <td><div class="cell-tags">${(i.devices||[]).map(d=>`<span class="pill p-acc">${esc(d)}</span>`).join('') || '<span class="muted-value">Unmapped</span>'}</div></td></tr>`).join('')}
   </table></div>`;
 }
 
@@ -3030,11 +3200,11 @@ function tools() {
       return rank(b) - rank(a) || (b[1].devices||[]).length - (a[1].devices||[]).length;
     });
   return `<h2>Tools</h2><p class="lede">The same tool in a browser, a desktop app and a CLI is three different exposures, so surfaces are listed separately. Tools that need a look sort first: <span class="pill p-warn">attention</span> when several factors stack up, <span class="pill p-amb">watch</span> for one. Open a tool to see which. Editors that bundle AI, such as Cursor or Windsurf, show as <span class="pill p-mut">installed only</span> until something shows a model actually ran. "Identities from sources" counts people a source named directly; the AI register also counts people linked through a device, so the two can differ.</p>
-  <div class="tcard"><table><tr><th>tool</th><th></th><th>devices</th>
-    <th title="People a SOURCE named on this tool. A cloud sign-in carries a person; an endpoint finding carries a machine, and the person behind it comes from the identity map - so this is lower than the register's user count for tools found on endpoints.">identities from sources</th>
-    <th>by surface</th></tr>
-  ${rows.map(([k,t,a]) => `<tr data-open="tool" data-key="${esc(k)}" style="cursor:pointer">
-    <td>${esc(k)}</td><td>${attnPill(a)}${t.usage === 'installed'
+  <div class="tcard"><table class="astra-page-table"><thead><tr><th>AI tool</th><th>Status</th><th>Devices</th>
+    <th title="People a SOURCE named on this tool. A cloud sign-in carries a person; an endpoint finding carries a machine, and the person behind it comes from the identity map - so this is lower than the register's user count for tools found on endpoints.">Identities from sources</th>
+    <th>By surface</th></tr></thead>
+  <tbody>${rows.map(([k,t,a]) => `<tr data-open="tool" data-key="${esc(k)}" style="cursor:pointer">
+    <td><strong>${esc(astraToolName(k))}</strong><span class="astra-id">${esc(astraToolInfo(k).vendor ? astraToolInfo(k).vendor + ' · ' : '')}${esc(k)}</span></td><td>${attnPill(a)}${t.usage === 'installed'
       ? `<span class="pill p-mut" title="Found installed, but nothing has shown a model actually running - no account, no sign-in, and no traffic to the completion backend. Editors that bundle AI (Cursor, Windsurf/Devin Desktop) are useful all day without it.">installed only</span>`
       : ''}</td>
     <td>${(t.devices||[]).length}${(t.devices_active||[]).length < (t.devices||[]).length
@@ -3045,12 +3215,12 @@ function tools() {
       || (t.surfaces||[]).filter(Boolean).map(s2 =>
         `<span class="pill p-mut">${esc(s2)}</span>`).join('')
       || '<span class="src-note">seen in cloud sign-ins only - no device attribution</span>'}</td>
-  </tr>`).join('')}</table></div>
+  </tr>`).join('')}</tbody></table></div>
   ${ents(G.bridges||{}).length ? `<div class="tcard">
   <div class="cardhead"><h3>Bridge targets</h3></div>
   <p class="lede">Where an AI tool reached. Not a tool inventory: these are
   destinations of an integration, not something someone installed.</p>
-  <table><tr><th>resource</th><th>devices</th></tr>
+  <table class="astra-page-table"><thead><tr><th>Resource</th><th>Devices</th></tr></thead>
   ${ents(G.bridges).sort((a,b)=>b[1].devices.length-a[1].devices.length)
     .map(([k,b])=>`<tr><td>${esc(k)}</td><td>${b.devices.length}</td></tr>`).join('')}
   </table></div>` : ''}`;
@@ -3059,9 +3229,9 @@ function tools() {
 function coverage() {
   const gaps = ents(G.devices).filter(([,d]) => d.scanner_seen && !d.collector_seen);
   return `<h2>Coverage</h2><p class="lede">Machines an inventory or telemetry source knows about, but no endpoint collector has reported from. Usually the collector is not installed there yet.</p>
-  ${gaps.length ? `<div class="tcard"><table><tr><th>device</th><th>sources</th><th>tools seen</th></tr>
-  ${gaps.map(([k,d])=>`<tr><td>${esc(label(k,d))}</td>
-    <td>${(d.sources||[]).map(s=>`<span class="pill p-mut">${esc(s)}</span>`).join('')}</td>
+  ${gaps.length ? `<div class="tcard"><table class="astra-page-table"><thead><tr><th>Device</th><th>Seen by</th><th>AI tools seen</th></tr></thead>
+  ${gaps.map(([k,d])=>`<tr><td><strong>${esc(label(k,d))}</strong></td>
+    <td><div class="cell-tags">${(d.sources||[]).map(x => astraSourceChip(x)).join('')}</div></td>
     <td>${(d.tools||[]).length}</td></tr>`).join('')}</table></div>`
   : dataOk()
     ? '<p class="lede">Every device with a scanner finding also has a collector reporting.</p>'
@@ -3132,15 +3302,15 @@ function mcp() {
     <div><dt>${tools.length}</dt><dd>configuring tools</dd></div>
   </dl>
 
-  ${rows.length ? `<div class="tcard"><table>
-  <tr><th>server</th><th>devices</th><th>configured by</th>
-  <th>first seen</th><th>last seen</th></tr>
+  ${rows.length ? `<div class="tcard"><table class="astra-page-table">
+  <thead><tr><th>Server</th><th>Devices</th><th>Configured by</th>
+  <th>First seen</th><th>Last seen</th></tr></thead>
   ${rows.map(r => `<tr data-open="mcp" data-key="${esc(r.server)}" style="cursor:pointer">
-    <td>${esc(r.server)}</td>
+    <td><strong>${esc(r.server)}</strong></td>
     <td>${(r.devices||[]).length}</td>
-    <td>${(r.tools||[]).map(t=>`<span class="pill p-mut">${esc(t)}</span>`).join('')}</td>
-    <td style="color:var(--mut)">${esc((r.first_seen||'').slice(0,10) || '—')}</td>
-    <td style="color:var(--mut)">${esc((r.last_seen||'').slice(0,10) || '—')}</td>
+    <td><div class="cell-tags">${(r.tools||[]).map(t=>astraToolChip(t)).join('')}</div></td>
+    <td class="astra-muted">${esc((r.first_seen||'').slice(0,10) || '—')}</td>
+    <td class="astra-muted">${esc((r.last_seen||'').slice(0,10) || '—')}</td>
   </tr>`).join('')}</table>
   <p class="src-note" style="margin-bottom:8px">Click a server to see which machines it's configured on.
   Widest reach is listed first.</p></div>`
@@ -3200,26 +3370,40 @@ function personal() {
     match(r.user) || match(r.account_domain) || match(r.tool) ||
     match(r.device) || match(r.device_name));
   const lifecycle = CFG.managed && CFG.managed.enabled && PSTAT !== null;
+  const all = G.personal_accounts || [];
+  const st = r => (paStatus(r) || {}).status || 'open';
+  const nOpen = all.filter(r => st(r) !== 'accepted').length;
+  const nAck = all.filter(r => st(r) === 'acknowledged').length;
+  const nAcc = all.filter(r => st(r) === 'accepted').length;
+  const nTools = new Set(all.map(r => r.tool)).size;
+  const nPeople = new Set(all.filter(r => r.user).map(r => r.user)).size;
+  const summary = !all.length ? '' : `<div class="inventory-summary" aria-label="Personal account summary">
+    <span class="${nOpen ? 'risk' : ''}"><b>${nOpen}</b> open</span>
+    ${lifecycle ? `<span><b>${nAck}</b> acknowledged</span><span><b>${nAcc}</b> accepted</span>` : ''}
+    <span><b>${nPeople}</b> people named</span>
+    <span><b>${nTools}</b> AI tool${nTools === 1 ? '' : 's'} involved</span>
+  </div>`;
   return `<h2>Personal accounts</h2>
   <p class="lede" data-tour="personal">AI tools signed in with personal accounts. Even on an approved tool, that means company data going somewhere you do not manage, with access that outlives offboarding. Personal means the account domain is not in your corporate domains list. Treat each one as a lead to follow up, not a verdict${lifecycle ? `, and record where it got to: acknowledged keeps it visible, accepted needs a reason and takes it out of the open count` : ''}.</p>
-  ${rows.length ? `<div class="tcard"><table>
-  <tr><th>who</th><th>account domain</th><th>tool</th><th>device</th>
-  <th>surface</th><th>first seen</th><th>last seen</th><th>source</th>
-  ${lifecycle ? '<th>status</th>' : ''}</tr>
-  ${rows.map(r => `<tr${paStatus(r) ? ' style="opacity:.6"' : ''}>
+  ${summary}
+  ${rows.length ? `<div class="tcard"><table class="astra-page-table">
+  <thead><tr><th>Person</th><th>Account</th><th>AI tool</th><th>Device</th>
+  <th>Surface</th><th>First seen</th><th>Last seen</th><th>Source</th>
+  ${lifecycle ? '<th>Status</th>' : ''}</tr></thead>
+  <tbody>${rows.map(r => `<tr${paStatus(r) ? ' class="astra-settled"' : ''}>
     <td>${r.user
       ? esc(r.user) + (r.user_via === 'device'
         ? ' <span class="pill p-mut" title="This source reported no account name. The person is the one the identity map attaches to this machine.">via device</span>' : '')
       : '<span class="pill p-mut">no identity</span>'}</td>
-    <td><span class="pill p-warn">${esc(r.account_domain)}</span></td>
-    <td>${esc(r.tool)}</td>
+    <td><span class="astra-badge risk">${esc(r.account_domain)}</span></td>
+    <td>${astraToolChip(r.tool)}</td>
     <td>${esc(r.device_name || r.device || '—')}</td>
-    <td>${(r.surfaces||[]).map(x=>`<span class="pill p-mut">${esc(x)}</span>`).join('')}</td>
-    <td style="color:var(--mut)">${esc((r.first_seen||'').slice(0,10) || '—')}</td>
-    <td style="color:var(--mut)">${esc((r.last_seen||'').slice(0,10) || '—')}</td>
-    <td style="color:var(--mut)">${esc((r.sources||[]).join(', ')) || '—'}</td>
-    ${lifecycle ? `<td class="nw">${paChip(paStatus(r))} ${paActions(r)}</td>` : ''}
-  </tr>`).join('')}</table></div>`
+    <td>${(r.surfaces||[]).map(x=>`<span class="astra-surface">${esc(x)}</span>`).join('')}</td>
+    <td class="astra-muted">${esc((r.first_seen||'').slice(0,10) || '—')}</td>
+    <td class="astra-muted">${esc((r.last_seen||'').slice(0,10) || '—')}</td>
+    <td>${(r.sources||[]).map(x => astraSourceChip(x)).join('') || '<span class="astra-muted">—</span>'}</td>
+    ${lifecycle ? `<td class="nw astra-row-actions">${paChip(paStatus(r))} ${paActions(r)}</td>` : ''}
+  </tr>`).join('')}</tbody></table></div>`
   : `<p class="lede">None seen in the last ${hoursNow()} hours.
   Worth trusting only if the sources on the Setup page are reporting.</p>`}`;
 }
@@ -4037,11 +4221,11 @@ async function paste() {
     regenerate the policy artifacts to roll it out.</p></div>` : ''}
 
   ${rows.length ? `<div class="tcard"><table>
-  <tr><th>tool</th><th class="n">warned</th><th class="n">overridden</th>
-  <th class="n">blocked</th><th class="n">devices</th><th>detectors</th>
-  <th>last seen</th></tr>
+  <thead><tr><th>AI tool</th><th class="n">Warned</th><th class="n">Overridden</th>
+  <th class="n">Blocked</th><th class="n">Devices</th><th>Detectors</th>
+  <th>Last seen</th></tr></thead>
   ${rows.map(r => `<tr>
-    <td>${esc(r.tool)}</td>
+    <td>${astraToolChip(r.tool)}</td>
     <td class="n">${num(r.warned)}</td>
     <td class="n">${r.overridden
       ? `<span class="pill p-warn">${r.overridden}</span>` : num(0)}</td>
@@ -8636,6 +8820,14 @@ async function managedAction(act, el) {
     if (r.ok) USERS = null;
     render(); return;
   }
+  if (act === 'astra-tools-filter') {
+    ASTRA_PERSONAL_TOOLS = el.getAttribute('data-filter') === 'personal';
+    render(); return;
+  }
+  if (act === 'astra-density') {
+    await prefSet('display.compact', pref('display.compact', '0') === '1' ? '0' : '1');
+    render(); return;
+  }
   if (act === 'ov-edit') {
     const live = overviewWidgets();
     OVEDIT = {order: live.all.map(wKey), hidden: live.hidden.slice(),
@@ -9644,7 +9836,8 @@ function overviewTools() {
   const hidden = overviewWidgets().hidden.length;
   return `${hidden ? `<button class="mini" data-act="ov-showall"
     >Restore ${hidden} hidden ${hidden === 1 ? 'widget' : 'widgets'}</button>` : ''}
-    <button class="mini" data-act="ov-edit">Edit</button>`;
+    <button class="mini astra-density" data-act="astra-density" aria-pressed="${pref('display.compact', '0') === '1'}">${pref('display.compact', '0') === '1' ? 'Comfortable view' : 'Compact view'}</button>
+    <button class="mini" data-act="ov-edit">Edit widgets</button>`;
 }
 
 // Did the estate data actually arrive? Every "none seen, and that is a
@@ -10001,6 +10194,7 @@ function decorateView() {
 // the tour's own check hangs off the wrapper rather than the body - a call
 // per branch is a call somebody adding the twelfth view forgets.
 async function render() {
+  document.body.classList.toggle('astra-compact', pref('display.compact', '0') === '1');
   await renderView();
   decorateView();
   drawSetup();

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2269,10 +2269,10 @@ function trendChart(days, a, b, aLabel, bLabel) {
 }
 
 
-// Astra presentation helpers: use the same graph, lifecycle and register reads
+// the console layer presentation helpers: use the same graph, lifecycle and register reads
 // as the working views. No demo fixtures or network calls live in renderers.
-let ASTRA_PERSONAL_TOOLS = false;
-function astraOverviewFacts() {
+let UI_PERSONAL_TOOLS = false;
+function uiOverviewFacts() {
   const devices = ents(G.devices), personal = G.personal_accounts || [];
   const open = PSTAT
     ? personal.filter(r => (PSTAT[paKey(r)] || {}).status !== 'accepted') : personal;
@@ -2290,25 +2290,25 @@ function astraOverviewFacts() {
     people: new Set(personal.filter(r => r.user).map(r => r.user)).size,
     unnamed: new Set(personal.filter(r => !r.user && r.device).map(r => r.device)).size};
 }
-function astraToolInfo(id) {
+function uiToolInfo(id) {
   return ((REG && REG.rows) || []).find(r => r.id === id)
     || (REGTOOLS || []).find(r => r.id === id) || {name:id, vendor:''};
 }
 // Registry names for identifiers, and catalogue labels for source ids, so
 // the inventory pages read the way the Overview does. The id stays in the
 // title, and search still matches it.
-function astraToolName(id) { return astraToolInfo(id).name || id; }
-function astraToolChip(id, cls) {
-  return `<span class="astra-tool-chip${cls ? ' ' + cls : ''}" title="${esc(id)}">${esc(astraToolName(id))}</span>`;
+function uiToolName(id) { return uiToolInfo(id).name || id; }
+function uiToolChip(id, cls) {
+  return `<span class="ui-tool-chip${cls ? ' ' + cls : ''}" title="${esc(id)}">${esc(uiToolName(id))}</span>`;
 }
-function astraSourceLabel(id) {
+function uiSourceLabel(id) {
   const src = ((S && S.groups) || []).flatMap(g => g.sources || []).find(x => x.source === id);
   return src && src.label ? src.label : id;
 }
-function astraSourceChip(id) {
-  return `<span class="astra-tool-chip" title="${esc(id)}">${esc(astraSourceLabel(id))}</span>`;
+function uiSourceChip(id) {
+  return `<span class="ui-tool-chip" title="${esc(id)}">${esc(uiSourceLabel(id))}</span>`;
 }
-function astraIcon(name) {
+function uiIcon(name) {
   const paths = {
     accounts:'<circle cx="9" cy="8" r="3"/><path d="M3 21v-3a6 6 0 0 1 12 0v3m1-16a3 3 0 0 1 0 6m2 4a5 5 0 0 1 3 5"/>',
     coverage:'<rect x="3" y="3" width="18" height="13" rx="2"/><path d="M12 16v5m-5 0h10"/>',
@@ -2316,18 +2316,18 @@ function astraIcon(name) {
     shield:NAVICONS.governance,
     arrow:'<path d="M4 12h16m-6-6 6 6-6 6"/>'
   };
-  return `<svg class="astra-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+  return `<svg class="ui-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
     stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${paths[name] || paths.arrow}</svg>`;
 }
-function astraFocusRows(f) {
-  if (!f.known) return '<p class="astra-empty">Findings are unavailable. Check System health before interpreting these counts.</p>';
+function uiFocusRows(f) {
+  if (!f.known) return '<p class="ui-empty">Findings are unavailable. Check System health before interpreting these counts.</p>';
   const action = (route, icon, mood, title, text, badge, note) => `
-    <button class="astra-action" data-nav="${route}">
-      <span class="astra-action-icon ${mood}">${astraIcon(icon)}</span>
-      <span class="astra-action-copy"><strong>${title}</strong><span>${text}</span>
-        <small><b class="astra-badge ${mood}">${badge}</b>${note}</small></span>${astraIcon('arrow')}</button>`;
+    <button class="ui-action" data-nav="${route}">
+      <span class="ui-action-icon ${mood}">${uiIcon(icon)}</span>
+      <span class="ui-action-copy"><strong>${title}</strong><span>${text}</span>
+        <small><b class="ui-badge ${mood}">${badge}</b>${note}</small></span>${uiIcon('arrow')}</button>`;
   const names = [...new Set(f.open.map(r => r.tool))].slice(0,4)
-    .map(id => esc(astraToolInfo(id).name || id)).join(' · ');
+    .map(id => esc(uiToolInfo(id).name || id)).join(' · ');
   return action('personal','accounts',f.open.length ? 'risk' : 'good',
     f.open.length ? 'Review personal AI accounts' : 'Personal accounts reviewed',
     f.open.length ? 'Follow up on activity in accounts outside your corporate domains.' : 'No open personal-account findings in this window.',
@@ -2342,58 +2342,58 @@ function astraFocusRows(f) {
       f.overdue === null ? 'Not read' : f.overdue ? `${f.overdue} overdue review${f.overdue === 1 ? '' : 's'}`
         : `${f.recorded.length} decisions`, 'Confirm ownership and permitted use');
 }
-function astraToolsTable(rows) {
-  const f = astraOverviewFacts(), series = (G.trends || {}).tools || {};
-  return `<div class="astra-table-scroll" tabindex="0" role="region" aria-label="Discovered tools table">
-    <table class="astra-inventory"><thead><tr><th>AI tool</th><th>Observed surfaces</th>
+function uiToolsTable(rows) {
+  const f = uiOverviewFacts(), series = (G.trends || {}).tools || {};
+  return `<div class="ui-table-scroll" tabindex="0" role="region" aria-label="Discovered tools table">
+    <table class="ui-inventory"><thead><tr><th>AI tool</th><th>Observed surfaces</th>
       <th class="num" aria-sort="descending">Devices ↓</th><th class="num">Cloud identities</th>
       <th>Personal accounts</th><th>Activity</th><th><span class="sr-only">Details</span></th></tr></thead>
     <tbody>${rows.map(([id,t]) => {
-      const info = astraToolInfo(id), name = info.name || id;
+      const info = uiToolInfo(id), name = info.name || id;
       const n = f.open.filter(r => r.tool === id).length;
       return `<tr data-open="tool" data-key="${esc(id)}">
-        <td><button class="astra-tool-button" data-open="tool" data-key="${esc(id)}"
-          aria-label="View ${esc(name)} details"><span class="astra-tool-initial" aria-hidden="true">${esc(name.slice(0,1).toUpperCase())}</span>
+        <td><button class="ui-tool-button" data-open="tool" data-key="${esc(id)}"
+          aria-label="View ${esc(name)} details"><span class="ui-tool-initial" aria-hidden="true">${esc(name.slice(0,1).toUpperCase())}</span>
           <span><strong>${esc(name)}</strong><small>${esc(info.vendor || id)}</small></span></button></td>
-        <td>${(t.surfaces || []).map(x => `<span class="astra-surface">${esc(x)}</span>`).join('')}</td>
+        <td>${(t.surfaces || []).map(x => `<span class="ui-surface">${esc(x)}</span>`).join('')}</td>
         <td class="num">${(t.devices || []).length}</td><td class="num">${(t.identities || []).length}</td>
-        <td>${n ? `<span class="astra-badge risk">${n} open</span>` : '<span class="astra-muted">None observed</span>'}</td>
-        <td>${astraActivity(series[id], name)}</td>
-        <td><button class="astra-row-open" data-open="tool" data-key="${esc(id)}" aria-label="Inspect ${esc(name)}">${astraIcon('arrow')}</button></td>
+        <td>${n ? `<span class="ui-badge risk">${n} open</span>` : '<span class="ui-muted">None observed</span>'}</td>
+        <td>${uiActivity(series[id], name)}</td>
+        <td><button class="ui-row-open" data-open="tool" data-key="${esc(id)}" aria-label="Inspect ${esc(name)}">${uiIcon('arrow')}</button></td>
       </tr>`;
     }).join('')}</tbody></table></div>
-    ${astraToolsList(rows)}`;
+    ${uiToolsList(rows)}`;
 }
 // The same inventory as a list, for a card narrower than the table can
 // be. Which one shows is the container's width, in CSS; both are drawn
 // from the same rows so a size change never re-fetches or re-sorts.
-function astraToolsList(rows) {
-  const f = astraOverviewFacts(), series = (G.trends || {}).tools || {};
-  return `<ul class="astra-tool-list" aria-label="Discovered tools">${rows.map(([id,t]) => {
-    const info = astraToolInfo(id), name = info.name || id;
+function uiToolsList(rows) {
+  const f = uiOverviewFacts(), series = (G.trends || {}).tools || {};
+  return `<ul class="ui-tool-list" aria-label="Discovered tools">${rows.map(([id,t]) => {
+    const info = uiToolInfo(id), name = info.name || id;
     const n = f.open.filter(r => r.tool === id).length;
     const days = series[id] || [], total = days.reduce((a, b) => a + b, 0);
-    return `<li><button class="astra-tool-item" data-open="tool" data-key="${esc(id)}" aria-label="View ${esc(name)} details">
-      <span class="astra-tool-initial" aria-hidden="true">${esc(name.slice(0,1).toUpperCase())}</span>
-      <span class="astra-tool-main"><strong>${esc(name)}</strong>
+    return `<li><button class="ui-tool-item" data-open="tool" data-key="${esc(id)}" aria-label="View ${esc(name)} details">
+      <span class="ui-tool-initial" aria-hidden="true">${esc(name.slice(0,1).toUpperCase())}</span>
+      <span class="ui-tool-main"><strong>${esc(name)}</strong>
         <small>${esc(info.vendor || id)}${(t.surfaces || []).length ? ' · ' + esc((t.surfaces || []).join(', ')) : ''}${total ? ` · ${total} in ${esc(fmtWindow(hoursNow()))}` : ''}</small></span>
-      <span class="astra-tool-nums"><b>${(t.devices || []).length}</b><i>devices</i></span>
-      <span class="astra-tool-nums astra-tool-cloud"><b>${(t.identities || []).length}</b><i>cloud</i></span>
-      <span class="astra-tool-flag">${n ? `<span class="astra-badge risk">${n} open</span>` : ''}</span>
-      ${astraIcon('arrow')}</button></li>`;
+      <span class="ui-tool-nums"><b>${(t.devices || []).length}</b><i>devices</i></span>
+      <span class="ui-tool-nums ui-tool-cloud"><b>${(t.identities || []).length}</b><i>cloud</i></span>
+      <span class="ui-tool-flag">${n ? `<span class="ui-badge risk">${n} open</span>` : ''}</span>
+      ${uiIcon('arrow')}</button></li>`;
   }).join('')}</ul>`;
 }
 // Findings per day as a sparkline once the window holds enough days to
 // make a shape; below that a single bar reads as a glitch, so the total
 // for the window is written out instead.
-function astraActivity(series, name) {
+function uiActivity(series, name) {
   const days = series || [], total = days.reduce((a, b) => a + b, 0);
   const tip = esc(name + ': findings over the last ' + fmtWindow(hoursNow()));
   if (days.length >= 3 && days.some(v => v)) return `<span data-ctip="${tip}">${spark(days)}</span>`;
-  return total ? `<span data-ctip="${tip}"><b class="astra-activity-count">${total}</b><span class="astra-muted"> in ${esc(fmtWindow(hoursNow()))}</span></span>`
-    : '<span class="astra-muted">None in window</span>';
+  return total ? `<span data-ctip="${tip}"><b class="ui-activity-count">${total}</b><span class="ui-muted"> in ${esc(fmtWindow(hoursNow()))}</span></span>`
+    : '<span class="ui-muted">None in window</span>';
 }
-function astraReviewQueueDetail() {
+function uiReviewQueueDetail() {
     // The queue that replaces a weekly review pipeline: observed tools no
     // one has decided about. Recording the decision IS the acknowledgment,
     // so an empty queue means exactly what it says. Not-in-registry rows
@@ -2489,43 +2489,43 @@ const WIDGETS = {
   // The count is the headline; the rows are the ones with nothing to revoke,
   // because a scheduled job under a real account is not the finding.
   agentic: () => {
-    const head = (n) => `<div class="astra-panel-head"><div><h3>Running on its own${n === undefined ? '' : ` <span class="count">${n}</span>`}</h3>
-      <p>AI that starts itself, and who answers for it</p></div><span class="astra-eyebrow">Agentic</span></div>`;
-    if (!AGENTIC) return `<div class="wcard w6 astra-widget astra-agentic-card">${head()}
-      <p class="astra-empty">Not read yet. Open Agentic AI.</p>
-      <div class="astra-panel-footer"><span></span><button class="mini" data-nav="agentic">Open Agentic AI ${astraIcon('arrow')}</button></div></div>`;
+    const head = (n) => `<div class="ui-panel-head"><div><h3>Running on its own${n === undefined ? '' : ` <span class="count">${n}</span>`}</h3>
+      <p>AI that starts itself, and who answers for it</p></div><span class="ui-eyebrow">Agentic</span></div>`;
+    if (!AGENTIC) return `<div class="wcard w6 ui-widget ui-agentic-card">${head()}
+      <p class="ui-empty">Not read yet. Open Agentic AI.</p>
+      <div class="ui-panel-footer"><span></span><button class="mini" data-nav="agentic">Open Agentic AI ${uiIcon('arrow')}</button></div></div>`;
     const c = AGENTIC.counts || {};
     const loose = (AGENTIC.agents || []).filter(
       a => a.autonomous && !a.accountable);
     const body = !c.autonomous
-      ? `<p class="astra-empty">Nothing reported starting itself.${
+      ? `<p class="ui-empty">Nothing reported starting itself.${
         c.unrecognised ? ` ${c.unrecognised} process${c.unrecognised === 1 ? '' : 'es'}
         reached a model unrecognised, which is a different question.` : ''} That is either
         true or the collectors have not been updated to look. System health says which.</p>`
-      : `<p class="astra-widget-lede">${c.unaccountable
+      : `<p class="ui-widget-lede">${c.unaccountable
           ? `<b>${c.unaccountable}</b> of ${c.autonomous} answer to nobody: a credential with no
              person behind it, so revoking a sign-on does not stop them.`
           : 'All of them run under an identity somebody can be asked about.'}</p>
-        ${loose.length ? `<div class="astra-table-scroll"><table class="astra-inventory astra-widget-table">
-          <thead><tr><th>Device</th><th class="astra-col-l">Runs</th><th class="astra-col-m">Schedule</th><th class="astra-col-l">Reaches</th><th>Answers to</th></tr></thead>
+        ${loose.length ? `<div class="ui-table-scroll"><table class="ui-inventory ui-widget-table">
+          <thead><tr><th>Device</th><th class="ui-col-l">Runs</th><th class="ui-col-m">Schedule</th><th class="ui-col-l">Reaches</th><th>Answers to</th></tr></thead>
           <tbody>${loose.slice(0, 10).map(a => `<tr>
-            <td><strong>${esc(label(a.device, G.devices[a.device] || {}))}</strong>${a.os ? `<small class="astra-col-s">${esc(a.os)}</small>` : ''}</td>
-            <td class="astra-col-l">${a.tool ? esc(astraToolName(a.tool)) : a.process ? `<span class="mono">${esc(a.process)}</span>` : '<span class="astra-muted">—</span>'}</td>
-            <td class="astra-col-m astra-muted">${esc(a.trigger || a.evidence || '')}</td>
-            <td class="astra-col-l">${(a.reach || []).length ? (a.reach || []).slice(0, 3).map(x => `<span class="astra-surface">${esc(x)}</span>`).join('') + ((a.reach || []).length > 3 ? ` <span class="astra-muted">+${a.reach.length - 3}</span>` : '') : '<span class="astra-muted">nothing configured</span>'}</td>
+            <td><strong>${esc(label(a.device, G.devices[a.device] || {}))}</strong>${a.os ? `<small class="ui-col-s">${esc(a.os)}</small>` : ''}</td>
+            <td class="ui-col-l">${a.tool ? esc(uiToolName(a.tool)) : a.process ? `<span class="mono">${esc(a.process)}</span>` : '<span class="ui-muted">—</span>'}</td>
+            <td class="ui-col-m ui-muted">${esc(a.trigger || a.evidence || '')}</td>
+            <td class="ui-col-l">${(a.reach || []).length ? (a.reach || []).slice(0, 3).map(x => `<span class="ui-surface">${esc(x)}</span>`).join('') + ((a.reach || []).length > 3 ? ` <span class="ui-muted">+${a.reach.length - 3}</span>` : '') : '<span class="ui-muted">nothing configured</span>'}</td>
             <td>${a.process
-              ? '<span class="astra-badge risk">no tool we know</span>'
-              : '<span class="astra-badge risk">' + esc(a.identity || 'unattributed') + '</span>'}</td>
+              ? '<span class="ui-badge risk">no tool we know</span>'
+              : '<span class="ui-badge risk">' + esc(a.identity || 'unattributed') + '</span>'}</td>
           </tr>`).join('')}</tbody></table></div>` : ''}`;
-    return `<div class="wcard w6 astra-widget astra-agentic-card">${head(c.autonomous || 0)}
+    return `<div class="wcard w6 ui-widget ui-agentic-card">${head(c.autonomous || 0)}
       ${body}
-      <div class="astra-panel-footer"><span>${c.unrecognised ? `${c.unrecognised} unrecognised process${c.unrecognised === 1 ? '' : 'es'} reached a model` : ''}</span>
-        <button class="mini" data-nav="agentic">Open Agentic AI ${astraIcon('arrow')}</button></div>
+      <div class="ui-panel-footer"><span>${c.unrecognised ? `${c.unrecognised} unrecognised process${c.unrecognised === 1 ? '' : 'es'} reached a model` : ''}</span>
+        <button class="mini" data-nav="agentic">Open Agentic AI ${uiIcon('arrow')}</button></div>
     </div>`;
   },
 
   stat_row: () => {
-    const f = astraOverviewFacts(), open = f.open, gaps = f.gaps;
+    const f = uiOverviewFacts(), open = f.open, gaps = f.gaps;
     const freshH = Math.min(hoursNow(), 168), week = Date.now()/1000 - freshH*3600;
     const fresh = f.personal.filter(r => r.first_seen && Date.parse(r.first_seen)/1000 > week).length;
     const tr = G.trends || {};
@@ -2533,11 +2533,11 @@ const WIDGETS = {
     const silent = !S || !S.reporting;
     const mood = !f.known ? 'silent' : silent ? 'silent' : attention ? 'needs-attention' : 'healthy';
     const value = n => f.known ? n : '—';
-    return `<div class="astra-estate-line"><span>Your estate at a glance</span>
+    return `<div class="ui-estate-line"><span>Your estate at a glance</span>
       <span>${f.known ? `${f.devices.length} observed devices · last ${esc(fmtWindow(hoursNow()))}` : 'Findings unavailable'}</span></div>
     <div class="overview-executive w12 ${mood}" data-tour="stats">
       <section class="executive-posture">
-        <span>${astraIcon('shield')}Overall posture</span>
+        <span>${uiIcon('shield')}Overall posture</span>
         <strong>${!f.known ? 'Data unavailable' : silent ? 'Nothing reporting' : attention ? 'Needs attention' : 'Monitoring healthy'}</strong>
         <p>${!f.known ? 'The findings could not be read. Open System health to check the connection.' : silent
           ? 'No detection source reported in this window. These counts are missing data, not a clean result.'
@@ -2546,7 +2546,7 @@ const WIDGETS = {
           ${open.length && f.known ? '<button class="mini" data-nav="personal">Review accounts</button>' : ''}
           <button class="mini" data-nav="coverage">Verify coverage</button>
         </div>
-        <small class="astra-posture-note">${f.known
+        <small class="ui-posture-note">${f.known
           ? `${f.people} people named in personal-account findings${f.unnamed ? ` · ${f.unnamed} unnamed devices` : ''}`
           : 'Do not interpret unavailable data as a clean result.'}</small>
       </section>
@@ -2556,9 +2556,9 @@ const WIDGETS = {
             open.length !== f.personal.length ? ` · ${f.personal.length - open.length} accepted` : ''}` : 'Findings unavailable'}</small></div>
         <div><dt>${value(f.toolIds.length)}</dt><dd>AI tools observed</dd>
           <small>Across endpoint, browser and cloud sources</small></div>
-        <div><dt>${f.known && f.coverage !== null ? f.coverage + '<span class="astra-percent">%</span>' : '—'}</dt>
+        <div><dt>${f.known && f.coverage !== null ? f.coverage + '<span class="ui-percent">%</span>' : '—'}</dt>
           <dd>Collector coverage</dd><small>${f.known ? `${f.collectors} of ${f.devices.length} observed devices` : 'Findings unavailable'}</small></div>
-        <div><dt>${f.known && f.recorded ? f.recorded.length + '<span class="astra-denominator">/ ' + f.toolIds.length + '</span>' : '—'}</dt>
+        <div><dt>${f.known && f.recorded ? f.recorded.length + '<span class="ui-denominator">/ ' + f.toolIds.length + '</span>' : '—'}</dt>
           <dd>Register decisions</dd><small>${!f.known || !f.recorded ? 'Register data unavailable'
             : `${f.undecided} tools without a recorded decision`}</small></div>
       </dl>
@@ -2571,66 +2571,66 @@ const WIDGETS = {
     // zeros on a deployment that never linked a tool would be noise.
     if (!BUDGET) return '';
     const subs = BUDGET.subscriptions || [];
-    const head = `<div class="astra-panel-head"><div><h3>AI spend</h3><p>Tracked subscriptions against observed use</p></div>
-      <span class="astra-eyebrow">Budget</span></div>`;
+    const head = `<div class="ui-panel-head"><div><h3>AI spend</h3><p>Tracked subscriptions against observed use</p></div>
+      <span class="ui-eyebrow">Budget</span></div>`;
     if (!subs.length) {
-      return `<div class="wcard w6 astra-widget astra-spend-card">${head}
-      <p class="astra-empty">Nothing linked yet. The Budget view records what
+      return `<div class="wcard w6 ui-widget ui-spend-card">${head}
+      <p class="ui-empty">Nothing linked yet. The Budget view records what
       each AI tool costs and joins it against observed use.</p>
-      <div class="astra-panel-footer"><span></span><button class="mini" data-nav="budget">Open Budget ${astraIcon('arrow')}</button></div></div>`;
+      <div class="ui-panel-footer"><span></span><button class="mini" data-nav="budget">Open Budget ${uiIcon('arrow')}</button></div></div>`;
     }
     const next = subs.filter(s => s.renewal_date)
       .sort((a, b) => a.renewal_date.localeCompare(b.renewal_date))[0];
     const unob = subs.reduce((a, s) =>
       a + bReconcile(s).unobserved.length, 0);
     const conv = bConverted(subs);
-    return `<div class="wcard w6 astra-widget astra-spend-card">${head}
-    <dl class="astra-tiles">
+    return `<div class="wcard w6 ui-widget ui-spend-card">${head}
+    <dl class="ui-tiles">
       <div><dt>${conv ? bMoney(conv.total, bPrefCur()) : bSpendParts(subs).join(' + ')}</dt>
         <dd>tracked per month${conv ? ` <span title="${esc(bSpendParts(subs).join(' + '))}">· ECB ${esc(conv.date)}</span>` : ''}</dd></div>
       <div><dt>${subs.length}</dt><dd>tools linked</dd></div>
       <div><dt${unob ? ' class="attention"' : ''}>${unob}</dt><dd>paid seats never observed</dd></div>
     </dl>
-    <div class="astra-table-scroll"><table class="astra-inventory astra-widget-table astra-spend-table">
-      <thead><tr><th>Subscription</th><th class="astra-col-l">Plan</th><th class="num astra-col-m">Monthly</th>
-        <th class="num astra-col-m">Seats in use</th><th class="num astra-col-l">Observed</th><th class="astra-col-l">Renews</th><th>Review</th></tr></thead>
+    <div class="ui-table-scroll"><table class="ui-inventory ui-widget-table ui-spend-table">
+      <thead><tr><th>Subscription</th><th class="ui-col-l">Plan</th><th class="num ui-col-m">Monthly</th>
+        <th class="num ui-col-m">Seats in use</th><th class="num ui-col-l">Observed</th><th class="ui-col-l">Renews</th><th>Review</th></tr></thead>
       <tbody>${subs.map(sub => {
         const r = bReconcile(sub);
         const seats = (sub.seat_tiers || []).reduce((x, t) => x + (t.seats || 0), 0);
         return `<tr data-nav="budget">
-          <td><strong>${esc(astraToolName(sub.tool_id))}</strong>${sub.plan ? `<small class="astra-col-s">${esc(sub.plan)}</small>` : ''}</td>
-          <td class="astra-col-l">${esc(sub.plan || '—')}</td>
-          <td class="num astra-col-m">${bMoney(bSubMonthly(sub), sub.currency)}</td>
-          <td class="num astra-col-m">${r.matched.length} of ${seats}</td>
-          <td class="num astra-col-l">${r.matched.length + r.strangers.length}</td>
-          <td class="astra-col-l astra-muted">${sub.renewal_date ? esc(sub.renewal_date) : '—'}</td>
-          <td>${r.unobserved.length ? `<span class="astra-badge attention">${r.unobserved.length} idle</span>` : ''}${r.strangers.length
-            ? ` <span class="astra-badge governance">${r.strangers.length} unseated</span>` : ''}${!r.unobserved.length && !r.strangers.length ? '<span class="astra-muted">Nothing flagged</span>' : ''}</td></tr>`;
+          <td><strong>${esc(uiToolName(sub.tool_id))}</strong>${sub.plan ? `<small class="ui-col-s">${esc(sub.plan)}</small>` : ''}</td>
+          <td class="ui-col-l">${esc(sub.plan || '—')}</td>
+          <td class="num ui-col-m">${bMoney(bSubMonthly(sub), sub.currency)}</td>
+          <td class="num ui-col-m">${r.matched.length} of ${seats}</td>
+          <td class="num ui-col-l">${r.matched.length + r.strangers.length}</td>
+          <td class="ui-col-l ui-muted">${sub.renewal_date ? esc(sub.renewal_date) : '—'}</td>
+          <td>${r.unobserved.length ? `<span class="ui-badge attention">${r.unobserved.length} idle</span>` : ''}${r.strangers.length
+            ? ` <span class="ui-badge governance">${r.strangers.length} unseated</span>` : ''}${!r.unobserved.length && !r.strangers.length ? '<span class="ui-muted">Nothing flagged</span>' : ''}</td></tr>`;
       }).join('')}</tbody></table></div>
-    <div class="astra-panel-footer"><span>${next ? `Next renewal: ${esc(astraToolName(next.tool_id))} ${when(next.renewal_date)}` : 'No renewal dates recorded'}</span>
-      <button class="mini" data-nav="budget">Open Budget ${astraIcon('arrow')}</button></div></div>`;
+    <div class="ui-panel-footer"><span>${next ? `Next renewal: ${esc(uiToolName(next.tool_id))} ${when(next.renewal_date)}` : 'No renewal dates recorded'}</span>
+      <button class="mini" data-nav="budget">Open Budget ${uiIcon('arrow')}</button></div></div>`;
   },
 
   top_tools: () => {
-    const f = astraOverviewFacts();
+    const f = uiOverviewFacts();
     const rows = ents(G.tools).filter(([id]) => {
-      const info = astraToolInfo(id);
+      const info = uiToolInfo(id);
       return (match(id) || match(info.name || '') || match(info.vendor || ''))
-        && (!ASTRA_PERSONAL_TOOLS || f.open.some(r => r.tool === id));
+        && (!UI_PERSONAL_TOOLS || f.open.some(r => r.tool === id));
     }).sort((a,b)=>(b[1].devices||[]).length-(a[1].devices||[]).length);
     const bars = widgetForm('top_tools') === 'bar';
-    return `<div class="wcard ${bars ? 'w6' : 'w12'} astra-tools-card">
-      <div class="astra-panel-head"><h3>${formToggle('top_tools')}Discovered AI tools <span class="count">${f.toolIds.length}</span></h3>
-        <div class="astra-tool-filters" role="group" aria-label="Filter discovered tools">
-          <button class="${!ASTRA_PERSONAL_TOOLS ? 'on' : ''}" data-act="astra-tools-filter" data-filter="all" aria-pressed="${!ASTRA_PERSONAL_TOOLS}">All tools</button>
-          <button class="${ASTRA_PERSONAL_TOOLS ? 'on' : ''}" data-act="astra-tools-filter" data-filter="personal" aria-pressed="${ASTRA_PERSONAL_TOOLS}">Personal accounts</button>
+    return `<div class="wcard ${bars ? 'w6' : 'w12'} ui-tools-card">
+      <div class="ui-panel-head"><h3>${formToggle('top_tools')}Discovered AI tools <span class="count">${f.toolIds.length}</span></h3>
+        <div class="ui-tool-filters" role="group" aria-label="Filter discovered tools">
+          <button class="${!UI_PERSONAL_TOOLS ? 'on' : ''}" data-act="ui-tools-filter" data-filter="all" aria-pressed="${!UI_PERSONAL_TOOLS}">All tools</button>
+          <button class="${UI_PERSONAL_TOOLS ? 'on' : ''}" data-act="ui-tools-filter" data-filter="personal" aria-pressed="${UI_PERSONAL_TOOLS}">Personal accounts</button>
         </div></div>
-      ${!f.known ? '<p class="astra-empty">Findings are unavailable.</p>' : rows.length ? (bars
-        ? '<div class="astra-tool-bars">' + barRows(rows.map(([k,t]) => [k,(t.devices||[]).length]), 'devices', 'tool') + '</div>'
-        : astraToolsTable(rows)) : '<p class="astra-empty">No tools match this view.</p>'}
-      <div class="astra-panel-footer"><span>${f.known ? `${rows.length} of ${f.toolIds.length} discovered tools` : 'No data available'}</span>
-        <button class="mini" data-nav="tools">Open discovered tools ${astraIcon('arrow')}</button></div>
-      <p class="src-note astra-table-note">${bars ? 'Observed devices per tool. Cloud-only tools may have zero associated devices.'
+      ${!f.known ? '<p class="ui-empty">Findings are unavailable.</p>' : rows.length ? (bars
+        ? '<div class="ui-tool-bars">' + barRows(rows.map(([k,t]) => [k,(t.devices||[]).length]), 'devices', 'tool') + '</div>'
+        : uiToolsTable(rows)) : '<p class="ui-empty">No tools match this view.</p>'}
+      <div class="ui-panel-footer"><span>${f.known ? `${rows.length} of ${f.toolIds.length} discovered tools` : 'No data available'}</span>
+        <button class="mini" data-nav="tools">Open discovered tools ${uiIcon('arrow')}</button></div>
+      <p class="src-note ui-table-note">${bars ? 'Observed devices per tool. Cloud-only tools may have zero associated devices.'
         : 'One bar per day for the last ' + fmtWindow(hoursNow()) + ', written as a total when the window holds fewer than three days. Devices and cloud identities are counted separately.'}</p>
     </div>`;
   },
@@ -2639,28 +2639,28 @@ const WIDGETS = {
     // Ten rows are drawn; the card's width decides how many show and which
     // columns (CSS, by container). The footer count is the whole window.
     const pa = (G.personal_accounts || []).slice(0, 10);
-    const body = pa.length ? `<div class="astra-table-scroll"><table class="astra-inventory astra-widget-table astra-people-table">
-      <thead><tr><th>Person</th><th>Account</th><th class="astra-col-m">AI tool</th><th class="astra-col-l">Device</th>
-        <th class="astra-col-l">Surface</th><th class="astra-col-l">Source</th><th>Last seen</th></tr></thead>
+    const body = pa.length ? `<div class="ui-table-scroll"><table class="ui-inventory ui-widget-table ui-people-table">
+      <thead><tr><th>Person</th><th>Account</th><th class="ui-col-m">AI tool</th><th class="ui-col-l">Device</th>
+        <th class="ui-col-l">Surface</th><th class="ui-col-l">Source</th><th>Last seen</th></tr></thead>
       <tbody>${pa.map(r => `<tr>
         <td><strong>${esc(r.user || r.device_name || r.device)}</strong></td>
-        <td><span class="astra-badge risk">${esc(r.account_domain)}</span></td>
-        <td class="astra-col-m">${esc(astraToolInfo(r.tool).name || r.tool)}</td>
-        <td class="astra-col-l">${esc(r.device_name || r.device || '—')}</td>
-        <td class="astra-col-l">${(r.surfaces || []).map(x => `<span class="astra-surface">${esc(x)}</span>`).join('') || '<span class="astra-muted">—</span>'}</td>
-        <td class="astra-col-l">${(r.sources || []).map(x => astraSourceChip(x)).join('') || '<span class="astra-muted">—</span>'}</td>
-        <td class="astra-muted">${esc((r.last_seen || '').slice(0, 10))}</td>
+        <td><span class="ui-badge risk">${esc(r.account_domain)}</span></td>
+        <td class="ui-col-m">${esc(uiToolInfo(r.tool).name || r.tool)}</td>
+        <td class="ui-col-l">${esc(r.device_name || r.device || '—')}</td>
+        <td class="ui-col-l">${(r.surfaces || []).map(x => `<span class="ui-surface">${esc(x)}</span>`).join('') || '<span class="ui-muted">—</span>'}</td>
+        <td class="ui-col-l">${(r.sources || []).map(x => uiSourceChip(x)).join('') || '<span class="ui-muted">—</span>'}</td>
+        <td class="ui-muted">${esc((r.last_seen || '').slice(0, 10))}</td>
       </tr>`).join('')}</tbody></table></div>`
       : dataOk()
-        ? '<p class="astra-empty">None seen. That is a result, not an absence of one.</p>'
-        : '<p class="astra-empty">Nothing to show: the findings could not be read.</p>';
-    return `<div class="wcard w6 astra-widget astra-people-card">
-      <div class="astra-panel-head"><div><h3>Recent personal accounts</h3>
+        ? '<p class="ui-empty">None seen. That is a result, not an absence of one.</p>'
+        : '<p class="ui-empty">Nothing to show: the findings could not be read.</p>';
+    return `<div class="wcard w6 ui-widget ui-people-card">
+      <div class="ui-panel-head"><div><h3>Recent personal accounts</h3>
         <p>Latest activity in accounts outside your corporate domains</p></div>
-        <span class="astra-eyebrow">Last ${esc(fmtWindow(hoursNow()))}</span></div>
+        <span class="ui-eyebrow">Last ${esc(fmtWindow(hoursNow()))}</span></div>
       ${body}
-      <div class="astra-panel-footer"><span>${pa.length ? `${(G.personal_accounts || []).length} in this window` : ''}</span>
-        <button class="mini" data-nav="personal">Open personal accounts ${astraIcon('arrow')}</button></div>
+      <div class="ui-panel-footer"><span>${pa.length ? `${(G.personal_accounts || []).length} in this window` : ''}</span>
+        <button class="mini" data-nav="personal">Open personal accounts ${uiIcon('arrow')}</button></div>
     </div>`;
   },
 
@@ -2669,24 +2669,24 @@ const WIDGETS = {
     // One square per source, filled when it reports: 1/5 should look like
     // four dark squares, not a bar length to squint at.
     const meter = widgetForm('detection_coverage') === 'meter';
-    const f = astraOverviewFacts();
-    return `<div class="wcard w6 astra-visibility-card">
-    <div class="astra-panel-head"><div><h3>Visibility across your estate</h3><p>Collector signals across observed devices</p></div>${astraIcon('shield')}</div>
-    <div class="astra-coverage-overview">
-      <div class="astra-ring-block">
-        <div class="astra-ring" role="img" aria-label="${f.known && f.coverage !== null ? `${f.collectors} of ${f.devices.length} devices have a collector signal` : 'Collector coverage unavailable'}">
-          <svg viewBox="0 0 112 112" aria-hidden="true"><circle class="astra-ring-track" cx="56" cy="56" r="48"/>
-            <circle class="astra-ring-value" cx="56" cy="56" r="48" pathLength="100" stroke-dasharray="${f.known && f.devices.length ? f.collectors / f.devices.length * 100 : 0} 100"/></svg>
+    const f = uiOverviewFacts();
+    return `<div class="wcard w6 ui-visibility-card">
+    <div class="ui-panel-head"><div><h3>Visibility across your estate</h3><p>Collector signals across observed devices</p></div>${uiIcon('shield')}</div>
+    <div class="ui-coverage-overview">
+      <div class="ui-ring-block">
+        <div class="ui-ring" role="img" aria-label="${f.known && f.coverage !== null ? `${f.collectors} of ${f.devices.length} devices have a collector signal` : 'Collector coverage unavailable'}">
+          <svg viewBox="0 0 112 112" aria-hidden="true"><circle class="ui-ring-track" cx="56" cy="56" r="48"/>
+            <circle class="ui-ring-value" cx="56" cy="56" r="48" pathLength="100" stroke-dasharray="${f.known && f.devices.length ? f.collectors / f.devices.length * 100 : 0} 100"/></svg>
           <div><strong>${f.known && f.coverage !== null ? f.coverage + '<span>%</span>' : '—'}</strong></div>
         </div>
-        <small class="astra-ring-caption">Collector coverage</small>
+        <small class="ui-ring-caption">Collector coverage</small>
       </div>
-      <div class="astra-coverage-legend"><p><i></i>Collector observed <b>${f.known ? f.collectors : '—'}</b></p>
+      <div class="ui-coverage-legend"><p><i></i>Collector observed <b>${f.known ? f.collectors : '—'}</b></p>
         <p><i class="gap"></i>No collector signal <b>${f.known ? f.devices.length - f.collectors : '—'}</b></p>
         <small>Of devices seen by any source in this window.</small></div>
     </div>
-    <div class="astra-source-heading"><h4>Detection sources</h4><span>${S.reporting || 0}/${(S.groups || []).reduce((n,g) => n + g.total, 0)} reporting</span>${formToggle('detection_coverage')}</div>
-    <div class="astra-source-grid">
+    <div class="ui-source-heading"><h4>Detection sources</h4><span>${S.reporting || 0}/${(S.groups || []).reduce((n,g) => n + g.total, 0)} reporting</span>${formToggle('detection_coverage')}</div>
+    <div class="ui-source-grid">
     ${meter ? (S.groups||[]).map(g => `<div class="meterrow"
         data-ctip="${esc(g.group + ' · ' + g.reporting + ' of ' + g.total
                          + ' dedicated sources reporting')}">
@@ -2708,8 +2708,8 @@ const WIDGETS = {
         <span>${esc(g.group)}</span>${dots}
         <b>${g.reporting}/${g.total}</b></div>`;
     }).join('')}</div>
-    <div class="astra-panel-footer"><span>Source catalogue, not configured integrations</span><button class="mini" data-nav="setup">Review sources ${astraIcon('arrow')}</button></div>
-    <details class="astra-coverage-note"><summary>How to read coverage</summary><p class="src-note">Collector coverage uses devices observed by any source, not your entire company fleet. An unobserved source may be unconfigured or inapplicable. These are dedicated sources per surface; other sources can also produce findings for it.</p></details></div>`;
+    <div class="ui-panel-footer"><span>Source catalogue, not configured integrations</span><button class="mini" data-nav="setup">Review sources ${uiIcon('arrow')}</button></div>
+    <details class="ui-coverage-note"><summary>How to read coverage</summary><p class="src-note">Collector coverage uses devices observed by any source, not your entire company fleet. An unobserved source may be unconfigured or inapplicable. These are dedicated sources per surface; other sources can also produce findings for it.</p></details></div>`;
   },
 
   // The change dimension, which the estate has had all along and shown
@@ -2736,19 +2736,19 @@ const WIDGETS = {
     const groups = (S.groups || []).map(g => ({group: g.group, total: g.total,
       silent: (g.sources || []).filter(r => !r.reporting)})).filter(g => g.silent.length);
     const silent = groups.reduce((n, g) => n + g.silent.length, 0);
-    return `<div class="wcard w4 astra-widget astra-silent-card">
-      <div class="astra-panel-head"><div><h3>Silent sources <span class="count">${silent}</span></h3>
+    return `<div class="wcard w4 ui-widget ui-silent-card">
+      <div class="ui-panel-head"><div><h3>Silent sources <span class="count">${silent}</span></h3>
         <p>In the catalogue, nothing reported in this window</p></div></div>
-      ${silent ? `<div class="astra-table-scroll"><table class="astra-inventory astra-widget-table astra-silent-table">
+      ${silent ? `<div class="ui-table-scroll"><table class="ui-inventory ui-widget-table ui-silent-table">
         <thead><tr><th>Surface</th><th class="num">Silent</th><th>Sources</th></tr></thead>
         <tbody>${groups.map(g => `<tr>
           <td><strong>${esc(g.group)}</strong></td>
           <td class="num">${g.silent.length} of ${g.total}</td>
           <td>${g.silent.map(r => `<span title="${esc(r.source)}">${esc(r.label || r.source)}</span>`).join('<i>·</i>')}</td>
         </tr>`).join('')}</tbody></table></div>`
-        : '<p class="astra-empty">Every listed source is reporting.</p>'}
-      <div class="astra-panel-footer"><span>Unconfigured or not applicable, not necessarily broken</span>
-        <button class="mini" data-nav="setup">Review sources ${astraIcon('arrow')}</button></div>
+        : '<p class="ui-empty">Every listed source is reporting.</p>'}
+      <div class="ui-panel-footer"><span>Unconfigured or not applicable, not necessarily broken</span>
+        <button class="mini" data-nav="setup">Review sources ${uiIcon('arrow')}</button></div>
     </div>`;
   },
 
@@ -2761,40 +2761,40 @@ const WIDGETS = {
     // Two numbers, not four. The overview is a glance: is the guard running,
     // and did somebody ignore it. Warned and blocked are the detail behind
     // that, and they have a page.
-    const head = `<div class="astra-panel-head"><div><h3>Paste guard</h3><p>Browser extension, on the devices it reached</p></div></div>`;
-    if (!PG) return `<div class="wcard w4 astra-widget astra-paste-card">${head}
-      <p class="astra-empty">No paste guard data.</p></div>`;
+    const head = `<div class="ui-panel-head"><div><h3>Paste guard</h3><p>Browser extension, on the devices it reached</p></div></div>`;
+    if (!PG) return `<div class="wcard w4 ui-widget ui-paste-card">${head}
+      <p class="ui-empty">No paste guard data.</p></div>`;
     const over = PG.overridden || 0, live = PG.guard_devices || 0;
     const warned = PG.warned || 0;
     const versions = (PG.guard_versions || []).length;
     const warnMode = (PG.guard_modes || []).some(m => m.mode === 'warn');
-    return `<div class="wcard w4 astra-widget astra-paste-card">${head}
-      <dl class="astra-tiles astra-tiles-2">
+    return `<div class="wcard w4 ui-widget ui-paste-card">${head}
+      <dl class="ui-tiles ui-tiles-2">
         <div><dt${live ? '' : ' class="risk"'}>${live}</dt><dd>devices running the guard</dd></div>
         <div><dt${over ? ' class="risk"' : ''}>${over}</dt><dd>warnings overridden</dd></div>
       </dl>
-      <ul class="astra-notes">
+      <ul class="ui-notes">
         ${warnMode && warned ? `<li class="attention">In block mode, ${warned} warned paste${warned === 1 ? '' : 's'} would have been stopped outright. The breakdown is on the Paste guard page.</li>` : ''}
         <li>${live
           ? `Running on ${live} device${live === 1 ? '' : 's'}${versions > 1 ? ` across ${versions} versions` : ''}, so low numbers here genuinely mean few risky pastes.`
           : 'No device has checked in yet, so zero here means "not deployed", not "nobody pasted anything".'}</li>
       </ul>
-      <div class="astra-panel-footer"><span>${warned ? `${warned} warned in this window` : 'Nothing warned in this window'}</span>
-        <button class="mini" data-nav="paste">Open Paste guard ${astraIcon('arrow')}</button></div></div>`;
+      <div class="ui-panel-footer"><span>${warned ? `${warned} warned in this window` : 'Nothing warned in this window'}</span>
+        <button class="mini" data-nav="paste">Open Paste guard ${uiIcon('arrow')}</button></div></div>`;
   },
 
   review_queue: () => {
-    const f = astraOverviewFacts();
+    const f = uiOverviewFacts();
     const candidates = (CAND || []).filter(c => !c.resolved && !c.dismissed_at);
-    return `<div class="wcard w6 astra-focus-card"><div class="astra-panel-head">
+    return `<div class="wcard w6 ui-focus-card"><div class="ui-panel-head">
       <div><h3>Where to focus</h3><p>Follow-ups across your AI estate</p></div>
-      <span class="astra-eyebrow">Action queue</span></div>
-      ${astraFocusRows(f)}
-      <details class="astra-queue-details">
+      <span class="ui-eyebrow">Action queue</span></div>
+      ${uiFocusRows(f)}
+      <details class="ui-queue-details">
         <summary>Decision & discovery queue <span>${candidates.length
           ? `${candidates.length} new discover${candidates.length === 1 ? 'y' : 'ies'}`
           : f.undecided === null ? 'Register not read' : `${f.undecided} awaiting a decision`}</span></summary>
-        ${astraReviewQueueDetail()}
+        ${uiReviewQueueDetail()}
       </details></div>`;
   },
 
@@ -3026,8 +3026,8 @@ function devices() {
     <tbody>${rows.map(([k,d]) => `<tr data-open="device" data-key="${esc(k)}">
       <td><strong>${esc(label(k,d))}</strong><br><span class="mono row-key">${esc(k)}</span></td>
       <td>${d.person ? `<span class="pill p-ok">${esc(d.person)}</span>` : '<span class="muted-value">Unattributed</span>'}</td>
-      <td><div class="cell-tags">${(d.tools||[]).map(t=>astraToolChip(t)).join('') || '<span class="muted-value">None observed</span>'}</div></td>
-      <td><div class="cell-tags">${(d.personal_accounts||[]).map(a=>`<span class="astra-badge risk">${esc(a)}</span>`).join('') || '<span class="muted-value">None</span>'}</div></td>
+      <td><div class="cell-tags">${(d.tools||[]).map(t=>uiToolChip(t)).join('') || '<span class="muted-value">None observed</span>'}</div></td>
+      <td><div class="cell-tags">${(d.personal_accounts||[]).map(a=>`<span class="ui-badge risk">${esc(a)}</span>`).join('') || '<span class="muted-value">None</span>'}</div></td>
       <td><div class="cell-tags">${(d.local_users||[]).map(u=>`<span class="pill p-mut">${esc(u)}</span>`).join('') || '<span class="muted-value">—</span>'}</div></td>
     </tr>`).join('')}</tbody>
   </table></div>`;
@@ -3167,11 +3167,11 @@ async function people() {
   const unattributed = ents(G.devices).filter(([,d]) => !d.person).length;
   return `<h2>People</h2><p class="lede">People named by cloud sources, which see accounts rather than machines. A device shows against a person only where the identity map links them.</p>
   ${identityMapPanel(unattributed)}
-  <div class="tcard"><table class="astra-page-table"><thead><tr><th>Identity</th><th>AI tools</th><th>Devices</th></tr></thead>
+  <div class="tcard"><table class="ui-page-table"><thead><tr><th>Identity</th><th>AI tools</th><th>Devices</th></tr></thead>
   ${rows.map(([k,i]) => `<tr><td><strong>${esc(k)}</strong>${(i.aliases||[]).length
     ? `<br><span class="src-note" style="font-style:normal">also seen as
        ${(i.aliases).map(a => esc(a)).join(', ')}</span>` : ''}</td>
-    <td><div class="cell-tags">${(i.tools||[]).map(t=>astraToolChip(t)).join('')}</div></td>
+    <td><div class="cell-tags">${(i.tools||[]).map(t=>uiToolChip(t)).join('')}</div></td>
     <td><div class="cell-tags">${(i.devices||[]).map(d=>`<span class="pill p-acc">${esc(d)}</span>`).join('') || '<span class="muted-value">Unmapped</span>'}</div></td></tr>`).join('')}
   </table></div>`;
 }
@@ -3212,11 +3212,11 @@ function tools() {
       return rank(b) - rank(a) || (b[1].devices||[]).length - (a[1].devices||[]).length;
     });
   return `<h2>Tools</h2><p class="lede">The same tool in a browser, a desktop app and a CLI is three different exposures, so surfaces are listed separately. Tools that need a look sort first: <span class="pill p-warn">attention</span> when several factors stack up, <span class="pill p-amb">watch</span> for one. Open a tool to see which. Editors that bundle AI, such as Cursor or Windsurf, show as <span class="pill p-mut">installed only</span> until something shows a model actually ran. "Identities from sources" counts people a source named directly; the AI register also counts people linked through a device, so the two can differ.</p>
-  <div class="tcard"><table class="astra-page-table"><thead><tr><th>AI tool</th><th>Status</th><th>Devices</th>
+  <div class="tcard"><table class="ui-page-table"><thead><tr><th>AI tool</th><th>Status</th><th>Devices</th>
     <th title="People a SOURCE named on this tool. A cloud sign-in carries a person; an endpoint finding carries a machine, and the person behind it comes from the identity map - so this is lower than the register's user count for tools found on endpoints.">Identities from sources</th>
     <th>By surface</th></tr></thead>
   <tbody>${rows.map(([k,t,a]) => `<tr data-open="tool" data-key="${esc(k)}" style="cursor:pointer">
-    <td><strong>${esc(astraToolName(k))}</strong><span class="astra-id">${esc(astraToolInfo(k).vendor ? astraToolInfo(k).vendor + ' · ' : '')}${esc(k)}</span></td><td>${attnPill(a)}${t.usage === 'installed'
+    <td><strong>${esc(uiToolName(k))}</strong><span class="ui-id">${esc(uiToolInfo(k).vendor ? uiToolInfo(k).vendor + ' · ' : '')}${esc(k)}</span></td><td>${attnPill(a)}${t.usage === 'installed'
       ? `<span class="pill p-mut" title="Found installed, but nothing has shown a model actually running - no account, no sign-in, and no traffic to the completion backend. Editors that bundle AI (Cursor, Windsurf/Devin Desktop) are useful all day without it.">installed only</span>`
       : ''}</td>
     <td>${(t.devices||[]).length}${(t.devices_active||[]).length < (t.devices||[]).length
@@ -3232,7 +3232,7 @@ function tools() {
   <div class="cardhead"><h3>Bridge targets</h3></div>
   <p class="lede">Where an AI tool reached. Not a tool inventory: these are
   destinations of an integration, not something someone installed.</p>
-  <table class="astra-page-table"><thead><tr><th>Resource</th><th>Devices</th></tr></thead>
+  <table class="ui-page-table"><thead><tr><th>Resource</th><th>Devices</th></tr></thead>
   ${ents(G.bridges).sort((a,b)=>b[1].devices.length-a[1].devices.length)
     .map(([k,b])=>`<tr><td>${esc(k)}</td><td>${b.devices.length}</td></tr>`).join('')}
   </table></div>` : ''}`;
@@ -3241,9 +3241,9 @@ function tools() {
 function coverage() {
   const gaps = ents(G.devices).filter(([,d]) => d.scanner_seen && !d.collector_seen);
   return `<h2>Coverage</h2><p class="lede">Machines an inventory or telemetry source knows about, but no endpoint collector has reported from. Usually the collector is not installed there yet.</p>
-  ${gaps.length ? `<div class="tcard"><table class="astra-page-table"><thead><tr><th>Device</th><th>Seen by</th><th>AI tools seen</th></tr></thead>
+  ${gaps.length ? `<div class="tcard"><table class="ui-page-table"><thead><tr><th>Device</th><th>Seen by</th><th>AI tools seen</th></tr></thead>
   ${gaps.map(([k,d])=>`<tr><td><strong>${esc(label(k,d))}</strong></td>
-    <td><div class="cell-tags">${(d.sources||[]).map(x => astraSourceChip(x)).join('')}</div></td>
+    <td><div class="cell-tags">${(d.sources||[]).map(x => uiSourceChip(x)).join('')}</div></td>
     <td>${(d.tools||[]).length}</td></tr>`).join('')}</table></div>`
   : dataOk()
     ? '<p class="lede">Every device with a scanner finding also has a collector reporting.</p>'
@@ -3314,15 +3314,15 @@ function mcp() {
     <div><dt>${tools.length}</dt><dd>configuring tools</dd></div>
   </dl>
 
-  ${rows.length ? `<div class="tcard"><table class="astra-page-table">
+  ${rows.length ? `<div class="tcard"><table class="ui-page-table">
   <thead><tr><th>Server</th><th>Devices</th><th>Configured by</th>
   <th>First seen</th><th>Last seen</th></tr></thead>
   ${rows.map(r => `<tr data-open="mcp" data-key="${esc(r.server)}" style="cursor:pointer">
     <td><strong>${esc(r.server)}</strong></td>
     <td>${(r.devices||[]).length}</td>
-    <td><div class="cell-tags">${(r.tools||[]).map(t=>astraToolChip(t)).join('')}</div></td>
-    <td class="astra-muted">${esc((r.first_seen||'').slice(0,10) || '—')}</td>
-    <td class="astra-muted">${esc((r.last_seen||'').slice(0,10) || '—')}</td>
+    <td><div class="cell-tags">${(r.tools||[]).map(t=>uiToolChip(t)).join('')}</div></td>
+    <td class="ui-muted">${esc((r.first_seen||'').slice(0,10) || '—')}</td>
+    <td class="ui-muted">${esc((r.last_seen||'').slice(0,10) || '—')}</td>
   </tr>`).join('')}</table>
   <p class="src-note" style="margin-bottom:8px">Click a server to see which machines it's configured on.
   Widest reach is listed first.</p></div>`
@@ -3398,23 +3398,23 @@ function personal() {
   return `<h2>Personal accounts</h2>
   <p class="lede" data-tour="personal">AI tools signed in with personal accounts. Even on an approved tool, that means company data going somewhere you do not manage, with access that outlives offboarding. Personal means the account domain is not in your corporate domains list. Treat each one as a lead to follow up, not a verdict${lifecycle ? `, and record where it got to: acknowledged keeps it visible, accepted needs a reason and takes it out of the open count` : ''}.</p>
   ${summary}
-  ${rows.length ? `<div class="tcard"><table class="astra-page-table">
+  ${rows.length ? `<div class="tcard"><table class="ui-page-table">
   <thead><tr><th>Person</th><th>Account</th><th>AI tool</th><th>Device</th>
   <th>Surface</th><th>First seen</th><th>Last seen</th><th>Source</th>
   ${lifecycle ? '<th>Status</th>' : ''}</tr></thead>
-  <tbody>${rows.map(r => `<tr${paStatus(r) ? ' class="astra-settled"' : ''}>
+  <tbody>${rows.map(r => `<tr${paStatus(r) ? ' class="ui-settled"' : ''}>
     <td>${r.user
       ? esc(r.user) + (r.user_via === 'device'
         ? ' <span class="pill p-mut" title="This source reported no account name. The person is the one the identity map attaches to this machine.">via device</span>' : '')
       : '<span class="pill p-mut">no identity</span>'}</td>
-    <td><span class="astra-badge risk">${esc(r.account_domain)}</span></td>
-    <td>${astraToolChip(r.tool)}</td>
+    <td><span class="ui-badge risk">${esc(r.account_domain)}</span></td>
+    <td>${uiToolChip(r.tool)}</td>
     <td>${esc(r.device_name || r.device || '—')}</td>
-    <td>${(r.surfaces||[]).map(x=>`<span class="astra-surface">${esc(x)}</span>`).join('')}</td>
-    <td class="astra-muted">${esc((r.first_seen||'').slice(0,10) || '—')}</td>
-    <td class="astra-muted">${esc((r.last_seen||'').slice(0,10) || '—')}</td>
-    <td>${(r.sources||[]).map(x => astraSourceChip(x)).join('') || '<span class="astra-muted">—</span>'}</td>
-    ${lifecycle ? `<td class="nw astra-row-actions">${paChip(paStatus(r))} ${paActions(r)}</td>` : ''}
+    <td>${(r.surfaces||[]).map(x=>`<span class="ui-surface">${esc(x)}</span>`).join('')}</td>
+    <td class="ui-muted">${esc((r.first_seen||'').slice(0,10) || '—')}</td>
+    <td class="ui-muted">${esc((r.last_seen||'').slice(0,10) || '—')}</td>
+    <td>${(r.sources||[]).map(x => uiSourceChip(x)).join('') || '<span class="ui-muted">—</span>'}</td>
+    ${lifecycle ? `<td class="nw ui-row-actions">${paChip(paStatus(r))} ${paActions(r)}</td>` : ''}
   </tr>`).join('')}</tbody></table></div>`
   : `<p class="lede">None seen in the last ${hoursNow()} hours.
   Worth trusting only if the sources on the Setup page are reporting.</p>`}`;
@@ -4237,7 +4237,7 @@ async function paste() {
   <th class="n">Blocked</th><th class="n">Devices</th><th>Detectors</th>
   <th>Last seen</th></tr></thead>
   ${rows.map(r => `<tr>
-    <td>${astraToolChip(r.tool)}</td>
+    <td>${uiToolChip(r.tool)}</td>
     <td class="n">${num(r.warned)}</td>
     <td class="n">${r.overridden
       ? `<span class="pill p-warn">${r.overridden}</span>` : num(0)}</td>
@@ -8832,11 +8832,11 @@ async function managedAction(act, el) {
     if (r.ok) USERS = null;
     render(); return;
   }
-  if (act === 'astra-tools-filter') {
-    ASTRA_PERSONAL_TOOLS = el.getAttribute('data-filter') === 'personal';
+  if (act === 'ui-tools-filter') {
+    UI_PERSONAL_TOOLS = el.getAttribute('data-filter') === 'personal';
     render(); return;
   }
-  if (act === 'astra-density') {
+  if (act === 'ui-density') {
     await prefSet('display.compact', pref('display.compact', '0') === '1' ? '0' : '1');
     render(); return;
   }
@@ -9848,7 +9848,7 @@ function overviewTools() {
   const hidden = overviewWidgets().hidden.length;
   return `${hidden ? `<button class="mini" data-act="ov-showall"
     >Restore ${hidden} hidden ${hidden === 1 ? 'widget' : 'widgets'}</button>` : ''}
-    <button class="mini astra-density" data-act="astra-density" aria-pressed="${pref('display.compact', '0') === '1'}">${pref('display.compact', '0') === '1' ? 'Comfortable view' : 'Compact view'}</button>
+    <button class="mini ui-density" data-act="ui-density" aria-pressed="${pref('display.compact', '0') === '1'}">${pref('display.compact', '0') === '1' ? 'Comfortable view' : 'Compact view'}</button>
     <button class="mini" data-act="ov-edit">Edit widgets</button>`;
 }
 
@@ -10206,7 +10206,7 @@ function decorateView() {
 // the tour's own check hangs off the wrapper rather than the body - a call
 // per branch is a call somebody adding the twelfth view forgets.
 async function render() {
-  document.body.classList.toggle('astra-compact', pref('display.compact', '0') === '1');
+  document.body.classList.toggle('ui-compact', pref('display.compact', '0') === '1');
   await renderView();
   decorateView();
   drawSetup();

--- a/portal/tests/astra_overview.test.cjs
+++ b/portal/tests/astra_overview.test.cjs
@@ -1,0 +1,77 @@
+// Run with: node --test portal/tests/astra_overview.test.cjs
+// Exercise the actual browser renderers with controlled API-shaped data.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const html = fs.readFileSync(path.join(__dirname, '../app/static/index.html'), 'utf8');
+const helpers = html.slice(html.indexOf('let ASTRA_PERSONAL_TOOLS = false;'), html.indexOf('const WIDGETS = {'));
+const widgets = html.slice(html.indexOf('const WIDGETS = {'), html.indexOf('// The truncation banner'));
+const escape = s => String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+function context(overrides={}) {
+  const c = vm.createContext({
+    G:{devices:{one:{collector_seen:true},two:{scanner_seen:true}},tools:{cloud:{devices:[],identities:['a','b'],surfaces:['cloud']}},personal_accounts:[{key:'a',tool:'cloud',user:'a'}]},
+    REG:{rows:[{id:'cloud',name:'Cloud tool',vendor:'Vendor',status_source:'registry'}]},
+    REGTOOLS:[], PSTAT:null, CAND:[], S:{reporting:1,groups:[{group:'cloud',reporting:1,total:5,sources:[]}]},
+    CFG:{}, AUTH:null, dataOk:()=>true, ents:o=>Object.entries(o||{}),paKey:r=>r.key,
+    esc:escape, fmtWindow:h=>h+' hours',hoursNow:()=>24,trendChip:()=>'',spark:()=>'<svg></svg>',
+    match:()=>true, NAVICONS:{governance:'<path/>'},widgetForm:()=> 'table',formToggle:()=>'',
+    fetch:()=>{throw new Error('Renderers must not fetch');},...overrides
+  });
+  vm.runInContext(helpers+widgets+'; this.widgets = WIDGETS;',c);
+  return c;
+}
+test('accepted findings leave the open count, acknowledged findings do not',()=>{
+  const c=context({G:{devices:{},tools:{a:{}},personal_accounts:[{key:'accepted',tool:'a'},{key:'ack',tool:'a'}]},PSTAT:{accepted:{status:'accepted'},ack:{status:'acknowledged'}}});
+  const f=c.astraOverviewFacts();
+  assert.equal(f.personal.length,2);assert.equal(f.open.length,1);assert.equal(f.open[0].key,'ack');
+});
+test('collector coverage counts actual signals, including a source-less observed device',()=>{
+  const c=context({G:{devices:{a:{collector_seen:true},b:{scanner_seen:true},c:{}},tools:{},personal_accounts:[]}});
+  const f=c.astraOverviewFacts();
+  assert.equal(f.collectors,1);assert.equal(f.coverage,33);assert.equal(f.gaps.length,1);
+  assert.match(c.widgets.detection_coverage(),/No collector signal <b>2<\/b>/);
+});
+test('no observed devices gives unavailable coverage rather than an invented percentage',()=>{
+  const c=context({G:{devices:{},tools:{},personal_accounts:[]},S:{reporting:0,groups:[]}});
+  assert.equal(c.astraOverviewFacts().coverage,null);
+  const out=c.widgets.stat_row();assert.match(out,/Nothing reporting/);assert.doesNotMatch(out,/Monitoring healthy/);
+  assert.match(c.widgets.detection_coverage(),/Collector coverage unavailable/);
+});
+test('a failed findings read never presents retained counts as current data',()=>{
+  const c=context({dataOk:()=>false});
+  assert.match(c.widgets.stat_row(),/Data unavailable/);
+  assert.doesNotMatch(c.widgets.stat_row(),/Monitoring healthy/);
+  assert.match(c.widgets.top_tools(),/Findings are unavailable/);
+  assert.match(c.widgets.detection_coverage(),/Collector coverage unavailable/);
+});
+test('unavailable register data is separate from zero decisions',()=>{
+  const c=context({REG:null});
+  assert.equal(c.astraOverviewFacts().recorded,null);
+  assert.match(c.widgets.stat_row(),/Register data unavailable/);
+  assert.match(c.astraFocusRows(c.astraOverviewFacts()),/Register data is unavailable/);
+});
+test('only explicit decisions for discovered tools contribute to the register metric',()=>{
+  const c=context({G:{devices:{},tools:{a:{},b:{},c:{}},personal_accounts:[]},REG:{rows:[{id:'a',status_source:'governance',status:'refused'},{id:'b',status_source:'portal',status:'reviewing',days_overdue:2},{id:'c',status_source:'registry'},{id:'unobserved',status_source:'portal'}]}});
+  const f=c.astraOverviewFacts();assert.equal(f.recorded.length,2);assert.equal(f.undecided,1);assert.equal(f.overdue,1);
+});
+test('cloud-only tools retain zero devices alongside their separate identity count',()=>{
+  const c=context();const out=c.widgets.top_tools();
+  assert.match(out,/<td class="num">0<\/td><td class="num">2<\/td>/);
+  assert.match(out,/View Cloud tool details/);assert.match(out,/data-open="tool" data-key="cloud"/);
+});
+test('the table contains every matching tool instead of truncating away cloud-only tools',()=>{
+  const many=Object.fromEntries(Array.from({length:9},(_,i)=>['t'+i,{devices:[],identities:[],surfaces:[]}]))
+  const c=context({G:{devices:{},tools:many,personal_accounts:[]}});
+  const out=c.widgets.top_tools();assert.match(out,/9 of 9 discovered tools/);assert.match(out,/data-key="t8"/);
+});
+test('the personal filter uses open lifecycle findings, not all historic personal rows',()=>{
+  const c=context({PSTAT:{a:{status:'accepted'}}});vm.runInContext('ASTRA_PERSONAL_TOOLS = true;',c);
+  const out=c.widgets.top_tools();assert.match(out,/No tools match this view/);assert.match(out,/0 of 1 discovered tools/);
+});
+test('tool metadata and finding identifiers are escaped before becoming markup',()=>{
+  const id='x" onclick="bad';const attack='<img src=x onerror=bad>';
+  const c=context({G:{devices:{},tools:{[id]:{devices:[],identities:[],surfaces:[attack]}},personal_accounts:[]},REG:{rows:[{id,name:attack,vendor:attack}]}});
+  const out=c.widgets.top_tools();assert.doesNotMatch(out,/<img /);assert.doesNotMatch(out,/data-key="x" onclick=/);assert.match(out,/&lt;img/);
+});

--- a/portal/tests/overview_renderers.test.cjs
+++ b/portal/tests/overview_renderers.test.cjs
@@ -1,4 +1,4 @@
-// Run with: node --test portal/tests/astra_overview.test.cjs
+// Run with: node --test portal/tests/overview_renderers.test.cjs
 // Exercise the actual browser renderers with controlled API-shaped data.
 const test = require('node:test');
 const assert = require('node:assert/strict');
@@ -6,7 +6,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const vm = require('node:vm');
 const html = fs.readFileSync(path.join(__dirname, '../app/static/index.html'), 'utf8');
-const helpers = html.slice(html.indexOf('let ASTRA_PERSONAL_TOOLS = false;'), html.indexOf('const WIDGETS = {'));
+const helpers = html.slice(html.indexOf('let UI_PERSONAL_TOOLS = false;'), html.indexOf('const WIDGETS = {'));
 const widgets = html.slice(html.indexOf('const WIDGETS = {'), html.indexOf('// The truncation banner'));
 const escape = s => String(s).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
 function context(overrides={}) {
@@ -24,18 +24,18 @@ function context(overrides={}) {
 }
 test('accepted findings leave the open count, acknowledged findings do not',()=>{
   const c=context({G:{devices:{},tools:{a:{}},personal_accounts:[{key:'accepted',tool:'a'},{key:'ack',tool:'a'}]},PSTAT:{accepted:{status:'accepted'},ack:{status:'acknowledged'}}});
-  const f=c.astraOverviewFacts();
+  const f=c.uiOverviewFacts();
   assert.equal(f.personal.length,2);assert.equal(f.open.length,1);assert.equal(f.open[0].key,'ack');
 });
 test('collector coverage counts actual signals, including a source-less observed device',()=>{
   const c=context({G:{devices:{a:{collector_seen:true},b:{scanner_seen:true},c:{}},tools:{},personal_accounts:[]}});
-  const f=c.astraOverviewFacts();
+  const f=c.uiOverviewFacts();
   assert.equal(f.collectors,1);assert.equal(f.coverage,33);assert.equal(f.gaps.length,1);
   assert.match(c.widgets.detection_coverage(),/No collector signal <b>2<\/b>/);
 });
 test('no observed devices gives unavailable coverage rather than an invented percentage',()=>{
   const c=context({G:{devices:{},tools:{},personal_accounts:[]},S:{reporting:0,groups:[]}});
-  assert.equal(c.astraOverviewFacts().coverage,null);
+  assert.equal(c.uiOverviewFacts().coverage,null);
   const out=c.widgets.stat_row();assert.match(out,/Nothing reporting/);assert.doesNotMatch(out,/Monitoring healthy/);
   assert.match(c.widgets.detection_coverage(),/Collector coverage unavailable/);
 });
@@ -48,13 +48,13 @@ test('a failed findings read never presents retained counts as current data',()=
 });
 test('unavailable register data is separate from zero decisions',()=>{
   const c=context({REG:null});
-  assert.equal(c.astraOverviewFacts().recorded,null);
+  assert.equal(c.uiOverviewFacts().recorded,null);
   assert.match(c.widgets.stat_row(),/Register data unavailable/);
-  assert.match(c.astraFocusRows(c.astraOverviewFacts()),/Register data is unavailable/);
+  assert.match(c.uiFocusRows(c.uiOverviewFacts()),/Register data is unavailable/);
 });
 test('only explicit decisions for discovered tools contribute to the register metric',()=>{
   const c=context({G:{devices:{},tools:{a:{},b:{},c:{}},personal_accounts:[]},REG:{rows:[{id:'a',status_source:'governance',status:'refused'},{id:'b',status_source:'portal',status:'reviewing',days_overdue:2},{id:'c',status_source:'registry'},{id:'unobserved',status_source:'portal'}]}});
-  const f=c.astraOverviewFacts();assert.equal(f.recorded.length,2);assert.equal(f.undecided,1);assert.equal(f.overdue,1);
+  const f=c.uiOverviewFacts();assert.equal(f.recorded.length,2);assert.equal(f.undecided,1);assert.equal(f.overdue,1);
 });
 test('cloud-only tools retain zero devices alongside their separate identity count',()=>{
   const c=context();const out=c.widgets.top_tools();
@@ -67,7 +67,7 @@ test('the table contains every matching tool instead of truncating away cloud-on
   const out=c.widgets.top_tools();assert.match(out,/9 of 9 discovered tools/);assert.match(out,/data-key="t8"/);
 });
 test('the personal filter uses open lifecycle findings, not all historic personal rows',()=>{
-  const c=context({PSTAT:{a:{status:'accepted'}}});vm.runInContext('ASTRA_PERSONAL_TOOLS = true;',c);
+  const c=context({PSTAT:{a:{status:'accepted'}}});vm.runInContext('UI_PERSONAL_TOOLS = true;',c);
   const out=c.widgets.top_tools();assert.match(out,/No tools match this view/);assert.match(out,/0 of 1 discovered tools/);
 });
 test('tool metadata and finding identifiers are escaped before becoming markup',()=>{

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -65,7 +65,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.29.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.30.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
The portal's console design. Same data, same actions, same preferences; the page now reads in the order the work happens, and the stylesheet is one cascade.

## Overview

- The posture panel leads, with the four counts that matter beside it: open personal accounts, tools observed, collector coverage, register decisions. Then what to do next, then the inventory.
- Every supporting widget has the same shape: a head with its purpose, a body, and a footer naming the way into the full page. Widgets fill the frame their size gives them and stay that shape in comfortable, compact and edit modes.
- The tool inventory is a table when the card is wide enough and a list when it is not, chosen by the card's own width. Widget tables show more columns and more rows as the card grows, and put the last column at the right edge.
- Activity is written as a total when the window holds fewer than three days, and drawn as a sparkline once it can make a shape.
- Compact density is a real step: type one size down, panels lose a third of their padding, rows a third of their height.

## Across the portal

- One table grammar on every inventory page: sentence-case headers on a secondary surface, no vertical rules, hover only on rows that open an inspector.
- Tools, Devices, People, Personal accounts, Coverage, MCP servers and Paste guard show registry names, vendors and catalogue labels instead of ids; the id stays in the tooltip and search still matches it.
- Personal accounts gains a summary strip: open, acknowledged, accepted, people named, tools involved.
- Running text runs to the edge of its column; three earlier width caps are gone.
- The sidebar keeps item labels on one line, and the logo has the line beneath it.

## Under it

- `enterprise.css` is the earlier three generations of skin collapsed into one cascade: the screen-only wrappers removed and 509 declarations that a later rule on the same selector had already overridden dropped. Order is untouched, so every specificity tie resolves as before.
- The evidence index printed its theme names over the evidence text because a print rule expected four columns where the row has three. That predates this change and is fixed here. Screen-only controls stay off paper.
- Ten Node tests exercise the Overview renderers with controlled data, and CI runs them.

## Checked

671 portal tests, 12 CLI tests, 10 renderer tests. Both themes, comfortable and compact, edit mode, 390px, the guided tour, and the Overview and Evidence PDFs.

## Deploying

Portal, receiver and CLI images and the chart move to 0.30.0. Nothing stored changes.
