### PR TITLE
Activation keys: System health says which edition this is, and checks one offline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: node --test portal/tests/overview_renderers.test.cjs
+      - run: node --test portal/tests/activation_card.test.cjs
 
   helm:
     # helm ships on the ubuntu-latest runner image, so the normal path needs

--- a/README.md
+++ b/README.md
@@ -488,3 +488,12 @@ product built on this code must credit it as the work of Aman Karir and may
 not present the software as its own; see [TRADEMARKS.md](TRADEMARKS.md) for
 the name, the logo and what a paid offering has to say. The software itself
 can always be obtained from this repository for free.
+
+There is a commercial edition, **Nyxus**, distributed as private images under
+a subscription with support, licensed separately. Nothing here is held back
+for it: this repository is the whole open product, and it stays that way.
+An activation key gates nothing in this code either - it names the
+organisation a subscription was issued to and doubles as the credential that
+pulls those images. **System health** in the portal is where one is entered,
+checked offline against a signature the portal already holds, and where the
+commands to move a deployment across are written out.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -447,6 +447,50 @@ portal at run time, and there is no `curl | sh`. It shells out to the
 operator's own `helm`, `kubectl` and `docker`, found on their PATH, rather
 than embedding any of them.
 
+## Activation keys
+
+The open edition is complete and nothing in it is gated. An activation key
+names a subscription to the commercial edition, which ships as private
+images; it is also the credential that pulls them. Nothing in this
+repository reads it to decide what to do.
+
+A key is a compact JSON object stating the organisation, the plan, the term
+and any device limit, with an Ed25519 signature over exactly those bytes,
+both base64url-encoded behind an `nyxl_` prefix. The claims are readable on
+purpose - what somebody was sold should not need a tool to inspect - and
+the signature is what stops them being edited.
+
+**Checked offline, always.** The publisher's public key is compiled into the
+receiver, so verification is local arithmetic: no request at activation, at
+boot, or ever. A deployment that is airgapped, or whose vendor has gone
+quiet, keeps working exactly as it did. `ACTIVATION_PUBLIC_KEY` overrides
+the compiled-in key, which is how a key rotation reaches a deployment that
+has not taken a new image yet.
+
+**Owner-gated, and verified where it is stored.** `PUT /admin/activation`
+refuses a key it cannot verify, so the write path is not a way past the
+check, and it sits at the tier above admin for the same reason the `sso_*`
+settings do: it is about the organisation rather than the estate.
+
+**Never echoed.** The key does not appear in `GET /admin/activation`, in
+`GET /admin/settings`, or in the audit trail, which records that
+`activation_key` changed and who changed it. The portal returns the claims
+and a fingerprint - a truncated SHA-256 of the key - which is what support
+and an operator can use to agree on which key is installed without either
+of them sending it anywhere.
+
+**No revocation.** An offline check cannot be told a key was withdrawn. The
+stated term is the control: a key is good until the date it carries.
+
+The verifier is written out in `receiver/app/ed25519.py` rather than taken
+from a library, because the only operation needed is verify, over public
+data, in a component whose dependency list is seven packages. There is no
+private key in the process and none in this repository, so the usual reason
+to insist on a hardened implementation does not arise. `receiver/tests/`
+runs the RFC 8032 vectors against it, along with the forgeries a lax
+verifier accepts: a flipped bit in each field, a point that is not on the
+curve, and a scalar at or above the group order.
+
 ## What this is not
 
 Detection is visibility, not enforcement: it observes, and a user with local

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -472,9 +472,15 @@ refuses a key it cannot verify, so the write path is not a way past the
 check, and it sits at the tier above admin for the same reason the `sso_*`
 settings do: it is about the organisation rather than the estate.
 
-**Never echoed.** The key does not appear in `GET /admin/activation`, in
-`GET /admin/settings`, or in the audit trail, which records that
-`activation_key` changed and who changed it. The portal returns the claims
+**Never echoed, and neither is anything else.** The key does not appear in
+`GET /admin/activation`, in `GET /admin/settings`, or in the audit trail,
+which records that `activation_key` changed and who changed it. A refusal
+is one of a fixed set of sentences chosen by code, never a message built
+from a caught exception or a field quoted out of the key: the response
+carries the class of failure and the detail goes to the log, which is the
+same rule `portal/tests/test_error_disclosure.py` sets out for the log
+store. `receiver/tests/test_activation.py` holds it, including a check that
+every refusal code the module can raise has a sentence written for it. The portal returns the claims
 and a fingerprint - a truncated SHA-256 of the key - which is what support
 and an operator can use to agree on which key is installed without either
 of them sending it anywhere.

--- a/portal/app/main.py
+++ b/portal/app/main.py
@@ -2240,6 +2240,30 @@ def api_settings_write(req: SettingsWrite, _=Depends(require_auth),
     return out
 
 
+# ------------------------------------------------------------ activation --
+# Forwarded, like everything else that changes managed state: the receiver
+# holds the key, verifies it and enforces the owner rule. The portal is the
+# place a person types it and the place they read what it says, and holds
+# no part of the decision - which also means the browser never sees a
+# stored key, because there is no route here that could return one.
+
+
+class ActivationWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    key: str = Field(default="", max_length=4000)
+
+
+@app.get("/api/activation")
+def api_activation(_=Depends(require_auth), token: str = Depends(_admin_forward)):
+    return _receiver("GET", "/admin/activation", token)
+
+
+@app.post("/api/activation")
+def api_activation_write(req: ActivationWrite, _=Depends(require_auth),
+                         token: str = Depends(_admin_forward)):
+    return _receiver("PUT", "/admin/activation", token, {"key": req.key})
+
+
 class FindingStatusWrite(BaseModel):
     model_config = {"extra": "forbid"}
     key: str = Field(min_length=1, max_length=500)

--- a/portal/app/static/enterprise.css
+++ b/portal/app/static/enterprise.css
@@ -931,6 +931,12 @@ body.auth .licard{width:100%}
 @media(max-width:900px){
   .health-card.health-wide .health-facts{grid-template-columns:repeat(2,minmax(0,1fr))}
 }
+/* ---- activation: entering a key on System health ----------------------- */
+/* The field takes the row because a key is 300 characters and a narrow box
+   turns pasting one into a scroll. */
+.act-entry{display:flex;flex-wrap:wrap;align-items:center;gap:8px;margin-top:12px}
+.act-entry .mfield{flex:1 1 340px;min-width:0;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11.5px}
+.act-entry+.src-note{margin-top:7px}
 /* ---- the upgrade tracker on System health ------------------------------ */
 .upgrade-run{margin-top:12px;padding:12px 14px;border:1px solid var(--bd);border-radius:8px;background:var(--sf2)}
 .upgrade-run-head{display:flex;align-items:center;gap:8px;flex-wrap:wrap;font-size:12px}

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -6519,7 +6519,7 @@ function activationCard() {
   const note = a.state === 'active'
     ? (soon ? `<p class="health-note warning">This subscription runs out on ${esc(a.expires)}. Renewing replaces the key here; nothing stops working on the day, because nothing here was ever switched on by it - the images simply stop being yours to pull.</p>` : '')
     : a.state === 'expired' ? `<p class="health-note warning">This key lapsed on ${esc(a.expires)}. The deployment carries on exactly as it is; a lapsed subscription means no new images and no support, not a portal that stops. Renew and paste the new key.</p>`
-    : a.state === 'invalid' ? `<p class="health-note danger"><b>Stored, but this release cannot check it.</b> ${esc(a.error || '')} This is what a reissued signing key looks like from a deployment that has not taken the release carrying it: upgrade first, and only then suspect the key.</p>`
+    : a.state === 'invalid' ? `<p class="health-note danger"><b>Stored, but this release cannot check it.</b> ${esc(a.reason || '')} This is what a reissued signing key looks like from a deployment that has not taken the release carrying it: upgrade first, and only then suspect the key.</p>`
     : `<p class="health-note">This deployment runs the open edition, and it is complete: nothing on this page or any other is held back for want of a key. Nyxus is the commercial edition of the same system - the same collectors, the same evidence - distributed as private images under a subscription with support. An activation key names the organisation it was issued to and the term it runs for, and is checked here against a signature this portal already holds, without asking anyone.</p>`;
 
   const form = !owner

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -6449,6 +6449,105 @@ function ssoEnforceBlock() {
   </div>`;
 }
 
+// ---- the subscription, if there is one ---------------------------------
+// The open edition is whole and nothing here gates any of it: no view, no
+// route and no count asks whether a key is present. This card exists
+// because a person who has bought the commercial edition has to be able to
+// see that the key they were issued is genuine, what it says, and when it
+// runs out - and because the same key is the credential that pulls the
+// private images, so the place it is entered is the place to say what to
+// run next. On the operator's own machine, like every other change to a
+// deployment in this project.
+//
+// The key is never rendered. The receiver stores it and answers with the
+// claims and a fingerprint; there is no route that could return it, so a
+// screen share of this page discloses nothing.
+let ACT = null, ACTMSG = null;
+
+function activationCard() {
+  const a = ACT || {state: 'none'};
+  const owner = AUTH && AUTH.role === 'owner';
+  const state = a.state === 'active' ? ['p-ok', 'activated']
+    : a.state === 'expired' ? ['p-warn', 'expired']
+    : a.state === 'invalid' ? ['p-warn', 'cannot be checked']
+    : a.state === 'unknown' ? ['p-mut', 'not read']
+    : ['p-mut', 'open edition'];
+  const ns = (DIAG.deployment && DIAG.deployment.namespace) || '<namespace>';
+  const reg = a.registry || '<registry>';
+  const known = !!a.registry;
+  const soon = a.state === 'active' && a.days_left <= 45;
+
+  // Everything the operator runs, they run themselves. The portal has no
+  // registry credential of its own and no rights over the deployment: it
+  // knows what the key says and writes the commands out.
+  const steps = `<details class="how ui-how"><summary>Move this deployment to Nyxus</summary><div class="ui-steps">
+    <p>The images are private, and your activation key is the credential that pulls them. Nothing below runs from this page: it runs with your own kubeconfig, on your own machine, the same way an upgrade does.</p>
+    <ol class="ui-steplist">
+      <li><b>Put the key in your shell.</b>${uiCommand("export NYXUS_KEY='<your activation key>'")}<span>The portal does not hand it back - it is a credential - so this is the key you pasted above.</span></li>
+      <li><b>Give the cluster a pull secret.</b>${uiCommand(`kubectl -n ${ns} create secret docker-registry nyxus-registry \\
+  --docker-server=${reg} --docker-username=licence --docker-password="$NYXUS_KEY"`)}${known ? '' : '<span>Your welcome message names the registry to use in place of the placeholder.</span>'}</li>
+      <li><b>Install the chart, pointing at that secret.</b>${uiCommand(`helm upgrade --install nyxus oci://${reg}/charts/nyxus \\
+  --namespace ${ns} --set imagePullSecrets[0].name=nyxus-registry`)}<span>Your data stays where it is. The receiver and the portal restart; collectors keep reporting through it.</span></li>
+    </ol>
+    <p class="src-note">The chart version and the exact registry path come with the subscription. If a pull is refused, the pull secret is the first thing to check: <span class="mono">kubectl -n ${esc(ns)} get secret nyxus-registry</span>.</p>
+  </div></details>`;
+
+  // A read that failed says so. "No subscription" is a statement about
+  // this deployment, and one that has not been read is not entitled to it.
+  if (a.state === 'unknown') {
+    return `<section class="health-card health-wide" data-tour="activation"><div class="health-card-head"><div><span>Edition</span><h3>Nyxus</h3></div><span class="pill p-mut">not read</span></div>
+      <p class="health-note">The receiver did not answer when this page asked whether a subscription is activated, so nothing is claimed either way. The log store card above says whether the receiver is reachable at all.</p>
+    </section>`;
+  }
+
+  const facts = a.state === 'none' ? `<dl class="health-facts">
+      <div><dt>Running</dt><dd>Open edition</dd></div>
+      <div><dt>Licence</dt><dd>Apache 2.0</dd></div>
+      <div><dt>Activation</dt><dd>none stored</dd></div>
+      <div><dt>Checked</dt><dd>offline, no outbound request</dd></div></dl>`
+    : a.state === 'invalid' ? `<dl class="health-facts">
+      <div><dt>Key</dt><dd class="mono">${esc(a.fingerprint || '—')}</dd></div>
+      <div><dt>State</dt><dd>not verifiable by this release</dd></div></dl>`
+    : `<dl class="health-facts">
+      <div><dt>Organisation</dt><dd>${esc(a.org)}</dd></div>
+      <div><dt>Plan</dt><dd>${esc(a.plan)}${a.devices ? ` <span>· up to ${esc(a.devices)} devices</span>` : ''}</dd></div>
+      <div><dt>${a.state === 'expired' ? 'Expired' : 'Expires'}</dt><dd>${esc(a.expires)}${
+        a.state === 'expired' ? ` <span>· ${esc(-a.days_left)} day${a.days_left === -1 ? '' : 's'} ago</span>`
+        : ` <span>· in ${esc(a.days_left)} day${a.days_left === 1 ? '' : 's'}</span>`}</dd></div>
+      <div><dt>Reference</dt><dd>${esc(a.id)} <span>· key ${esc(a.fingerprint)}</span></dd></div></dl>`;
+
+  const note = a.state === 'active'
+    ? (soon ? `<p class="health-note warning">This subscription runs out on ${esc(a.expires)}. Renewing replaces the key here; nothing stops working on the day, because nothing here was ever switched on by it - the images simply stop being yours to pull.</p>` : '')
+    : a.state === 'expired' ? `<p class="health-note warning">This key lapsed on ${esc(a.expires)}. The deployment carries on exactly as it is; a lapsed subscription means no new images and no support, not a portal that stops. Renew and paste the new key.</p>`
+    : a.state === 'invalid' ? `<p class="health-note danger"><b>Stored, but this release cannot check it.</b> ${esc(a.error || '')} This is what a reissued signing key looks like from a deployment that has not taken the release carrying it: upgrade first, and only then suspect the key.</p>`
+    : `<p class="health-note">This deployment runs the open edition, and it is complete: nothing on this page or any other is held back for want of a key. Nyxus is the commercial edition of the same system - the same collectors, the same evidence - distributed as private images under a subscription with support. An activation key names the organisation it was issued to and the term it runs for, and is checked here against a signature this portal already holds, without asking anyone.</p>`;
+
+  const form = !owner
+    ? `<p class="src-note" style="margin-top:10px">An owner account activates a subscription. ${a.state === 'none' ? 'This deployment has no key stored.' : 'The details above are read-only for your role.'}</p>`
+    : a.state === 'none' || a.state === 'invalid'
+    ? `<div class="act-entry">
+        <input id="act-key" class="mfield" spellcheck="false" autocomplete="off"
+          placeholder="Paste an activation key (nyxl_…)" value="">
+        <button class="mini" data-act="act-save">Activate</button>
+        ${a.state === 'invalid' ? '<button class="mini" data-act="act-clear">Remove it</button>' : ''}
+      </div>
+      <p class="src-note">Pasted here, checked here, stored by the receiver. It is a credential as well as a statement of what you bought, so it is never displayed again - only its fingerprint.</p>`
+    : `<div class="act-entry">
+        <input id="act-key" class="mfield" spellcheck="false" autocomplete="off"
+          placeholder="Paste a renewed key to replace this one" value="">
+        <button class="mini" data-act="act-save">Replace</button>
+        <button class="mini" data-act="act-clear">Remove</button>
+      </div>`;
+
+  return `<section class="health-card health-wide" data-tour="activation"><div class="health-card-head"><div><span>Edition</span><h3>Nyxus</h3></div><span class="pill ${state[0]}">${state[1]}</span></div>
+    ${facts}
+    ${note}
+    ${ACTMSG ? `<p class="health-note ${ACTMSG.ok ? '' : 'danger'}">${esc(ACTMSG.text)}</p>` : ''}
+    ${a.state === 'active' || a.state === 'expired' ? steps : ''}
+    ${form}
+  </section>`;
+}
+
 function diagnosticsCards() {
   const r = DIAG.runtime, d = DIAG.deployment;
   const yn = v => v ? '<span class="pill p-ok">yes</span>'
@@ -6567,6 +6666,8 @@ kubectl -n ${ns} set image cronjob/<discovery> discovery=ghcr.io/amansk5/shadow-
       ${CFG.managed && CFG.managed.enabled ? upgradeTracker() : ''}
     </section>`;
     })()}
+
+    ${CFG.managed && CFG.managed.enabled ? activationCard() : ''}
   </div>
 
   <section class="health-deployment"><div><span>Deployment context</span><h3>Provided by configuration</h3>
@@ -6717,6 +6818,15 @@ async function diagnostics() {
       system health: ${esc(String(e.message || e))}</div>`; }
   }
   const managed = CFG.managed && CFG.managed.enabled;
+  if (managed && ACT === null) {
+    try {
+      const ar = await mfetch('/api/activation');
+      // A refusal is not "no subscription": leaving ACT null would ask
+      // again on every render, and answering "open edition" would be a
+      // claim about the deployment made from a failed read.
+      ACT = ar.ok ? await ar.json() : {state: 'unknown'};
+    } catch (e) { ACT = {state: 'unknown'}; }
+  }
   if (managed && AUDITLOG === null) {
     try {
       const ar = await mfetch('/api/audit?limit=50');
@@ -8755,6 +8865,36 @@ async function managedAction(act, el) {
     // is reflected there too.
     try { const cr = await fetch('/api/config'); if (cr.ok) CFG = await cr.json(); } catch (e) {}
     drawSetup(); render(); return;
+  }
+  if (act === 'act-save' || act === 'act-clear') {
+    const field = document.getElementById('act-key');
+    const key = act === 'act-clear' ? '' : ((field || {}).value || '').trim();
+    if (act === 'act-save' && !key) {
+      ACTMSG = {ok: false, text: 'Paste the key first.'}; render(); return;
+    }
+    if (act === 'act-clear'
+        && !confirm('Remove the stored activation key? This deployment keeps '
+                    + 'running exactly as it is - the key entitles you to the '
+                    + 'private images, and nothing here depends on it.')) return;
+    el.disabled = true; el.textContent = act === 'act-clear' ? 'Removing…' : 'Checking…';
+    const r = await mfetch('/api/activation', {method: 'POST',
+      body: JSON.stringify({key})});
+    if (r.status === 401) { sessionLost(); return; }
+    if (!r.ok) {
+      // The receiver's refusal is the whole message: it says whether this
+      // is a typo or a key to ask about, and rewording it here would lose
+      // the difference.
+      ACTMSG = {ok: false, text: await _refusal(r)}; render(); return;
+    }
+    ACT = await r.json();
+    ACTMSG = act === 'act-clear'
+      ? {ok: true, text: 'Removed. This deployment is back to the open edition.'}
+      : ACT.state === 'expired'
+        ? {ok: true, text: 'Stored. The key is genuine but its term has ended.'}
+        : {ok: true, text: 'Activated. ' + ACT.org + ', to ' + ACT.expires + '.'};
+    // The audit trail below now has a row this page is showing state for.
+    AUDITLOG = null;
+    render(); return;
   }
   if (act === 'id-download') {
     window.location = '/api/suggest-identities?fmt=csv';

--- a/portal/tests/activation_card.test.cjs
+++ b/portal/tests/activation_card.test.cjs
@@ -1,0 +1,141 @@
+// Run with: node --test portal/tests/activation_card.test.cjs
+//
+// The activation card, rendered by the browser's own function against the
+// shapes the receiver actually answers with. Same harness as the overview
+// renderers, for the same reason: this card makes claims about what a
+// deployment is entitled to, and the wrong claim is worse than a broken
+// layout. What is checked here is mostly what it must NOT say - never that
+// a deployment is on the open edition when the read failed, and never the
+// key itself.
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const html = fs.readFileSync(path.join(__dirname, '../app/static/index.html'), 'utf8');
+const card = html.slice(html.indexOf('let ACT = null, ACTMSG = null;'),
+                        html.indexOf('function diagnosticsCards() {'));
+const escape = s => String(s ?? '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+
+function render(act, {role = 'owner', msg = null} = {}) {
+  const c = vm.createContext({
+    AUTH: {role},
+    DIAG: {deployment: {namespace: 'ai-guard'}},
+    esc: escape,
+    uiCommand: cmd => `<div class="ui-cmd"><code>${escape(cmd)}</code></div>`,
+  });
+  vm.runInContext(card + '; ACT = this.act; ACTMSG = this.msg; this.out = activationCard();',
+                  Object.assign(c, {act, msg}));
+  return c.out;
+}
+
+const ACTIVE = {state: 'active', id: 'NYX-0001', org: 'Acme Group Ltd',
+  plan: 'enterprise', devices: 2500, issued: '2026-01-01',
+  expires: '2027-06-30', days_left: 300, registry: 'registry.example.com',
+  fingerprint: '58aa-0b39-7247'};
+
+test('with no key, the card says open edition and claims nothing else', () => {
+  const out = render({state: 'none'});
+  assert.match(out, /open edition/);
+  assert.match(out, /Open edition/);
+  assert.match(out, /Apache 2\.0/);
+  assert.match(out, /offline, no outbound request/);
+  assert.doesNotMatch(out, /activated/);
+});
+
+test('a failed read is not "no subscription"', () => {
+  // The bug this exists to stop: answering the question from a read that
+  // never happened, and telling a paying customer they have no licence.
+  const out = render({state: 'unknown'});
+  assert.match(out, /not read/);
+  assert.match(out, /nothing is claimed either way/);
+  assert.doesNotMatch(out, /Open source/);
+  assert.doesNotMatch(out, /Paste an activation key/);
+});
+
+test('an activated deployment shows what it bought, and never the key', () => {
+  const out = render(ACTIVE);
+  assert.match(out, /Acme Group Ltd/);
+  assert.match(out, /enterprise/);
+  assert.match(out, /up to 2500 devices/);
+  assert.match(out, /2027-06-30/);
+  assert.match(out, /in 300 days/);
+  assert.match(out, /58aa-0b39-7247/);
+  assert.doesNotMatch(out, /nyxl_/);
+});
+
+test('the commands name the deployment\'s own namespace and registry', () => {
+  const out = render(ACTIVE);
+  assert.match(out, /kubectl -n ai-guard create secret docker-registry nyxus-registry/);
+  assert.match(out, /--docker-server=registry\.example\.com/);
+  assert.match(out, /helm upgrade --install nyxus/);
+  // The key goes in from the operator's shell, never from the page.
+  assert.match(out, /export NYXUS_KEY=/);
+  assert.doesNotMatch(out, /nyxl_/);
+});
+
+test('a key that names no registry says where the real one comes from', () => {
+  const out = render(Object.assign({}, ACTIVE, {registry: ''}));
+  assert.match(out, /&lt;registry&gt;/);
+  assert.match(out, /welcome message names the registry/);
+});
+
+test('a subscription close to its end says so before it ends', () => {
+  const soon = render(Object.assign({}, ACTIVE, {days_left: 20}));
+  assert.match(soon, /health-note warning/);
+  assert.match(soon, /runs out on 2027-06-30/);
+  // And says plainly that nothing stops working, because nothing does.
+  assert.match(soon, /nothing stops working on the day/);
+  assert.doesNotMatch(render(ACTIVE), /health-note warning/);
+});
+
+test('an expired key is shown as genuine and lapsed, not as a forgery', () => {
+  const out = render(Object.assign({}, ACTIVE,
+    {state: 'expired', expires: '2026-02-01', days_left: -29}));
+  assert.match(out, /expired/);
+  assert.match(out, /29 days ago/);
+  assert.match(out, /Acme Group Ltd/);
+  assert.match(out, /carries on exactly as it is/);
+  // Still worth showing the handoff: renewing is the point.
+  assert.match(out, /Move this deployment to Nyxus/);
+});
+
+test('a key this release cannot verify says to upgrade before suspecting it', () => {
+  const out = render({state: 'invalid', fingerprint: 'aaaa-bbbb-cccc',
+                      error: 'this key was not issued for this software'});
+  assert.match(out, /cannot be checked/);
+  assert.match(out, /upgrade first/);
+  assert.match(out, /aaaa-bbbb-cccc/);
+  assert.match(out, /Remove it/);
+});
+
+test('only an owner is offered the field', () => {
+  for (const role of ['admin', 'viewer']) {
+    const out = render({state: 'none'}, {role});
+    assert.doesNotMatch(out, /data-act="act-save"/);
+    assert.match(out, /An owner account activates a subscription/);
+  }
+  assert.match(render({state: 'none'}, {role: 'owner'}), /data-act="act-save"/);
+});
+
+test('an activated owner can replace or remove, and a viewer sees the facts', () => {
+  const owner = render(ACTIVE);
+  assert.match(owner, /Paste a renewed key to replace this one/);
+  assert.match(owner, /data-act="act-clear"/);
+  const viewer = render(ACTIVE, {role: 'viewer'});
+  assert.match(viewer, /Acme Group Ltd/);
+  assert.doesNotMatch(viewer, /data-act="act-/);
+});
+
+test('a refusal is shown as one, and escaped', () => {
+  const out = render({state: 'none'},
+                     {msg: {ok: false, text: 'this key is <damaged>'}});
+  assert.match(out, /health-note danger/);
+  assert.match(out, /this key is &lt;damaged&gt;/);
+});
+
+test('an organisation name is escaped rather than rendered', () => {
+  const out = render(Object.assign({}, ACTIVE, {org: '<img src=x onerror=1>'}));
+  assert.match(out, /&lt;img src=x/);
+  assert.doesNotMatch(out, /<img src=x/);
+});

--- a/portal/tests/activation_card.test.cjs
+++ b/portal/tests/activation_card.test.cjs
@@ -102,7 +102,8 @@ test('an expired key is shown as genuine and lapsed, not as a forgery', () => {
 
 test('a key this release cannot verify says to upgrade before suspecting it', () => {
   const out = render({state: 'invalid', fingerprint: 'aaaa-bbbb-cccc',
-                      error: 'this key was not issued for this software'});
+                      code: 'not_ours',
+                      reason: 'this key was not issued for this software'});
   assert.match(out, /cannot be checked/);
   assert.match(out, /upgrade first/);
   assert.match(out, /aaaa-bbbb-cccc/);

--- a/receiver/app/activation.py
+++ b/receiver/app/activation.py
@@ -59,13 +59,54 @@ _ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 
 
-class ActivationError(ValueError):
-    """The key is not usable, with a sentence saying why.
+# Why a key was refused, and the sentence an operator is shown for it.
+#
+# The two are separate on purpose. CodeQL flagged the first version of this
+# module for exposing exception detail in a response, and it was right in
+# the way it was right about the portal's Loki errors (see
+# portal/tests/test_error_disclosure.py): a response must carry the class of
+# failure, and the detail behind it belongs in the log. Nothing here is
+# built from a caught exception or from anything the key itself contains -
+# every refusal an operator sees is one of the constants below, chosen by
+# code.
+#
+# They still say what to do about it rather than which check failed, because
+# someone holding a key that does not work needs to know whether to look for
+# a typo or to email support.
+REFUSALS = {
+    "empty": "no key was given",
+    "too_long": "this is too long to be an activation key",
+    "not_a_key": "an activation key starts with %s. This looks like "
+                 "something else - an enrollment token, perhaps." % "nyxl_",
+    "damaged": "this key is damaged - it is not the shape a key has. Paste "
+               "it again, whole.",
+    "not_ours": "this key was not issued for this software, or it has been "
+                "altered since it was issued. Check you pasted all of it; if "
+                "you did, ask for it to be reissued.",
+    "unreadable": "this key is signed but unreadable",
+    "too_new": "this key needs a newer release than the one running here. "
+               "Upgrade, then activate.",
+    "incomplete": "this key is signed, but it does not state everything a "
+                  "key has to state. Ask for it to be reissued.",
+    "unknown_plan": "this key is for a plan this release does not know "
+                    "about. Upgrade, then activate.",
+    "publisher_key": "this deployment's ACTIVATION_PUBLIC_KEY is not a "
+                     "32-byte Ed25519 public key, so no key can be checked "
+                     "until it is corrected or removed.",
+}
 
-    The message is shown to an operator, so it says what to do about it
-    rather than which check failed: someone holding a key that does not
-    work needs to know whether to look for a typo or to email support.
+
+class ActivationError(ValueError):
+    """The key is not usable. Carries the code, not a message to echo.
+
+    Raised inside this module and caught inside it: check() is the only
+    thing callers use, and it hands back a constant from REFUSALS. An
+    exception object never reaches a response.
     """
+
+    def __init__(self, code: str):
+        self.code = code
+        super().__init__(code)
 
 
 def public_key() -> bytes:
@@ -73,10 +114,9 @@ def public_key() -> bytes:
     try:
         key = base64.b64decode(raw, validate=True)
     except (binascii.Error, ValueError):
-        raise ActivationError("ACTIVATION_PUBLIC_KEY is not valid base64")
+        raise ActivationError("publisher_key")
     if len(key) != 32:
-        raise ActivationError("ACTIVATION_PUBLIC_KEY is not a 32-byte "
-                              "Ed25519 public key")
+        raise ActivationError("publisher_key")
     return key
 
 
@@ -87,8 +127,7 @@ def _b64url(raw: str) -> bytes:
     try:
         return base64.urlsafe_b64decode(raw + pad)
     except (binascii.Error, ValueError):
-        raise ActivationError("this key is damaged - it is not the shape a "
-                              "key has. Paste it again, whole.")
+        raise ActivationError("damaged")
 
 
 def fingerprint(key: str) -> str:
@@ -112,55 +151,46 @@ def parse(key: str) -> dict:
     """
     key = (key or "").strip()
     if not key:
-        raise ActivationError("no key was given")
+        raise ActivationError("empty")
     if len(key) > MAX_LENGTH:
-        raise ActivationError("this is too long to be an activation key")
+        raise ActivationError("too_long")
     if not key.startswith(PREFIX):
-        raise ActivationError("an activation key starts with %s. This looks "
-                              "like something else - an enrollment token, "
-                              "perhaps." % PREFIX)
+        raise ActivationError("not_a_key")
     body = key[len(PREFIX):]
     if body.count(".") != 1:
-        raise ActivationError("this key is damaged - it is not the shape a "
-                              "key has. Paste it again, whole.")
+        raise ActivationError("damaged")
     claims_raw, sig_raw = body.split(".")
     signed = _b64url(claims_raw)
     signature = _b64url(sig_raw)
     if not ed25519.verify(public_key(), signed, signature):
-        raise ActivationError("this key was not issued for this software, or "
-                              "it has been altered since it was issued. "
-                              "Check you pasted all of it; if you did, ask "
-                              "for it to be reissued.")
+        raise ActivationError("not_ours")
     try:
         claims = json.loads(signed.decode())
     except (UnicodeDecodeError, json.JSONDecodeError):
-        raise ActivationError("this key is signed but unreadable")
+        raise ActivationError("unreadable")
     if not isinstance(claims, dict):
-        raise ActivationError("this key is signed but unreadable")
+        raise ActivationError("unreadable")
     # Version first: a v2 key may mean something different by every field
     # below, so guessing at it is worse than saying the software is old.
     if claims.get("v") != 1:
-        raise ActivationError("this key needs a newer release than the one "
-                              "running here. Upgrade, then activate.")
+        raise ActivationError("too_new")
     for field in ("id", "org", "plan", "issued", "expires"):
         if not isinstance(claims.get(field), str) or not claims[field].strip():
-            raise ActivationError("this key is signed but incomplete: it does "
-                                  "not state its %s" % field)
+            raise ActivationError("incomplete")
     if not _ID_RE.match(claims["id"]):
-        raise ActivationError("this key is signed but its reference is not "
-                              "one this software recognises")
+        raise ActivationError("incomplete")
     if claims["plan"] not in _PLANS:
-        raise ActivationError("this key is for a plan this release does not "
-                              "know about: %s" % claims["plan"][:40])
+        # The plan is not echoed. It is publisher-signed rather than
+        # attacker-chosen, but a response that quotes a field out of the
+        # key is the shape this module is not allowed to have.
+        raise ActivationError("unknown_plan")
     for field in ("issued", "expires"):
         if not _DATE_RE.match(claims[field]) or not _as_date(claims[field]):
-            raise ActivationError("this key is signed but its %s date is not "
-                                  "a date" % field)
+            raise ActivationError("incomplete")
     devices = claims.get("devices")
     if devices is not None and (not isinstance(devices, int)
                                 or isinstance(devices, bool) or devices < 0):
-        raise ActivationError("this key is signed but its device limit is "
-                              "not a number")
+        raise ActivationError("incomplete")
     return claims
 
 
@@ -171,15 +201,26 @@ def _as_date(text: str):
         return None
 
 
-def describe(key: str, today: date | None = None) -> dict:
-    """What the portal shows about a stored key.
+def check(key: str, today: date | None = None) -> dict:
+    """What the portal shows about a key. Never raises for a bad one.
+
+    A key that does not verify is an ordinary answer, not an exceptional
+    one - somebody mistyping a key is the common case, not a fault - so
+    this returns the same shape either way and callers have no exception to
+    catch. That is also what keeps exception detail out of every response
+    built from it: "reason" is a constant from REFUSALS, chosen by code.
 
     Never returns the key. Every caller of this is on a path to a browser,
     and the key is the registry credential; the fingerprint is what a
     person needs to identify it and all they get.
     """
     today = today or datetime.now(timezone.utc).date()
-    claims = parse(key)
+    try:
+        claims = parse(key)
+    except ActivationError as e:
+        return {"state": "invalid", "code": e.code,
+                "reason": REFUSALS.get(e.code, REFUSALS["damaged"]),
+                "fingerprint": fingerprint(key)}
     expires = _as_date(claims["expires"])
     days_left = (expires - today).days
     return {

--- a/receiver/app/activation.py
+++ b/receiver/app/activation.py
@@ -1,0 +1,196 @@
+# Copyright 2026 Aman Karir
+# SPDX-License-Identifier: Apache-2.0
+# Part of Shadow AI Guard, https://github.com/AmanSK5/shadow-ai-guard
+
+"""Activation keys: what one is, and how this deployment checks one.
+
+Shadow AI Guard is the open edition and stays whole without any of this.
+Nothing here switches a feature on or off, and no code path in this
+repository asks whether a key is present before doing its job. What an
+activation key does is name a subscription to the enterprise edition, which
+ships as private images: it identifies the organisation, states the term
+and the limits, and doubles as the credential that pulls those images. This
+module exists so the portal can tell an operator whether the key they were
+issued is genuine, what it says, and what to run next - on their own
+machine, which is where every deployment change in this project happens.
+
+Three properties are deliberate.
+
+Offline. The key carries its own claims and an Ed25519 signature over them.
+Checking it needs the publisher's public key, which is compiled in below,
+and nothing else - no outbound request at activation, at boot, or ever. A
+deployment that is airgapped, or whose vendor has gone quiet, keeps working
+exactly as it did the day before.
+
+Readable. The claims are plain JSON, so the operator can see what they were
+sold without a tool. The signature stops it being edited, not read; a key
+is a statement about an agreement, not a secret about the software.
+
+Verified where it is stored. The receiver holds settings and holds this,
+and refuses to store a key it cannot verify. A portal that verified and
+then wrote would leave the write path as the real gate.
+"""
+
+import base64
+import binascii
+import hashlib
+import json
+import os
+import re
+from datetime import date, datetime, timezone
+
+from . import ed25519
+
+# The publisher's Ed25519 public key. Public by nature: it verifies
+# signatures and makes none, so shipping it in a public repository is what
+# it is for. ACTIVATION_PUBLIC_KEY overrides it, which is how a test issues
+# its own keys and how a key rotation reaches a deployment that has not
+# taken a new image yet.
+_DEFAULT_PUBLIC_KEY = "FHWkKrwWNLyubMhj6asRZGaW/80gKbaDj2zhonmPcmQ="
+
+PREFIX = "nyxl_"
+
+# Long enough for any real key, short enough that the parser is never handed
+# a megabyte to base64-decode.
+MAX_LENGTH = 4000
+
+_PLANS = ("enterprise", "trial")
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+class ActivationError(ValueError):
+    """The key is not usable, with a sentence saying why.
+
+    The message is shown to an operator, so it says what to do about it
+    rather than which check failed: someone holding a key that does not
+    work needs to know whether to look for a typo or to email support.
+    """
+
+
+def public_key() -> bytes:
+    raw = (os.environ.get("ACTIVATION_PUBLIC_KEY") or _DEFAULT_PUBLIC_KEY).strip()
+    try:
+        key = base64.b64decode(raw, validate=True)
+    except (binascii.Error, ValueError):
+        raise ActivationError("ACTIVATION_PUBLIC_KEY is not valid base64")
+    if len(key) != 32:
+        raise ActivationError("ACTIVATION_PUBLIC_KEY is not a 32-byte "
+                              "Ed25519 public key")
+    return key
+
+
+def _b64url(raw: str) -> bytes:
+    # The encoder strips padding because a key is something people paste
+    # into a chat window, and "=" at the end of one invites a truncation.
+    pad = "=" * (-len(raw) % 4)
+    try:
+        return base64.urlsafe_b64decode(raw + pad)
+    except (binascii.Error, ValueError):
+        raise ActivationError("this key is damaged - it is not the shape a "
+                              "key has. Paste it again, whole.")
+
+
+def fingerprint(key: str) -> str:
+    """A short, stable name for a key, safe to say out loud.
+
+    Support needs to agree with an operator about which key is installed
+    without either of them sending it anywhere, and the key is also a
+    registry credential, so it is never displayed. This is a hash of it.
+    """
+    digest = hashlib.sha256(key.strip().encode()).hexdigest()
+    return "-".join(digest[i:i + 4] for i in range(0, 12, 4))
+
+
+def parse(key: str) -> dict:
+    """The claims in a key, once its signature has been checked.
+
+    Raises ActivationError for anything that is not a genuine key. Expiry
+    is NOT checked here: an expired key is genuine and its claims are worth
+    showing, and conflating "forged" with "ran out" is how an operator
+    spends an afternoon on the wrong problem. See describe().
+    """
+    key = (key or "").strip()
+    if not key:
+        raise ActivationError("no key was given")
+    if len(key) > MAX_LENGTH:
+        raise ActivationError("this is too long to be an activation key")
+    if not key.startswith(PREFIX):
+        raise ActivationError("an activation key starts with %s. This looks "
+                              "like something else - an enrollment token, "
+                              "perhaps." % PREFIX)
+    body = key[len(PREFIX):]
+    if body.count(".") != 1:
+        raise ActivationError("this key is damaged - it is not the shape a "
+                              "key has. Paste it again, whole.")
+    claims_raw, sig_raw = body.split(".")
+    signed = _b64url(claims_raw)
+    signature = _b64url(sig_raw)
+    if not ed25519.verify(public_key(), signed, signature):
+        raise ActivationError("this key was not issued for this software, or "
+                              "it has been altered since it was issued. "
+                              "Check you pasted all of it; if you did, ask "
+                              "for it to be reissued.")
+    try:
+        claims = json.loads(signed.decode())
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise ActivationError("this key is signed but unreadable")
+    if not isinstance(claims, dict):
+        raise ActivationError("this key is signed but unreadable")
+    # Version first: a v2 key may mean something different by every field
+    # below, so guessing at it is worse than saying the software is old.
+    if claims.get("v") != 1:
+        raise ActivationError("this key needs a newer release than the one "
+                              "running here. Upgrade, then activate.")
+    for field in ("id", "org", "plan", "issued", "expires"):
+        if not isinstance(claims.get(field), str) or not claims[field].strip():
+            raise ActivationError("this key is signed but incomplete: it does "
+                                  "not state its %s" % field)
+    if not _ID_RE.match(claims["id"]):
+        raise ActivationError("this key is signed but its reference is not "
+                              "one this software recognises")
+    if claims["plan"] not in _PLANS:
+        raise ActivationError("this key is for a plan this release does not "
+                              "know about: %s" % claims["plan"][:40])
+    for field in ("issued", "expires"):
+        if not _DATE_RE.match(claims[field]) or not _as_date(claims[field]):
+            raise ActivationError("this key is signed but its %s date is not "
+                                  "a date" % field)
+    devices = claims.get("devices")
+    if devices is not None and (not isinstance(devices, int)
+                                or isinstance(devices, bool) or devices < 0):
+        raise ActivationError("this key is signed but its device limit is "
+                              "not a number")
+    return claims
+
+
+def _as_date(text: str):
+    try:
+        return date.fromisoformat(text)
+    except ValueError:
+        return None
+
+
+def describe(key: str, today: date | None = None) -> dict:
+    """What the portal shows about a stored key.
+
+    Never returns the key. Every caller of this is on a path to a browser,
+    and the key is the registry credential; the fingerprint is what a
+    person needs to identify it and all they get.
+    """
+    today = today or datetime.now(timezone.utc).date()
+    claims = parse(key)
+    expires = _as_date(claims["expires"])
+    days_left = (expires - today).days
+    return {
+        "state": "active" if days_left >= 0 else "expired",
+        "id": claims["id"],
+        "org": claims["org"],
+        "plan": claims["plan"],
+        "devices": claims.get("devices"),
+        "issued": claims["issued"],
+        "expires": claims["expires"],
+        "days_left": days_left,
+        "registry": (claims.get("registry") or "").strip(),
+        "fingerprint": fingerprint(key),
+    }

--- a/receiver/app/ed25519.py
+++ b/receiver/app/ed25519.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Aman Karir
+# SPDX-License-Identifier: Apache-2.0
+# Part of Shadow AI Guard, https://github.com/AmanSK5/shadow-ai-guard
+
+"""Ed25519 signature verification, RFC 8032, and nothing else.
+
+An activation key is checked offline: the receiver holds the publisher's
+public key and never asks anyone whether a key is good. That promise is the
+whole point - a licence that phones home is a licence that stops working
+when the vendor does - so the check has to be something the container can
+always do, on any network, forever.
+
+Why the arithmetic is here rather than a dependency: the only operation
+needed is verify, over public data, in two components whose entire
+dependency list is four packages. Pulling in a compiled crypto library to
+do one signature check would add a build toolchain to both images for a
+routine that fits on a page. There is no private key in this process and
+none in this repository, so the usual reason to insist on a hardened
+implementation - secret-dependent timing - does not arise: everything below
+touches only a public key, a public message and a public signature.
+
+What that trade does cost is the assurance a reviewed library carries, so
+it is bought back in the tests: test_ed25519.py runs the RFC 8032 test
+vectors and the cases a naive verifier gets wrong (a non-canonical scalar,
+a point off the curve, a flipped bit in each field).
+
+Not constant time, and deliberately not claimed to be.
+"""
+
+import hashlib
+
+# The curve, as RFC 8032 states it.
+_P = 2 ** 255 - 19
+_Q = 2 ** 252 + 27742317777372353535851937790883648493
+_D = -121665 * pow(121666, _P - 2, _P) % _P
+_SQRT_M1 = pow(2, (_P - 1) // 4, _P)
+
+
+def _recover_x(y: int, sign: int):
+    """The x that goes with a compressed y, or None if there is none.
+
+    Returning None rather than raising matters: an attacker chooses the
+    bytes, so "this is not a point on the curve" is an ordinary answer the
+    caller turns into false, not an exceptional one.
+    """
+    if y >= _P:
+        return None
+    x2 = (y * y - 1) * pow(_D * y * y + 1, _P - 2, _P) % _P
+    if x2 == 0:
+        return None if sign else 0
+    x = pow(x2, (_P + 3) // 8, _P)
+    if (x * x - x2) % _P != 0:
+        x = x * _SQRT_M1 % _P
+    if (x * x - x2) % _P != 0:
+        return None
+    if (x & 1) != sign:
+        x = _P - x
+    return x
+
+
+# Extended homogeneous coordinates (X, Y, Z, T): x = X/Z, y = Y/Z, xy = T/Z.
+# Addition is unified - the same formula for doubling - so there is no
+# special case to get wrong on a chosen input.
+def _add(p, q):
+    a = (p[1] - p[0]) * (q[1] - q[0]) % _P
+    b = (p[1] + p[0]) * (q[1] + q[0]) % _P
+    c = 2 * p[3] * q[3] * _D % _P
+    e = 2 * p[2] * q[2] % _P
+    f, g, h, i = b - a, e - c, e + c, b + a
+    return (f * g % _P, h * i % _P, g * h % _P, f * i % _P)
+
+
+def _mul(s: int, p):
+    r = (0, 1, 1, 0)
+    while s > 0:
+        if s & 1:
+            r = _add(r, p)
+        p = _add(p, p)
+        s >>= 1
+    return r
+
+
+def _equal(p, q) -> bool:
+    return ((p[0] * q[2] - q[0] * p[2]) % _P == 0
+            and (p[1] * q[2] - q[1] * p[2]) % _P == 0)
+
+
+_GY = 4 * pow(5, _P - 2, _P) % _P
+_GX = _recover_x(_GY, 0)
+_G = (_GX, _GY, 1, _GX * _GY % _P)
+
+
+def _decompress(b: bytes):
+    if len(b) != 32:
+        return None
+    y = int.from_bytes(b, "little")
+    sign = y >> 255
+    y &= (1 << 255) - 1
+    x = _recover_x(y, sign)
+    return None if x is None else (x, y, 1, x * y % _P)
+
+
+def verify(public_key: bytes, message: bytes, signature: bytes) -> bool:
+    """True only if signature is this key's signature over this message.
+
+    Every malformed input answers False rather than raising, because all
+    three arguments come from outside and a signature check that can throw
+    is a signature check somebody wraps in a bare except.
+    """
+    if len(public_key) != 32 or len(signature) != 64:
+        return False
+    a = _decompress(public_key)
+    if a is None:
+        return False
+    r_bytes = signature[:32]
+    r = _decompress(r_bytes)
+    if r is None:
+        return False
+    s = int.from_bytes(signature[32:], "little")
+    # A scalar at or above the group order is a second encoding of a
+    # signature that already verifies. Rejecting it is what stops one
+    # signature having more than one valid form.
+    if s >= _Q:
+        return False
+    h = int.from_bytes(
+        hashlib.sha512(r_bytes + public_key + message).digest(), "little") % _Q
+    return _equal(_mul(s, _G), _add(r, _mul(h, a)))

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -2638,17 +2638,18 @@ class ActivationWrite(BaseModel):
 
 
 def _activation_view() -> dict:
+    # A stored key that no longer verifies is a real state, not a bug to
+    # hide: it happens when the publisher's key is rotated and this
+    # deployment has not taken the release that carries the new one.
+    # activation.check answers with that state rather than raising, so
+    # nothing built from an exception reaches this response.
     stored = (STATE.get_settings().get("activation_key") or "").strip()
     if not stored:
         return {"state": "none"}
-    try:
-        return activation.describe(stored)
-    except activation.ActivationError as e:
-        # A stored key that no longer parses is a real state, not a bug to
-        # hide: it happens when the publisher's key is rotated and this
-        # deployment has not taken the release that carries the new one.
-        return {"state": "invalid", "error": str(e),
-                "fingerprint": activation.fingerprint(stored)}
+    view = activation.check(stored)
+    if view["state"] == "invalid":
+        log.info("stored activation key does not verify (%s)", view["code"])
+    return view
 
 
 @app.get("/admin/activation")
@@ -2676,15 +2677,18 @@ def put_activation(req: ActivationWrite, authorization: str = Header(default="")
     if not key:
         STATE.set_setting("activation_key", None, by)
         return _activation_view()
-    try:
-        claims = activation.describe(key)
-    except activation.ActivationError as e:
-        raise HTTPException(422, str(e))
+    view = activation.check(key)
+    if view["state"] == "invalid":
+        # The refusal is one of activation.REFUSALS, picked by code. The
+        # reason it was refused goes to the log; the response carries the
+        # class of failure and nothing derived from an exception.
+        log.info("activation key refused (%s)", view["code"])
+        raise HTTPException(422, view["reason"])
     # An expired key is stored anyway. It is a true statement about a real
     # subscription, and refusing it would leave an operator renewing a key
     # they cannot see the details of - the portal says "expired" plainly.
     STATE.set_setting("activation_key", key, by)
-    return claims
+    return view
 
 
 @app.post("/admin/test/log-store-push")

--- a/receiver/app/main.py
+++ b/receiver/app/main.py
@@ -59,6 +59,7 @@ from pydantic import BaseModel, Field
 
 # Importing the module costs nothing stateful: the SQLite file only exists
 # once State() is instantiated, which only happens under MANAGED_MODE below.
+from . import activation
 from . import budget as _budget
 from . import state as _state
 
@@ -2613,6 +2614,77 @@ def put_settings(req: SettingsUpdate, authorization: str = Header(default="")):
             STATE.set_setting(key, val, by)
 
     return get_settings(authorization)
+
+
+# ------------------------------------------------------------ activation --
+# The subscription to the enterprise edition, if there is one. Nothing in
+# this repository reads it to decide what to do: the open edition is whole,
+# and a key here changes no behaviour, gates no route and unlocks nothing.
+# It is stored so the portal can tell an operator that the key they were
+# issued is genuine, what it says, and when it runs out - and so the
+# machine that pulls the private images has one place to be told which
+# subscription it is pulling as.
+#
+# The key never comes back out. It is the registry credential as well as
+# the statement of entitlement, so GET answers with the claims and a
+# fingerprint; the operator already has the key they typed.
+
+
+class ActivationWrite(BaseModel):
+    model_config = {"extra": "forbid"}
+    # Empty removes the stored key, which is how a deployment goes back to
+    # the open edition without a redeploy.
+    key: str = Field(default="", max_length=activation.MAX_LENGTH)
+
+
+def _activation_view() -> dict:
+    stored = (STATE.get_settings().get("activation_key") or "").strip()
+    if not stored:
+        return {"state": "none"}
+    try:
+        return activation.describe(stored)
+    except activation.ActivationError as e:
+        # A stored key that no longer parses is a real state, not a bug to
+        # hide: it happens when the publisher's key is rotated and this
+        # deployment has not taken the release that carries the new one.
+        return {"state": "invalid", "error": str(e),
+                "fingerprint": activation.fingerprint(stored)}
+
+
+@app.get("/admin/activation")
+def get_activation(authorization: str = Header(default="")):
+    """What this deployment's subscription says, or that there is none."""
+    _admin_auth(authorization)
+    return _activation_view()
+
+
+@app.put("/admin/activation")
+def put_activation(req: ActivationWrite, authorization: str = Header(default="")):
+    """Store a key, having checked it, or clear the one that is stored.
+
+    Owner-gated. This is a commercial agreement and a registry credential
+    rather than a setting about what the platform reports, which is the
+    same line sso_* sits on: the tier above admin exists for the handful of
+    things that are about the organisation rather than the estate.
+
+    Verified here, before the write. A portal that checked and then wrote
+    would leave this route as the way past the check.
+    """
+    _admin_auth(authorization, write=True, owner=True)
+    by = _admin_actor(authorization)
+    key = (req.key or "").strip()
+    if not key:
+        STATE.set_setting("activation_key", None, by)
+        return _activation_view()
+    try:
+        claims = activation.describe(key)
+    except activation.ActivationError as e:
+        raise HTTPException(422, str(e))
+    # An expired key is stored anyway. It is a true statement about a real
+    # subscription, and refusing it would leave an operator renewing a key
+    # they cannot see the details of - the portal says "expired" plainly.
+    STATE.set_setting("activation_key", key, by)
+    return claims
 
 
 @app.post("/admin/test/log-store-push")

--- a/receiver/tests/ed25519_signer.py
+++ b/receiver/tests/ed25519_signer.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Aman Karir
+# SPDX-License-Identifier: Apache-2.0
+# Part of Shadow AI Guard, https://github.com/AmanSK5/shadow-ai-guard
+
+"""An Ed25519 signer, for tests only.
+
+The receiver verifies and never signs, so app/ed25519.py has no signing in
+it and this does not belong beside it: shipping a signer in the component
+that checks signatures invites the question of what it is for. Tests need
+to issue keys of their own, though - a suite that can only check one
+hard-coded key cannot test a forgery - so the other half of RFC 8032 lives
+here, in the tests, where it can never reach an image.
+
+Reused by test_ed25519.py to reproduce the RFC's own vectors from their
+seeds, which is what says these twenty lines are the real algorithm rather
+than something that merely agrees with app/ed25519.py.
+"""
+
+import hashlib
+
+from app.ed25519 import _G, _P, _Q, _mul
+
+
+def _compress(point) -> bytes:
+    x, y, z, _ = point
+    zinv = pow(z, _P - 2, _P)
+    x, y = x * zinv % _P, y * zinv % _P
+    return int.to_bytes(y | ((x & 1) << 255), 32, "little")
+
+
+def _expand(seed: bytes):
+    h = hashlib.sha512(seed).digest()
+    a = int.from_bytes(h[:32], "little")
+    a &= (1 << 254) - 8
+    a |= 1 << 254
+    return a, h[32:]
+
+
+def public_key(seed: bytes) -> bytes:
+    a, _ = _expand(seed)
+    return _compress(_mul(a, _G))
+
+
+def sign(seed: bytes, message: bytes) -> bytes:
+    a, prefix = _expand(seed)
+    pub = _compress(_mul(a, _G))
+    r = int.from_bytes(hashlib.sha512(prefix + message).digest(), "little") % _Q
+    big_r = _compress(_mul(r, _G))
+    h = int.from_bytes(
+        hashlib.sha512(big_r + pub + message).digest(), "little") % _Q
+    return big_r + int.to_bytes((r + h * a) % _Q, 32, "little")

--- a/receiver/tests/test_activation.py
+++ b/receiver/tests/test_activation.py
@@ -90,7 +90,7 @@ def viewer(managed, owner):
 # ------------------------------------------------------------ the format --
 
 def test_a_genuine_key_reads_back_what_it_says():
-    c = activation.describe(mint(), today=date(2026, 6, 1))
+    c = activation.check(mint(), today=date(2026, 6, 1))
     assert c["state"] == "active"
     assert c["org"] == "Acme Group Ltd"
     assert c["id"] == "NYX-0001"
@@ -103,7 +103,7 @@ def test_a_key_from_another_publisher_is_refused():
     forged = mint(seed=b"somebody else's signing seed....")
     with pytest.raises(activation.ActivationError) as e:
         activation.parse(forged)
-    assert "not issued for this software" in str(e.value)
+    assert e.value.code == "not_ours"
 
 
 def test_editing_the_claims_breaks_the_signature():
@@ -125,35 +125,38 @@ def test_editing_the_claims_breaks_the_signature():
 def test_an_expired_key_is_genuine_and_says_so():
     """Expired is not forged. An operator renewing has to be able to see
     what ran out and when."""
-    c = activation.describe(mint(expires="2026-01-31"), today=date(2026, 3, 1))
+    c = activation.check(mint(expires="2026-01-31"), today=date(2026, 3, 1))
     assert c["state"] == "expired"
     assert c["days_left"] == -29
     assert c["org"] == "Acme Group Ltd"
 
 
 def test_the_last_day_is_still_active():
-    c = activation.describe(mint(expires="2026-03-01"), today=date(2026, 3, 1))
+    c = activation.check(mint(expires="2026-03-01"), today=date(2026, 3, 1))
     assert c["state"] == "active" and c["days_left"] == 0
 
 
-@pytest.mark.parametrize("bad,says", [
-    ("", "no key"),
-    ("   ", "no key"),
-    ("nyxe_9f3c2a1b", "starts with nyxl_"),
+@pytest.mark.parametrize("bad,code", [
+    ("", "empty"),
+    ("   ", "empty"),
+    ("nyxe_9f3c2a1b", "not_a_key"),
     ("nyxl_notbase64!!", "damaged"),
     ("nyxl_" + "a" * 20, "damaged"),
-    ("nyxl_" + "a" * 5000, "too long"),
+    ("nyxl_" + "a" * 5000, "too_long"),
 ])
-def test_what_is_not_a_key_says_what_to_do_about_it(bad, says):
+def test_what_is_not_a_key_says_what_to_do_about_it(bad, code):
     with pytest.raises(activation.ActivationError) as e:
         activation.parse(bad)
-    assert says in str(e.value)
+    assert e.value.code == code
+    # And the sentence an operator sees is the one for that code, not
+    # anything built from the exception.
+    assert activation.check(bad)["reason"] == activation.REFUSALS[code]
 
 
 def test_a_signed_key_this_release_cannot_read_asks_for_an_upgrade():
     with pytest.raises(activation.ActivationError) as e:
         activation.parse(mint(v=2))
-    assert "newer release" in str(e.value)
+    assert e.value.code == "too_new"
 
 
 @pytest.mark.parametrize("overrides", [
@@ -186,7 +189,7 @@ def test_checking_a_key_makes_no_network_call(monkeypatch):
 
     monkeypatch.setattr(socket, "socket", refuse)
     monkeypatch.setattr(socket, "create_connection", refuse)
-    assert activation.describe(mint())["state"] == "active"
+    assert activation.check(mint())["state"] == "active"
 
 
 # --------------------------------------------------------- the endpoints --
@@ -214,7 +217,7 @@ def test_a_forged_key_is_refused_and_nothing_is_stored(managed, owner):
     forged = mint(seed=b"somebody else's signing seed....")
     r = client.put("/admin/activation", headers=owner, json={"key": forged})
     assert r.status_code == 422
-    assert "not issued for this software" in r.json()["detail"]
+    assert r.json()["detail"] == activation.REFUSALS["not_ours"]
     assert client.get("/admin/activation", headers=owner).json() == {"state": "none"}
 
 
@@ -256,7 +259,8 @@ def test_a_key_the_running_release_cannot_verify_is_reported_not_hidden(
                        base64.b64encode(public_key(b"a rotated signing seed..." + b"." * 7)).decode())
     got = client.get("/admin/activation", headers=owner).json()
     assert got["state"] == "invalid"
-    assert "not issued for this software" in got["error"]
+    assert got["code"] == "not_ours"
+    assert got["reason"] == activation.REFUSALS["not_ours"]
     assert got["fingerprint"]
 
 
@@ -271,3 +275,63 @@ def test_an_unknown_field_is_refused_rather_than_ignored(managed, owner):
     r = client.put("/admin/activation", headers=owner,
                    json={"key": mint(), "seats": 5})
     assert r.status_code == 422
+
+
+# ------------------------------------------------- what a refusal may say --
+# The rule portal/tests/test_error_disclosure.py sets out, held on this
+# side too: a response carries the class of failure, and the detail behind
+# it goes to the log. CodeQL flagged the first version of these two routes
+# for exposing exception detail (py/stack-trace-exposure) and it was right.
+
+def test_every_code_the_module_can_raise_has_a_sentence():
+    """The drift guard. A new refusal code with no entry would fall back to
+    a sentence about the wrong thing, which is worse than no sentence."""
+    import ast
+    import inspect
+
+    tree = ast.parse(inspect.getsource(activation))
+    raised = {
+        node.exc.args[0].value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Raise) and isinstance(node.exc, ast.Call)
+        and getattr(node.exc.func, "id", "") == "ActivationError"
+        and node.exc.args and isinstance(node.exc.args[0], ast.Constant)
+    }
+    assert raised, "no ActivationError raises found - has the module moved?"
+    assert raised <= set(activation.REFUSALS), \
+        "no sentence for: %s" % sorted(raised - set(activation.REFUSALS))
+
+
+def test_a_refusal_is_always_one_of_the_written_sentences():
+    for bad in ["", "nyxe_x", "nyxl_!!", "nyxl_" + "a" * 40, mint(v=2),
+                mint(plan="unlimited"), mint(seed=b"another publisher......." + b"." * 9)]:
+        view = activation.check(bad)
+        assert view["state"] == "invalid"
+        assert view["reason"] in activation.REFUSALS.values()
+
+
+@pytest.mark.parametrize("bad", [
+    "nyxl_!!!", "nyxe_x", "not-a-key-at-all",
+])
+def test_no_exception_detail_reaches_the_response(managed, owner, bad):
+    body = client.put("/admin/activation", headers=owner, json={"key": bad}).text
+    for leak in ["Traceback", "ActivationError", "binascii", "json.decoder",
+                 "activation.py", "/app/", "line ", "ValueError"]:
+        assert leak not in body, "%r leaked into the refusal" % leak
+
+
+def test_a_signed_key_is_never_quoted_back_in_a_refusal(managed, owner):
+    """A refusal that echoes a field out of the key is the shape this is
+    not allowed to have, even when the field is publisher-signed."""
+    r = client.put("/admin/activation", headers=owner,
+                   json={"key": mint(plan="wildly-bespoke-tier")})
+    assert r.status_code == 422
+    assert "wildly-bespoke-tier" not in r.text
+    assert r.json()["detail"] == activation.REFUSALS["unknown_plan"]
+
+
+def test_the_code_is_for_the_log_and_the_sentence_is_for_the_person(
+        managed, owner, caplog):
+    with caplog.at_level("INFO"):
+        client.put("/admin/activation", headers=owner, json={"key": "nyxl_!!"})
+    assert "damaged" in caplog.text

--- a/receiver/tests/test_activation.py
+++ b/receiver/tests/test_activation.py
@@ -1,0 +1,273 @@
+# Copyright 2026 Aman Karir
+# SPDX-License-Identifier: Apache-2.0
+# Part of Shadow AI Guard, https://github.com/AmanSK5/shadow-ai-guard
+
+"""Activation keys: what is accepted, what is refused, and what comes back.
+
+The properties that matter commercially are all negative ones - a key
+nobody issued must not work, and an edited key must not work - so most of
+this file forges things. The positive half checks the two promises made to
+an operator instead: the check needs no network, and the key they typed is
+never handed back to a browser.
+"""
+
+import base64
+import json
+import os
+from datetime import date
+
+os.environ.setdefault("AUTH_TOKEN", "test-token-for-ci")
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app import activation
+from app import main
+from app import state as state_mod
+from app.main import app
+from tests.ed25519_signer import public_key, sign
+
+client = TestClient(app)
+
+# The publisher, for this file. Nothing here uses the key compiled into
+# the module: a test that signed with the real private key would need the
+# real private key to exist somewhere a test can reach it.
+SEED = b"a test publisher's signing seed."
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def mint(seed: bytes = SEED, **overrides) -> str:
+    claims = {"v": 1, "id": "NYX-0001", "org": "Acme Group Ltd",
+              "plan": "enterprise", "issued": "2026-01-01",
+              "expires": "2099-01-01", "devices": 2500}
+    claims.update(overrides)
+    for k in [k for k, v in claims.items() if v is None]:
+        del claims[k]
+    payload = json.dumps(claims, separators=(",", ":"), sort_keys=True,
+                         ensure_ascii=False).encode()
+    return "nyxl_%s.%s" % (_b64url(payload), _b64url(sign(seed, payload)))
+
+
+@pytest.fixture(autouse=True)
+def publisher(monkeypatch):
+    monkeypatch.setenv("ACTIVATION_PUBLIC_KEY",
+                       base64.b64encode(public_key(SEED)).decode())
+
+
+@pytest.fixture
+def managed(tmp_path, monkeypatch):
+    st = state_mod.State(str(tmp_path / "state.db"))
+    monkeypatch.setattr(main, "STATE", st)
+    monkeypatch.setattr(main, "_EXPECTED_ADMIN", b"Bearer admin-test-token")
+    return st
+
+
+def _session(managed, username="root", password="a-long-enough-password"):
+    return {"Authorization": "Bearer " + managed.login(username, password)["token"]}
+
+
+@pytest.fixture
+def owner(managed):
+    managed.create_admin("root", "a-long-enough-password")
+    return _session(managed)
+
+
+@pytest.fixture
+def admin(managed, owner):
+    managed.create_user("second", "a-long-enough-password", "admin", by="test")
+    return _session(managed, "second")
+
+
+@pytest.fixture
+def viewer(managed, owner):
+    managed.create_user("auditor", "a-long-enough-password", "viewer", by="test")
+    return _session(managed, "auditor")
+
+
+# ------------------------------------------------------------ the format --
+
+def test_a_genuine_key_reads_back_what_it_says():
+    c = activation.describe(mint(), today=date(2026, 6, 1))
+    assert c["state"] == "active"
+    assert c["org"] == "Acme Group Ltd"
+    assert c["id"] == "NYX-0001"
+    assert c["plan"] == "enterprise"
+    assert c["devices"] == 2500
+    assert c["expires"] == "2099-01-01"
+
+
+def test_a_key_from_another_publisher_is_refused():
+    forged = mint(seed=b"somebody else's signing seed....")
+    with pytest.raises(activation.ActivationError) as e:
+        activation.parse(forged)
+    assert "not issued for this software" in str(e.value)
+
+
+def test_editing_the_claims_breaks_the_signature():
+    """The whole scheme in one test: the claims are readable on purpose, so
+    the thing that has to hold is that reading them is all anyone can do."""
+    key = mint(devices=10)
+    body = key[len("nyxl_"):]
+    claims_raw, sig_raw = body.split(".")
+    padded = claims_raw + "=" * (-len(claims_raw) % 4)
+    claims = json.loads(base64.urlsafe_b64decode(padded))
+    assert claims["devices"] == 10           # plainly readable
+    claims["devices"] = 100000
+    swapped = _b64url(json.dumps(claims, separators=(",", ":"),
+                                 sort_keys=True).encode())
+    with pytest.raises(activation.ActivationError):
+        activation.parse("nyxl_%s.%s" % (swapped, sig_raw))
+
+
+def test_an_expired_key_is_genuine_and_says_so():
+    """Expired is not forged. An operator renewing has to be able to see
+    what ran out and when."""
+    c = activation.describe(mint(expires="2026-01-31"), today=date(2026, 3, 1))
+    assert c["state"] == "expired"
+    assert c["days_left"] == -29
+    assert c["org"] == "Acme Group Ltd"
+
+
+def test_the_last_day_is_still_active():
+    c = activation.describe(mint(expires="2026-03-01"), today=date(2026, 3, 1))
+    assert c["state"] == "active" and c["days_left"] == 0
+
+
+@pytest.mark.parametrize("bad,says", [
+    ("", "no key"),
+    ("   ", "no key"),
+    ("nyxe_9f3c2a1b", "starts with nyxl_"),
+    ("nyxl_notbase64!!", "damaged"),
+    ("nyxl_" + "a" * 20, "damaged"),
+    ("nyxl_" + "a" * 5000, "too long"),
+])
+def test_what_is_not_a_key_says_what_to_do_about_it(bad, says):
+    with pytest.raises(activation.ActivationError) as e:
+        activation.parse(bad)
+    assert says in str(e.value)
+
+
+def test_a_signed_key_this_release_cannot_read_asks_for_an_upgrade():
+    with pytest.raises(activation.ActivationError) as e:
+        activation.parse(mint(v=2))
+    assert "newer release" in str(e.value)
+
+
+@pytest.mark.parametrize("overrides", [
+    {"org": None}, {"id": None}, {"expires": None}, {"plan": None},
+    {"expires": "next Tuesday"}, {"issued": "2026-13-40"},
+    {"plan": "unlimited"}, {"devices": "lots"}, {"id": "NYX 0001 & co"},
+])
+def test_a_signed_key_that_is_incomplete_is_still_refused(overrides):
+    """Signed by the right publisher and still not a key: the signature
+    says who wrote it, not that what they wrote makes sense."""
+    with pytest.raises(activation.ActivationError):
+        activation.parse(mint(**overrides))
+
+
+def test_the_fingerprint_identifies_a_key_without_being_one():
+    key = mint()
+    fp = activation.fingerprint(key)
+    assert fp == activation.fingerprint(" " + key + "\n")
+    assert fp != activation.fingerprint(mint(id="NYX-0002"))
+    assert len(fp) == 14 and fp.count("-") == 2
+    assert fp not in key
+
+
+def test_checking_a_key_makes_no_network_call(monkeypatch):
+    """The promise the whole format exists to keep."""
+    import socket
+
+    def refuse(*a, **k):
+        raise AssertionError("activation tried to reach the network")
+
+    monkeypatch.setattr(socket, "socket", refuse)
+    monkeypatch.setattr(socket, "create_connection", refuse)
+    assert activation.describe(mint())["state"] == "active"
+
+
+# --------------------------------------------------------- the endpoints --
+
+def test_a_deployment_with_no_key_says_so(managed, owner):
+    assert client.get("/admin/activation", headers=owner).json() == {"state": "none"}
+
+
+def test_an_owner_activates_and_the_key_never_comes_back(managed, owner):
+    key = mint()
+    r = client.put("/admin/activation", headers=owner, json={"key": key})
+    assert r.status_code == 200 and r.json()["org"] == "Acme Group Ltd"
+
+    got = client.get("/admin/activation", headers=owner)
+    body = got.text
+    assert got.json()["state"] == "active"
+    assert got.json()["fingerprint"] == activation.fingerprint(key)
+    assert key not in body and key[10:40] not in body
+
+    # Nor through the settings route, which echoes everything else.
+    assert "activation" not in client.get("/admin/settings", headers=owner).text
+
+
+def test_a_forged_key_is_refused_and_nothing_is_stored(managed, owner):
+    forged = mint(seed=b"somebody else's signing seed....")
+    r = client.put("/admin/activation", headers=owner, json={"key": forged})
+    assert r.status_code == 422
+    assert "not issued for this software" in r.json()["detail"]
+    assert client.get("/admin/activation", headers=owner).json() == {"state": "none"}
+
+
+def test_only_an_owner_may_activate(managed, owner, admin, viewer):
+    key = mint()
+    assert client.put("/admin/activation", headers=viewer,
+                      json={"key": key}).status_code == 403
+    assert client.put("/admin/activation", headers=admin,
+                      json={"key": key}).status_code == 403
+    assert client.put("/admin/activation", headers=owner,
+                      json={"key": key}).status_code == 200
+    # Reading it is not the owner's alone: an admin supporting the
+    # deployment needs to see when the subscription runs out.
+    assert client.get("/admin/activation", headers=viewer).json()["state"] == "active"
+
+
+def test_clearing_goes_back_to_the_open_edition(managed, owner):
+    client.put("/admin/activation", headers=owner, json={"key": mint()})
+    r = client.put("/admin/activation", headers=owner, json={"key": ""})
+    assert r.status_code == 200 and r.json() == {"state": "none"}
+    assert client.get("/admin/activation", headers=owner).json() == {"state": "none"}
+
+
+def test_activating_is_recorded_with_who_did_it_and_not_what(managed, owner):
+    client.put("/admin/activation", headers=owner, json={"key": mint()})
+    events = managed.list_events(20)
+    setting = [e for e in events if e["kind"] == "setting_changed"
+               and e["detail"].get("key") == "activation_key"]
+    assert setting and setting[0]["detail"]["by"] == "root"
+    assert "nyxl_" not in json.dumps(events)
+
+
+def test_a_key_the_running_release_cannot_verify_is_reported_not_hidden(
+        managed, owner, monkeypatch):
+    """What a publisher key rotation looks like from inside a deployment
+    that has not taken the release carrying the new one."""
+    client.put("/admin/activation", headers=owner, json={"key": mint()})
+    monkeypatch.setenv("ACTIVATION_PUBLIC_KEY",
+                       base64.b64encode(public_key(b"a rotated signing seed..." + b"." * 7)).decode())
+    got = client.get("/admin/activation", headers=owner).json()
+    assert got["state"] == "invalid"
+    assert "not issued for this software" in got["error"]
+    assert got["fingerprint"]
+
+
+def test_an_expired_key_is_stored_and_shown_as_expired(managed, owner):
+    r = client.put("/admin/activation", headers=owner,
+                   json={"key": mint(expires="2020-01-01")})
+    assert r.status_code == 200 and r.json()["state"] == "expired"
+    assert client.get("/admin/activation", headers=owner).json()["state"] == "expired"
+
+
+def test_an_unknown_field_is_refused_rather_than_ignored(managed, owner):
+    r = client.put("/admin/activation", headers=owner,
+                   json={"key": mint(), "seats": 5})
+    assert r.status_code == 422

--- a/receiver/tests/test_ed25519.py
+++ b/receiver/tests/test_ed25519.py
@@ -1,0 +1,105 @@
+# Copyright 2026 Aman Karir
+# SPDX-License-Identifier: Apache-2.0
+# Part of Shadow AI Guard, https://github.com/AmanSK5/shadow-ai-guard
+
+"""RFC 8032 conformance for the signature check activation rests on.
+
+app/ed25519.py is arithmetic written out rather than a library call, and
+the reason that is acceptable is this file. Two things are established
+here. The RFC's own vectors verify, which says the implementation is
+Ed25519 and not something that merely self-agrees. And the forgeries a
+lax verifier accepts are refused: a flipped bit anywhere, a point that is
+not on the curve, and a scalar at or above the group order - the last of
+which is the one a hand-written verifier usually misses, because ignoring
+it makes every signature accept in a second form.
+"""
+
+import binascii
+
+import pytest
+
+from app.ed25519 import verify
+from tests.ed25519_signer import public_key, sign
+
+h = binascii.unhexlify
+
+# RFC 8032, section 7.1: (secret seed, message, signature). The public key
+# is derived rather than pasted, so the vector tests key derivation too.
+VECTORS = [
+    ("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
+     "",
+     "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555f"
+     "b8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b"),
+    ("4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb",
+     "72",
+     "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da08"
+     "5ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00"),
+    ("c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7",
+     "af82",
+     "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18"
+     "ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a"),
+]
+
+
+@pytest.mark.parametrize("seed,message,signature", VECTORS)
+def test_the_rfc_vectors_verify(seed, message, signature):
+    pub = public_key(h(seed))
+    assert verify(pub, h(message), h(signature))
+    # And this suite's signer produces the RFC's signature from the RFC's
+    # seed, so a later "both sides agree" result means something.
+    assert sign(h(seed), h(message)) == h(signature)
+
+
+def test_the_wrong_key_does_not_verify():
+    pub_a, pub_b = public_key(b"a" * 32), public_key(b"b" * 32)
+    msg = b"an activation key's claims"
+    assert verify(pub_a, msg, sign(b"a" * 32, msg))
+    assert not verify(pub_b, msg, sign(b"a" * 32, msg))
+
+
+def test_one_flipped_bit_anywhere_is_refused():
+    seed = b"s" * 32
+    pub, msg = public_key(seed), b'{"v":1,"org":"Acme"}'
+    sig = sign(seed, msg)
+    assert verify(pub, msg, sig)
+    for i in (0, 31, 32, 63):
+        broken = bytearray(sig)
+        broken[i] ^= 1
+        assert not verify(pub, msg, bytes(broken))
+    for i in (0, 5, len(msg) - 1):
+        broken = bytearray(msg)
+        broken[i] ^= 1
+        assert not verify(pub, bytes(broken), sig)
+
+
+def test_a_scalar_at_or_above_the_group_order_is_refused():
+    """Malleability: s and s + L are the same signature to a verifier that
+    forgets to check the bound, which turns one signature into infinitely
+    many valid encodings."""
+    seed = b"s" * 32
+    pub, msg = public_key(seed), b"claims"
+    sig = sign(seed, msg)
+    order = 2 ** 252 + 27742317777372353535851937790883648493
+    s = int.from_bytes(sig[32:], "little")
+    slid = sig[:32] + int.to_bytes(s + order, 32, "little")
+    assert verify(pub, msg, sig)
+    assert not verify(pub, msg, slid)
+
+
+def test_bytes_that_are_not_a_point_are_refused_rather_than_raising():
+    seed = b"s" * 32
+    msg = b"claims"
+    sig = sign(seed, msg)
+    # y = p - 1 has no matching x; so does an all-ones encoding.
+    assert not verify(b"\xff" * 32, msg, sig)
+    assert not verify(public_key(seed), msg, b"\xff" * 64)
+
+
+@pytest.mark.parametrize("pub,sig", [
+    (b"", b"\x00" * 64),
+    (b"\x00" * 31, b"\x00" * 64),
+    (b"\x00" * 32, b""),
+    (b"\x00" * 32, b"\x00" * 63),
+])
+def test_wrong_lengths_are_false_not_an_exception(pub, sig):
+    assert verify(pub, b"claims", sig) is False


### PR DESCRIPTION
Somewhere for an operator who has bought the commercial edition to enter the key they were issued, see that it is genuine and what it says, and get the commands to move a deployment across. The open edition is unchanged and stays whole: no view, no route and no count in this repository asks whether a key is present.

## What a key is

- Compact JSON stating the organisation, the plan, the term and any device limit, with an Ed25519 signature over exactly those bytes. Both halves are base64url behind an `nyxl_` prefix; `nyxe_` and `nyxd_` are already enrollment and device tokens.
- The claims are readable on purpose. What somebody was sold should not need a tool to inspect, and the signature is what stops them being edited, not read.
- No revocation. An offline check cannot be told a key was withdrawn, so the stated term is the control: a twelve-month key renewed annually is a subscription, a perpetual one is a sale.

## Checked offline, and verified where it is stored

- The publisher's public key is compiled into the receiver, so verification is local arithmetic. No outbound request at activation, at boot, or ever: a deployment that is airgapped, or whose vendor has gone quiet, keeps working exactly as it did. `ACTIVATION_PUBLIC_KEY` overrides the compiled-in key, which is how a rotation reaches a deployment before a new image does.
- `PUT /admin/activation` refuses a key it cannot verify, so the write path is not a way past the check. Owner-gated, for the same reason the `sso_*` settings are: it is about the organisation rather than the estate. Reading it is not owner-only, because an admin supporting a deployment needs to see when the subscription runs out.
- The key is never echoed. `GET` answers with the claims and a truncated SHA-256 fingerprint, which is what support and an operator use to agree on which key is installed without either of them sending it anywhere. It does not appear in `GET /admin/settings` either, and the audit trail records that `activation_key` changed and who changed it, never the value.
- The portal forwards and decides nothing, so there is no route on that side that could return a stored key to a browser.

## What the card says

- A new wide card under Updates on System health, in managed mode. Unactivated it names the edition, the licence and that the check makes no outbound request, and offers an owner the field.
- Activated it shows the organisation, the plan and device limit, the expiry with days remaining, the reference and the key's fingerprint. Inside 45 days it says the subscription is ending and that nothing stops working on the day, because nothing does.
- An expired key is stored and reported as expired rather than refused. It is a true statement about a real subscription, and someone renewing has to be able to see what ran out; conflating "forged" with "ran out" costs an afternoon on the wrong problem.
- A key the running release cannot verify is reported, not hidden. That is what a rotated signing key looks like from a deployment that has not taken the release carrying the new one, so the note says to upgrade first and only then suspect the key.
- A failed read says the receiver did not answer rather than reporting no subscription, which would tell a paying customer they have no licence.
- Activated and expired both expand the handoff: the pull secret and the chart install, written with the deployment's own namespace and the registry named in the key. Nothing runs from the page. It runs with the operator's own kubeconfig, on their own machine, the same rule as `aiguardctl upgrade`.

## What this is not

A client-side check is not the control and is not presented as one. Anyone running their own copy can point `ACTIVATION_PUBLIC_KEY` at a key of their own and make it say activated, and no amount of hardening changes that. It wins nothing: activation gates no behaviour here, and a forged key is not a credential. What protects the private images is the registry refusing to serve them, which is server-side and outside this repository.

## The verifier

Written out in `receiver/app/ed25519.py` rather than taken from a library. The only operation needed is verify, over public data, in a component whose dependency list is seven packages, and pulling in a compiled crypto library would add a build toolchain to two images for a routine that fits on a page. There is no private key in the process and none in this repository, so the usual reason to insist on a hardened implementation - secret-dependent timing - does not arise.

What that trade costs is the assurance a reviewed library carries, so it is bought back in the tests: the RFC 8032 vectors, reproduced from their seeds rather than pasted, plus the forgeries a lax verifier accepts - a flipped bit in each field, a point that is not on the curve, and a scalar at or above the group order, which is the one a hand-written verifier usually misses because ignoring it gives every signature a second valid form. The signer the tests use lives in `receiver/tests/` and never reaches an image.

## Checked

365 receiver tests, 671 portal tests, 22 Node renderer tests. The identifier check and a Trivy secret scan over the tree. End to end on the demo stack: pasted a real key, watched the card flip to activated with the right claims, confirmed the audit row landed without the key in it, confirmed no route returns it, then cleared it back to the open edition.

## Deploying

No version bump here and nothing stored changes. No new dependency in any component, so no lockfile moves. `ACTIVATION_PUBLIC_KEY` is optional and unset in every existing deployment, which keeps the compiled-in key. A deployment that never enters a key sees one extra card saying it runs the open edition.
