### PR TITLE
Estate scale: a planner for the Overview, widgets that fit, an upgrade that closes its run

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -10,14 +10,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.30.0
+version: 0.31.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.30.0"
+appVersion: "0.31.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 maintainers:
   - name: Aman Karir

--- a/cli/README.md
+++ b/cli/README.md
@@ -15,9 +15,15 @@ portal itself restarts. The design and its threat model are in
 
 ## Install
 
-From a tagged release of this repository, once:
+It needs Python 3.10 or newer and `pipx` (`brew install pipx` on a Mac,
+`pip install --user pipx` elsewhere). From a tagged release of this
+repository, once:
 
-    pipx install "git+https://github.com/AmanSK5/shadow-ai-guard@v0.29.0#subdirectory=cli"
+    pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@v0.30.0#subdirectory=cli"
+    pipx ensurepath
+
+`pipx ensurepath` puts the command on your PATH; a shell opened before that
+will not find it until it is reopened.
 
 No third-party dependencies, so what runs is what the tag contains. It
 shells out to your own `helm`, `kubectl` and `docker`, found on your PATH.

--- a/cli/README.md
+++ b/cli/README.md
@@ -19,7 +19,7 @@ It needs Python 3.10 or newer and `pipx` (`brew install pipx` on a Mac,
 `pip install --user pipx` elsewhere). From a tagged release of this
 repository, once:
 
-    pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@v0.30.0#subdirectory=cli"
+    pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@v0.31.0#subdirectory=cli"
     pipx ensurepath
 
 `pipx ensurepath` puts the command on your PATH; a shell opened before that

--- a/cli/aiguardctl/__init__.py
+++ b/cli/aiguardctl/__init__.py
@@ -10,4 +10,4 @@ context and reports each step back so the portal can show it. Nothing in
 the platform gains a right over the deployment. See SECURITY.md,
 "Upgrading", in the project repository.
 """
-__version__ = "0.30.0"
+__version__ = "0.31.0"

--- a/cli/aiguardctl/api.py
+++ b/cli/aiguardctl/api.py
@@ -45,3 +45,8 @@ def request(portal: str, method: str, path: str, body: dict | None = None,
         raise ApiError(e.code, str(detail)) from None
     except urllib.error.URLError as e:
         raise ApiError(0, "could not reach %s: %s" % (portal, e.reason)) from None
+    except OSError as e:
+        # A read that timed out or a socket that closed under us: the portal
+        # restarting mid-rollout looks exactly like this. Same shape as
+        # unreachable, so callers retry rather than fall over.
+        raise ApiError(0, "no answer from %s: %s" % (portal, e)) from None

--- a/cli/aiguardctl/cli.py
+++ b/cli/aiguardctl/cli.py
@@ -64,13 +64,29 @@ def cmd_upgrade(a) -> int:
                  + [s["service"] for s in found.get("services", [])]}},
         token=token)
     rep = upgrade.Reporter(portal, token, run["id"], say)
-    ok = upgrade.apply(found, target, rep)
-    if not ok:
-        rep.finish("failed", "a command exited non-zero; see the terminal")
-        return 1
-    result = upgrade.verify(portal, token, target, say)
+    # Whatever happens from here, the run is closed with an outcome: a run
+    # left "running" on System health after the terminal is gone is the one
+    # thing an owner cannot tell apart from an upgrade still in progress.
+    try:
+        ok = upgrade.apply(found, target, rep)
+        if not ok:
+            rep.finish("failed", "a command exited non-zero; see the terminal")
+            return 1
+        result = upgrade.verify(portal, token, target, say)
+    except KeyboardInterrupt:
+        rep.finish("aborted", "interrupted at the terminal")
+        say("Interrupted. The commands that already ran are not undone; "
+            "System health shows how far it got.")
+        return 130
+    except Exception as e:  # noqa: BLE001 - closed with a reason, then re-raised
+        rep.finish("failed", ("the command stopped: %s" % e)[:300])
+        raise
     if result is None:
-        rep.finish("failed", "the portal did not come back as %s in time" % target)
+        rep.finish("unverified", "the commands ran, but the portal did not confirm "
+                   "%s within the wait; check System health" % target)
+        say("The upgrade commands ran, but the portal did not confirm %s in time. "
+            "Open System health: if it shows %s, the upgrade is done and only the "
+            "confirmation was missed." % (target, target))
         return 1
     srcs = result.get("sources") or {}
     detail = "portal %s, receiver %s" % (result.get("portal_version"), result.get("receiver_version"))

--- a/cli/aiguardctl/upgrade.py
+++ b/cli/aiguardctl/upgrade.py
@@ -134,11 +134,18 @@ def verify(portal: str, token: str, target: str, say, request=api.request,
     deadline = time.time() + timeout
     say("  waiting for the portal to come back as %s" % want)
     while time.time() < deadline:
+        # Anything the network throws while the portal is coming back is
+        # a reason to wait, not to stop: the upgrade itself already ran.
         try:
             health = request(portal, "GET", "/healthz")
-            if str(health.get("version", "")).lstrip("v") == want:
-                return request(portal, "GET", "/api/upgrade/verify", token=token)
-        except api.ApiError:
-            pass
+        except (api.ApiError, OSError):
+            health = {}
+        if str(health.get("version", "")).lstrip("v") == want:
+            for _ in range(6):
+                try:
+                    return request(portal, "GET", "/api/upgrade/verify", token=token)
+                except (api.ApiError, OSError):
+                    sleep(5)
+            return None
         sleep(5)
     return None

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiguardctl"
-version = "0.30.0"
+version = "0.31.0"
 description = "Upgrade a Shadow AI Guard deployment from your own machine, with your own credentials, while the portal shows the progress"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/cli/tests/test_aiguardctl.py
+++ b/cli/tests/test_aiguardctl.py
@@ -193,3 +193,42 @@ def test_the_command_has_no_third_party_dependencies():
                 mod = line.split()[1].split(".")[0]
                 assert mod in {"json", "urllib", "hashlib", "secrets", "time", "webbrowser", "shutil",
                                "subprocess", "argparse", "sys", "__future__"}, line
+
+
+def test_verify_waits_through_a_restart_and_a_timed_out_read():
+    """The portal restarts mid-rollout by design. A read that times out while
+    it comes back used to escape as a traceback after the commands had already
+    run, leaving the run open on System health."""
+    calls = {"n": 0}
+
+    def request(portal, method, path, body=None, token=""):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise TimeoutError("The read operation timed out")
+        if calls["n"] == 2:
+            raise api.ApiError(0, "could not reach")
+        if path == "/healthz":
+            return {"version": "0.30.0"}
+        if calls["n"] == 4:
+            raise TimeoutError("still restarting")
+        return {"portal_version": "0.30.0", "receiver_version": "0.30.0"}
+
+    said = []
+    out = upgrade.verify("http://p", "aigu_t", "v0.30.0", said.append,
+                         request=request, sleep=lambda s: None, timeout=60)
+    assert out == {"portal_version": "0.30.0", "receiver_version": "0.30.0"}
+    assert calls["n"] == 5
+
+
+def test_a_timed_out_read_is_an_api_error_not_a_crash(monkeypatch):
+    import urllib.request
+
+    def boom(req, timeout=0):
+        raise TimeoutError("The read operation timed out")
+    monkeypatch.setattr(urllib.request, "urlopen", boom)
+    try:
+        api.request("http://p", "GET", "/healthz")
+    except api.ApiError as e:
+        assert e.status == 0 and "no answer" in e.detail
+    else:
+        raise AssertionError("expected ApiError")

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -164,6 +164,10 @@ services:
       PORTAL_URL: "http://localhost:8091"
     volumes:
       - ./seed.sh:/seed.sh:ro
+      # The larger estate, run by hand when the question is how the pages
+      # look with a fleet's worth of findings:
+      #   docker compose run --rm --entrypoint "/bin/sh /seed-large.sh" seeder
+      - ./seed-large.sh:/seed-large.sh:ro
     depends_on:
       receiver:
         condition: service_healthy

--- a/demo/seed-large.sh
+++ b/demo/seed-large.sh
@@ -1,0 +1,161 @@
+#!/bin/sh
+# Copyright 2026 Aman Karir
+# SPDX-License-Identifier: Apache-2.0
+# Part of Shadow AI Guard, https://github.com/AmanSK5/shadow-ai-guard
+
+# A larger synthetic estate on top of seed.sh: fifty-odd devices, two dozen
+# tools, twenty personal accounts, six subscriptions. The point is not the
+# story of any one finding but the shape of the pages when there is a lot of
+# them - which is what a real estate looks like and what the demo's handful
+# of findings cannot show. Everything is fake: users are Pokemon, domains
+# are example / gmail / outlook, devices are made up. Safe to re-run.
+#
+#   docker compose run --rm --entrypoint "/bin/sh /seed-large.sh" seeder
+# shellcheck disable=SC2088  # evidence strings are data, not paths to expand
+set -e
+R="${RECEIVER:-http://receiver:8080}/report"
+T="${TOKEN:-demo-token}"
+A="${RECEIVER:-http://receiver:8080}"
+now() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+post() {
+  curl -s -o /dev/null -w '.' -X POST "$R" -H "Authorization: Bearer $T" \
+    -H "Content-Type: application/json" --data "$1"
+}
+# f TOOL SURFACE OS DOMAIN DEVICE USER EVIDENCE SEVERITY SOURCE [extra json]
+f() {
+  post "{\"tool\":\"$1\",\"surface\":\"$2\",\"os\":\"$3\",\"account_domain\":\"$4\",\"device\":\"$5\",\"user\":\"$6\",\"evidence\":\"$7\",\"severity\":\"$8\",\"reported_at\":\"$(now)\",\"source\":\"$9\"${10:+,${10}}}"
+}
+echo "seeding a large synthetic estate -> $R"
+
+# --- the fleet: macOS, Windows and Linux machines with a local user each ---
+MAC="abra alakazam arbok arcanine beedrill bellsprout blastoise butterfree caterpie chansey clefable clefairy cloyster cubone dewgong diglett dodrio doduo dragonair dragonite"
+WIN="dratini drowzee dugtrio ekans electabuzz electrode exeggcute exeggutor farfetchd fearow flareon gastly geodude gloom golbat golduck"
+NIX="goldeen golem graveler grimer growlithe gyarados haunter hitmonchan hitmonlee horsea hypno ivysaur"
+
+# Endpoint collectors see the tools people installed. The mix leans the way
+# real estates do: a few tools everywhere, a long tail on one or two machines.
+i=0
+for u in $MAC; do
+  d="MBP-$(echo $u | tr a-z A-Z)"; i=$((i+1))
+  f claude browser macos example.com "$d" "$u" "claude.ai in Chrome" info collector-macos
+  [ $((i % 2)) -eq 0 ] && f claude-code cli macos example.com "$d" "$u" "~/.claude.json" info collector-macos
+  [ $((i % 3)) -eq 0 ] && f chatgpt desktop macos example.com "$d" "$u" "/Applications/ChatGPT.app" info collector-macos
+  [ $((i % 4)) -eq 0 ] && f cursor desktop macos "" "$d" "$u" "/Applications/Cursor.app" info collector-macos
+  [ $((i % 5)) -eq 0 ] && f wispr-flow desktop macos "" "$d" "$u" "/Applications/Wispr Flow.app" info collector-macos
+  [ $((i % 6)) -eq 0 ] && f warp desktop macos "" "$d" "$u" "/Applications/Warp.app" info collector-macos
+  [ $((i % 7)) -eq 0 ] && f ollama desktop macos "" "$d" "$u" "ollama binary" info collector-macos
+  [ $((i % 8)) -eq 0 ] && f lm-studio desktop macos "" "$d" "$u" "/Applications/LM Studio.app" info collector-macos
+  [ $((i % 9)) -eq 0 ] && f perplexity desktop macos "" "$d" "$u" "/Applications/Perplexity.app" info collector-macos
+  [ $((i % 5)) -eq 1 ] && f claude-code-mcp mcp macos "" "$d" "$u" ".claude.json mcpServers: github,linear" info collector-macos
+done
+for u in $WIN; do
+  d="WIN-$(echo $u | tr a-z A-Z)"; i=$((i+1))
+  f microsoft-copilot browser windows example.com "$d" "$u" "copilot.microsoft.com in Edge" info collector-windows
+  [ $((i % 2)) -eq 0 ] && f claude-code cli windows example.com "$d" "$u" "%USERPROFILE%\\\\.claude.json" info collector-windows
+  [ $((i % 3)) -eq 0 ] && f github-copilot ide windows "" "$d" "$u" "VS Code extension GitHub.copilot" info collector-windows
+  [ $((i % 4)) -eq 0 ] && f codeium ide windows "" "$d" "$u" "VS Code extension Codeium.codeium" info collector-windows
+  [ $((i % 5)) -eq 0 ] && f grammarly browser windows "" "$d" "$u" "Chrome extension Grammarly" info collector-windows
+  [ $((i % 6)) -eq 0 ] && f notion-ai browser windows example.com "$d" "$u" "notion.so AI in Edge" info collector-windows
+done
+for u in $NIX; do
+  d="NIX-$(echo $u | tr a-z A-Z)"; i=$((i+1))
+  f claude-code cli linux example.com "$d" "$u" "~/.claude.json" info collector-linux
+  [ $((i % 2)) -eq 0 ] && f codex-cli cli linux example.com "$d" "$u" "~/.codex/config.toml" info collector-linux
+  [ $((i % 3)) -eq 0 ] && f gemini-cli cli linux "" "$d" "$u" "~/.gemini/settings.json" info collector-linux
+  [ $((i % 4)) -eq 0 ] && f ollama desktop linux "" "$d" "$u" "ollama binary" info collector-linux
+  [ $((i % 5)) -eq 0 ] && f warp desktop linux "" "$d" "$u" "warp-terminal binary" info collector-linux
+done
+
+# --- personal accounts: twenty, across the tools people actually use ---
+p=0
+for pair in abra:chatgpt alakazam:chatgpt arbok:chatgpt arcanine:chatgpt beedrill:gemini bellsprout:claude-code \
+            blastoise:claude-code butterfree:codex-cli caterpie:codex-cli chansey:chatgpt dratini:chatgpt \
+            drowzee:claude dugtrio:claude-code ekans:chatgpt goldeen:codex-cli golem:claude-code graveler:codex-cli \
+            grimer:chatgpt growlithe:claude-code gyarados:gemini; do
+  u=${pair%%:*}; t=${pair##*:}; p=$((p+1))
+  case "$u" in
+    drat*|drow*|dugt*|ekan*) d="WIN-$(echo $u | tr a-z A-Z)"; os=windows; src=collector-windows;;
+    gold*|gole*|grav*|grim*|grow*|gyar*) d="NIX-$(echo $u | tr a-z A-Z)"; os=linux; src=collector-linux;;
+    *) d="MBP-$(echo $u | tr a-z A-Z)"; os=macos; src=collector-macos;;
+  esac
+  dom=gmail.com; [ $((p % 4)) -eq 0 ] && dom=outlook.com; [ $((p % 7)) -eq 0 ] && dom=me.com
+  case "$t" in
+    chatgpt|gemini|claude) f "$t" browser "$os" "$dom" "$d" "$u" "signed in as $u@$dom" warn browser_extension;;
+    *) f "$t" cli "$os" "$dom" "$d" "$u" "~/.config credentials: $u@$dom" warn "$src";;
+  esac
+done
+
+# --- cloud identities: sign-ins the tenant saw, with no machine attached ---
+for u in $MAC $WIN; do
+  case "$u" in a*|b*|d*) f chatgpt cloud unknown example.com "" "$u" "interactive sign-in to ChatGPT" info entra_sign_in;; esac
+  case "$u" in c*|e*|f*) f fireflies cloud unknown example.com "" "$u" "interactive sign-in to Fireflies" info entra_sign_in;; esac
+  case "$u" in g*) f github-copilot cloud unknown example.com "" "$u" "interactive sign-in to GitHub" info entra_sign_in;; esac
+done
+for u in abra beedrill chansey dodrio ekans flareon; do
+  f openai-api-platform cloud unknown example.com "" "$u" "consent grant: OpenAI API" info entra_consent_grant
+done
+for u in arbok cloyster dragonite golbat; do
+  f atlassian-rovo cloud unknown example.com "" "$u" "interactive sign-in to Atlassian" info entra_sign_in
+done
+
+# --- machines only the scanners know: the coverage gaps ---
+GAP="jigglypuff jolteon jynx kabuto kabutops kadabra kakuna kangaskhan kingler koffing krabby lapras lickitung machamp machoke machop magikarp magmar magnemite magneton mankey marowak"
+g=0
+for u in $GAP; do
+  g=$((g+1)); d="LT-$(echo $u | tr a-z A-Z)"
+  if [ $((g % 2)) -eq 0 ]; then
+    f claude network unknown "" "$d" "" "DNS lookup for claude.ai (via Google Chrome)" info sentinelone_dns
+  else
+    f paste-guard browser windows "" "$d" "" "heartbeat version=1.1.1 mode=warn" info paste_guard
+  fi
+  [ $((g % 3)) -eq 0 ] && f chatgpt network unknown "" "$d" "" "DNS lookup for chatgpt.com (via Edge)" info sentinelone_dns
+  [ $((g % 5)) -eq 0 ] && f deepseek network unknown "" "$d" "" "dns:deepseek.com" info sentinelone_dns
+done
+
+# --- the paste guard, on the machines that have it ---
+for u in $MAC $WIN; do
+  case "$u" in a*|b*|c*|d*|e*|f*)
+    case "$u" in d*|e*|f*) d="WIN-$(echo $u | tr a-z A-Z)"; os=windows;; *) d="MBP-$(echo $u | tr a-z A-Z)"; os=macos;; esac
+    f paste-guard browser "$os" "" "$d" "" "heartbeat version=1.1.1 mode=warn" info paste_guard;;
+  esac
+done
+f chatgpt.com browser macos "" MBP-ABRA "" "paste warned: aws_access_key" warn paste_guard
+f claude.ai browser windows "" WIN-DRATINI "" "paste warned: classification_marking" warn paste_guard
+
+# --- what runs without a person ---
+f claude-code cli linux "" NIX-GOLDEEN "" "/etc/systemd/system/nightly-triage.service" warn collector-linux '"mode":"autonomous","identity":"machine","trigger":"systemd timer, every 15 min","schedule":"oncalendar:*:0/15"'
+f claude-code cli macos "" MBP-ARBOK "" "~/Library/LaunchAgents/ai.helper.plist" warn collector-macos '"mode":"autonomous","identity":"machine","trigger":"launchd, at login","schedule":"atlogin"'
+f claude-code cli macos example.com MBP-ABRA abra "~/Library/LaunchAgents/daily-notes.plist" info collector-macos '"mode":"autonomous","identity":"person","trigger":"launchd, every 6 hours","schedule":"interval:21600"'
+f claude network linux "" NIX-GOLEM "" "DNS lookup for api.anthropic.com (via python3)" warn sentinelone_dns '"trigger":"cron, 0 2 * * *","schedule":"cron:0 2 * * *"'
+
+echo ""
+# --- six subscriptions, with the seat lists a vendor export would carry ---
+U="${OWNER_USER:-gengar}"; PW="${OWNER_PASSWORD:-gengar-demo-portal}"
+sess=$(curl -s -X POST "$A/admin/login" -H 'Content-Type: application/json' \
+  --data "{\"username\":\"$U\",\"password\":\"$PW\"}")
+tok=$(printf '%s' "$sess" | sed -n 's/.*"token": *"\([^"]*\)".*/\1/p')
+if [ -z "$tok" ]; then echo "could not sign in as $U; budget not seeded"; exit 0; fi
+auth="Authorization: Bearer $tok"
+put() { curl -s -o /dev/null -w '%{http_code} ' -X PUT "$A$1" -H "$auth" -H 'Content-Type: application/json' --data "$2"; }
+members() {
+  # members TOOL PLAN TIER names...
+  t=$1; pk=$2; tier=$3; shift 3; out=""
+  for n in "$@"; do out="$out{\"email\":\"$n@example.com\",\"name\":\"$n\",\"role\":\"member\",\"seat_tier\":\"$tier\"},"; done
+  put /admin/budget/members "{\"tool_id\":\"$t\",\"plan_key\":\"$pk\",\"source\":\"csv\",\"members\":[${out%,}]}"
+}
+printf 'budget plans: '
+put /admin/budget/subscription '{"tool_id":"chatgpt","plan_key":"business","vendor":"OpenAI","plan":"Business","currency":"GBP","renewal_date":"2027-03-31","owner":"Security","seat_tiers":[{"name":"Business","seats":13,"unit_price_monthly":25}],"covers":["codex-cli"]}'
+put /admin/budget/subscription '{"tool_id":"claude","plan_key":"team","vendor":"Anthropic","plan":"Team","currency":"GBP","renewal_date":"2026-10-01","owner":"Engineering","seat_tiers":[{"name":"Standard","seats":10,"unit_price_monthly":27},{"name":"Premium","seats":3,"unit_price_monthly":120,"covers":["claude-code"]}],"covers":["claude-code"]}'
+put /admin/budget/subscription '{"tool_id":"claude","plan_key":"max-20","vendor":"Anthropic","plan":"Max 20","currency":"GBP","renewal_date":"2026-10-01","owner":"Engineering","seat_tiers":[{"name":"Max 20","seats":4,"unit_price_monthly":180,"covers":["claude-code"]}],"covers":["claude-code"]}'
+put /admin/budget/subscription '{"tool_id":"claude","plan_key":"max-5","vendor":"Anthropic","plan":"Max 5","currency":"GBP","renewal_date":"2026-10-01","owner":"Engineering","seat_tiers":[{"name":"Max 5","seats":6,"unit_price_monthly":90,"covers":["claude-code"]}],"covers":["claude-code"]}'
+put /admin/budget/subscription '{"tool_id":"cursor","plan_key":"teams","vendor":"Anysphere","plan":"Teams","currency":"USD","renewal_date":"2026-10-01","owner":"Engineering","seat_tiers":[{"name":"Teams","seats":1,"unit_price_monthly":40}]}'
+put /admin/budget/subscription '{"tool_id":"fireflies","plan_key":"enterprise","vendor":"Fireflies","plan":"Enterprise","currency":"USD","renewal_date":"2027-07-14","owner":"Operations","seat_tiers":[{"name":"Enterprise","seats":14,"unit_price_monthly":39}]}'
+echo; printf 'budget members: '
+members chatgpt business Business abra alakazam arbok arcanine beedrill bellsprout blastoise butterfree caterpie chansey clefable clefairy cloyster
+members claude team Standard abra dratini drowzee dugtrio ekans electabuzz electrode exeggcute exeggutor farfetchd
+members claude max-20 "Max 20" goldeen golem graveler grimer
+members claude max-5 "Max 5" growlithe gyarados haunter hitmonchan hitmonlee horsea
+members cursor teams Teams cubone
+members fireflies enterprise Enterprise caterpie chansey clefable clefairy cloyster cubone dewgong diglett dodrio doduo dragonair dragonite ekans electabuzz
+echo
+echo "done. the estate now has a fleet's worth of findings; sign in as $U to see it."

--- a/demo/seed-large.sh
+++ b/demo/seed-large.sh
@@ -3,8 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # Part of Shadow AI Guard, https://github.com/AmanSK5/shadow-ai-guard
 
-# A larger synthetic estate on top of seed.sh: fifty-odd devices, two dozen
-# tools, twenty personal accounts, six subscriptions. The point is not the
+# A larger synthetic estate on top of seed.sh: a couple of dozen devices,
+# well over a dozen tools, fifteen personal accounts, seven subscriptions. The point is not the
 # story of any one finding but the shape of the pages when there is a lot of
 # them - which is what a real estate looks like and what the demo's handful
 # of findings cannot show. Everything is fake: users are Pokemon, domains
@@ -28,20 +28,20 @@ f() {
 echo "seeding a large synthetic estate -> $R"
 
 # --- the fleet: macOS, Windows and Linux machines with a local user each ---
-MAC="abra alakazam arbok arcanine beedrill bellsprout blastoise butterfree caterpie chansey clefable clefairy cloyster cubone dewgong diglett dodrio doduo dragonair dragonite"
-WIN="dratini drowzee dugtrio ekans electabuzz electrode exeggcute exeggutor farfetchd fearow flareon gastly geodude gloom golbat golduck"
-NIX="goldeen golem graveler grimer growlithe gyarados haunter hitmonchan hitmonlee horsea hypno ivysaur"
+MAC="abra alakazam arbok arcanine"
+WIN="dratini drowzee dugtrio"
+NIX="goldeen golem"
 
 # Endpoint collectors see the tools people installed. The mix leans the way
 # real estates do: a few tools everywhere, a long tail on one or two machines.
 i=0
 for u in $MAC; do
-  d="MBP-$(echo $u | tr a-z A-Z)"; i=$((i+1))
+  d="MBP-$(echo "$u" | tr "[:lower:]" "[:upper:]")"; i=$((i+1))
   f claude browser macos example.com "$d" "$u" "claude.ai in Chrome" info collector-macos
   [ $((i % 2)) -eq 0 ] && f claude-code cli macos example.com "$d" "$u" "~/.claude.json" info collector-macos
   [ $((i % 3)) -eq 0 ] && f chatgpt desktop macos example.com "$d" "$u" "/Applications/ChatGPT.app" info collector-macos
   [ $((i % 4)) -eq 0 ] && f cursor desktop macos "" "$d" "$u" "/Applications/Cursor.app" info collector-macos
-  [ $((i % 5)) -eq 0 ] && f wispr-flow desktop macos "" "$d" "$u" "/Applications/Wispr Flow.app" info collector-macos
+  [ $((i % 3)) -eq 1 ] && f wispr-flow desktop macos "" "$d" "$u" "/Applications/Wispr Flow.app" info collector-macos
   [ $((i % 6)) -eq 0 ] && f warp desktop macos "" "$d" "$u" "/Applications/Warp.app" info collector-macos
   [ $((i % 7)) -eq 0 ] && f ollama desktop macos "" "$d" "$u" "ollama binary" info collector-macos
   [ $((i % 8)) -eq 0 ] && f lm-studio desktop macos "" "$d" "$u" "/Applications/LM Studio.app" info collector-macos
@@ -49,7 +49,7 @@ for u in $MAC; do
   [ $((i % 5)) -eq 1 ] && f claude-code-mcp mcp macos "" "$d" "$u" ".claude.json mcpServers: github,linear" info collector-macos
 done
 for u in $WIN; do
-  d="WIN-$(echo $u | tr a-z A-Z)"; i=$((i+1))
+  d="WIN-$(echo "$u" | tr "[:lower:]" "[:upper:]")"; i=$((i+1))
   f microsoft-copilot browser windows example.com "$d" "$u" "copilot.microsoft.com in Edge" info collector-windows
   [ $((i % 2)) -eq 0 ] && f claude-code cli windows example.com "$d" "$u" "%USERPROFILE%\\\\.claude.json" info collector-windows
   [ $((i % 3)) -eq 0 ] && f github-copilot ide windows "" "$d" "$u" "VS Code extension GitHub.copilot" info collector-windows
@@ -58,25 +58,24 @@ for u in $WIN; do
   [ $((i % 6)) -eq 0 ] && f notion-ai browser windows example.com "$d" "$u" "notion.so AI in Edge" info collector-windows
 done
 for u in $NIX; do
-  d="NIX-$(echo $u | tr a-z A-Z)"; i=$((i+1))
+  d="NIX-$(echo "$u" | tr "[:lower:]" "[:upper:]")"; i=$((i+1))
   f claude-code cli linux example.com "$d" "$u" "~/.claude.json" info collector-linux
   [ $((i % 2)) -eq 0 ] && f codex-cli cli linux example.com "$d" "$u" "~/.codex/config.toml" info collector-linux
   [ $((i % 3)) -eq 0 ] && f gemini-cli cli linux "" "$d" "$u" "~/.gemini/settings.json" info collector-linux
   [ $((i % 4)) -eq 0 ] && f ollama desktop linux "" "$d" "$u" "ollama binary" info collector-linux
-  [ $((i % 5)) -eq 0 ] && f warp desktop linux "" "$d" "$u" "warp-terminal binary" info collector-linux
+  [ $((i % 3)) -eq 0 ] && f warp desktop linux "" "$d" "$u" "warp-terminal binary" info collector-linux
 done
 
-# --- personal accounts: twenty, across the tools people actually use ---
+# --- personal accounts: eleven, across the tools people actually use ---
 p=0
-for pair in abra:chatgpt alakazam:chatgpt arbok:chatgpt arcanine:chatgpt beedrill:gemini bellsprout:claude-code \
-            blastoise:claude-code butterfree:codex-cli caterpie:codex-cli chansey:chatgpt dratini:chatgpt \
-            drowzee:claude dugtrio:claude-code ekans:chatgpt goldeen:codex-cli golem:claude-code graveler:codex-cli \
-            grimer:chatgpt growlithe:claude-code gyarados:gemini; do
+for pair in abra:chatgpt alakazam:chatgpt arbok:chatgpt arcanine:gemini abra:codex-cli \
+            dratini:chatgpt drowzee:claude dugtrio:claude-code dratini:claude-code \
+            goldeen:codex-cli golem:claude-code; do
   u=${pair%%:*}; t=${pair##*:}; p=$((p+1))
   case "$u" in
-    drat*|drow*|dugt*|ekan*) d="WIN-$(echo $u | tr a-z A-Z)"; os=windows; src=collector-windows;;
-    gold*|gole*|grav*|grim*|grow*|gyar*) d="NIX-$(echo $u | tr a-z A-Z)"; os=linux; src=collector-linux;;
-    *) d="MBP-$(echo $u | tr a-z A-Z)"; os=macos; src=collector-macos;;
+    drat*|drow*|dugt*|ekan*) d="WIN-$(echo "$u" | tr "[:lower:]" "[:upper:]")"; os=windows; src=collector-windows;;
+    gold*|gole*|grav*|grim*|grow*|gyar*) d="NIX-$(echo "$u" | tr "[:lower:]" "[:upper:]")"; os=linux; src=collector-linux;;
+    *) d="MBP-$(echo "$u" | tr "[:lower:]" "[:upper:]")"; os=macos; src=collector-macos;;
   esac
   dom=gmail.com; [ $((p % 4)) -eq 0 ] && dom=outlook.com; [ $((p % 7)) -eq 0 ] && dom=me.com
   case "$t" in
@@ -91,18 +90,18 @@ for u in $MAC $WIN; do
   case "$u" in c*|e*|f*) f fireflies cloud unknown example.com "" "$u" "interactive sign-in to Fireflies" info entra_sign_in;; esac
   case "$u" in g*) f github-copilot cloud unknown example.com "" "$u" "interactive sign-in to GitHub" info entra_sign_in;; esac
 done
-for u in abra beedrill chansey dodrio ekans flareon; do
+for u in abra dratini; do
   f openai-api-platform cloud unknown example.com "" "$u" "consent grant: OpenAI API" info entra_consent_grant
 done
-for u in arbok cloyster dragonite golbat; do
+for u in arbok drowzee; do
   f atlassian-rovo cloud unknown example.com "" "$u" "interactive sign-in to Atlassian" info entra_sign_in
 done
 
 # --- machines only the scanners know: the coverage gaps ---
-GAP="jigglypuff jolteon jynx kabuto kabutops kadabra kakuna kangaskhan kingler koffing krabby lapras lickitung machamp machoke machop magikarp magmar magnemite magneton mankey marowak"
+GAP="jigglypuff jolteon"
 g=0
 for u in $GAP; do
-  g=$((g+1)); d="LT-$(echo $u | tr a-z A-Z)"
+  g=$((g+1)); d="LT-$(echo "$u" | tr "[:lower:]" "[:upper:]")"
   if [ $((g % 2)) -eq 0 ]; then
     f claude network unknown "" "$d" "" "DNS lookup for claude.ai (via Google Chrome)" info sentinelone_dns
   else
@@ -115,7 +114,7 @@ done
 # --- the paste guard, on the machines that have it ---
 for u in $MAC $WIN; do
   case "$u" in a*|b*|c*|d*|e*|f*)
-    case "$u" in d*|e*|f*) d="WIN-$(echo $u | tr a-z A-Z)"; os=windows;; *) d="MBP-$(echo $u | tr a-z A-Z)"; os=macos;; esac
+    case "$u" in d*|e*|f*) d="WIN-$(echo "$u" | tr "[:lower:]" "[:upper:]")"; os=windows;; *) d="MBP-$(echo "$u" | tr "[:lower:]" "[:upper:]")"; os=macos;; esac
     f paste-guard browser "$os" "" "$d" "" "heartbeat version=1.1.1 mode=warn" info paste_guard;;
   esac
 done

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -288,10 +288,13 @@ Or from your machine with `aiguardctl`, which does exactly that with your
 own kubeconfig, finds the CronJobs by their image, shows the plan, waits for
 an owner to approve in the portal, and reports progress to System health:
 
-    pipx install "git+https://github.com/AmanSK5/shadow-ai-guard@<version>#subdirectory=cli"
+    pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@<version>#subdirectory=cli"
+    pipx ensurepath
     aiguardctl upgrade --portal https://ai-guard-portal.example.com
 
-Nothing in the cluster gains a right either way; see SECURITY.md, *Upgrading*.
+It needs Python 3.10 or newer and `pipx` on the machine that runs it; a
+shell opened before `pipx ensurepath` needs reopening before the command is
+found. Nothing in the cluster gains a right either way; see SECURITY.md, *Upgrading*.
 
 ### Authentication
 

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.30.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.31.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.30.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.31.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -1979,7 +1979,7 @@ class UpgradeStepWrite(BaseModel):
 
 class UpgradeFinishWrite(BaseModel):
     model_config = {"extra": "forbid"}
-    outcome: str = Field(pattern=r"^(succeeded|failed|aborted)$")
+    outcome: str = Field(pattern=r"^(succeeded|failed|aborted|unverified)$")
     detail: str = Field(default="", max_length=300)
 
 

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1642,3 +1642,18 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .ov-chip>.ov-stack-zone{display:none!important}
 .oedit.ov-previewing{border-left:3px solid var(--pri)}
 .oedit.ov-previewing b{color:var(--fg);margin-right:4px}
+
+/* The canvas while arranging: two columns on a dotted ground, and a target
+   at the end that is always there, so a drag never needs a card to land on. */
+.grid.ov-canvas{padding:14px;border-radius:12px;background-color:var(--sf2);background-image:radial-gradient(color-mix(in srgb,var(--mut) 28%,transparent) 1px,transparent 1px);background-size:18px 18px;min-height:220px;align-content:flex-start}
+.ov-drop-end{flex-basis:100%;display:flex;align-items:center;justify-content:center;min-height:64px;margin-top:4px;border:1px dashed var(--bd);border-radius:10px;color:var(--mut);font-size:11.5px}
+.ov-drop-end.empty{min-height:180px;font-size:12.5px}
+.ov-drop-end.over{border-color:var(--acc);border-style:solid;background:color-mix(in srgb,var(--acc) 10%,var(--sf));color:var(--acc)}
+.dragging .ov-drop-end{border-color:color-mix(in srgb,var(--acc) 60%,var(--bd))}
+/* Tray chips keep their own width and wrap; a half-width placeholder on the
+   canvas stays half, so the empty half beside it is visible while arranging. */
+.ov-tray>.ov-chip{flex:0 0 auto!important;width:auto;min-width:max-content}
+.ov-chip b{white-space:nowrap}
+.grid.ov-canvas>.gitem{flex-grow:0}
+.ov-tray>.ov-chip{container-type:normal}
+.ov-tray>.ov-chip{flex-direction:row!important}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1714,3 +1714,14 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
    and the price, seats and badges sit level with its middle rather than
    floating at the top over a band of nothing. */
 .gcard[data-wk=budget_spend] .ui-widget-table td{vertical-align:middle}
+/* Devices: the tools column carries the rows, so it takes the width the
+   single-chip columns were holding. */
+.device-inventory th:nth-child(1){width:19%}
+.device-inventory th:nth-child(2){width:13%}
+.device-inventory th:nth-child(3){width:40%}
+.device-inventory th:nth-child(4){width:15%}
+.device-inventory th:nth-child(5){width:13%}
+.ui-chip-more{color:var(--mut);background:transparent;border-style:dashed}
+.ui-compact .device-inventory td{height:44px}
+.ui-compact .device-inventory td strong{font-size:12px}
+.ui-compact .cell-tags .ui-tool-chip{margin:1px 3px 1px 0;padding:1px 6px}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1605,3 +1605,21 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .exposure-trend-card .tchart{flex:1 1 190px;min-height:140px;max-height:320px;position:relative}
 .exposure-trend-card .tchart svg{height:100%;min-height:140px;max-height:320px;display:block}
 .exposure-trend-card>.src-note{margin-top:10px}
+
+/* Arranging: the stack strip appears on every card while a drag is in
+   progress and is the only place a drop stacks. Everywhere else the drop
+   line says where the card will move to. */
+.ov-stack-zone{display:none}
+.dragging .editing .gcard>.ov-stack-zone,.dragging .gcard>.ov-stack-zone{display:flex;align-items:center;justify-content:center;position:absolute;left:0;right:0;bottom:0;height:34px;z-index:4;border:1px dashed var(--acc);border-radius:0 0 10px 10px;background:color-mix(in srgb,var(--acc) 10%,var(--sf));color:var(--acc);font-size:10.5px;font-weight:600;letter-spacing:.3px;pointer-events:auto}
+.dragging .gcard.drag>.ov-stack-zone{display:none}
+.dragging .gcard.into>.ov-stack-zone{background:color-mix(in srgb,var(--acc) 22%,var(--sf));border-style:solid}
+.editing .gcard.into{outline:1px dashed var(--bd)}
+.editing .gcard.into>.wcard,.editing .gcard.into>.stats{background:var(--sf)}
+.editing .gcard.over::after{height:3px}
+
+/* In a stack, only a card that can use height grows into the column: a list
+   shows more rows, everything else keeps its natural size and the room left
+   over sits at the end of the column, not inside a card. */
+.gitem.stack>.gcard{flex:0 0 auto}
+.gitem.stack>.gcard:has(.ui-table-scroll),.gitem.stack>.gcard:has(.ui-tool-list),.gitem.stack>.gcard:has(.ui-tool-bars){flex:1 1 auto}
+.gitem.stack>.gcard:has(.ui-queue-details){flex:1 1 auto}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1683,3 +1683,15 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 /* On the canvas nothing stretches: a placeholder is its own height, and a
    stack is the sum of its cards, so what you see is the arrangement. */
 .grid.ov-canvas{align-items:flex-start}
+/* A half card is half on the page too. The grid used to let a lone half
+   card grow across its row, so the arrangement someone drew - half, with
+   the other half open - came out full once they previewed it. */
+.grid>.gitem.w6{flex:0 0 calc(50% - 9px)}
+.grid>.gitem.w12{flex:0 0 100%}
+.ui-compact .grid>.gitem.w6{flex-basis:calc(50% - 5px)}
+@media(max-width:900px){.grid>.gitem.w6{flex-basis:100%}}
+/* The preview banner is one line: the sentence is short enough to share
+   it with the buttons, so it does not need the height the arranging
+   banner's explanation does. */
+.oedit.ov-previewing{padding:5px 12px 5px 14px;align-items:center}
+.oedit.ov-previewing>span:first-child{flex:1 1 auto}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1568,12 +1568,12 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 /* A list's body has a budget as its basis and grows into whatever the row
    gives it; past the budget it scrolls inside the card. Opened, the card
    takes its full height and the row follows. */
-.ui-widget>.ui-table-scroll{flex:1 1 auto;min-height:0;overflow:auto}
-.ui-people-card>.ui-table-scroll{flex-basis:262px}
-.ui-spend-card>.ui-table-scroll{flex-basis:300px}
-.ui-agentic-card>.ui-table-scroll{flex-basis:200px}
+.ui-widget>.ui-table-scroll{flex:1 1 auto;min-height:0;overflow:hidden;--ui-budget:262}
+.ui-people-card>.ui-table-scroll{--ui-budget:262}
+.ui-spend-card>.ui-table-scroll{--ui-budget:300}
+.ui-agentic-card>.ui-table-scroll{--ui-budget:220}
 .ui-tools-card{display:flex;flex-direction:column}
-.ui-tools-card>.ui-table-scroll,.ui-tools-card>.ui-tool-list,.ui-tools-card>.ui-tool-bars{flex:1 1 470px;min-height:0;overflow:auto}
+.ui-tools-card>.ui-table-scroll,.ui-tools-card>.ui-tool-list,.ui-tools-card>.ui-tool-bars{flex:1 1 auto;min-height:0;overflow:hidden;--ui-budget:470}
 .ui-tools-card>.ui-panel-footer,.ui-tools-card>.ui-table-note{flex-shrink:0}
 .ui-open>.ui-table-scroll,.ui-tools-card.ui-open>.ui-table-scroll,.ui-tools-card.ui-open>.ui-tool-list,.ui-tools-card.ui-open>.ui-tool-bars{flex-basis:auto;overflow:visible}
 .ui-widget-table thead th,.ui-inventory thead th{position:sticky;top:0;z-index:1}
@@ -1662,3 +1662,17 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .grid.ov-canvas>.gitem.w6{flex:0 0 calc(50% - 9px)}
 .grid.ov-canvas>.gitem.w12{flex:0 0 100%}
 .ui-compact .grid.ov-canvas>.gitem.w6{flex-basis:calc(50% - 5px)}
+
+/* Whole rows only: the fit pass hides what would not fit, and says so. */
+.ui-cut{display:none!important}
+.ui-shown:empty{display:none}
+.ui-shown{font-style:normal;color:var(--mut)}
+.ui-shown::before{content:"· "}
+.ui-paste-card>.ui-table-scroll{--ui-budget:180}
+/* Visibility: the latest report per surface, growing into the card. */
+.ui-latest-heading{padding-top:12px}
+.ui-visibility-card>.ui-latest{flex:1 1 auto;min-height:0;overflow:hidden;margin-top:6px}
+.ui-visibility-card>.ui-latest .ui-widget-table td{padding-top:7px;padding-bottom:7px}
+.ui-visibility-card>.ui-latest td:first-child strong{text-transform:capitalize}
+.ui-silent-table td:last-child em{font-style:normal;color:var(--mut);opacity:.85;font-size:10px;margin-left:5px}
+.wcard.ui-paste-card .ui-widget-table th:last-child,.wcard.ui-paste-card .ui-widget-table td:last-child{text-align:left;width:auto;white-space:normal}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1623,3 +1623,20 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .gitem.stack>.gcard{flex:0 0 auto}
 .gitem.stack>.gcard:has(.ui-table-scroll),.gitem.stack>.gcard:has(.ui-tool-list),.gitem.stack>.gcard:has(.ui-tool-bars){flex:1 1 auto}
 .gitem.stack>.gcard:has(.ui-queue-details){flex:1 1 auto}
+
+/* The planner: while arranging, every card is a placeholder of one height,
+   so the whole arrangement fits on a screen and a drag is a short one. */
+.editing .gcard{min-height:0}
+.ov-placeholder{display:flex;flex-direction:column;justify-content:center;gap:4px;min-height:112px;padding:44px 18px 16px;border:1px solid var(--bd);border-radius:10px;background:var(--sf)}
+.ov-placeholder b{font-size:13px;font-weight:600;color:var(--fg)}
+.ov-placeholder span{font-size:11px;color:var(--mut);line-height:1.45}
+.ov-placeholder small{font-size:10px;color:var(--mut);text-transform:uppercase;letter-spacing:.6px;margin-top:4px}
+.editing .gitem.stack>.gcard{flex:0 0 auto}
+.editing .gcard>.ov-stack-zone{border-radius:0 0 10px 10px}
+.ov-tray{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin:0 0 16px;padding:12px 14px;border:1px dashed var(--bd);border-radius:10px;background:var(--sf2)}
+.ov-tray-label{flex-basis:100%;font-size:11px;color:var(--mut)}
+.ov-chip{display:inline-flex;align-items:center;gap:10px;padding:8px 8px 8px 12px;border:1px solid var(--bd);border-radius:8px;background:var(--sf);cursor:grab;outline:0!important;flex:0 0 auto}
+.ov-chip>*{flex:0 0 auto}
+.ov-chip b{font-size:12px;font-weight:600;color:var(--fg)}
+.ov-chip button{font:inherit;font-size:10.5px;padding:3px 9px;border:1px solid var(--bd);border-radius:5px;background:var(--sf2);color:var(--pri);cursor:pointer}
+.ov-chip>.ov-stack-zone{display:none!important}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1695,3 +1695,18 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
    banner's explanation does. */
 .oedit.ov-previewing{padding:5px 12px 5px 14px;align-items:center}
 .oedit.ov-previewing>span:first-child{flex:1 1 auto}
+/* The fit pass owns the footer button: it is in the markup whenever the
+   card has rows and shows only when some are hidden. */
+.ui-panel-footer .ui-more.ui-idle{display:none}
+/* The bar list starts where the head ends and keeps its bottom padding,
+   so the first bar is not adrift under the filters and the last one is
+   not on the divider. */
+.ui-tool-bars{padding:0 20px 15px}
+.ui-tool-bars .bars{margin-top:0}
+.ui-compact .ui-tool-bars{padding:0 16px 12px}
+/* Dots are a stepped meter: one segment per dedicated source, across the
+   same track the meter uses, so the two forms read against each other
+   instead of five slivers huddled beside the count. */
+.ui-source-grid .covrow .dots{flex:1;display:flex;justify-content:flex-start;gap:4px;min-width:25px}
+.ui-source-grid .dots i{flex:1 1 0;height:8px;width:auto;border-radius:2px;background:var(--bd)}
+.ui-source-grid .dots i.on{background:linear-gradient(90deg,var(--pri),var(--chart))}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1640,3 +1640,5 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .ov-chip b{font-size:12px;font-weight:600;color:var(--fg)}
 .ov-chip button{font:inherit;font-size:10.5px;padding:3px 9px;border:1px solid var(--bd);border-radius:5px;background:var(--sf2);color:var(--pri);cursor:pointer}
 .ov-chip>.ov-stack-zone{display:none!important}
+.oedit.ov-previewing{border-left:3px solid var(--pri)}
+.oedit.ov-previewing b{color:var(--fg);margin-right:4px}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1373,7 +1373,7 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .inventory-summary b{font-size:22px;font-weight:580;letter-spacing:-.6px}
 /* Supporting widgets: head, body, footer; sized to content, never stretched
      into dead space; the same geometry in comfortable, compact and edit modes. */
-.ui-widget{padding:0;overflow:hidden;display:flex;flex-direction:column;min-height:100%}
+.ui-widget{padding:0;overflow:hidden;display:flex;flex-direction:column}
 .ui-widget>.ui-panel-head{padding-bottom:14px}
 .ui-widget>.ui-table-scroll,.ui-widget>.ui-notes,.ui-widget>.ui-empty{flex:1 0 auto}
 .ui-widget>.ui-panel-footer{margin-top:auto}
@@ -1404,16 +1404,12 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 /* Columns and rows by the card's width: S keeps the identity and the verdict, M adds the
    working figures, L adds the detail. Ten rows are drawn; S shows four, M six, L ten. */
 .ui-widget-table .ui-col-l{display:none}
-.ui-widget-table tbody tr:nth-child(n+7){display:none}
 @container (min-width:720px){
   .ui-widget-table .ui-col-l{display:table-cell}
   .ui-widget-table td small.ui-col-s{display:none}
-  .ui-widget-table tbody tr:nth-child(n+7){display:table-row}
-  .ui-widget-table tbody tr:nth-child(n+11){display:none}
 }
 @container (max-width:430px){
   .ui-widget-table .ui-col-m{display:none}
-  .ui-widget-table tbody tr:nth-child(n+5){display:none}
 }
 .ui-widget-table th.num{text-align:right}
 .ui-silent-table td:last-child{color:var(--mut);font-size:11px;line-height:1.5}
@@ -1564,3 +1560,17 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .ui-compact .bars{gap:6px}
 .ui-compact .barrow{min-height:24px}
 .wcard .ui-silent-table th:last-child,.wcard .ui-silent-table td:last-child{text-align:left;width:auto;white-space:normal}
+
+/* Cards are as tall as what they hold. On an estate of any size a stretched
+   row is a void beside every short card; the row budgets above keep the tall
+   ones honest instead. */
+.grid{align-items:flex-start}
+.gitem{align-self:flex-start}
+.gcard[data-wk=review_queue],.gcard[data-wk=detection_coverage]{height:auto}
+.gcard[data-wk=review_queue]>.wcard,.gcard[data-wk=detection_coverage]>.wcard{min-height:0}
+.ui-visibility-card>.ui-source-grid{flex:0 0 auto;align-content:start}
+.ui-focus-card>.ui-queue-details{flex:0 0 auto}
+.ui-people-table td:first-child,.ui-people-table td:nth-child(4){white-space:nowrap}
+.ui-panel-footer>span{display:flex;align-items:center;gap:10px;flex-wrap:wrap;min-width:0}
+.ui-panel-footer .ui-more{min-height:24px;padding:2px 8px;font-size:10px;color:var(--fg);border:1px solid var(--bd);background:var(--sf2)}
+.ui-panel-footer .ui-more:hover{border-color:var(--pri)}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1657,3 +1657,8 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .grid.ov-canvas>.gitem{flex-grow:0}
 .ov-tray>.ov-chip{container-type:normal}
 .ov-tray>.ov-chip{flex-direction:row!important}
+/* On the canvas a half is exactly half: two of them make a row, and the
+   space a lone half leaves is exactly the space a second one would take. */
+.grid.ov-canvas>.gitem.w6{flex:0 0 calc(50% - 9px)}
+.grid.ov-canvas>.gitem.w12{flex:0 0 100%}
+.ui-compact .grid.ov-canvas>.gitem.w6{flex-basis:calc(50% - 5px)}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1676,3 +1676,10 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .ui-visibility-card>.ui-latest td:first-child strong{text-transform:capitalize}
 .ui-silent-table td:last-child em{font-style:normal;color:var(--mut);opacity:.85;font-size:10px;margin-left:5px}
 .wcard.ui-paste-card .ui-widget-table th:last-child,.wcard.ui-paste-card .ui-widget-table td:last-child{text-align:left;width:auto;white-space:normal}
+/* The two cards that fill a row of their own by height must not claim a
+   whole stacked column, in the planner or on the page: in a stack the flex
+   rules above decide who grows. */
+.gitem.stack>.gcard[data-wk=review_queue],.gitem.stack>.gcard[data-wk=detection_coverage],.editing .gcard[data-wk=review_queue],.editing .gcard[data-wk=detection_coverage]{height:auto}
+/* On the canvas nothing stretches: a placeholder is its own height, and a
+   stack is the sum of its cards, so what you see is the arrangement. */
+.grid.ov-canvas{align-items:flex-start}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1574,3 +1574,18 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .ui-panel-footer>span{display:flex;align-items:center;gap:10px;flex-wrap:wrap;min-width:0}
 .ui-panel-footer .ui-more{min-height:24px;padding:2px 8px;font-size:10px;color:var(--fg);border:1px solid var(--bd);background:var(--sf2)}
 .ui-panel-footer .ui-more:hover{border-color:var(--pri)}
+
+/* Instructions somebody follows: numbered, full width, each command on its
+   own line with a copy control, inline commands set apart from the prose. */
+.health-card details.how.ui-how{max-width:none}
+.ui-steps>p{margin:8px 0 12px;font-size:12px;line-height:1.55;color:var(--mut);font-style:normal}
+.ui-steplist{margin:0;padding:0;list-style:none;counter-reset:step;display:flex;flex-direction:column;gap:12px}
+.ui-steplist>li{position:relative;padding-left:32px;font-size:12px;line-height:1.55;color:var(--mut);counter-increment:step}
+.ui-steplist>li::before{content:counter(step);position:absolute;left:0;top:1px;width:22px;height:22px;border-radius:6px;display:grid;place-items:center;background:var(--sf2);border:1px solid var(--bd);color:var(--fg);font-size:10.5px;font-weight:600}
+.ui-steplist>li>b{display:block;color:var(--fg);font-weight:600;margin:2px 0 4px}
+.ui-steplist>li>span{display:block;margin-top:6px}
+.ui-steplist code,.ui-steps code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;padding:1px 6px;border-radius:4px;background:var(--sf2);border:1px solid var(--bd);color:var(--pri);white-space:nowrap}
+.ui-cmd{display:flex;align-items:center;gap:12px;margin:4px 0;padding:8px 10px 8px 12px;border:1px solid var(--bd);border-radius:6px;background:var(--sf2)}
+.ui-cmd>code{flex:1;min-width:0;padding:0;border:0;background:transparent;font-size:11.5px;color:var(--pri);white-space:pre-wrap;overflow-wrap:anywhere}
+.ui-cmd>.ui-copy{flex-shrink:0;min-height:26px;padding:3px 10px;font-size:10.5px;background:var(--sf);color:var(--fg);border:1px solid var(--bd)}
+.ui-cmd>.ui-copy:hover{border-color:var(--pri);color:var(--pri)}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1564,10 +1564,19 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 /* Cards are as tall as what they hold. On an estate of any size a stretched
    row is a void beside every short card; the row budgets above keep the tall
    ones honest instead. */
-.grid{align-items:flex-start}
-.gitem{align-self:flex-start}
-.gcard[data-wk=review_queue],.gcard[data-wk=detection_coverage]{height:auto}
-.gcard[data-wk=review_queue]>.wcard,.gcard[data-wk=detection_coverage]>.wcard{min-height:0}
+.ui-widget,.ui-tools-card{min-height:100%}
+/* A list's body has a budget as its basis and grows into whatever the row
+   gives it; past the budget it scrolls inside the card. Opened, the card
+   takes its full height and the row follows. */
+.ui-widget>.ui-table-scroll{flex:1 1 auto;min-height:0;overflow:auto}
+.ui-people-card>.ui-table-scroll{flex-basis:262px}
+.ui-spend-card>.ui-table-scroll{flex-basis:300px}
+.ui-agentic-card>.ui-table-scroll{flex-basis:200px}
+.ui-tools-card{display:flex;flex-direction:column}
+.ui-tools-card>.ui-table-scroll,.ui-tools-card>.ui-tool-list,.ui-tools-card>.ui-tool-bars{flex:1 1 470px;min-height:0;overflow:auto}
+.ui-tools-card>.ui-panel-footer,.ui-tools-card>.ui-table-note{flex-shrink:0}
+.ui-open>.ui-table-scroll,.ui-tools-card.ui-open>.ui-table-scroll,.ui-tools-card.ui-open>.ui-tool-list,.ui-tools-card.ui-open>.ui-tool-bars{flex-basis:auto;overflow:visible}
+.ui-widget-table thead th,.ui-inventory thead th{position:sticky;top:0;z-index:1}
 .ui-visibility-card>.ui-source-grid{flex:0 0 auto;align-content:start}
 .ui-focus-card>.ui-queue-details{flex:0 0 auto}
 .ui-people-table td:first-child,.ui-people-table td:nth-child(4){white-space:nowrap}
@@ -1589,3 +1598,10 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .ui-cmd>code{flex:1;min-width:0;padding:0;border:0;background:transparent;font-size:11.5px;color:var(--pri);white-space:pre-wrap;overflow-wrap:anywhere}
 .ui-cmd>.ui-copy{flex-shrink:0;min-height:26px;padding:3px 10px;font-size:10.5px;background:var(--sf);color:var(--fg);border:1px solid var(--bd)}
 .ui-cmd>.ui-copy:hover{border-color:var(--pri);color:var(--pri)}
+/* The trend card fills its frame with the chart rather than with air; the
+   chart is drawn to a viewBox with no aspect lock, so it stretches. */
+.exposure-trend-card{display:flex;flex-direction:column;min-height:100%}
+.exposure-trend-card .exposure-chart{flex:0 0 auto;display:flex;flex-direction:column;min-height:0}
+.exposure-trend-card .tchart{flex:1 1 190px;min-height:140px;max-height:320px;position:relative}
+.exposure-trend-card .tchart svg{height:100%;min-height:140px;max-height:320px;display:block}
+.exposure-trend-card>.src-note{margin-top:10px}

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -1710,3 +1710,7 @@ td{font-size:12px;padding-top:11px;padding-bottom:11px}
 .ui-source-grid .covrow .dots{flex:1;display:flex;justify-content:flex-start;gap:4px;min-width:25px}
 .ui-source-grid .dots i{flex:1 1 0;height:8px;width:auto;border-radius:2px;background:var(--bd)}
 .ui-source-grid .dots i.on{background:linear-gradient(90deg,var(--pri),var(--chart))}
+/* The subscription cell is name over plan, so the row is two lines tall
+   and the price, seats and badges sit level with its middle rather than
+   floating at the top over a band of nothing. */
+.gcard[data-wk=budget_spend] .ui-widget-table td{vertical-align:middle}

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2315,6 +2315,14 @@ function uiToolInfo(id) {
 // the inventory pages read the way the Overview does. The id stays in the
 // title, and search still matches it.
 function uiToolName(id) { return uiToolInfo(id).name || id; }
+// "3h ago" from a timestamp, for the small print beside a source.
+function uiAgo(t) {
+  const m = Math.round((Date.now() - Date.parse(t)) / 60000);
+  if (!(m >= 0)) return '';
+  if (m < 90) return m + 'm ago';
+  const h = Math.round(m / 60);
+  return h < 36 ? h + 'h ago' : Math.round(h / 24) + 'd ago';
+}
 function uiToolChip(id, cls) {
   return `<span class="ui-tool-chip${cls ? ' ' + cls : ''}" title="${esc(id)}">${esc(uiToolName(id))}</span>`;
 }
@@ -2518,8 +2526,10 @@ const WIDGETS = {
       <p class="ui-empty">Not read yet. Open Agentic AI.</p>
       <div class="ui-panel-footer"><span></span><button class="mini" data-nav="agentic">Open Agentic AI ${uiIcon('arrow')}</button></div></div>`;
     const c = AGENTIC.counts || {};
-    const loose = (AGENTIC.agents || []).filter(
-      a => a.autonomous && !a.accountable);
+    // Every run that reported starting itself, the unaccountable ones
+    // first: the count above is all of them, so the table is too.
+    const loose = (AGENTIC.agents || []).filter(a => a.autonomous)
+      .sort((a, b) => (a.accountable ? 1 : 0) - (b.accountable ? 1 : 0));
     const body = !c.autonomous
       ? `<p class="ui-empty">Nothing reported starting itself.${
         c.unrecognised ? ` ${c.unrecognised} process${c.unrecognised === 1 ? '' : 'es'}
@@ -2538,11 +2548,12 @@ const WIDGETS = {
             <td class="ui-col-l">${(a.reach || []).length ? (a.reach || []).slice(0, 3).map(x => `<span class="ui-surface">${esc(x)}</span>`).join('') + ((a.reach || []).length > 3 ? ` <span class="ui-muted">+${a.reach.length - 3}</span>` : '') : '<span class="ui-muted">nothing configured</span>'}</td>
             <td>${a.process
               ? '<span class="ui-badge risk">no tool we know</span>'
+              : a.accountable ? '<span class="ui-badge good">' + esc(a.user || a.identity || 'a person') + '</span>'
               : '<span class="ui-badge risk">' + esc(a.identity || 'unattributed') + '</span>'}</td>
           </tr>`).join('')}</tbody></table></div>` : ''}`;
     return `<div class="wcard w6 ui-widget ui-agentic-card">${head(c.autonomous || 0)}
       ${body}
-      <div class="ui-panel-footer"><span>${c.unrecognised ? `${c.unrecognised} unrecognised process${c.unrecognised === 1 ? '' : 'es'} reached a model` : ''}</span>
+      <div class="ui-panel-footer"><span>${c.unrecognised ? `${c.unrecognised} unrecognised process${c.unrecognised === 1 ? '' : 'es'} reached a model` : ''}<i class="ui-shown"></i></span>
         <button class="mini" data-nav="agentic">Open Agentic AI ${uiIcon('arrow')}</button></div>
     </div>`;
   },
@@ -2631,7 +2642,7 @@ const WIDGETS = {
           <td>${r.unobserved.length ? `<span class="ui-badge attention">${r.unobserved.length} idle</span>` : ''}${r.strangers.length
             ? ` <span class="ui-badge governance">${r.strangers.length} unseated</span>` : ''}${!r.unobserved.length && !r.strangers.length ? '<span class="ui-muted">Nothing flagged</span>' : ''}</td></tr>`;
       }).join('')}</tbody></table></div>
-    <div class="ui-panel-footer"><span>${next ? `Next renewal: ${esc(uiToolName(next.tool_id))} ${when(next.renewal_date)}` : 'No renewal dates recorded'}
+    <div class="ui-panel-footer"><span>${next ? `Next renewal: ${esc(uiToolName(next.tool_id))} ${when(next.renewal_date)}` : 'No renewal dates recorded'}<i class="ui-shown"></i>
       ${uiMoreButton('budget_spend', shown, 'subscriptions')}</span>
       <button class="mini" data-nav="budget">Open Budget ${uiIcon('arrow')}</button></div></div>`;
   },
@@ -2654,7 +2665,7 @@ const WIDGETS = {
       ${!f.known ? '<p class="ui-empty">Findings are unavailable.</p>' : rows.length ? (bars
         ? '<div class="ui-tool-bars">' + barRows(rows.map(([k,t]) => [k,(t.devices||[]).length, uiToolName(k)]).slice(0, shown.rows.length), 'devices', 'tool') + '</div>'
         : uiToolsTable(shown.rows)) : '<p class="ui-empty">No tools match this view.</p>'}
-      <div class="ui-panel-footer"><span>${f.known ? `${rows.length} of ${f.toolIds.length} discovered tools` : 'No data available'}
+      <div class="ui-panel-footer"><span>${f.known ? `${rows.length} of ${f.toolIds.length} discovered tools` : 'No data available'}<i class="ui-shown"></i>
         ${uiMoreButton('top_tools', shown, 'tools')}</span>
         <button class="mini" data-nav="tools">Open discovered tools ${uiIcon('arrow')}</button></div>
       <p class="src-note ui-table-note">${bars ? 'Observed devices per tool. Cloud-only tools may have zero associated devices.'
@@ -2687,7 +2698,7 @@ const WIDGETS = {
         <p>Latest activity in accounts outside your corporate domains</p></div>
         <span class="ui-eyebrow">Last ${esc(fmtWindow(hoursNow()))}</span></div>
       ${body}
-      <div class="ui-panel-footer"><span>${pa.length ? `${shown.all} in this window` : ''}
+      <div class="ui-panel-footer"><span>${pa.length ? `${shown.all} in this window` : ''}<i class="ui-shown"></i>
         ${uiMoreButton('recent_personal_accounts', shown, 'accounts')}</span>
         <button class="mini" data-nav="personal">Open personal accounts ${uiIcon('arrow')}</button></div>
     </div>`;
@@ -2737,6 +2748,16 @@ const WIDGETS = {
         <span>${esc(g.group)}</span>${dots}
         <b>${g.reporting}/${g.total}</b></div>`;
     }).join('')}</div>
+    <div class="ui-source-heading ui-latest-heading"><h4>Latest report by surface</h4><span>findings · devices in this window</span></div>
+    <div class="ui-table-scroll ui-latest"><table class="ui-inventory ui-widget-table"><tbody>${(S.groups||[]).map(g => {
+      const srcs = (g.sources || []).filter(x => x.last_seen).sort((a, b) => a.last_seen < b.last_seen ? 1 : -1);
+      const last = srcs[0];
+      const findings = (g.sources || []).reduce((n, x) => n + (x.findings || 0), 0);
+      const devices = (g.sources || []).reduce((n, x) => n + (x.devices || 0), 0);
+      return `<tr><td><strong>${esc(g.group)}</strong></td>
+        <td>${last ? `${esc(last.label || last.source)} <span class="ui-muted">· ${esc(uiAgo(last.last_seen))}</span>` : '<span class="ui-muted">nothing yet</span>'}</td>
+        <td class="num">${findings}<span class="ui-muted"> · ${devices}</span></td></tr>`;
+    }).join('')}</tbody></table></div>
     <div class="ui-panel-footer"><span>Source catalogue, not configured integrations</span><button class="mini" data-nav="setup">Review sources ${uiIcon('arrow')}</button></div>
     <details class="ui-coverage-note"><summary>How to read coverage</summary><p class="src-note">Collector coverage uses devices observed by any source, not your entire company fleet. An unobserved source may be unconfigured or inapplicable. These are dedicated sources per surface; other sources can also produce findings for it.</p></details></div>`;
   },
@@ -2773,7 +2794,7 @@ const WIDGETS = {
         <tbody>${groups.map(g => `<tr>
           <td><strong>${esc(g.group)}</strong></td>
           <td class="num">${g.silent.length} of ${g.total}</td>
-          <td>${g.silent.map(r => `<span title="${esc(r.source)}">${esc(r.label || r.source)}</span>`).join('<i>·</i>')}</td>
+          <td>${g.silent.map(r => `<span title="${esc(r.source)}">${esc(r.label || r.source)}<em>${r.last_seen ? esc(uiAgo(r.last_seen)) : 'never'}</em></span>`).join('<i>·</i>')}</td>
         </tr>`).join('')}</tbody></table></div>`
         : '<p class="ui-empty">Every listed source is reporting.</p>'}
       <div class="ui-panel-footer"><span>Unconfigured or not applicable, not necessarily broken</span>
@@ -2803,12 +2824,21 @@ const WIDGETS = {
         <div><dt${over ? ' class="risk"' : ''}>${over}</dt><dd>warnings overridden</dd></div>
       </dl>
       <ul class="ui-notes">
-        ${warnMode && warned ? `<li class="attention">In block mode, ${warned} warned paste${warned === 1 ? '' : 's'} would have been stopped outright. The breakdown is on the Paste guard page.</li>` : ''}
+        ${warnMode && warned ? `<li class="attention">In block mode, ${warned} warned paste${warned === 1 ? '' : 's'} would have been stopped outright.</li>` : ''}
         <li>${live
           ? `Running on ${live} device${live === 1 ? '' : 's'}${versions > 1 ? ` across ${versions} versions` : ''}, so low numbers here genuinely mean few risky pastes.`
           : 'No device has checked in yet, so zero here means "not deployed", not "nobody pasted anything".'}</li>
       </ul>
-      <div class="ui-panel-footer"><span>${warned ? `${warned} warned in this window` : 'Nothing warned in this window'}</span>
+      ${(PG.rows || []).length ? `<div class="ui-table-scroll"><table class="ui-inventory ui-widget-table">
+        <thead><tr><th>Where pastes went</th><th class="num">Warned</th><th class="num ui-col-m">Overridden</th><th class="num ui-col-l">Blocked</th><th>Detectors</th></tr></thead>
+        <tbody>${(PG.rows || []).slice(0, 30).map(r => `<tr>
+          <td><strong>${esc(uiToolName(r.tool))}</strong></td>
+          <td class="num">${num(r.warned)}</td>
+          <td class="num ui-col-m">${r.overridden ? `<span class="ui-badge risk">${num(r.overridden)}</span>` : num(0)}</td>
+          <td class="num ui-col-l">${num(r.blocked)}</td>
+          <td>${(r.detectors || []).slice(0, 3).map(d => `<span class="ui-surface">${esc(d)}</span>`).join('')}</td>
+        </tr>`).join('')}</tbody></table></div>` : ''}
+      <div class="ui-panel-footer"><span>${warned ? `${warned} warned in this window` : 'Nothing warned in this window'}<i class="ui-shown"></i></span>
         <button class="mini" data-nav="paste">Open Paste guard ${uiIcon('arrow')}</button></div></div>`;
   },
 
@@ -10327,7 +10357,46 @@ async function render() {
   decorateView();
   drawSetup();
   maybeTour();
+  requestAnimationFrame(uiFit);
 }
+// A list card shows whole rows only. Its body has the height its row gives
+// it; any row that would not fit in full is hidden, and the footer says how
+// many are on show. Runs after every render and on resize, so a density
+// change, a neighbour growing, or a narrower window never leaves a row cut
+// through the middle. An opened card ("Show all") is left alone.
+function uiFit() {
+  const bodies = [...document.querySelectorAll('.ui-widget:not(.ui-open)>.ui-table-scroll, .ui-tools-card:not(.ui-open)>.ui-table-scroll, .ui-tools-card:not(.ui-open)>.ui-tool-list, .ui-tools-card:not(.ui-open)>.ui-tool-bars')]
+    .filter(b => b.offsetParent);
+  // First the basis: a body asks its row for the smaller of its content and
+  // its budget, so a short list never props a card open, and a long one
+  // never sets the row taller than the budget. It still grows when a
+  // neighbour is taller. Then, after that has settled, the row cut.
+  bodies.forEach(body => {
+    const budget = parseFloat(getComputedStyle(body).getPropertyValue('--ui-budget')) || 470;
+    const content = body.firstElementChild ? body.firstElementChild.getBoundingClientRect().height : 0;
+    body.style.flexBasis = Math.min(budget, Math.ceil(content)) + 'px';
+  });
+  requestAnimationFrame(() => uiCut(bodies));
+}
+function uiCut(bodies) {
+  bodies.forEach(body => {
+    const rows = [...body.querySelectorAll(':scope tbody>tr, :scope>li, :scope .bars>.barrow')];
+    if (!rows.length) return;
+    rows.forEach(r => { r.classList.remove('ui-cut'); });
+    const limit = body.getBoundingClientRect().bottom + 1;
+    let shown = 0;
+    rows.forEach(r => {
+      if (r.getBoundingClientRect().bottom > limit) r.classList.add('ui-cut'); else shown++;
+    });
+    const card = body.parentElement;
+    const note = card.querySelector('.ui-shown');
+    if (note) note.textContent = shown < rows.length ? `${shown} shown` : '';
+  });
+}
+let UI_FIT_TIMER = null;
+window.addEventListener('resize', () => {
+  clearTimeout(UI_FIT_TIMER); UI_FIT_TIMER = setTimeout(uiFit, 120);
+});
 // A detail opens in the inspector beside the list rather than replacing it.
 // Opening touches only the drawer, so the list keeps its scroll position;
 // a data-open inside the drawer (a device on a tool page) swaps the drawer

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2951,14 +2951,18 @@ const WIDGET_SIZES = {
 
 // The working copy while arranging. Null means not arranging.
 let OVEDIT = null;
+// Looking at the draft with real data, before saving it.
+let OVPREVIEW = false;
 
 function overview() {
   const live = overviewWidgets();
-  const editing = !!OVEDIT;
-  const order = editing ? OVEDIT.order : live.all.map(wKey);
-  const hidden = editing ? OVEDIT.hidden : live.hidden;
-  const sizes = editing ? OVEDIT.sizes : live.sizes;
-  const stacked = editing ? OVEDIT.stacked : live.stacked;
+  // A draft in hand is "drafting"; the planner shows it as placeholders,
+  // the preview shows it with the real cards. Both read the same draft.
+  const drafting = !!OVEDIT, editing = drafting && !OVPREVIEW;
+  const order = drafting ? OVEDIT.order : live.all.map(wKey);
+  const hidden = drafting ? OVEDIT.hidden : live.hidden;
+  const sizes = drafting ? OVEDIT.sizes : live.sizes;
+  const stacked = drafting ? OVEDIT.stacked : live.stacked;
   const by = new Map(live.all.map(w => [wKey(w), w]));
   const draw = order.filter(k => by.has(k) && (editing || hidden.indexOf(k) < 0));
 
@@ -3054,6 +3058,14 @@ function overview() {
         ? ' - the widgets a deployment offers are set under Settings' : ''}.</span>
     <span class="sp"></span>
     <button class="ghost" data-act="ov-reset">Reset to default</button>
+    <button class="ghost" data-act="ov-cancel">Cancel</button>
+    <button class="ghost" data-act="ov-preview">Preview</button>
+    <button class="pri" data-act="ov-save">Save</button>
+  </div>` : drafting ? `<div class="oedit ov-previewing">
+    <span><b>Previewing your arrangement.</b> This is how the page will read with
+    today's data. Nothing is saved until you say so.</span>
+    <span class="sp"></span>
+    <button class="ghost" data-act="ov-plan">Back to arranging</button>
     <button class="ghost" data-act="ov-cancel">Cancel</button>
     <button class="pri" data-act="ov-save">Save</button>
   </div>` : ''}
@@ -8944,12 +8956,14 @@ async function managedAction(act, el) {
               stacked: live.stacked.slice()};
     render(); return;
   }
-  if (act === 'ov-cancel') { OVEDIT = null; render(); return; }
+  if (act === 'ov-cancel') { OVEDIT = null; OVPREVIEW = false; render(); return; }
+  if (act === 'ov-preview') { OVPREVIEW = true; render(); window.scrollTo(0, 0); return; }
+  if (act === 'ov-plan') { OVPREVIEW = false; render(); window.scrollTo(0, 0); return; }
   if (act === 'ov-save') {
     await prefSet('overview.layout', JSON.stringify(
       {order: OVEDIT.order, hidden: OVEDIT.hidden, sizes: OVEDIT.sizes,
        stacked: OVEDIT.stacked}));
-    OVEDIT = null; render(); return;
+    OVEDIT = null; OVPREVIEW = false; render(); return;
   }
   if (act === 'ov-reset') {
     // Deleting the key rather than saving today's default: the default is

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2330,6 +2330,16 @@ function uiAgo(t) {
 function uiToolChip(id, cls) {
   return `<span class="ui-tool-chip${cls ? ' ' + cls : ''}" title="${esc(id)}">${esc(uiToolName(id))}</span>`;
 }
+// A run of tool chips capped for a table cell: the busiest device in a
+// large estate had ten tools and a row four lines tall. The tail says how
+// many more; the row opens to the device, which lists all of them.
+function uiChipRun(ids, cap, empty) {
+  if (!ids.length) return empty;
+  const shown = ids.length > cap ? ids.slice(0, cap - 1) : ids;
+  const rest = ids.length - shown.length;
+  return shown.map(t => uiToolChip(t)).join('')
+    + (rest ? `<span class="ui-tool-chip ui-chip-more" title="${esc(ids.slice(shown.length).map(uiToolName).join(', '))}">+${rest} more</span>` : '');
+}
 function uiSourceLabel(id) {
   const src = ((S && S.groups) || []).flatMap(g => g.sources || []).find(x => x.source === id);
   return src && src.label ? src.label : id;
@@ -3135,9 +3145,9 @@ function devices() {
     <thead><tr><th>Device</th><th>Person</th><th>AI tools</th>
       <th>Personal accounts</th><th>Local users</th></tr></thead>
     <tbody>${rows.map(([k,d]) => `<tr data-open="device" data-key="${esc(k)}">
-      <td><strong>${esc(label(k,d))}</strong><br><span class="mono row-key">${esc(k)}</span></td>
+      <td><strong>${esc(label(k,d))}</strong>${label(k,d) === k ? '' : `<br><span class="mono row-key">${esc(k)}</span>`}</td>
       <td>${d.person ? `<span class="pill p-ok">${esc(d.person)}</span>` : '<span class="muted-value">Unattributed</span>'}</td>
-      <td><div class="cell-tags">${(d.tools||[]).map(t=>uiToolChip(t)).join('') || '<span class="muted-value">None observed</span>'}</div></td>
+      <td><div class="cell-tags">${uiChipRun(d.tools||[], 6, '<span class="muted-value">None observed</span>')}</div></td>
       <td><div class="cell-tags">${(d.personal_accounts||[]).map(a=>`<span class="ui-badge risk">${esc(a)}</span>`).join('') || '<span class="muted-value">None</span>'}</div></td>
       <td><div class="cell-tags">${(d.local_users||[]).map(u=>`<span class="pill p-mut">${esc(u)}</span>`).join('') || '<span class="muted-value">—</span>'}</div></td>
     </tr>`).join('')}</tbody>

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -10357,13 +10357,14 @@ async function render() {
   decorateView();
   drawSetup();
   maybeTour();
-  requestAnimationFrame(uiFit);
+  setTimeout(uiFit, 0);
 }
 // A list card shows whole rows only. Its body has the height its row gives
 // it; any row that would not fit in full is hidden, and the footer says how
 // many are on show. Runs after every render and on resize, so a density
 // change, a neighbour growing, or a narrower window never leaves a row cut
 // through the middle. An opened card ("Show all") is left alone.
+let UI_FIT_TIMER = null;
 function uiFit() {
   const bodies = [...document.querySelectorAll('.ui-widget:not(.ui-open)>.ui-table-scroll, .ui-tools-card:not(.ui-open)>.ui-table-scroll, .ui-tools-card:not(.ui-open)>.ui-tool-list, .ui-tools-card:not(.ui-open)>.ui-tool-bars')]
     .filter(b => b.offsetParent);
@@ -10371,18 +10372,30 @@ function uiFit() {
   // its budget, so a short list never props a card open, and a long one
   // never sets the row taller than the budget. It still grows when a
   // neighbour is taller. Then, after that has settled, the row cut.
+  // Measured with every row showing: a second pass (a resize) must not
+  // read a list already cut down by the first and shrink it further.
+  bodies.forEach(body => {
+    body.querySelectorAll('.ui-cut').forEach(r => r.classList.remove('ui-cut'));
+    body.style.flexBasis = '';
+  });
   bodies.forEach(body => {
     const budget = parseFloat(getComputedStyle(body).getPropertyValue('--ui-budget')) || 470;
-    const content = body.firstElementChild ? body.firstElementChild.getBoundingClientRect().height : 0;
-    body.style.flexBasis = Math.min(budget, Math.ceil(content)) + 'px';
+    body.style.flexBasis = Math.min(budget, Math.ceil(body.scrollHeight)) + 'px';
   });
-  requestAnimationFrame(() => uiCut(bodies));
+  // A timer, not an animation frame: frames do not run in a tab that is
+  // not visible, and a page that fits itself only once it is looked at
+  // shows its rows cut through the middle for the first paint.
+  setTimeout(() => uiCut(bodies), 0);
 }
+// Every replacement of the page's content is a new layout to fit: the
+// views redraw themselves as later reads arrive, not only through render().
+new MutationObserver(() => {
+  clearTimeout(UI_FIT_TIMER); UI_FIT_TIMER = setTimeout(uiFit, 40);
+}).observe(document.getElementById('app'), {childList: true});
 function uiCut(bodies) {
   bodies.forEach(body => {
     const rows = [...body.querySelectorAll(':scope tbody>tr, :scope>li, :scope .bars>.barrow')];
     if (!rows.length) return;
-    rows.forEach(r => { r.classList.remove('ui-cut'); });
     const limit = body.getBoundingClientRect().bottom + 1;
     let shown = 0;
     rows.forEach(r => {
@@ -10393,7 +10406,6 @@ function uiCut(bodies) {
     if (note) note.textContent = shown < rows.length ? `${shown} shown` : '';
   });
 }
-let UI_FIT_TIMER = null;
 window.addEventListener('resize', () => {
   clearTimeout(UI_FIT_TIMER); UI_FIT_TIMER = setTimeout(uiFit, 120);
 });

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2904,7 +2904,23 @@ function overviewWidgets() {
 // has an <h3> for the edit controls to sit beside; without one they float
 // in a strip attached to nothing, which reads as a control that has come
 // loose rather than one belonging to the card under it.
-const WIDGET_TITLES = {stat_row: 'Headline numbers'};
+const WIDGET_TITLES = {stat_row: 'Headline numbers', top_tools: 'Discovered AI tools',
+  review_queue: 'Where to focus', detection_coverage: 'Visibility across your estate',
+  recent_personal_accounts: 'Recent personal accounts', budget_spend: 'AI spend',
+  paste_guard: 'Paste guard', source_health: 'Silent sources',
+  activity_trend: 'Personal-account exposure', agentic: 'Running on its own'};
+// One line each, for the planner: what the card is for, so the arrangement
+// can be made from names rather than by reading every widget in full.
+const WIDGET_BLURB = {stat_row: 'Posture and the four headline counts',
+  top_tools: 'Every tool observed, with devices, identities and personal accounts',
+  review_queue: 'The follow-ups, and the decision and discovery queue',
+  detection_coverage: 'Collector coverage and which sources report',
+  recent_personal_accounts: 'Latest activity in accounts outside your domains',
+  budget_spend: 'Subscriptions against observed use',
+  paste_guard: 'The browser extension, on the devices it reached',
+  source_health: 'Catalogue sources that reported nothing',
+  activity_trend: 'Daily detections against reporting coverage',
+  agentic: 'AI that starts itself, and who answers for it', grafana: 'A Grafana panel'};
 
 const SIZES = ['w4', 'w6', 'w12'];
 const SIZE_LABEL = {w4: 'S', w6: 'M', w12: 'L'};
@@ -2966,9 +2982,13 @@ function overview() {
   const cols = [];
   draw.forEach(k => {
     if (!drawn.get(k)) return;
+    // While arranging, a hidden card is in the tray, not in a column.
+    if (editing && hidden.indexOf(k) >= 0) return;
     if (cols.length && stacked.indexOf(k) >= 0) cols[cols.length - 1].push(k);
     else cols.push([k]);
   });
+  const titleOf = k => { const w = by.get(k);
+    return w.kind === 'grafana' ? (w.ref || 'Grafana panel') : (WIDGET_TITLES[w.kind] || w.kind); };
 
   const cardOf = k => {
     const w = by.get(k), body = drawn.get(k);
@@ -2976,12 +2996,16 @@ function overview() {
     const can = WIDGET_SIZES[w.kind] || [ownSpan(k, body)];
     const span = can.indexOf(sizes[k]) >= 0 ? sizes[k] : ownSpan(k, body);
     const isStacked = stacked.indexOf(k) >= 0;
-    const titled = body.indexOf('<h3') >= 0;
+    const titled = editing || body.indexOf('<h3') >= 0;
+    // The planner draws a placeholder in the card's place: its name, what
+    // it is for, and its size. The arrangement is made from those; the
+    // data comes back when the arrangement is saved.
+    const shown = editing ? `<div class="ov-placeholder"><b>${esc(titleOf(k))}</b>
+      <span>${esc(WIDGET_BLURB[w.kind] || '')}</span>
+      <small>${esc(SIZE_NAME[span])}${isStacked ? ' · stacked beneath the card above' : ''}</small></div>` : body;
     return `<div class="gcard${titled ? '' : ' notitle'}" data-wk="${esc(k)}"
       ${editing ? 'draggable="true"' : ''}
       style="${off ? 'opacity:.45' : ''}">
-      ${editing && !titled ? `<h3 class="gname">${
-        esc(WIDGET_TITLES[w.kind] || w.kind)}</h3>` : ''}
       ${editing ? `<span class="gtools">${
         // A stacked card takes the column's width from the card at its
         // head, so offering it a width of its own would be a control that
@@ -2994,9 +3018,19 @@ function overview() {
         : ''}${isStacked ? `<button data-act="w-unstack" data-key="${esc(k)}"
         title="give this card a column of its own again"
         >Unstack</button>` : ''}<button data-act="w-hide" data-key="${esc(k)}"
-        >${off ? 'Show' : 'Hide'}</button></span>` : ''}${body}${editing
+        >${off ? 'Show' : 'Hide'}</button></span>` : ''}${shown}${editing
         ? `<div class="ov-stack-zone" aria-hidden="true">Stack beneath</div>` : ''}</div>`;
   };
+  // Cards not on the page, while arranging: named, draggable into place,
+  // or added at the end with a click.
+  const tray = !editing ? '' : (() => {
+    const off = draw.filter(k => hidden.indexOf(k) >= 0);
+    return `<div class="ov-tray"><span class="ov-tray-label">${off.length
+      ? 'Not on the page. Drag one into place, or add it at the end.'
+      : 'Every card is on the page.'}</span>${off.map(k =>
+      `<div class="gcard ov-chip" draggable="true" data-wk="${esc(k)}"><b>${esc(titleOf(k))}</b>
+        <button data-act="w-hide" data-key="${esc(k)}">Add</button></div>`).join('')}</div>`;
+  })();
 
   const colOf = (col, i) => {
     const head = col[0], body = drawn.get(head);
@@ -3011,9 +3045,10 @@ function overview() {
   return `<h2>Overview</h2><p class="lede">Your AI estate. The exposure, the coverage, the next action.</p>
   ${truncNote(G.findings_truncated)}
   ${editing ? `<div class="oedit">
-    <span>Drag a card between others to move it, or onto the middle of one
-    to stack them in a column - two short cards share the height of a tall
-    one that way. This is your own view and changes nothing for anyone
+    <span>Each card is shown as its name and size. Drag one to move it: the
+    line shows where it lands. Drop it on the strip beneath another card to
+    stack the two in one column. Cards not on the page wait in the tray
+    below. This is your own view and changes nothing for anyone
     else${
       AUTH && AUTH.role !== 'viewer'
         ? ' - the widgets a deployment offers are set under Settings' : ''}.</span>
@@ -3022,6 +3057,7 @@ function overview() {
     <button class="ghost" data-act="ov-cancel">Cancel</button>
     <button class="pri" data-act="ov-save">Save</button>
   </div>` : ''}
+  ${tray}
   <div class="grid${editing ? ' editing' : ''}">${cols.map(colOf).join('')}</div>`;
 }
 
@@ -10449,6 +10485,8 @@ app.addEventListener('drop', e => {
     if (heir >= 0) st.splice(heir, 1);
   }
   o.splice(o.indexOf(from), 1);
+  const wasHidden = OVEDIT.hidden.indexOf(from);
+  if (wasHidden >= 0) OVEDIT.hidden.splice(wasHidden, 1);
   const wasStacked = st.indexOf(from);
   if (wasStacked >= 0) st.splice(wasStacked, 1);
 

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2322,6 +2322,12 @@ function uiSourceLabel(id) {
 function uiSourceChip(id) {
   return `<span class="ui-tool-chip" title="${esc(id)}">${esc(uiSourceLabel(id))}</span>`;
 }
+// A command somebody will paste: monospace, one line, its own copy control.
+// The text rides in a data attribute, escaped like any other, so the button
+// copies exactly what is shown.
+function uiCommand(cmd) {
+  return `<div class="ui-cmd"><code>${esc(cmd)}</code><button class="mini ui-copy" data-act="ui-copy" data-copy="${esc(cmd)}" title="Copy to clipboard">Copy</button></div>`;
+}
 function uiIcon(name) {
   const paths = {
     accounts:'<circle cx="9" cy="8" r="3"/><path d="M3 21v-3a6 6 0 0 1 12 0v3m1-16a3 3 0 0 1 0 6m2 4a5 5 0 0 1 3 5"/>',
@@ -6453,12 +6459,14 @@ kubectl -n ${ns} set image cronjob/<discovery> discovery=ghcr.io/amansk5/shadow-
         <p class="src-note">Afterwards this page should read ${esc(u.latest)} under Running, and Sources should show the same collectors reporting.</p>
       </div></details>
       ${u.notes ? `<details class="how"><summary>Release notes</summary><div><pre class="mono" style="white-space:pre-wrap;max-height:320px;overflow:auto">${esc(u.notes)}</pre></div></details>` : ''}` : ''}
-      ${CFG.managed && CFG.managed.enabled ? `<details class="how"><summary>Upgrade from your own machine</summary><div>
-        <p class="src-note">The command runs with your kubeconfig or Docker context and reports its progress here. The portal never upgrades anything itself; it approves the request (owners only) and shows the run. It needs Python 3.10 or newer and <span class="mono">pipx</span> on your machine (<span class="mono">brew install pipx</span> on a Mac, <span class="mono">pip install --user pipx</span> elsewhere). Install once from a tagged release, then run it:</p>
-        <pre class="mono" style="white-space:pre-wrap">pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@${esc(u.latest || 'v0.30.0')}#subdirectory=cli"
-pipx ensurepath
-aiguardctl upgrade --portal ${esc(location.origin)}</pre>
-        <p class="src-note">If the shell says the command is not found after installing, <span class="mono">pipx ensurepath</span> has added it to your PATH and a new terminal picks it up. Your browser opens this portal to approve the request; compare the code it shows with your terminal. <span class="mono">--dry-run</span> prints every command without running one.</p>
+      ${CFG.managed && CFG.managed.enabled ? `<details class="how ui-how"><summary>Upgrade from your own machine</summary><div class="ui-steps">
+        <p>The command runs with your kubeconfig or Docker context and reports its progress here. The portal never upgrades anything itself; it approves the request (owners only) and shows the run.</p>
+        <ol class="ui-steplist">
+          <li><b>Have Python 3.10 or newer and pipx on your machine.</b><span>On a Mac, <code>brew install pipx</code>; elsewhere, <code>pip install --user pipx</code>.</span></li>
+          <li><b>Install the command once, from a tagged release.</b>${uiCommand(`pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@${u.latest || 'v0.30.0'}#subdirectory=cli"`)}</li>
+          <li><b>Put it on your PATH.</b>${uiCommand('pipx ensurepath')}<span>A shell opened before this will not find the command until it is reopened.</span></li>
+          <li><b>Run it.</b>${uiCommand('aiguardctl upgrade --portal ' + location.origin)}<span>Your browser opens this portal to approve the request; compare the code it shows with your terminal. <code>--dry-run</code> prints every command without running one.</span></li>
+        </ol>
       </div></details>` : ''}
       ${u.enabled ? `<p class="src-note" style="margin-top:8px"><button class="mini" data-act="update-check">Check now</button></p>` : ''}
       ${CFG.managed && CFG.managed.enabled ? upgradeTracker() : ''}
@@ -8862,6 +8870,23 @@ async function managedAction(act, el) {
   if (act === 'ui-tools-filter') {
     UI_PERSONAL_TOOLS = el.getAttribute('data-filter') === 'personal';
     render(); return;
+  }
+  if (act === 'ui-copy') {
+    // The clipboard API wants a secure context and a real click; where it
+    // refuses, the older path still works, and failing that the command is
+    // left selected so one keystroke finishes the job.
+    const text = el.getAttribute('data-copy') || '';
+    const code = el.parentElement && el.parentElement.querySelector('code');
+    let ok = false;
+    try { await navigator.clipboard.writeText(text); ok = true; } catch (e) { /* fall through */ }
+    if (!ok && code) {
+      const range = document.createRange(); range.selectNodeContents(code);
+      const sel = window.getSelection(); sel.removeAllRanges(); sel.addRange(range);
+      try { ok = document.execCommand('copy'); } catch (e) { ok = false; }
+    }
+    el.textContent = ok ? 'Copied' : 'Selected, press Ctrl+C';
+    setTimeout(() => { el.textContent = 'Copy'; }, 2200);
+    return;
   }
   if (act === 'ui-expand') {
     const k = el.getAttribute('data-key');

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2217,7 +2217,7 @@ function barRows(rows, unit, open) {
     return `<div class="barrow"${open ? ` data-open="${esc(open)}"
       data-key="${esc(name)}" tabindex="0"` : ''}
       data-ctip="${esc(name + ' · ' + r[1] + ' ' + unit)}">
-      <span class="bl" title="${esc(name)}">${esc(name)}</span>
+      <span class="bl" title="${esc(name)}">${esc(r[2] || name)}</span>
       <span class="bt"><span class="bf" style="width:${
         Math.max(2, Math.round(r[1] / max * 100))}%"></span></span>
       <b>${r[1]}</b></div>`;
@@ -2272,6 +2272,20 @@ function trendChart(days, a, b, aLabel, bLabel) {
 // the console layer presentation helpers: use the same graph, lifecycle and register reads
 // as the working views. No demo fixtures or network calls live in renderers.
 let UI_PERSONAL_TOOLS = false;
+// Widgets the person asked to see in full, this page view. A widget draws a
+// budget of rows and offers the rest; on an estate of any size an uncapped
+// list is the tallest thing on the page and every neighbour pays for it.
+const UI_EXPANDED = new Set();
+function uiRows(key, rows, cap) {
+  const all = rows.length, open = UI_EXPANDED.has(key);
+  return {rows: open || all <= cap ? rows : rows.slice(0, cap), all,
+    hidden: open || all <= cap ? 0 : all - cap, open};
+}
+function uiMoreButton(key, r, noun) {
+  if (!r.hidden && !r.open) return '';
+  return `<button class="mini ui-more" data-act="ui-expand" data-key="${esc(key)}">${
+    r.open ? 'Show fewer' : `Show all ${r.all} ${esc(noun)}`}</button>`;
+}
 function uiOverviewFacts() {
   const devices = ents(G.devices), personal = G.personal_accounts || [];
   const open = PSTAT
@@ -2584,6 +2598,7 @@ const WIDGETS = {
     const unob = subs.reduce((a, s) =>
       a + bReconcile(s).unobserved.length, 0);
     const conv = bConverted(subs);
+    const shown = uiRows('budget_spend', subs, 6);
     return `<div class="wcard w6 ui-widget ui-spend-card">${head}
     <dl class="ui-tiles">
       <div><dt>${conv ? bMoney(conv.total, bPrefCur()) : bSpendParts(subs).join(' + ')}</dt>
@@ -2594,7 +2609,7 @@ const WIDGETS = {
     <div class="ui-table-scroll"><table class="ui-inventory ui-widget-table ui-spend-table">
       <thead><tr><th>Subscription</th><th class="ui-col-l">Plan</th><th class="num ui-col-m">Monthly</th>
         <th class="num ui-col-m">Seats in use</th><th class="num ui-col-l">Observed</th><th class="ui-col-l">Renews</th><th>Review</th></tr></thead>
-      <tbody>${subs.map(sub => {
+      <tbody>${shown.rows.map(sub => {
         const r = bReconcile(sub);
         const seats = (sub.seat_tiers || []).reduce((x, t) => x + (t.seats || 0), 0);
         return `<tr data-nav="budget">
@@ -2607,7 +2622,8 @@ const WIDGETS = {
           <td>${r.unobserved.length ? `<span class="ui-badge attention">${r.unobserved.length} idle</span>` : ''}${r.strangers.length
             ? ` <span class="ui-badge governance">${r.strangers.length} unseated</span>` : ''}${!r.unobserved.length && !r.strangers.length ? '<span class="ui-muted">Nothing flagged</span>' : ''}</td></tr>`;
       }).join('')}</tbody></table></div>
-    <div class="ui-panel-footer"><span>${next ? `Next renewal: ${esc(uiToolName(next.tool_id))} ${when(next.renewal_date)}` : 'No renewal dates recorded'}</span>
+    <div class="ui-panel-footer"><span>${next ? `Next renewal: ${esc(uiToolName(next.tool_id))} ${when(next.renewal_date)}` : 'No renewal dates recorded'}
+      ${uiMoreButton('budget_spend', shown, 'subscriptions')}</span>
       <button class="mini" data-nav="budget">Open Budget ${uiIcon('arrow')}</button></div></div>`;
   },
 
@@ -2619,6 +2635,7 @@ const WIDGETS = {
         && (!UI_PERSONAL_TOOLS || f.open.some(r => r.tool === id));
     }).sort((a,b)=>(b[1].devices||[]).length-(a[1].devices||[]).length);
     const bars = widgetForm('top_tools') === 'bar';
+    const shown = uiRows('top_tools', rows, 10);
     return `<div class="wcard ${bars ? 'w6' : 'w12'} ui-tools-card">
       <div class="ui-panel-head"><h3>${formToggle('top_tools')}Discovered AI tools <span class="count">${f.toolIds.length}</span></h3>
         <div class="ui-tool-filters" role="group" aria-label="Filter discovered tools">
@@ -2626,9 +2643,10 @@ const WIDGETS = {
           <button class="${UI_PERSONAL_TOOLS ? 'on' : ''}" data-act="ui-tools-filter" data-filter="personal" aria-pressed="${UI_PERSONAL_TOOLS}">Personal accounts</button>
         </div></div>
       ${!f.known ? '<p class="ui-empty">Findings are unavailable.</p>' : rows.length ? (bars
-        ? '<div class="ui-tool-bars">' + barRows(rows.map(([k,t]) => [k,(t.devices||[]).length]), 'devices', 'tool') + '</div>'
-        : uiToolsTable(rows)) : '<p class="ui-empty">No tools match this view.</p>'}
-      <div class="ui-panel-footer"><span>${f.known ? `${rows.length} of ${f.toolIds.length} discovered tools` : 'No data available'}</span>
+        ? '<div class="ui-tool-bars">' + barRows(rows.map(([k,t]) => [k,(t.devices||[]).length, uiToolName(k)]).slice(0, shown.rows.length), 'devices', 'tool') + '</div>'
+        : uiToolsTable(shown.rows)) : '<p class="ui-empty">No tools match this view.</p>'}
+      <div class="ui-panel-footer"><span>${f.known ? `${rows.length} of ${f.toolIds.length} discovered tools${shown.hidden ? `, ${shown.rows.length} shown` : ''}` : 'No data available'}
+        ${uiMoreButton('top_tools', shown, 'tools')}</span>
         <button class="mini" data-nav="tools">Open discovered tools ${uiIcon('arrow')}</button></div>
       <p class="src-note ui-table-note">${bars ? 'Observed devices per tool. Cloud-only tools may have zero associated devices.'
         : 'One bar per day for the last ' + fmtWindow(hoursNow()) + ', written as a total when the window holds fewer than three days. Devices and cloud identities are counted separately.'}</p>
@@ -2638,7 +2656,8 @@ const WIDGETS = {
   recent_personal_accounts: () => {
     // Ten rows are drawn; the card's width decides how many show and which
     // columns (CSS, by container). The footer count is the whole window.
-    const pa = (G.personal_accounts || []).slice(0, 10);
+    const shown = uiRows('recent_personal_accounts', G.personal_accounts || [], 6);
+    const pa = shown.rows;
     const body = pa.length ? `<div class="ui-table-scroll"><table class="ui-inventory ui-widget-table ui-people-table">
       <thead><tr><th>Person</th><th>Account</th><th class="ui-col-m">AI tool</th><th class="ui-col-l">Device</th>
         <th class="ui-col-l">Surface</th><th class="ui-col-l">Source</th><th>Last seen</th></tr></thead>
@@ -2659,7 +2678,8 @@ const WIDGETS = {
         <p>Latest activity in accounts outside your corporate domains</p></div>
         <span class="ui-eyebrow">Last ${esc(fmtWindow(hoursNow()))}</span></div>
       ${body}
-      <div class="ui-panel-footer"><span>${pa.length ? `${(G.personal_accounts || []).length} in this window` : ''}</span>
+      <div class="ui-panel-footer"><span>${pa.length ? `${shown.all} in this window${shown.hidden ? `, ${pa.length} shown` : ''}` : ''}
+        ${uiMoreButton('recent_personal_accounts', shown, 'accounts')}</span>
         <button class="mini" data-nav="personal">Open personal accounts ${uiIcon('arrow')}</button></div>
     </div>`;
   },
@@ -6434,10 +6454,11 @@ kubectl -n ${ns} set image cronjob/<discovery> discovery=ghcr.io/amansk5/shadow-
       </div></details>
       ${u.notes ? `<details class="how"><summary>Release notes</summary><div><pre class="mono" style="white-space:pre-wrap;max-height:320px;overflow:auto">${esc(u.notes)}</pre></div></details>` : ''}` : ''}
       ${CFG.managed && CFG.managed.enabled ? `<details class="how"><summary>Upgrade from your own machine</summary><div>
-        <p class="src-note">The command runs with your kubeconfig or Docker context and reports its progress here. The portal never upgrades anything itself; it approves the request (owners only) and shows the run. Install once from a tagged release, then:</p>
-        <pre class="mono" style="white-space:pre-wrap">pipx install "git+https://github.com/AmanSK5/shadow-ai-guard@${esc(u.latest || 'v0.29.0')}#subdirectory=cli"
+        <p class="src-note">The command runs with your kubeconfig or Docker context and reports its progress here. The portal never upgrades anything itself; it approves the request (owners only) and shows the run. It needs Python 3.10 or newer and <span class="mono">pipx</span> on your machine (<span class="mono">brew install pipx</span> on a Mac, <span class="mono">pip install --user pipx</span> elsewhere). Install once from a tagged release, then run it:</p>
+        <pre class="mono" style="white-space:pre-wrap">pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@${esc(u.latest || 'v0.30.0')}#subdirectory=cli"
+pipx ensurepath
 aiguardctl upgrade --portal ${esc(location.origin)}</pre>
-        <p class="src-note">Your browser opens this portal to approve the request; compare the code it shows with your terminal. <span class="mono">--dry-run</span> prints every command without running one.</p>
+        <p class="src-note">If the shell says the command is not found after installing, <span class="mono">pipx ensurepath</span> has added it to your PATH and a new terminal picks it up. Your browser opens this portal to approve the request; compare the code it shows with your terminal. <span class="mono">--dry-run</span> prints every command without running one.</p>
       </div></details>` : ''}
       ${u.enabled ? `<p class="src-note" style="margin-top:8px"><button class="mini" data-act="update-check">Check now</button></p>` : ''}
       ${CFG.managed && CFG.managed.enabled ? upgradeTracker() : ''}
@@ -6560,8 +6581,13 @@ function upgradeTracker() {
   if (UPDOWN) return `<div id="upgrade-tracker" class="health-note warning"><b>Portal restarting</b> - the page cannot reach it right now, which is expected mid-rollout. It keeps trying.</div>`;
   if (!r) return `<div id="upgrade-tracker"></div>`;
   const pill = r.status === 'running' ? '<span class="pill p-amb">running</span>'
+    : r.status === 'stale' ? '<span class="pill p-warn">not confirmed</span>'
     : r.outcome === 'succeeded' ? '<span class="pill p-ok">succeeded</span>'
+    : r.outcome === 'unverified' ? '<span class="pill p-amb">ran, not confirmed</span>'
     : `<span class="pill p-warn">${esc(r.outcome || 'finished')}</span>`;
+  const note = r.status === 'stale'
+    ? 'The command stopped reporting before it confirmed the result, so this run was never closed. Running, above, says what is actually deployed.'
+    : r.outcome === 'unverified' ? 'The commands ran, but the command could not confirm the result. Running, above, says what is actually deployed.' : '';
   const stat = s => s === 'done' ? 'p-ok' : s === 'failed' ? 'p-warn' : s === 'skipped' ? 'p-mut' : 'p-amb';
   // A step is reported twice, once when it starts and once when it ends;
   // one line per step, carrying whichever report came last.
@@ -6573,7 +6599,8 @@ function upgradeTracker() {
   return `<div id="upgrade-tracker" class="upgrade-run">
     <div class="upgrade-run-head"><b>Upgrade ${esc(r.from_version)} → ${esc(r.to_version)}</b> ${pill}
       <span>${esc(r.route)} · started ${when(r.started_at)} by ${esc(r.started_by_name || 'an owner')}</span></div>
-    <ol class="upgrade-steps">${latest.map(s => `<li><span class="pill ${stat(s.status)}">${esc(s.status)}</span> ${esc(s.step)}${s.detail ? ` <span>· ${esc(s.detail)}</span>` : ''}</li>`).join('')
+    ${note ? `<p class="health-note warning">${note}</p>` : ''}
+    <ol class="upgrade-steps">${latest.map(s => `<li><span class="pill ${stat(s.status)}">${esc(s.status)}</span> <span class="upgrade-step" title="${esc(s.step)}">${esc(s.step)}</span>${s.detail ? ` <span>· ${esc(s.detail)}</span>` : ''}</li>`).join('')
       || '<li><span class="pill p-amb">running</span> waiting for the first step</li>'}</ol>
     ${r.status !== 'running' && r.detail ? `<p class="src-note">${esc(r.detail)}</p>` : ''}
   </div>`;
@@ -8834,6 +8861,11 @@ async function managedAction(act, el) {
   }
   if (act === 'ui-tools-filter') {
     UI_PERSONAL_TOOLS = el.getAttribute('data-filter') === 'personal';
+    render(); return;
+  }
+  if (act === 'ui-expand') {
+    const k = el.getAttribute('data-key');
+    if (UI_EXPANDED.has(k)) UI_EXPANDED.delete(k); else UI_EXPANDED.add(k);
     render(); return;
   }
   if (act === 'ui-density') {

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2922,30 +2922,26 @@ const WIDGET_BLURB = {stat_row: 'Posture and the four headline counts',
   activity_trend: 'Daily detections against reporting coverage',
   agentic: 'AI that starts itself, and who answers for it', grafana: 'A Grafana panel'};
 
-const SIZES = ['w4', 'w6', 'w12'];
-const SIZE_LABEL = {w4: 'S', w6: 'M', w12: 'L'};
-const SIZE_NAME = {w4: 'small', w6: 'medium', w12: 'large'};
+// Two columns. A third width squashed every table into a strip, and the
+// only widgets that survived it were the ones with nothing to show.
+const SIZES = ['w6', 'w12'];
+const SIZE_LABEL = {w6: 'Half', w12: 'Full'};
+const SIZE_NAME = {w6: 'half width', w12: 'full width'};
 const WIDGET_SIZES = {
-  // Checked by rendering each of these three to a row at 328px and
-  // looking, not by reasoning about it - the first pass of this list was
-  // guesswork and most of it was wrong. A KPI row wraps to two columns,
-  // bars keep their labels, the line chart compresses to something
-  // sparkline-shaped but still readable, and stat cells stack.
-  stat_row: ['w4', 'w6', 'w12'],
-  top_tools: ['w4', 'w6', 'w12'],
-  activity_trend: ['w4', 'w6', 'w12'],
-  budget_spend: ['w4', 'w6', 'w12'],
-  detection_coverage: ['w4', 'w6', 'w12'],
-  source_health: ['w4', 'w6', 'w12'],
-  paste_guard: ['w4', 'w6', 'w12'],
-  // These two genuinely break at a third width, which is the whole point
-  // of the list: the review queue's Add to registry / Dismiss buttons
-  // overflow the card and Dismiss is clipped mid-word, and a four-column
-  // table of people wraps every date onto three lines.
+  // Half or full for every card. The stat row and the tool inventory make
+  // most sense full; both still tile at half so a person can pair them.
+  stat_row: ['w6', 'w12'],
+  top_tools: ['w6', 'w12'],
+  activity_trend: ['w6', 'w12'],
+  budget_spend: ['w6', 'w12'],
+  detection_coverage: ['w6', 'w12'],
+  source_health: ['w6', 'w12'],
+  paste_guard: ['w6', 'w12'],
   recent_personal_accounts: ['w6', 'w12'],
   review_queue: ['w6', 'w12'],
+  agentic: ['w6', 'w12'],
   // A cross-origin frame decides its own layout and cannot be checked
-  // from here, so it is not offered a width nobody has seen it at.
+  // from here, so it is offered the same two widths as everything else.
   grafana: ['w6', 'w12'],
 };
 
@@ -3057,6 +3053,7 @@ function overview() {
       AUTH && AUTH.role !== 'viewer'
         ? ' - the widgets a deployment offers are set under Settings' : ''}.</span>
     <span class="sp"></span>
+    <button class="ghost" data-act="ov-clear" title="Move every card to the tray and start from nothing">Clear canvas</button>
     <button class="ghost" data-act="ov-reset">Reset to default</button>
     <button class="ghost" data-act="ov-cancel">Cancel</button>
     <button class="ghost" data-act="ov-preview">Preview</button>
@@ -3070,7 +3067,9 @@ function overview() {
     <button class="pri" data-act="ov-save">Save</button>
   </div>` : ''}
   ${tray}
-  <div class="grid${editing ? ' editing' : ''}">${cols.map(colOf).join('')}</div>`;
+  <div class="grid${editing ? ' editing ov-canvas' : ''}">${cols.map(colOf).join('')}${editing
+    ? `<div class="ov-drop-end${cols.length ? '' : ' empty'}">${cols.length
+        ? 'Drop here to add at the end' : 'The canvas is empty. Drag cards in from the tray.'}</div>` : ''}</div>`;
 }
 
 function card(k, d) {
@@ -8958,6 +8957,12 @@ async function managedAction(act, el) {
   }
   if (act === 'ov-cancel') { OVEDIT = null; OVPREVIEW = false; render(); return; }
   if (act === 'ov-preview') { OVPREVIEW = true; render(); window.scrollTo(0, 0); return; }
+  if (act === 'ov-clear') {
+    // Everything to the tray, nothing stacked: the canvas is bare and the
+    // arrangement is made from the tray. Cancel still discards all of it.
+    OVEDIT.hidden = OVEDIT.order.slice(); OVEDIT.stacked = [];
+    render(); return;
+  }
   if (act === 'ov-plan') { OVPREVIEW = false; render(); window.scrollTo(0, 0); return; }
   if (act === 'ov-save') {
     await prefSet('overview.layout', JSON.stringify(
@@ -10464,6 +10469,13 @@ function colKeys(card) {
 
 app.addEventListener('dragover', e => {
   if (!OVEDIT || !DRAGK) return;
+  const end = e.target.closest && e.target.closest('.ov-drop-end');
+  if (end) {
+    e.preventDefault();
+    app.querySelectorAll('.gcard.over, .gcard.into')
+       .forEach(n => n.classList.remove('over', 'into', 'before', 'after'));
+    end.classList.add('over'); return;
+  }
   const it = e.target.closest && e.target.closest('.gcard');
   if (!it) return;
   e.preventDefault();
@@ -10476,6 +10488,28 @@ app.addEventListener('dragover', e => {
 
 app.addEventListener('drop', e => {
   if (!OVEDIT || !DRAGK) return;
+  const end = e.target.closest && e.target.closest('.ov-drop-end');
+  if (end) {
+    // At the end, in a column of its own, on the page.
+    e.preventDefault();
+    const from = DRAGK; DRAGK = null;
+    document.body.classList.remove('dragging');
+    const o = OVEDIT.order.slice(), st = OVEDIT.stacked.slice();
+    const fromCard = [...app.querySelectorAll('.gcard')]
+      .find(c => c.getAttribute('data-wk') === from && !c.classList.contains('ov-chip'));
+    const fromCol = fromCard ? colKeys(fromCard) : [from];
+    if (fromCol[0] === from && fromCol.length > 1) {
+      const heir = st.indexOf(fromCol[1]);
+      if (heir >= 0) st.splice(heir, 1);
+    }
+    o.splice(o.indexOf(from), 1); o.push(from);
+    const wasStacked = st.indexOf(from);
+    if (wasStacked >= 0) st.splice(wasStacked, 1);
+    const wasHidden = OVEDIT.hidden.indexOf(from);
+    if (wasHidden >= 0) OVEDIT.hidden.splice(wasHidden, 1);
+    OVEDIT.order = o; OVEDIT.stacked = st;
+    render(); return;
+  }
   const it = e.target.closest && e.target.closest('.gcard');
   if (!it) return;
   e.preventDefault();

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2284,9 +2284,13 @@ function uiRows(key, rows, budget) {
   return {rows: rows.slice(0, 60), all, open,
     hidden: open || all <= budget ? 0 : all - budget};
 }
+// The button is always in the footer and the fit pass decides whether it
+// shows: a card beside a taller neighbour has room for every row, so a
+// "Show all 7" over seven visible rows did nothing, while a card cut
+// short in a stack had rows hidden and no way to ask for them.
 function uiMoreButton(key, r, noun) {
-  if (!r.hidden && !r.open) return '';
-  return `<button class="mini ui-more" data-act="ui-expand" data-key="${esc(key)}">${
+  if (!r.all) return '';
+  return `<button class="mini ui-more${!r.hidden && !r.open ? ' ui-idle' : ''}" data-act="ui-expand" data-key="${esc(key)}" data-all="${r.all}">${
     r.open ? 'Show fewer' : `Show all ${r.all} ${esc(noun)}`}</button>`;
 }
 function uiOverviewFacts() {
@@ -10396,7 +10400,10 @@ function uiCut(bodies) {
   bodies.forEach(body => {
     const rows = [...body.querySelectorAll(':scope tbody>tr, :scope>li, :scope .bars>.barrow')];
     if (!rows.length) return;
-    const limit = body.getBoundingClientRect().bottom + 1;
+    // The content box, not the border box: a row that ends inside the
+    // bottom padding sat on the divider.
+    const limit = body.getBoundingClientRect().bottom
+      - (parseFloat(getComputedStyle(body).paddingBottom) || 0) + 1;
     let shown = 0;
     rows.forEach(r => {
       if (r.getBoundingClientRect().bottom > limit) r.classList.add('ui-cut'); else shown++;
@@ -10404,6 +10411,9 @@ function uiCut(bodies) {
     const card = body.parentElement;
     const note = card.querySelector('.ui-shown');
     if (note) note.textContent = shown < rows.length ? `${shown} shown` : '';
+    const more = card.querySelector('.ui-more');
+    if (more) more.classList.toggle('ui-idle',
+      shown === rows.length && rows.length >= Number(more.dataset.all || 0));
   });
 }
 window.addEventListener('resize', () => {

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2994,7 +2994,8 @@ function overview() {
         : ''}${isStacked ? `<button data-act="w-unstack" data-key="${esc(k)}"
         title="give this card a column of its own again"
         >Unstack</button>` : ''}<button data-act="w-hide" data-key="${esc(k)}"
-        >${off ? 'Show' : 'Hide'}</button></span>` : ''}${body}</div>`;
+        >${off ? 'Show' : 'Hide'}</button></span>` : ''}${body}${editing
+        ? `<div class="ov-stack-zone" aria-hidden="true">Stack beneath</div>` : ''}</div>`;
   };
 
   const colOf = (col, i) => {
@@ -10376,6 +10377,7 @@ app.addEventListener('dragstart', e => {
   if (!it) return;
   DRAGK = it.getAttribute('data-wk');
   it.classList.add('drag');
+  document.body.classList.add('dragging');
   if (e.dataTransfer) {
     e.dataTransfer.effectAllowed = 'move';
     // Firefox will not start a drag without data on the transfer.
@@ -10384,6 +10386,7 @@ app.addEventListener('dragstart', e => {
 });
 app.addEventListener('dragend', () => {
   DRAGK = null;
+  document.body.classList.remove('dragging');
   app.querySelectorAll('.gcard.drag, .gcard.over')
      .forEach(n => n.classList.remove('drag', 'over'));
 });
@@ -10392,10 +10395,15 @@ app.addEventListener('dragend', () => {
 // place it as a column of its own before or after. Edges are relative to
 // the whole column, not the card under the pointer, so dropping beside a
 // stack never lands inside it by accident.
-function dropZone(card, y) {
+// A plain drag moves: above the card's midpoint lands before its column,
+// below lands after. Stacking is deliberate - only a drop on the strip each
+// card shows along its bottom edge while a drag is in progress stacks into
+// that column, so a move never snaps into a stack by accident.
+function dropZone(card, y, target) {
+  if (target && target.closest && target.closest('.ov-stack-zone')) return 'into';
   const r = card.getBoundingClientRect();
   const rel = (y - r.top) / (r.height || 1);
-  return rel < 0.28 ? 'before' : rel > 0.72 ? 'after' : 'into';
+  return rel < 0.5 ? 'before' : 'after';
 }
 
 function colKeys(card) {
@@ -10412,7 +10420,7 @@ app.addEventListener('dragover', e => {
   app.querySelectorAll('.gcard.over, .gcard.into')
      .forEach(n => n.classList.remove('over', 'into', 'before', 'after'));
   if (it.getAttribute('data-wk') === DRAGK) return;
-  const zone = dropZone(it, e.clientY);
+  const zone = dropZone(it, e.clientY, e.target);
   it.classList.add(zone === 'into' ? 'into' : 'over', zone);
 });
 
@@ -10422,7 +10430,8 @@ app.addEventListener('drop', e => {
   if (!it) return;
   e.preventDefault();
   const to = it.getAttribute('data-wk'), from = DRAGK;
-  const zone = dropZone(it, e.clientY);
+  const zone = dropZone(it, e.clientY, e.target);
+  document.body.classList.remove('dragging');
   const col = colKeys(it);
   DRAGK = null;
   if (!to || to === from) return;

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -2276,10 +2276,13 @@ let UI_PERSONAL_TOOLS = false;
 // budget of rows and offers the rest; on an estate of any size an uncapped
 // list is the tallest thing on the page and every neighbour pays for it.
 const UI_EXPANDED = new Set();
-function uiRows(key, rows, cap) {
+// Every row is drawn (to a sane ceiling); the card shows a budget of them
+// and scrolls the rest inside itself, growing to whatever height its row
+// has to give. "Show all" opens the card to its full list instead.
+function uiRows(key, rows, budget) {
   const all = rows.length, open = UI_EXPANDED.has(key);
-  return {rows: open || all <= cap ? rows : rows.slice(0, cap), all,
-    hidden: open || all <= cap ? 0 : all - cap, open};
+  return {rows: rows.slice(0, 60), all, open,
+    hidden: open || all <= budget ? 0 : all - budget};
 }
 function uiMoreButton(key, r, noun) {
   if (!r.hidden && !r.open) return '';
@@ -2605,7 +2608,7 @@ const WIDGETS = {
       a + bReconcile(s).unobserved.length, 0);
     const conv = bConverted(subs);
     const shown = uiRows('budget_spend', subs, 6);
-    return `<div class="wcard w6 ui-widget ui-spend-card">${head}
+    return `<div class="wcard w6 ui-widget ui-spend-card${shown.open ? ' ui-open' : ''}">${head}
     <dl class="ui-tiles">
       <div><dt>${conv ? bMoney(conv.total, bPrefCur()) : bSpendParts(subs).join(' + ')}</dt>
         <dd>tracked per month${conv ? ` <span title="${esc(bSpendParts(subs).join(' + '))}">· ECB ${esc(conv.date)}</span>` : ''}</dd></div>
@@ -2642,7 +2645,7 @@ const WIDGETS = {
     }).sort((a,b)=>(b[1].devices||[]).length-(a[1].devices||[]).length);
     const bars = widgetForm('top_tools') === 'bar';
     const shown = uiRows('top_tools', rows, 10);
-    return `<div class="wcard ${bars ? 'w6' : 'w12'} ui-tools-card">
+    return `<div class="wcard ${bars ? 'w6' : 'w12'} ui-tools-card${shown.open ? ' ui-open' : ''}">
       <div class="ui-panel-head"><h3>${formToggle('top_tools')}Discovered AI tools <span class="count">${f.toolIds.length}</span></h3>
         <div class="ui-tool-filters" role="group" aria-label="Filter discovered tools">
           <button class="${!UI_PERSONAL_TOOLS ? 'on' : ''}" data-act="ui-tools-filter" data-filter="all" aria-pressed="${!UI_PERSONAL_TOOLS}">All tools</button>
@@ -2651,7 +2654,7 @@ const WIDGETS = {
       ${!f.known ? '<p class="ui-empty">Findings are unavailable.</p>' : rows.length ? (bars
         ? '<div class="ui-tool-bars">' + barRows(rows.map(([k,t]) => [k,(t.devices||[]).length, uiToolName(k)]).slice(0, shown.rows.length), 'devices', 'tool') + '</div>'
         : uiToolsTable(shown.rows)) : '<p class="ui-empty">No tools match this view.</p>'}
-      <div class="ui-panel-footer"><span>${f.known ? `${rows.length} of ${f.toolIds.length} discovered tools${shown.hidden ? `, ${shown.rows.length} shown` : ''}` : 'No data available'}
+      <div class="ui-panel-footer"><span>${f.known ? `${rows.length} of ${f.toolIds.length} discovered tools` : 'No data available'}
         ${uiMoreButton('top_tools', shown, 'tools')}</span>
         <button class="mini" data-nav="tools">Open discovered tools ${uiIcon('arrow')}</button></div>
       <p class="src-note ui-table-note">${bars ? 'Observed devices per tool. Cloud-only tools may have zero associated devices.'
@@ -2679,12 +2682,12 @@ const WIDGETS = {
       : dataOk()
         ? '<p class="ui-empty">None seen. That is a result, not an absence of one.</p>'
         : '<p class="ui-empty">Nothing to show: the findings could not be read.</p>';
-    return `<div class="wcard w6 ui-widget ui-people-card">
+    return `<div class="wcard w6 ui-widget ui-people-card${shown.open ? ' ui-open' : ''}">
       <div class="ui-panel-head"><div><h3>Recent personal accounts</h3>
         <p>Latest activity in accounts outside your corporate domains</p></div>
         <span class="ui-eyebrow">Last ${esc(fmtWindow(hoursNow()))}</span></div>
       ${body}
-      <div class="ui-panel-footer"><span>${pa.length ? `${shown.all} in this window${shown.hidden ? `, ${pa.length} shown` : ''}` : ''}
+      <div class="ui-panel-footer"><span>${pa.length ? `${shown.all} in this window` : ''}
         ${uiMoreButton('recent_personal_accounts', shown, 'accounts')}</span>
         <button class="mini" data-nav="personal">Open personal accounts ${uiIcon('arrow')}</button></div>
     </div>`;

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -6558,7 +6558,7 @@ kubectl -n ${ns} set image cronjob/<discovery> discovery=ghcr.io/amansk5/shadow-
         <p>The command runs with your kubeconfig or Docker context and reports its progress here. The portal never upgrades anything itself; it approves the request (owners only) and shows the run.</p>
         <ol class="ui-steplist">
           <li><b>Have Python 3.10 or newer and pipx on your machine.</b><span>On a Mac, <code>brew install pipx</code>; elsewhere, <code>pip install --user pipx</code>.</span></li>
-          <li><b>Install the command once, from a tagged release.</b>${uiCommand(`pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@${u.latest || 'v0.30.0'}#subdirectory=cli"`)}</li>
+          <li><b>Install the command once, from a tagged release.</b>${uiCommand(`pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@${u.latest || 'v0.31.0'}#subdirectory=cli"`)}</li>
           <li><b>Put it on your PATH.</b>${uiCommand('pipx ensurepath')}<span>A shell opened before this will not find the command until it is reopened.</span></li>
           <li><b>Run it.</b>${uiCommand('aiguardctl upgrade --portal ' + location.origin)}<span>Your browser opens this portal to approve the request; compare the code it shows with your terminal. <code>--dry-run</code> prints every command without running one.</span></li>
         </ol>

--- a/portal/tests/test_overview_layout.py
+++ b/portal/tests/test_overview_layout.py
@@ -108,19 +108,14 @@ def test_every_offered_size_is_a_real_grid_width():
         assert set(sizes) <= {"w4", "w6", "w12"}, kind
 
 
-def test_the_widgets_kept_off_the_smallest_size_are_the_ones_that_break():
-    """Established by rendering each of them at 328px and looking. The
-    review queue's Add to registry / Dismiss buttons overflow the card
-    with Dismiss clipped mid-word, and a four-column table of people
-    wraps every date onto three lines. Everything else holds, including
-    the KPI row, which simply wraps to two columns."""
-    narrow = {k for k, v in _sizes().items() if "w4" in v}
-    assert "recent_personal_accounts" not in narrow
-    assert "review_queue" not in narrow
-    assert "grafana" not in narrow, "a cross-origin frame cannot be checked"
-    assert narrow == {"stat_row", "top_tools", "activity_trend",
-                      "budget_spend", "detection_coverage", "source_health",
-                      "paste_guard"}
+def test_every_card_is_offered_half_or_full_and_nothing_narrower():
+    """A third width squashed every table into a strip; the only cards that
+    survived it had nothing to show. The canvas is two columns now: every
+    card is offered exactly half or full, and the small width is not a
+    thing anybody can choose, however old their saved layout is."""
+    for kind, sizes in _sizes().items():
+        assert sizes == ["w6", "w12"], kind
+    assert "const SIZES = ['w6', 'w12'];" in INDEX
 
 
 def test_a_saved_size_the_widget_no_longer_offers_falls_back():

--- a/portal/tests/test_overview_layout.py
+++ b/portal/tests/test_overview_layout.py
@@ -255,9 +255,11 @@ def test_a_titleless_card_is_named_while_arranging():
     Without one they float in a strip attached to nothing, which reads as
     a control that has come loose rather than one belonging to the card
     under it."""
-    assert "const WIDGET_TITLES = {stat_row: 'Headline numbers'};" in INDEX
-    assert "editing && !titled" in DRAW
-    assert "body.indexOf('<h3') >= 0" in DRAW
+    assert "const WIDGET_TITLES = {stat_row: 'Headline numbers'," in INDEX
+    # While arranging every card is a named placeholder, so the strip always
+    # has a title beneath it; outside arranging the h3 test still decides.
+    assert "const titled = editing || body.indexOf('<h3') >= 0" in DRAW
+    assert "<div class=\"ov-placeholder\"><b>${esc(titleOf(k))}</b>" in DRAW
 
 
 def test_the_strip_clears_the_outline_above_and_the_content_below():

--- a/portal/tests/test_upgrade_cli.py
+++ b/portal/tests/test_upgrade_cli.py
@@ -100,7 +100,7 @@ def test_the_page_carries_the_approval_view_and_the_tracker():
     assert 'data-act="cli-approve"' in INDEX and 'data-act="cli-deny"' in INDEX
     assert "function upgradeTracker()" in INDEX and "function upgradeWatch()" in INDEX
     assert "<b>Portal restarting</b>" in INDEX
-    assert "aiguardctl upgrade --portal ${esc(location.origin)}" in INDEX
+    assert "uiCommand('aiguardctl upgrade --portal ' + location.origin)" in INDEX
 
 
 def test_the_portal_still_runs_nothing():

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -1624,7 +1624,7 @@ class UpgradeStep(BaseModel):
 
 class UpgradeFinish(BaseModel):
     model_config = {"extra": "forbid"}
-    outcome: str = Field(pattern=r"^(succeeded|failed|aborted)$")
+    outcome: str = Field(pattern=r"^(succeeded|failed|aborted|unverified)$")
     detail: str = Field(default="", max_length=300)
 
 

--- a/receiver/app/state.py
+++ b/receiver/app/state.py
@@ -575,6 +575,16 @@ class State:
             (_now(), kind, json.dumps(detail)),
         )
 
+    def _name(self, user_id) -> str:
+        """The username behind an id, for the audit trail's "who" column.
+        Callers hold the lock. An unknown id reads as blank, never as
+        somebody else."""
+        if not user_id:
+            return ""
+        row = self._db.execute(
+            "SELECT username FROM admin_users WHERE id = ?", (user_id,)).fetchone()
+        return row["username"] if row else ""
+
     # ------------------------------------------------- enrollment tokens --
 
     def mint_token(self, note: str, ttl_days: int = 180) -> dict:
@@ -945,7 +955,7 @@ class State:
                 (gid, purpose, _hash(device), code, verifier_hash,
                  requester[:120], now, expires))
             self._event("cli_grant_requested",
-                        {"grant": gid, "purpose": purpose})
+                        {"grant": gid, "purpose": purpose, "by": requester[:120]})
             self._db.commit()
         return {"device_code": device, "user_code": code,
                 "expires_at": expires, "interval": GRANT_POLL_INTERVAL}
@@ -989,7 +999,7 @@ class State:
                 " decided_at = ? WHERE id = ?",
                 (status, user_id, now, row["id"]))
             self._event("cli_grant_" + status,
-                        {"grant": row["id"], "user": user_id})
+                        {"grant": row["id"], "user": user_id, "by": self._name(user_id)})
             self._db.commit()
         return {"grant": row["id"], "status": status}
 
@@ -1043,7 +1053,8 @@ class State:
                 " token_expires_at = ? WHERE id = ?",
                 (_hash(token), texp, row["id"]))
             self._event("cli_token_issued", {"grant": row["id"],
-                                             "user": row["decided_by"]})
+                                             "user": row["decided_by"],
+                                             "by": self._name(row["decided_by"])})
             self._db.commit()
         return {"state": "ok", "token": token, "expires_at": texp}
 
@@ -1082,6 +1093,7 @@ class State:
             self._db.execute("UPDATE cli_grants SET status = 'running'"
                              " WHERE id = ?", (grant_id,))
             self._event("upgrade_started", {"run": rid, "user": g["decided_by"],
+                                            "by": self._name(g["decided_by"]),
                                             "route": route[:32],
                                             "from": from_version[:64],
                                             "to": to_version[:64]})
@@ -1127,7 +1139,8 @@ class State:
             self._db.execute("UPDATE cli_grants SET status = 'consumed',"
                              " token_hash = NULL WHERE id = ?", (grant_id,))
             self._event("upgrade_finished", {"run": run_id, "outcome": outcome,
-                                             "user": row["started_by"]})
+                                             "user": row["started_by"],
+                                             "by": self._name(row["started_by"])})
             self._db.commit()
         return self.current_run()
 
@@ -1142,6 +1155,18 @@ class State:
         out = dict(row)
         out["plan"] = json.loads(out["plan"] or "{}")
         out["steps"] = json.loads(out["steps"] or "[]")
+        # A run still "running" after its token could possibly be alive is
+        # one the command never finished - it crashed, or the terminal was
+        # closed. Reported as stale rather than left spinning; the row is
+        # not rewritten, because what happened is what happened.
+        if out.get("status") == "running":
+            try:
+                started = datetime.fromisoformat(out["started_at"])
+                if datetime.now(timezone.utc) - started > timedelta(
+                        seconds=UPGRADE_TOKEN_TTL_SECONDS):
+                    out["status"] = "stale"
+            except (TypeError, ValueError):
+                pass
         return out
 
     # ------------------------------------------------- account management --

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -65,7 +65,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.30.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.31.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything

--- a/receiver/tests/test_upgrade.py
+++ b/receiver/tests/test_upgrade.py
@@ -228,3 +228,46 @@ def test_polling_faster_than_told_is_slowed_down(managed, monkeypatch):
     verifier, grant = _ask()
     assert _poll(grant, verifier).status_code == 428
     assert _poll(grant, verifier).status_code == 429
+
+
+def _issued(managed):
+    owner = _owner()
+    verifier, grant = _ask()
+    client.post("/admin/cli/approve", headers=_hdr(owner),
+                json={"user_code": grant["user_code"], "approve": True})
+    return _poll(grant, verifier).json()["token"]
+
+
+def test_a_run_the_command_never_closed_reads_as_stale(managed):
+    """The command crashed after the commands ran, so nothing ever posted a
+    finish. Left alone the tracker spun forever. Once the token could not
+    possibly still be alive, the run is reported as stale - computed on
+    read, the row itself untouched."""
+    from datetime import datetime, timedelta, timezone
+    token = _issued(managed)
+    run = client.post("/admin/upgrade/runs", headers=_hdr(token), json={
+        "route": "helm", "from_version": "0.29.0", "to_version": "0.30.0"}).json()
+    assert managed.current_run()["status"] == "running"
+    past = (datetime.now(timezone.utc)
+            - timedelta(seconds=state_mod.UPGRADE_TOKEN_TTL_SECONDS + 60)).isoformat()
+    with managed._lock:
+        managed._db.execute("UPDATE upgrade_runs SET started_at = ? WHERE id = ?",
+                            (past, run["id"]))
+        managed._db.commit()
+    assert managed.current_run()["status"] == "stale"
+
+
+def test_the_audit_trail_names_who_approved_and_who_ran_it(managed):
+    """The trail showed "cli grant approved" with nobody in the who column:
+    the events carried a user id and the portal shows a name."""
+    import json
+    token = _issued(managed)
+    client.post("/admin/upgrade/runs", headers=_hdr(token), json={
+        "route": "helm", "from_version": "0.29.0", "to_version": "0.30.0"})
+    with managed._lock:
+        rows = managed._db.execute(
+            "SELECT kind, detail FROM events WHERE kind LIKE 'cli_%' OR kind LIKE 'upgrade_%'"
+        ).fetchall()
+    by = {row["kind"]: json.loads(row["detail"]).get("by") for row in rows}
+    assert by["cli_grant_requested"].startswith("aiguardctl")
+    assert by["cli_grant_approved"] == by["cli_token_issued"] == by["upgrade_started"] == "aman"


### PR DESCRIPTION
The first live run of `aiguardctl upgrade` and the first look at the Overview against an estate of real size. The command now always closes the run it opened, the Overview is arranged on a canvas instead of nudged in place, and every widget is sized by what it holds.

## The upgrade command

- The portal's upgrade fold is numbered steps, each command in its own block with a copy control. It says what to install first: Python 3.10 or later and pipx, then `pipx ensurepath` and a new shell, because the command was not on PATH the first time anyone tried it. The CLI README and the Kubernetes guide say the same.
- `verify` used to crash with a read timeout while the portal it was verifying restarted, and the run stayed "running" for ever. Timeouts are now API errors like any other, verification retries through the restart, and the command closes its run whichever way it ends: `succeeded`, `failed`, `aborted` on Ctrl-C, or `unverified` when it ran but could not confirm the version.
- The receiver reports a run older than its token as `stale`, so the portal's tracker stops polling and says "not confirmed" instead of spinning. Audit events raised by the CLI carry who ran them; the column was blank.

## Arranging the Overview

- Edit widgets is a planner. The canvas shows each card as its name, purpose and size; cards not on the page wait in a tray and can be dragged in or added at the end; Clear canvas starts from nothing.
- Moving and stacking are separate gestures: a drag moves a card and the line shows where it lands; dropping on the strip beneath another card stacks the two in one column.
- Sizes are Half and Full. Two halves sit side by side exactly, and a half card is half on the page as well, so the arrangement drawn is the one saved.
- Preview shows the arrangement with today's data before anything is saved.

## Widgets at scale

- Rows are equal height again, and each list body takes the smaller of its content and a per-widget budget. Rows that would not fit in full are hidden rather than cut through the middle, the footer says how many are shown, and Show all opens the card. The fit runs after every render and resize, including in a tab that is not visible.
- The button appears only when rows are actually hidden: a card beside a taller neighbour has room for everything, and a card cut short in a stack always has a way to ask for the rest.
- AI spend gets three tiles, a Plan and Renews column when wide, review badges last, and values centred on the two-line subscription name. Paste guard gets tiles, notes and a by-tool table. Visibility gets a latest-report-by-surface table, and its Dots form is a stepped meter across the same track the Meter uses. Running on its own lists every autonomous run, unaccountable first. Silent sources says when each source was last heard. Discovered AI tools is a table when wide and bars when not; the bar list keeps its padding.
- Names and labels do not wrap mid-word in any size, and the preview banner is one line.

## Devices

- The AI tools column takes the width the single-value columns were holding, chips are capped at six with a "+N more" tail, the key line is dropped when it repeats the name, and compact view is actually compact: the fixed row height that ignored it is gone.

## Demo

- `demo/seed-large.sh` seeds a synthetic estate on top of the demo: a couple of dozen devices, seventeen tools, fifteen personal accounts and seven subscriptions, all made up. It is what the pages above were tested against.

## Checked

671 portal tests, 322 receiver tests, 14 CLI tests, 10 renderer tests. Both densities, the planner, preview, stacks, all-Half and all-Full layouts, the Overview and Devices pages against the large seed.

## Deploying

Portal, receiver and CLI images and the chart move to 0.31.0. Nothing stored changes. Operators who have run `aiguardctl upgrade` once should reinstall the CLI from this tag to get the closing behaviour.
