### PR TITLE
0.32.0 - activation keys, checked offline on System health

### DIFF
--- a/charts/ai-guard/Chart.yaml
+++ b/charts/ai-guard/Chart.yaml
@@ -10,14 +10,14 @@ type: application
 # independently of appVersion: a repo index uses this to decide whether an
 # upgrade exists, so a chart change that leaves it alone is a change nobody
 # is offered.
-version: 0.31.0
+version: 0.32.0
 # The application version this chart installs by default. values.yaml derives
 # image.tag from it, so this IS what gets pulled unless someone overrides it.
 #
 # It sat at 0.2.0 through the 0.3.0 release: nothing checked it, so `helm
 # install` quietly deployed a receiver a full release behind what the tag
 # claimed. CI now fails a tag build if this and the tag disagree.
-appVersion: "0.31.0"
+appVersion: "0.32.0"
 home: https://github.com/AmanSK5/shadow-ai-guard
 maintainers:
   - name: Aman Karir

--- a/cli/README.md
+++ b/cli/README.md
@@ -19,7 +19,7 @@ It needs Python 3.10 or newer and `pipx` (`brew install pipx` on a Mac,
 `pip install --user pipx` elsewhere). From a tagged release of this
 repository, once:
 
-    pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@v0.31.0#subdirectory=cli"
+    pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@v0.32.0#subdirectory=cli"
     pipx ensurepath
 
 `pipx ensurepath` puts the command on your PATH; a shell opened before that

--- a/cli/aiguardctl/__init__.py
+++ b/cli/aiguardctl/__init__.py
@@ -10,4 +10,4 @@ context and reports each step back so the portal can show it. Nothing in
 the platform gains a right over the deployment. See SECURITY.md,
 "Upgrading", in the project repository.
 """
-__version__ = "0.31.0"
+__version__ = "0.32.0"

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aiguardctl"
-version = "0.31.0"
+version = "0.32.0"
 description = "Upgrade a Shadow AI Guard deployment from your own machine, with your own credentials, while the portal shows the progress"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -125,14 +125,14 @@ The same thing without Helm, if you would rather see the pieces.
 Published to GHCR by CI, so nothing needs building:
 
 ```
-ghcr.io/amansk5/shadow-ai-guard/receiver:0.31.0
+ghcr.io/amansk5/shadow-ai-guard/receiver:0.32.0
 ```
 
 Built for `linux/amd64` and `linux/arm64` under one tag, so it resolves on
 Graviton, Apple Silicon and a Pi without anything extra:
 
 ```bash
-docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.31.0
+docker buildx imagetools inspect ghcr.io/amansk5/shadow-ai-guard/receiver:0.32.0
 ```
 
 Pin a version. `latest` moves when a release is tagged, which means a pod

--- a/portal/app/static/index.html
+++ b/portal/app/static/index.html
@@ -6657,7 +6657,7 @@ kubectl -n ${ns} set image cronjob/<discovery> discovery=ghcr.io/amansk5/shadow-
         <p>The command runs with your kubeconfig or Docker context and reports its progress here. The portal never upgrades anything itself; it approves the request (owners only) and shows the run.</p>
         <ol class="ui-steplist">
           <li><b>Have Python 3.10 or newer and pipx on your machine.</b><span>On a Mac, <code>brew install pipx</code>; elsewhere, <code>pip install --user pipx</code>.</span></li>
-          <li><b>Install the command once, from a tagged release.</b>${uiCommand(`pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@${u.latest || 'v0.31.0'}#subdirectory=cli"`)}</li>
+          <li><b>Install the command once, from a tagged release.</b>${uiCommand(`pipx install -q "git+https://github.com/AmanSK5/shadow-ai-guard@${u.latest || 'v0.32.0'}#subdirectory=cli"`)}</li>
           <li><b>Put it on your PATH.</b>${uiCommand('pipx ensurepath')}<span>A shell opened before this will not find the command until it is reopened.</span></li>
           <li><b>Run it.</b>${uiCommand('aiguardctl upgrade --portal ' + location.origin)}<span>Your browser opens this portal to approve the request; compare the code it shows with your terminal. <code>--dry-run</code> prints every command without running one.</span></li>
         </ol>

--- a/receiver/deploy/receiver.yaml
+++ b/receiver/deploy/receiver.yaml
@@ -65,7 +65,7 @@ spec:
           # the field bounds. Anyone copying this file got materially weaker
           # ingestion than the chart gives them, from a file offered as the
           # simpler alternative.
-          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.31.0
+          image: ghcr.io/amansk5/shadow-ai-guard/receiver:0.32.0
           imagePullPolicy: IfNotPresent
           # The receiver writes nothing to disk: findings go to stdout and,
           # optionally, straight to Loki. An emptyDir covers /tmp for anything


### PR DESCRIPTION
Somewhere for an operator who has bought the commercial edition to enter the key they were issued, see that it is genuine and what it says, and get the commands to move a deployment across. The open edition is unchanged and stays whole: no view, no route and no count in this repository asks whether a key is present.

## Activation keys

- A key is compact JSON stating the organisation, the plan, the term and any device limit, with an Ed25519 signature over exactly those bytes. Both halves are base64url behind an `nyxl_` prefix. The claims are readable on purpose - what somebody was sold should not need a tool to inspect - and the signature is what stops them being edited.
- Checked offline, always. The publisher's public key is compiled into the receiver, so verification is local arithmetic: no outbound request at activation, at boot, or ever. A deployment that is airgapped, or whose vendor has gone quiet, keeps working exactly as it did. `ACTIVATION_PUBLIC_KEY` overrides the compiled-in key, which is how a rotation reaches a deployment before a new image does.
- Verified where it is stored. `PUT /admin/activation` refuses a key it cannot verify, so the write path is not a way past the check. Owner-gated, for the same reason the `sso_*` settings are. Reading it is not owner-only: an admin supporting a deployment needs to see when the subscription runs out.
- Never echoed. `GET` answers with the claims and a truncated SHA-256 fingerprint, which is what support and an operator use to agree on which key is installed without either of them sending it anywhere. It does not appear in `GET /admin/settings`, and the audit trail records that `activation_key` changed and who changed it, never the value.
- No revocation. An offline check cannot be told a key was withdrawn, so the stated term is the control.

## On System health

- A new wide card under Updates. Unactivated it names the edition, the licence and that the check makes no outbound request, and offers an owner the field.
- Activated it shows the organisation, the plan and device limit, the expiry with days remaining, the reference and the key's fingerprint. Inside 45 days it says the subscription is ending, and that nothing stops working on the day, because nothing does.
- An expired key is stored and reported as expired rather than refused. It is a true statement about a real subscription, and someone renewing has to be able to see what ran out.
- A key the running release cannot verify is reported, not hidden - that is what a rotated signing key looks like from a deployment that has not taken the release carrying the new one, so the note says to upgrade first and only then suspect the key.
- A failed read says the receiver did not answer rather than reporting no subscription, which would tell a paying customer they have no licence.
- Activated and expired both expand the handoff: the pull secret and the chart install, written with the deployment's own namespace and the registry named in the key. Nothing runs from the page - it runs with the operator's own kubeconfig, the same rule as `aiguardctl upgrade`.

## What a refusal may say

CodeQL flagged the first version of both routes for exposing exception detail in a response, and it was right in the way it was right about the portal's Loki errors: a response carries the class of failure, and the detail behind it belongs in the log. `ActivationError` now carries a code rather than a message, the sentences live in one table, and `activation.check()` does not raise for a bad key - so there is no exception object in the routes at all. One message quoted the plan out of the key; publisher-signed rather than attacker-chosen, so not a hole, but a refusal that quotes a field out of the key is the shape this is not allowed to have, and it is gone.

## What this is not

A client-side check is not the control and is not presented as one. Anyone running their own copy can point `ACTIVATION_PUBLIC_KEY` at a key of their own and make it say activated, and no amount of hardening changes that. It wins nothing: activation gates no behaviour here, and a forged key is not a credential. What protects the private images is the registry refusing to serve them, which is server-side and outside this repository.

## The verifier

Written out in `receiver/app/ed25519.py` rather than taken from a library. The only operation needed is verify, over public data, in a component whose dependency list is seven packages, and pulling in a compiled crypto library would add a build toolchain to two images for a routine that fits on a page. There is no private key in the process and none in this repository, so the usual reason to insist on a hardened implementation - secret-dependent timing - does not arise. What that trade costs is the assurance a reviewed library carries, so it is bought back in the tests: the RFC 8032 vectors, reproduced from their seeds rather than pasted, plus the forgeries a lax verifier accepts - a flipped bit in each field, a point that is not on the curve, and a scalar at or above the group order, which is the one a hand-written verifier usually misses because ignoring it gives every signature a second valid form.

## Checked

372 receiver tests, 671 portal tests, 14 CLI tests, 22 Node renderer tests. Both byte-identical invariants verified before the bump. Helm lint and render replayed locally across four values shapes. End to end on the demo stack: a real key activates and shows the right claims, a forged one is refused with a written sentence while the log gets the code, the audit row lands without the key in it, and no route returns it.

## Deploying

Portal, receiver, CLI and the chart move to 0.32.0. Nothing stored changes and there is no migration. No new dependency in any component, so no lockfile moves. `ACTIVATION_PUBLIC_KEY` is optional and unset everywhere, which keeps the compiled-in key. A deployment that never enters a key sees one extra card saying it runs the open edition.

The scanner and discovery CronJobs are outside the chart as always; nothing in this release changes them, so their tags can stay where they are.
